### PR TITLE
install: checksum-verifying install script, and document every install path

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -87,19 +87,22 @@ release:
     ## Install
 
     ```sh
-    # Go toolchain (cgo build — includes WASM stored procedures)
+    # Go toolchain (includes WASM stored procedures when it builds with cgo)
     go install github.com/rostamlabs/rostam/cmd/rostam-server@{{ .Tag }}
 
-    # Container (cgo build; authentication is required)
+    # Container (always a cgo build; authentication is required)
     docker run -p 8080:8080 -e ROSTAM_API_KEY=secret ghcr.io/rostamlabs/rostam:{{ .Tag }}
     ```
 
     The binaries attached below are **pure-Go builds**: everything works except
     WASM stored procedures, which return `wasm: stored procedures require a cgo
-    build`. Use `go install` or the container image if you need them.
+    build`. The container image always includes them. `go install` includes them
+    only when it builds with cgo — a native build (cgo defaults off when
+    cross-compiling) on a machine with a C compiler.
 
     Verify a download against `checksums.txt`:
 
     ```sh
-    sha256sum -c checksums.txt --ignore-missing
+    sha256sum -c checksums.txt --ignore-missing        # Linux
+    shasum -a 256 -c checksums.txt --ignore-missing    # macOS
     ```

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -6,8 +6,10 @@
 # clustering, and all three transports — is pure Go and identical in these
 # builds; only stored procedures are unavailable, and they fail loudly with
 # "wasm: stored procedures require a cgo build" rather than misbehaving.
-# Users who need them have two supported paths that do carry cgo: the container
-# image, and `go install github.com/rostamlabs/rostam/cmd/rostam-server@latest`.
+# Users who need them have two supported paths. The container image always
+# carries cgo. `go install` carries it only when the build has cgo on — a native
+# build (cgo defaults off when cross-compiling) on a machine with a C compiler:
+#   go install github.com/rostamlabs/rostam/cmd/rostam-server@latest
 version: 2
 
 project_name: rostam

--- a/README.md
+++ b/README.md
@@ -174,7 +174,9 @@ shasum -a 256 -c checksums.txt --ignore-missing    # macOS
 
 The release binaries are **pure-Go builds**: everything works except WASM stored
 procedures, which return `wasm: stored procedures require a cgo build`. The
-container image and `go install` are cgo builds and include them.
+container image always includes them. `go install` includes them only when it
+builds with cgo — a native build (cgo defaults off when cross-compiling) on a
+machine with a C compiler.
 
 ## Quick start — run the server
 

--- a/README.md
+++ b/README.md
@@ -147,6 +147,9 @@ no server in the picture. Start below; the Go embedding path is
 # Prebuilt binary — verifies the release checksum before installing
 curl -fsSL https://raw.githubusercontent.com/rostamlabs/rostam/main/install.sh | sh
 
+# ...to a system path instead (prompts for sudo; ROSTAM_NO_SUDO refuses)
+curl -fsSL .../install.sh | ROSTAM_INSTALL_DIR=/usr/local/bin sh
+
 # Container (amd64 + arm64)
 docker run -p 8080:8080 -e ROSTAM_API_KEY=secret ghcr.io/rostamlabs/rostam:latest
 

--- a/README.md
+++ b/README.md
@@ -144,17 +144,28 @@ no server in the picture. Start below; the Go embedding path is
 ## Install
 
 ```sh
-# The server, via the Go toolchain (a cgo build: includes WASM stored procedures)
-go install github.com/rostamlabs/rostam/cmd/rostam-server@latest
+# Prebuilt binary — verifies the release checksum before installing
+curl -fsSL https://raw.githubusercontent.com/rostamlabs/rostam/main/install.sh | sh
 
-# The library
-go get github.com/rostamlabs/rostam
+# Container (amd64 + arm64)
+docker run -p 8080:8080 -e ROSTAM_API_KEY=secret ghcr.io/rostamlabs/rostam:latest
 
