### PR TITLE
docs(python): give the PyPI page an install path a Python user can follow

### DIFF
--- a/clients/python/README.md
+++ b/clients/python/README.md
@@ -16,24 +16,42 @@ pip install rostam-client[langchain] # + the LangChain VectorStore adapter
 
 ## Run a server
 
-The client talks to a Rostam HTTP server. Build and run one from this repo:
+This client speaks **HTTP** — it is built on `urllib`, so the server needs its
+`-http` listener and that is the port you point the client at. (The server also
+offers gRPC and a binary TCP protocol; this client uses neither.)
+
+Neither of these needs a Go toolchain or a checkout:
 
 ```bash
-go build -o rostam-server ./cmd/rostam-server
-./rostam-server -http 127.0.0.1:8080 -data ./data                    # REST/JSON
-./rostam-server -http 127.0.0.1:8080 -grpc 127.0.0.1:9090 -tcp 127.0.0.1:7000
-./rostam-server -http :8080 -api-key "$KEY"                          # reachable, with auth
+# Container. Auth is required because it binds 0.0.0.0 inside the container.
+docker run --rm -p 127.0.0.1:8080:8080 -e ROSTAM_API_KEY=dev-token \
+  -v rostam-data:/data ghcr.io/rostamlabs/rostam:latest -http 0.0.0.0:8080 -data /data
+
+# Prebuilt binary. Verifies the release checksum before installing.
+curl -fsSL https://raw.githubusercontent.com/rostamlabs/rostam/main/install.sh | sh
+rostam-server -http 127.0.0.1:8080 -data ./data
 ```
 
-Note the loopback addresses. With no authenticator configured the server
-**refuses to bind a reachable address** rather than serve an open datastore to
-the network, so a bare `:8080` will not start. To listen beyond loopback, give
-it auth (`-api-key` or `-keys-file`) as in the third line, or pass `-insecure`
-to run open deliberately.
+Then point the client at it:
 
-A single server can expose REST, gRPC, and the binary TCP protocol at once over
-one shared store — a write on any transport is visible on the others. Set a
-transport's flag to `""` to disable it.
+```python
+c = RostamClient("http://localhost:8080", api_key="dev-token")  # container
+c = RostamClient("http://localhost:8080")                       # loopback binary
+```
+
+Without `-data` the store is memory-only and everything is lost when the process
+exits — that is the container's default, which is why the command above mounts a
+volume.
+
+With no authenticator configured the server **refuses to bind a reachable
+address** rather than serve an open datastore to the network. That is why the
+container needs `ROSTAM_API_KEY` while a loopback binary does not, and why a
+bare `-http :8080` will not start. To listen beyond loopback, give it auth
+(`-api-key`/`ROSTAM_API_KEY` or `-keys-file`), or pass `-insecure` to run open
+deliberately.
+
+Building from source stays available for contributors:
+`go build -o rostam-server ./cmd/rostam-server`.
 
 ## Quickstart
 

--- a/clients/python/README.md
+++ b/clients/python/README.md
@@ -29,12 +29,15 @@ docker run --rm -p 127.0.0.1:8080:8080 -e ROSTAM_API_KEY=dev-token \
 
 # Prebuilt binary. Verifies the release checksum before installing.
 curl -fsSL https://raw.githubusercontent.com/rostamlabs/rostam/main/install.sh | sh
+export PATH="$PATH:$HOME/.local/bin"    # where the installer puts it
 rostam-server -http 127.0.0.1:8080 -data ./data
 ```
 
 Then point the client at it:
 
 ```python
+from rostam import RostamClient
+
 c = RostamClient("http://localhost:8080", api_key="dev-token")  # container
 c = RostamClient("http://localhost:8080")                       # loopback binary
 ```

--- a/clients/python/pyproject.toml
+++ b/clients/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "rostam-client"
-version = "0.1.1"
+version = "0.1.2"
 description = "Dependency-free Python client and LangChain adapter for the Rostam vector store"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/clients/python/rostam/__init__.py
+++ b/clients/python/rostam/__init__.py
@@ -25,4 +25,9 @@ __all__ = [
     "TextStore",
 ]
 
-__version__ = "0.1.0"
+# Keep in step with [project] version in pyproject.toml. test_version.py fails
+# when they drift: this constant sat at 0.1.0 through the 0.1.1 release, so
+# anything asking rostam.__version__ was told the wrong release, and nothing
+# noticed. It is a literal rather than an importlib.metadata lookup so that
+# importing the package stays free of a dist-info read.
+__version__ = "0.1.2"

--- a/clients/python/tests/test_version.py
+++ b/clients/python/tests/test_version.py
@@ -1,0 +1,36 @@
+"""The packaged version and the runtime constant must agree.
+
+`rostam.__version__` sat at 0.1.0 across the 0.1.1 release: anything reporting a
+client version — a bug report, a user agent, a diagnostic — named a release that
+was not the one running. Nothing caught it, because nothing compared the two.
+
+This does. It reads pyproject.toml with a regex rather than a TOML parser
+because the package supports Python 3.9 and `tomllib` arrived in 3.11; the field
+it needs is one line and unambiguous.
+"""
+
+import os
+import re
+import unittest
+
+import rostam
+
+_PYPROJECT = os.path.join(os.path.dirname(__file__), "..", "pyproject.toml")
+
+
+class VersionTest(unittest.TestCase):
+    def test_runtime_version_matches_the_package_metadata(self):
+        with open(_PYPROJECT, encoding="utf-8") as fh:
+            text = fh.read()
+        # The [project] table's own version, not a dependency pin.
+        m = re.search(r'^version\s*=\s*"([^"]+)"', text, re.M)
+        self.assertIsNotNone(m, "no version field found in pyproject.toml")
+        self.assertEqual(
+            m.group(1),
+            rostam.__version__,
+            "pyproject.toml and rostam.__version__ disagree; bump both",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Two problems on <https://pypi.org/project/rostam-client/>, both in **Run a server**.

**1. The instructions assume a Go developer.** The page said to `go build -o rostam-server ./cmd/rostam-server` from "this repo" — but someone who arrived via `pip install rostam-client` has no checkout, and may have no Go toolchain. The first actionable instruction on the page was one they could not follow. It now leads with the container and the install script; building from source stays as a note for contributors.

**2. It advertised transports this client cannot use.** One example line offered `-grpc` and `-tcp` next to `-http`. This client is `urllib`-based and speaks HTTP only — there is no `socket` import or gRPC code anywhere in the package, and every default is `:8080`. Listing the other two on the Python page invited the reading that the client might connect to one of them. The section now states the transport up front.

Two things the page omitted that the container makes easy to trip over are now documented: without `-data` the store is **memory-only** (the image's default), and the container binds `0.0.0.0` internally so it **requires auth**, where a loopback binary does not.

## Why the version bump

PyPI renders the description from the uploaded release, so this correction does not reach the project page until a new upload. `0.1.1` → `0.1.2`, published by pushing `py-v0.1.2` after this merges. No code changed.

## Verification

Against the real `v0.1.2` image, not a local build — the documented `docker run` verbatim:

- container starts, `data=/data`, and writes into the named volume owned by the `rostam` user (fresh-volume ownership being the usual failure here)
- the client then created a collection, upserted, and searched through it end to end
- listener was loopback-only (`127.0.0.1:8080`) and torn down afterwards

`36 passed, 36 skipped` in the client test suite.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded server setup guidance with HTTP-only usage, container and prebuilt-binary startup options, API-key requirements, storage choices, client connection examples, and source builds.
  * Simplified setup instructions by removing outdated multi-transport configuration examples.

* **Chores**
  * Updated the Python package version to 0.1.2.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->