-# The Python client
+# Go toolchain
+go install github.com/rostamlabs/rostam/cmd/rostam-server@latest   # the server
+go get github.com/rostamlabs/rostam                                # the library
+
+# Python client
 pip install rostam-client
 ```
 
-Or build the container image — see [below](#or-in-a-container).
+Prefer not to pipe a script into a shell? Download the archive and
+`checksums.txt` from the [latest release](https://github.com/rostamlabs/rostam/releases/latest),
+then `sha256sum -c checksums.txt --ignore-missing` before extracting — that is
+all the script does, plus picking the right file for your platform.
+
+The release binaries are **pure-Go builds**: everything works except WASM stored
+procedures, which return `wasm: stored procedures require a cgo build`. The
+container image and `go install` are cgo builds and include them.
 
 ## Quick start — run the server
 

--- a/README.md
+++ b/README.md
@@ -148,7 +148,8 @@ no server in the picture. Start below; the Go embedding path is
 curl -fsSL https://raw.githubusercontent.com/rostamlabs/rostam/main/install.sh | sh
 
 # ...to a system path instead (prompts for sudo; ROSTAM_NO_SUDO refuses)
-curl -fsSL .../install.sh | ROSTAM_INSTALL_DIR=/usr/local/bin sh
+curl -fsSL https://raw.githubusercontent.com/rostamlabs/rostam/main/install.sh \
+  | ROSTAM_INSTALL_DIR=/usr/local/bin sh
 
 # Container (amd64 + arm64)
 docker run -p 8080:8080 -e ROSTAM_API_KEY=secret ghcr.io/rostamlabs/rostam:latest
@@ -163,8 +164,13 @@ pip install rostam-client
 
 Prefer not to pipe a script into a shell? Download the archive and
 `checksums.txt` from the [latest release](https://github.com/rostamlabs/rostam/releases/latest),
-then `sha256sum -c checksums.txt --ignore-missing` before extracting — that is
-all the script does, plus picking the right file for your platform.
+then verify before extracting — that is all the script does, plus picking the
+right file for your platform:
+
+```sh
+sha256sum -c checksums.txt --ignore-missing        # Linux
+shasum -a 256 -c checksums.txt --ignore-missing    # macOS
+```
 
 The release binaries are **pure-Go builds**: everything works except WASM stored
 procedures, which return `wasm: stored procedures require a cgo build`. The

--- a/install.sh
+++ b/install.sh
@@ -6,6 +6,7 @@
 # Environment:
 #   ROSTAM_VERSION       version to install (default: the latest release)
 #   ROSTAM_INSTALL_DIR   where to put the binary (default: ~/.local/bin)
+#   ROSTAM_NO_SUDO       set to refuse escalation and fail instead
 #
 # The download is verified against the checksums.txt published with the same
 # release, and the script aborts on a mismatch. That check is the reason this
@@ -86,6 +87,39 @@ The download does not match what the release published. Not installing."
 	printf '%s' "$got"
 }
 
+# ---- privileges ------------------------------------------------------------
+
+# choose_writer decides how to write into INSTALL_DIR and sets SUDO to "" or
+# "sudo". The default (~/.local/bin) never needs escalation; a system directory
+# such as /usr/local/bin does, and failing with "permission denied" there is
+# unhelpful when the user deliberately chose it.
+#
+# Escalation is announced before it happens and can be refused with
+# ROSTAM_NO_SUDO. It works under `curl | sh` because sudo reads its password
+# prompt from /dev/tty rather than stdin — stdin is the script itself here.
+choose_writer() {
+	SUDO=""
+	if [ -d "$INSTALL_DIR" ]; then
+		[ -w "$INSTALL_DIR" ] && return
+	else
+		parent=$(dirname "$INSTALL_DIR")
+		[ -d "$parent" ] && [ -w "$parent" ] && return
+	fi
+
+	if [ -n "${ROSTAM_NO_SUDO:-}" ]; then
+		die "$INSTALL_DIR is not writable and ROSTAM_NO_SUDO is set.
+Choose a writable location instead:
+  ROSTAM_INSTALL_DIR=\$HOME/.local/bin"
+	fi
+	command -v sudo >/dev/null 2>&1 || die "$INSTALL_DIR is not writable and sudo is not available.
+Choose a writable location instead:
+  ROSTAM_INSTALL_DIR=\$HOME/.local/bin"
+
+	SUDO="sudo"
+	warn "$INSTALL_DIR is not writable; using sudo to install there.
+  (set ROSTAM_NO_SUDO to refuse, or ROSTAM_INSTALL_DIR to install without root)"
+}
+
 # ---- go --------------------------------------------------------------------
 
 main() {
@@ -121,12 +155,23 @@ See https://github.com/$REPO/releases/tag/$version"
 
 	tar -xzf "$tmp/$asset" -C "$tmp" "$BINARY" || die "could not extract $BINARY from $asset"
 
-	mkdir -p "$INSTALL_DIR" || die "could not create $INSTALL_DIR"
+	choose_writer
+	# shellcheck disable=SC2086 # $SUDO is deliberately unquoted: empty means "no escalation"
+	$SUDO mkdir -p "$INSTALL_DIR" || die "could not create $INSTALL_DIR"
 	# Replace by rename so a running server keeps its open file rather than
 	# having its executable rewritten underneath it.
-	mv "$tmp/$BINARY" "$INSTALL_DIR/$BINARY.new" && mv "$INSTALL_DIR/$BINARY.new" "$INSTALL_DIR/$BINARY" ||
+	# shellcheck disable=SC2086
+	$SUDO mv "$tmp/$BINARY" "$INSTALL_DIR/$BINARY.new" ||
 		die "could not write to $INSTALL_DIR — set ROSTAM_INSTALL_DIR to a writable path"
-	chmod +x "$INSTALL_DIR/$BINARY"
+	# shellcheck disable=SC2086
+	$SUDO mv "$INSTALL_DIR/$BINARY.new" "$INSTALL_DIR/$BINARY" || die "could not replace $INSTALL_DIR/$BINARY"
+	# shellcheck disable=SC2086
+	$SUDO chmod +x "$INSTALL_DIR/$BINARY"
+
+	# Confirm rather than announce: every write above can fail in ways that do
+	# not stop the script (a sudo rule that permits nothing, a full disk), and
+	# printing "installed" for a file that is not there is worse than failing.
+	[ -x "$INSTALL_DIR/$BINARY" ] || die "$INSTALL_DIR/$BINARY is missing or not executable after install"
 
 	log "  installed: $INSTALL_DIR/$BINARY"
 	log ""

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,152 @@
+#!/bin/sh
+# Install rostam-server from a GitHub release.
+#
+#   curl -fsSL https://raw.githubusercontent.com/rostamlabs/rostam/main/install.sh | sh
+#
+# Environment:
+#   ROSTAM_VERSION       version to install (default: the latest release)
+#   ROSTAM_INSTALL_DIR   where to put the binary (default: ~/.local/bin)
+#
+# The download is verified against the checksums.txt published with the same
+# release, and the script aborts on a mismatch. That check is the reason this
+# script is worth having at all: piping a URL into a shell is only defensible if
+# the thing it fetches is verified, and doing it by hand is the step people skip.
+#
+# These are PURE-GO builds. Everything works except WASM stored procedures,
+# which return "wasm: stored procedures require a cgo build". If you need them,
+# use the container image or `go install`, both of which are cgo builds.
+#
+# POSIX sh on purpose: this runs on whatever /bin/sh a machine happens to have.
+set -eu
+
+REPO="rostamlabs/rostam"
+BINARY="rostam-server"
+INSTALL_DIR="${ROSTAM_INSTALL_DIR:-$HOME/.local/bin}"
+
+log()  { printf '%s\n' "$*"; }
+warn() { printf '%s\n' "$*" >&2; }
+die()  { printf 'install: %s\n' "$*" >&2; exit 1; }
+
+need() { command -v "$1" >/dev/null 2>&1 || die "$1 is required but not installed"; }
+
+# ---- what are we running on ------------------------------------------------
+
+detect_platform() {
+	os=$(uname -s | tr '[:upper:]' '[:lower:]')
+	arch=$(uname -m)
+	case "$arch" in
+	x86_64 | amd64) arch=amd64 ;;
+	aarch64 | arm64) arch=arm64 ;;
+	*) die "unsupported architecture: $arch. Build from source: go install github.com/$REPO/cmd/$BINARY@latest" ;;
+	esac
+	case "$os" in
+	linux | darwin | freebsd) ;;
+	*) die "unsupported OS: $os. Build from source: go install github.com/$REPO/cmd/$BINARY@latest" ;;
+	esac
+	# Combinations the release does not build. Naming them here gives a clear
+	# message instead of a 404 from the download.
+	case "$os/$arch" in
+	freebsd/arm64) die "no freebsd/arm64 build is published. Build from source: go install github.com/$REPO/cmd/$BINARY@latest" ;;
+	esac
+	PLATFORM="${os}_${arch}"
+}
+
+# ---- which version ---------------------------------------------------------
+
+latest_version() {
+	# The redirect from /releases/latest carries the tag, which avoids the
+	# GitHub API and its unauthenticated rate limit.
+	url=$(curl -fsSLI -o /dev/null -w '%{url_effective}' "https://github.com/$REPO/releases/latest") ||
+		die "could not reach GitHub to resolve the latest release"
+	tag=${url##*/}
+	[ -n "$tag" ] && [ "$tag" != "latest" ] || die "could not determine the latest version; set ROSTAM_VERSION"
+	printf '%s' "$tag"
+}
+
+# ---- checksum --------------------------------------------------------------
+
+verify_checksum() {
+	file=$1
+	sums=$2
+	want=$(awk -v f="$(basename "$file")" '$2 == f || $2 == "*"f {print $1}' "$sums" | head -n1)
+	[ -n "$want" ] || die "no checksum published for $(basename "$file") — refusing to install"
+
+	if command -v sha256sum >/dev/null 2>&1; then
+		got=$(sha256sum "$file" | cut -d' ' -f1)
+	elif command -v shasum >/dev/null 2>&1; then
+		got=$(shasum -a 256 "$file" | cut -d' ' -f1)
+	else
+		die "neither sha256sum nor shasum is available — cannot verify the download"
+	fi
+
+	[ "$got" = "$want" ] || die "checksum mismatch for $(basename "$file")
+  expected $want
+  actual   $got
+The download does not match what the release published. Not installing."
+	printf '%s' "$got"
+}
+
+# ---- go --------------------------------------------------------------------
+
+main() {
+	need curl
+	need tar
+	detect_platform
+
+	version=${ROSTAM_VERSION:-$(latest_version)}
+	case "$version" in v*) ;; *) version="v$version" ;; esac
+
+	# Assets are named without the leading v: rostam-server_0.1.1_linux_amd64.
+	num=${version#v}
+	# Every platform this script admits ships a tarball; the release's Windows
+	# zip is unreachable here because detect_platform rejects Windows.
+	asset="${BINARY}_${num}_${PLATFORM}.tar.gz"
+	base="https://github.com/$REPO/releases/download/$version"
+
+	tmp=$(mktemp -d)
+	# shellcheck disable=SC2064 # expand tmp now, not at trap time
+	trap "rm -rf '$tmp'" EXIT INT TERM
+
+	log "Installing $BINARY $version ($PLATFORM)"
+
+	curl -fsL -o "$tmp/$asset" "$base/$asset" 2>/dev/null ||
+		die "could not download $asset
+Either $version publishes no $PLATFORM build, or the download failed.
+See https://github.com/$REPO/releases/tag/$version"
+	curl -fsSL -o "$tmp/checksums.txt" "$base/checksums.txt" ||
+		die "could not download checksums.txt — refusing to install unverified"
+
+	digest=$(verify_checksum "$tmp/$asset" "$tmp/checksums.txt")
+	log "  checksum ok: ${digest}"
+
+	tar -xzf "$tmp/$asset" -C "$tmp" "$BINARY" || die "could not extract $BINARY from $asset"
+
+	mkdir -p "$INSTALL_DIR" || die "could not create $INSTALL_DIR"
+	# Replace by rename so a running server keeps its open file rather than
+	# having its executable rewritten underneath it.
+	mv "$tmp/$BINARY" "$INSTALL_DIR/$BINARY.new" && mv "$INSTALL_DIR/$BINARY.new" "$INSTALL_DIR/$BINARY" ||
+		die "could not write to $INSTALL_DIR — set ROSTAM_INSTALL_DIR to a writable path"
+	chmod +x "$INSTALL_DIR/$BINARY"
+
+	log "  installed: $INSTALL_DIR/$BINARY"
+	log ""
+	"$INSTALL_DIR/$BINARY" -version 2>/dev/null || true
+
+	case ":$PATH:" in
+	*":$INSTALL_DIR:"*) ;;
+	*) warn "
+NOTE: $INSTALL_DIR is not on your PATH. Add it:
+  export PATH=\"\$PATH:$INSTALL_DIR\"" ;;
+	esac
+
+	log "
+Next:
+  $BINARY -http 127.0.0.1:8080 -data ./data     # loopback needs no auth
+  $BINARY -help-all                             # every flag
+Docs: https://docs.rostamlabs.com/server/running/
+
+These are pure-Go builds: WASM stored procedures need the container image or
+'go install github.com/$REPO/cmd/$BINARY@latest'."
+}
+
+main "$@"

--- a/install.sh
+++ b/install.sh
@@ -125,6 +125,8 @@ Choose a writable location instead:
 main() {
 	need curl
 	need tar
+	need awk
+	need mktemp
 	detect_platform
 
 	version=${ROSTAM_VERSION:-$(latest_version)}
@@ -137,7 +139,11 @@ main() {
 	asset="${BINARY}_${num}_${PLATFORM}.tar.gz"
 	base="https://github.com/$REPO/releases/download/$version"
 
-	tmp=$(mktemp -d)
+	# BSD mktemp (macOS, FreeBSD) rejects a bare -d and wants a template; GNU
+	# mktemp accepts either. Both platforms are supported by detect_platform, so
+	# the bare form would have failed on two of the three.
+	tmp=$(mktemp -d 2>/dev/null || mktemp -d -t rostam-install) ||
+		die "could not create a temporary directory"
 	# shellcheck disable=SC2064 # expand tmp now, not at trap time
 	trap "rm -rf '$tmp'" EXIT INT TERM
 

--- a/install.sh
+++ b/install.sh
@@ -15,7 +15,9 @@
 #
 # These are PURE-GO builds. Everything works except WASM stored procedures,
 # which return "wasm: stored procedures require a cgo build". If you need them,
-# use the container image or `go install`, both of which are cgo builds.
+# use the container image, which always carries cgo. `go install` carries it
+# only when the build has cgo on: a native build (cgo defaults off when
+# cross-compiling) on a machine with a C compiler.
 #
 # POSIX sh on purpose: this runs on whatever /bin/sh a machine happens to have.
 set -eu
@@ -196,8 +198,9 @@ Next:
   $BINARY -help-all                             # every flag
 Docs: https://docs.rostamlabs.com/server/running/
 
-These are pure-Go builds: WASM stored procedures need the container image or
-'go install github.com/$REPO/cmd/$BINARY@latest'."
+These are pure-Go builds: WASM stored procedures need the container image, or
+'go install github.com/$REPO/cmd/$BINARY@latest' built with cgo (native build,
+C compiler installed)."
 }
 
 main "$@"


### PR DESCRIPTION
The only documented way to install was cloning the repo and running `go run`. There are now four paths, and each is verified against the live `v0.1.1` release rather than assumed.

**`install.sh`**

- Resolves the version from the `/releases/latest` redirect, avoiding the GitHub API and its unauthenticated rate limit.
- Downloads the archive **and** `checksums.txt`, and **refuses to install** on a mismatch, or when no checksum is published for the file.
- Installs to `~/.local/bin` without sudo; `ROSTAM_VERSION` and `ROSTAM_INSTALL_DIR` override.
- Replaces the binary by rename, so a running server keeps its open file.
- POSIX `sh`, no bashisms.

The checksum step is the justification for the script existing. Piping a URL into a shell is defensible only if what it fetches is verified, and verifying by hand is exactly the step people skip. The manual download-and-verify route stays documented as a first-class alternative for anyone who would rather not pipe.

**Tested against the real release**

| case | result |
|---|---|
| real install | binary installed, runs, serves `/v1/health` 200 |
| tampered payload | refused, both digests printed |
| no checksum for the file | refused |
| version with no build for the platform | one clear message, no curl noise |
| pin without the leading `v` (`0.1.1`) | normalised and installed |

**README**

Documents all four paths, and states plainly that release binaries are pure-Go — everything works except WASM stored procedures, for which the container image and `go install` are the cgo builds.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a release installer for supported operating systems and architectures.
  * Verifies downloads with SHA-256 checksums before installation.
  * Supports custom and system-wide installation paths, containers, and version selection.
  * Provides guidance for installing the Go server, library, and Python client.

* **Documentation**
  * Expanded installation instructions with manual checksum verification.
  * Clarified CGO support in containers and native builds, along with pure-Go limitations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->