### PR TITLE
feat(http,python): binary query framing, and a pooled Python transport

### DIFF
--- a/clients/python/README.md
+++ b/clients/python/README.md
@@ -346,6 +346,16 @@ Documents must carry embeddings; writes use overwrite semantics.
 
 ## Notes
 
+- **Connections.** The client pools and reuses connections, so a sequence of
+  calls does not pay a TCP handshake each time, and it is safe to share one
+  client across threads. Use it as a context manager, or call `close()`, to
+  release the pool; the client stays usable afterwards. Connection reuse is
+  built on `http.client`, which does not consult `HTTP_PROXY`/`HTTPS_PROXY` —
+  behind an egress proxy, point `base_url` at the proxy.
+- **Search encoding.** Searches go out in Rostam's binary query framing rather
+  than as JSON text, which at dim=768 was 31% of the request. Against a server
+  too old to understand it the client notices and falls back to JSON for the
+  rest of its life; `RostamClient(url, binary_search=False)` opts out entirely.
 - **IDs.** Rostam point ids are `uint64`. The client takes integers directly. The
   LangChain adapter accepts string ids: a purely-numeric string is used verbatim,
   anything else is hashed (BLAKE2b) to a stable 64-bit id, so repeated

--- a/clients/python/rostam/client.py
+++ b/clients/python/rostam/client.py
@@ -196,9 +196,13 @@ _RVQ1_FLAG_FILTER = 1 << 0
 # The server refuses a declared dim above this, so a longer vector goes as JSON
 # rather than as a request the server is certain to reject.
 _RVQ1_MAX_DIM = 1 << 16
+# ...and the same for the filter blob. A filter past this is refused by the
+# binary route but well within the JSON route's 32 MiB body, so exceeding it has
+# to mean "send JSON", not "fail" — an `in_` over enough values gets there.
+_RVQ1_MAX_FILTER = 1 << 20
 
 
-def _encode_rvq1(query: Vector, k: int, filter: Optional[Dict[str, Any]]) -> bytearray:
+def _encode_rvq1(query: Vector, k: int, filter_blob: bytes = b"") -> bytearray:
     """Encode a search request in the binary query framing.
 
     Same shape as _encode_bulk on the ingest side, and big-endian for the same
@@ -212,18 +216,14 @@ def _encode_rvq1(query: Vector, k: int, filter: Optional[Dict[str, Any]]) -> byt
     them so that adding them later needs no second wire format.
     """
     vec = array.array("f", query)
-    blob = b""
-    flags = 0
-    if filter:
-        flags |= _RVQ1_FLAG_FILTER
-        blob = json.dumps(filter).encode("utf-8")
+    flags = _RVQ1_FLAG_FILTER if filter_blob else 0
     out = bytearray(struct.pack(">4sIIIBBHQ", _RVQ1_MAGIC, flags, k, len(vec), 0, 0, 0, 0))
     if sys.byteorder == "little":
         vec.byteswap()
     out += vec.tobytes()
-    if blob:
-        out += struct.pack(">I", len(blob))
-        out += blob
+    if filter_blob:
+        out += struct.pack(">I", len(filter_blob))
+        out += filter_blob
     return out
 
 
@@ -473,11 +473,15 @@ class RostamClient:
         # Encoding it here would raise struct.error instead — a different
         # exception type for the same misuse, decided by which encoding the
         # client happened to pick.
-        encodable = 0 <= k <= 0xFFFFFFFF and len(query) <= _RVQ1_MAX_DIM
+        # Encoded once here rather than inside _encode_rvq1, because its SIZE is
+        # part of deciding whether the binary path can carry this request at all.
+        blob = json.dumps(filter).encode("utf-8") if filter else b""
+        encodable = (0 <= k <= 0xFFFFFFFF and len(query) <= _RVQ1_MAX_DIM
+                     and len(blob) <= _RVQ1_MAX_FILTER)
         if self.binary_search and self._binary_search_supported and encodable:
             try:
                 res = self._send(
-                    "POST", path, _encode_rvq1(query, k, filter),
+                    "POST", path, _encode_rvq1(query, k, blob),
                     "application/octet-stream", idempotent=True,
                 )
                 return res or {}

--- a/clients/python/rostam/client.py
+++ b/clients/python/rostam/client.py
@@ -16,12 +16,12 @@ from Rostam's tagged wire form automatically — callers work in native Python.
 from __future__ import annotations
 
 import array
+import http.client
 import json
 import struct
 import sys
-import urllib.error
+import threading
 import urllib.parse
-import urllib.request
 from dataclasses import dataclass, field
 from typing import Any, Dict, List, Optional, Sequence, Union
 
@@ -190,6 +190,42 @@ def _encode_bulk_body(
     return out
 
 
+_RVQ1_MAGIC = b"RVQ1"
+_RVQ1_FLAG_FILTER = 1 << 0
+# The server refuses a declared dim above this, so a longer vector goes as JSON
+# rather than as a request the server is certain to reject.
+_RVQ1_MAX_DIM = 1 << 16
+
+
+def _encode_rvq1(query: Vector, k: int, filter: Optional[Dict[str, Any]]) -> bytearray:
+    """Encode a search request in the binary query framing.
+
+    Same shape as _encode_bulk on the ingest side, and big-endian for the same
+    reason: it lands in the server byte-identical to the op wire, so neither end
+    swaps per float. ``array.byteswap`` does the whole vector in one C call —
+    which is what makes this 0.011 ms where json.dumps of the same 768 floats is
+    0.258 ms.
+
+    read_consistency, on_partition_unavailable and max_staleness are written as
+    their defaults: this client has never exposed them, and the framing carries
+    them so that adding them later needs no second wire format.
+    """
+    vec = array.array("f", query)
+    blob = b""
+    flags = 0
+    if filter:
+        flags |= _RVQ1_FLAG_FILTER
+        blob = json.dumps(filter).encode("utf-8")
+    out = bytearray(struct.pack(">4sIIIBBHQ", _RVQ1_MAGIC, flags, k, len(vec), 0, 0, 0, 0))
+    if sys.byteorder == "little":
+        vec.byteswap()
+    out += vec.tobytes()
+    if blob:
+        out += struct.pack(">I", len(blob))
+        out += blob
+    return out
+
+
 # The server caps a single binary bulk body at 256 MiB and a single request at
 # 262,144 points. bulk_stage/batch_upsert therefore SPLIT a large load into
 # requests instead of sending one giant body — otherwise the advertised "load a
@@ -238,13 +274,97 @@ def _chunks(n: int, vectors: Sequence[Vector], payloads=None):
         yield lo, min(lo + step, n)
 
 
+class _ConnectionPool:
+    """Keep-alive connections to one host, safe to share between threads.
+
+    The client used to call ``urllib.request.urlopen`` per request, which opens
+    and tears down a TCP connection every time. Reusing one costs a lock and a
+    list; measured against a local server it was 1.49x the throughput on
+    repeated searches, and the gap widens with network latency because a fresh
+    connection pays a round-trip before the request is even sent.
+
+    ``urlopen`` was accidentally thread-safe — nothing was shared. A kept-alive
+    connection is not: two threads writing requests into one socket interleave
+    and desynchronize the response stream. So connections live here, one thread
+    holds one connection for the length of a request, and a connection is only
+    returned to the pool once its response has been fully read.
+    """
+
+    def __init__(self, base_url: str, timeout: float, maxsize: int = 8):
+        parts = urllib.parse.urlsplit(base_url)
+        if parts.scheme not in ("http", "https"):
+            raise ValueError(f"base_url must be http:// or https://, got {base_url!r}")
+        self._https = parts.scheme == "https"
+        self._host = parts.hostname or "localhost"
+        self._port = parts.port or (443 if self._https else 80)
+        self._timeout = timeout
+        self._maxsize = maxsize
+        self._idle: List[Any] = []
+        self._lock = threading.Lock()
+
+    def _new(self, timeout: float):
+        cls = http.client.HTTPSConnection if self._https else http.client.HTTPConnection
+        return cls(self._host, self._port, timeout=timeout)
+
+    def acquire(self, timeout: float):
+        """Return (connection, reused). A reused connection may be dead."""
+        with self._lock:
+            if self._idle:
+                return self._idle.pop(), True
+        return self._new(timeout), False
+
+    def release(self, conn) -> None:
+        with self._lock:
+            if len(self._idle) < self._maxsize:
+                self._idle.append(conn)
+                return
+        conn.close()
+
+    def discard(self, conn) -> None:
+        try:
+            conn.close()
+        except Exception:
+            pass
+
+    def close(self) -> None:
+        with self._lock:
+            idle, self._idle = self._idle, []
+        for c in idle:
+            self.discard(c)
+
+
 class RostamClient:
     """REST client for a Rostam HTTP server (see ``rostam.NewHTTPServer``)."""
 
-    def __init__(self, base_url: str, api_key: Optional[str] = None, timeout: float = 30.0):
+    def __init__(
+        self,
+        base_url: str,
+        api_key: Optional[str] = None,
+        timeout: float = 30.0,
+        *,
+        binary_search: bool = True,
+        pool_maxsize: int = 8,
+    ):
         self.base_url = base_url.rstrip("/")
         self.api_key = api_key
         self.timeout = timeout
+        # Whether to send search queries in the binary framing. Turning it off
+        # forces the JSON body; see _search_body for what the framing buys and
+        # for how an older server is detected and fallen back to automatically.
+        self.binary_search = binary_search
+        self._binary_search_supported = True
+        self._pool = _ConnectionPool(self.base_url, timeout, maxsize=pool_maxsize)
+        self._path_prefix = urllib.parse.urlsplit(self.base_url).path.rstrip("/")
+
+    def close(self) -> None:
+        """Close pooled connections. The client stays usable; it reconnects."""
+        self._pool.close()
+
+    def __enter__(self) -> "RostamClient":
+        return self
+
+    def __exit__(self, *exc: Any) -> None:
+        self.close()
 
     # ---- transport ----
 
@@ -260,27 +380,89 @@ class RostamClient:
         content_type: str,
         timeout: Optional[float] = None,
     ) -> Any:
-        url = self.base_url + path
-        req = urllib.request.Request(url, data=data, method=method)
-        req.add_header("Content-Type", content_type)
+        headers = {"Content-Type": content_type}
         if self.api_key:
-            req.add_header("Authorization", "Bearer " + self.api_key)
-        try:
-            with urllib.request.urlopen(req, timeout=timeout or self.timeout) as resp:
-                raw = resp.read()
-        except urllib.error.HTTPError as e:
-            raw = e.read()
-            msg = str(e)
+            headers["Authorization"] = "Bearer " + self.api_key
+        deadline = timeout or self.timeout
+        url = self._path_prefix + path
+
+        # One retry, and only for a connection taken from the pool. A server (or
+        # a proxy) is free to close an idle keep-alive connection at any moment,
+        # and it usually does so between our last response and this request — so
+        # the failure arrives when we write, before the server has seen anything
+        # to act on. Retrying a connection we just opened would instead be
+        # retrying a request that may well have been executed.
+        attempts = 2
+        while True:
+            attempts -= 1
+            conn, reused = self._pool.acquire(deadline)
             try:
-                msg = json.loads(raw).get("error", msg)
-            except Exception:
-                pass
-            raise RostamError(msg, status=e.code) from None
-        except urllib.error.URLError as e:
-            raise RostamError(f"transport error: {e.reason}", status=0) from None
-        if not raw:
-            return None
-        return json.loads(raw)
+                conn.request(method, url, body=data, headers=headers)
+                resp = conn.getresponse()
+                raw = resp.read()
+                status = resp.status
+            except (http.client.RemoteDisconnected, http.client.BadStatusLine,
+                    ConnectionResetError, BrokenPipeError) as e:
+                self._pool.discard(conn)
+                if reused and attempts > 0:
+                    continue
+                raise RostamError(f"transport error: {e}", status=0) from None
+            except (OSError, http.client.HTTPException) as e:
+                self._pool.discard(conn)
+                raise RostamError(f"transport error: {e}", status=0) from None
+
+            # Only a connection the server intends to keep goes back in the pool.
+            # A response that closes it (HTTP/1.0, or an explicit Connection:
+            # close) leaves a dead socket that the next caller would spend a
+            # failed write and a retry to discover — turning pooling into a
+            # per-request penalty against exactly the servers that opted out.
+            if resp.will_close:
+                self._pool.discard(conn)
+            else:
+                self._pool.release(conn)
+            if status >= 400:
+                msg = f"HTTP {status}"
+                try:
+                    msg = json.loads(raw).get("error", msg)
+                except Exception:
+                    pass
+                raise RostamError(msg, status=status)
+            if not raw:
+                return None
+            return json.loads(raw)
+
+    # ---- search encoding ----
+
+    def _search(
+        self, path: str, query: Vector, k: int, filter: Optional[Dict[str, Any]]
+    ) -> Dict[str, Any]:
+        """POST a search, in the binary framing when the server understands it.
+
+        The JSON body spends its time turning float32s into decimal for the
+        server to parse straight back. At dim=768, k=10, that encode is 0.258 ms
+        of a 0.845 ms request — 31% — against 0.011 ms to write the same vector
+        as bytes, and the server's matching decode disappears with it.
+        """
+        if self.binary_search and self._binary_search_supported and len(query) <= _RVQ1_MAX_DIM:
+            try:
+                res = self._send(
+                    "POST", path, _encode_rvq1(query, k, filter), "application/octet-stream"
+                )
+                return res or {}
+            except RostamError as e:
+                # A server without RVQ1 support routes the body to its JSON
+                # decoder, which chokes on byte one and says so. That specific
+                # message is the signal to stop offering binary for the life of
+                # this client and use JSON — anything else is a real error about
+                # this request (a bad k, a bad filter) and must surface as one.
+                if not (e.status == 400 and "invalid JSON body" in str(e)):
+                    raise
+                self._binary_search_supported = False
+
+        body: Dict[str, Any] = {"query": list(query), "k": k}
+        if filter:
+            body["filter"] = filter
+        return self._request("POST", path, body) or {}
 
     # ---- collections ----
 
@@ -600,10 +782,7 @@ class RostamClient:
         self, collection: str, query: Vector, k: int, *, filter: Optional[Dict[str, Any]] = None
     ) -> List[SearchResult]:
         """k-nearest-neighbor search, returning ids + distances."""
-        body = {"query": list(query), "k": k}
-        if filter:
-            body["filter"] = filter
-        res = self._request("POST", f"/v1/collections/{_seg(collection)}/points/search", body)
+        res = self._search(f"/v1/collections/{_seg(collection)}/points/search", query, k, filter)
         return [SearchResult(id=r["id"], distance=r.get("distance", 0.0), score=r.get("score", 0.0))
                 for r in (res.get("results") or [])]
 
@@ -611,10 +790,7 @@ class RostamClient:
         self, collection: str, query: Vector, k: int, *, filter: Optional[Dict[str, Any]] = None
     ) -> List[Document]:
         """kNN search returning each hit enriched with content + metadata."""
-        body = {"query": list(query), "k": k}
-        if filter:
-            body["filter"] = filter
-        res = self._request("POST", f"/v1/collections/{_seg(collection)}/points/search/docs", body)
+        res = self._search(f"/v1/collections/{_seg(collection)}/points/search/docs", query, k, filter)
         return [_to_document(d) for d in (res.get("documents") or [])]
 
     def search_groups(

--- a/clients/python/rostam/client.py
+++ b/clients/python/rostam/client.py
@@ -1,8 +1,9 @@
 """A dependency-free Python client for Rostam's REST API.
 
-Uses only the standard library (``urllib``), so it installs and runs anywhere
-with no transitive dependencies. Metadata and filter values are converted to and
-from Rostam's tagged wire form automatically — callers work in native Python.
+Uses only the standard library (``http.client``), so it installs and runs
+anywhere with no transitive dependencies. Metadata and filter values are
+converted to and from Rostam's tagged wire form automatically — callers work in
+native Python.
 
     from rostam import RostamClient
     from rostam import filters as f
@@ -158,8 +159,8 @@ def _encode_bulk_body(
 
     Returns the bytearray itself rather than ``bytes(out)``: the copy would
     momentarily double the body, which is the opposite of the point in a function
-    whose whole job is to make a large load cheap. urllib accepts any bytes-like
-    object as request data.
+    whose whole job is to make a large load cheap. http.client accepts any
+    bytes-like object as a request body.
     """
     n = len(ids)
     if len(vectors) != n:
@@ -290,14 +291,13 @@ class _ConnectionPool:
     returned to the pool once its response has been fully read.
     """
 
-    def __init__(self, base_url: str, timeout: float, maxsize: int = 8):
+    def __init__(self, base_url: str, maxsize: int = 8):
         parts = urllib.parse.urlsplit(base_url)
         if parts.scheme not in ("http", "https"):
             raise ValueError(f"base_url must be http:// or https://, got {base_url!r}")
         self._https = parts.scheme == "https"
         self._host = parts.hostname or "localhost"
         self._port = parts.port or (443 if self._https else 80)
-        self._timeout = timeout
         self._maxsize = maxsize
         self._idle: List[Any] = []
         self._lock = threading.Lock()
@@ -307,10 +307,22 @@ class _ConnectionPool:
         return cls(self._host, self._port, timeout=timeout)
 
     def acquire(self, timeout: float):
-        """Return (connection, reused). A reused connection may be dead."""
+        """Return (connection, reused), with `timeout` applied to it.
+
+        The timeout has to be re-applied on every acquire, not just at connect.
+        http.client fixes the socket timeout when the connection is made, so a
+        pooled connection carries whatever timeout its first caller happened to
+        want — and bulk_build asks for 24 hours. Inheriting an earlier 30-second
+        connection would abort a long build at 30 seconds, which urllib never
+        did because it applied the timeout per request.
+        """
         with self._lock:
             if self._idle:
-                return self._idle.pop(), True
+                conn = self._idle.pop()
+                conn.timeout = timeout
+                if conn.sock is not None:
+                    conn.sock.settimeout(timeout)
+                return conn, True
         return self._new(timeout), False
 
     def release(self, conn) -> None:
@@ -353,7 +365,7 @@ class RostamClient:
         # for how an older server is detected and fallen back to automatically.
         self.binary_search = binary_search
         self._binary_search_supported = True
-        self._pool = _ConnectionPool(self.base_url, timeout, maxsize=pool_maxsize)
+        self._pool = _ConnectionPool(self.base_url, maxsize=pool_maxsize)
         self._path_prefix = urllib.parse.urlsplit(self.base_url).path.rstrip("/")
 
     def close(self) -> None:
@@ -368,9 +380,14 @@ class RostamClient:
 
     # ---- transport ----
 
-    def _request(self, method: str, path: str, body: Optional[dict] = None) -> Any:
+    def _request(
+        self, method: str, path: str, body: Optional[dict] = None, *,
+        idempotent: Optional[bool] = None,
+    ) -> Any:
         data = None if body is None else json.dumps(body).encode("utf-8")
-        return self._send(method, path, data, "application/json")
+        if idempotent is None:
+            idempotent = method in ("GET", "HEAD")
+        return self._send(method, path, data, "application/json", idempotent=idempotent)
 
     def _send(
         self,
@@ -379,6 +396,8 @@ class RostamClient:
         data: Optional[Union[bytes, bytearray]],
         content_type: str,
         timeout: Optional[float] = None,
+        *,
+        idempotent: bool = False,
     ) -> Any:
         headers = {"Content-Type": content_type}
         if self.api_key:
@@ -386,13 +405,19 @@ class RostamClient:
         deadline = timeout or self.timeout
         url = self._path_prefix + path
 
-        # One retry, and only for a connection taken from the pool. A server (or
-        # a proxy) is free to close an idle keep-alive connection at any moment,
-        # and it usually does so between our last response and this request — so
-        # the failure arrives when we write, before the server has seen anything
-        # to act on. Retrying a connection we just opened would instead be
-        # retrying a request that may well have been executed.
-        attempts = 2
+        # One retry, and only for a request that is safe to send twice on a
+        # connection taken from the pool.
+        #
+        # A server is free to close an idle keep-alive connection at any moment,
+        # so a pooled connection can be dead before we use it. But the failure
+        # does not reliably arrive while writing: RemoteDisconnected and
+        # BadStatusLine are raised by getresponse(), by which point the request
+        # bytes are on the wire and the server may already have executed them.
+        # Retrying then would replay the write — a second /points insert that
+        # fails on a duplicate id, or a double batch. So the caller says whether
+        # the request can be repeated; reads say yes, writes say nothing and get
+        # an error they can act on.
+        attempts = 2 if idempotent else 1
         while True:
             attempts -= 1
             conn, reused = self._pool.acquire(deadline)
@@ -443,10 +468,17 @@ class RostamClient:
         of a 0.845 ms request — 31% — against 0.011 ms to write the same vector
         as bytes, and the server's matching decode disappears with it.
         """
-        if self.binary_search and self._binary_search_supported and len(query) <= _RVQ1_MAX_DIM:
+        # A k the framing cannot express (negative, or past u32) goes down the
+        # JSON path, where the server answers 400 exactly as it always has.
+        # Encoding it here would raise struct.error instead — a different
+        # exception type for the same misuse, decided by which encoding the
+        # client happened to pick.
+        encodable = 0 <= k <= 0xFFFFFFFF and len(query) <= _RVQ1_MAX_DIM
+        if self.binary_search and self._binary_search_supported and encodable:
             try:
                 res = self._send(
-                    "POST", path, _encode_rvq1(query, k, filter), "application/octet-stream"
+                    "POST", path, _encode_rvq1(query, k, filter),
+                    "application/octet-stream", idempotent=True,
                 )
                 return res or {}
             except RostamError as e:
@@ -462,7 +494,7 @@ class RostamClient:
         body: Dict[str, Any] = {"query": list(query), "k": k}
         if filter:
             body["filter"] = filter
-        return self._request("POST", path, body) or {}
+        return self._request("POST", path, body, idempotent=True) or {}
 
     # ---- collections ----
 

--- a/clients/python/tests/_fakestore.py
+++ b/clients/python/tests/_fakestore.py
@@ -9,6 +9,7 @@ faithfully without the Go binary.
 import json
 import threading
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from _wire import read_body
 
 
 def _dec(tv):
@@ -57,8 +58,7 @@ class FakeRostam:
                 pass
 
             def _body(self):
-                n = int(self.headers.get("Content-Length", 0))
-                return json.loads(self.rfile.read(n)) if n else None
+                return read_body(self.headers, self.rfile)
 
             def _send(self, code, obj):
                 b = json.dumps(obj).encode()

--- a/clients/python/tests/_wire.py
+++ b/clients/python/tests/_wire.py
@@ -1,0 +1,74 @@
+"""Read a request body in either encoding, for the fake servers.
+
+The client sends searches in the binary query framing ("RVQ1") when it can, so a
+fake that only calls ``json.loads`` crashes on byte one and the test surfaces as
+"Remote end closed connection without response" — a transport error for what is
+really an encoding the fake does not speak.
+
+This decodes the framing **from the server's specification**, deliberately
+without importing the client's encoder. A decoder built by calling the encoder
+in reverse agrees with the encoder by construction and would pass just as
+happily if both were wrong; this one fails when they disagree, which is the only
+thing it is here to detect. The layout below is copied from httpapi/binary_search.go.
+"""
+
+from __future__ import annotations
+
+import json
+import struct
+import sys
+from array import array
+from typing import Any, Dict, Optional
+
+RVQ1_MAGIC = b"RVQ1"
+RVQ1_HEADER = 28
+RVQ1_FLAG_FILTER = 1 << 0
+
+
+def decode_rvq1(raw: bytes) -> Dict[str, Any]:
+    """Decode an RVQ1 body into the dict its JSON twin would have produced."""
+    if len(raw) < RVQ1_HEADER:
+        raise ValueError(f"RVQ1 body too short: {len(raw)} bytes")
+    magic, flags, k, dim, rc, opa, pad, staleness = struct.unpack(">4sIIIBBHQ", raw[:RVQ1_HEADER])
+    if magic != RVQ1_MAGIC:
+        raise ValueError(f"bad magic {magic!r}")
+    if pad != 0:
+        raise ValueError("reserved bytes are not zero")
+
+    end = RVQ1_HEADER + dim * 4
+    if len(raw) < end:
+        raise ValueError(f"RVQ1 body truncated: want {end} bytes, have {len(raw)}")
+    vec = array("f")
+    vec.frombytes(raw[RVQ1_HEADER:end])
+    if sys.byteorder == "little":  # the wire is big-endian
+        vec.byteswap()
+
+    body: Dict[str, Any] = {"query": list(vec), "k": k}
+    if rc:
+        body["read_consistency"] = rc
+    if opa:
+        body["on_partition_unavailable"] = opa
+    if staleness:
+        body["max_staleness"] = staleness
+
+    if flags & RVQ1_FLAG_FILTER:
+        (blen,) = struct.unpack(">I", raw[end:end + 4])
+        body["filter"] = json.loads(raw[end + 4:end + 4 + blen])
+        end += 4 + blen
+    if flags & ~RVQ1_FLAG_FILTER:
+        raise ValueError(f"unknown flags {flags:#x}")
+    if len(raw) != end:
+        raise ValueError(f"trailing bytes after RVQ1 frame: {len(raw) - end}")
+    return body
+
+
+def read_body(headers, rfile) -> Optional[Dict[str, Any]]:
+    """Read one request body, JSON or RVQ1, and return it as a dict."""
+    n = int(headers.get("Content-Length", 0))
+    if not n:
+        return None
+    raw = rfile.read(n)
+    ctype = (headers.get("Content-Type") or "").split(";")[0].strip()
+    if ctype == "application/octet-stream" and raw[:4] == RVQ1_MAGIC:
+        return decode_rvq1(raw)
+    return json.loads(raw)

--- a/clients/python/tests/test_client.py
+++ b/clients/python/tests/test_client.py
@@ -13,6 +13,7 @@ from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 
 from rostam import RostamClient, RostamError
 from rostam import filters as f
+from _wire import read_body
 from _fakestore import FakeRostam
 
 # Captured requests, newest last; reset per test.
@@ -24,8 +25,7 @@ class _Handler(BaseHTTPRequestHandler):
         pass
 
     def _body(self):
-        n = int(self.headers.get("Content-Length", 0))
-        return json.loads(self.rfile.read(n)) if n else None
+        return read_body(self.headers, self.rfile)
 
     def _record(self):
         body = self._body()

--- a/clients/python/tests/test_cross_stack_binary_search.py
+++ b/clients/python/tests/test_cross_stack_binary_search.py
@@ -1,0 +1,146 @@
+"""Python<->Go cross-stack smoke for the binary query wire (RVQ1).
+
+Same reasoning as the bulk-wire test next door: the framing is a byte-level
+contract between two languages, and a fake proves only that the client agrees
+with itself. This launches the REAL rostam-server and asserts EQUIVALENCE — the
+same query sent in both encodings must come back with identical hits, in the
+same order, with identical distances. Anything less would let the binary path
+quietly become a second search semantics.
+
+A byte-order or f32/f64 slip does not usually produce an error; it produces a
+plausible ranking of the wrong neighbours. So the vectors below are chosen so
+that every point's nearest neighbour is itself, and the assertions compare
+distances rather than counts.
+
+The server binary is located via $ROSTAM_SERVER_BIN, or a `rostam-server*` built
+at the repo root. The whole module is skipped when no binary is found.
+"""
+
+from __future__ import annotations
+
+import socket
+import subprocess
+import tempfile
+import time
+import unittest
+
+from _serverbin import find_server_bin
+from rostam import RostamClient, RostamError
+
+DIM = 24
+N = 150
+
+
+def _free_port():
+    s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    s.bind(("127.0.0.1", 0))
+    port = s.getsockname()[1]
+    s.close()
+    return port
+
+
+def _vec(i):
+    return [i * 0.041 - 2.7 + d * 0.013 for d in range(DIM)]
+
+
+_BIN, _WHY = find_server_bin()
+
+
+@unittest.skipUnless(_BIN, _WHY)
+class CrossStackBinarySearchTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.port = _free_port()
+        cls.datadir = tempfile.mkdtemp(prefix="rostam-binsearch-")
+        cls.proc = subprocess.Popen(
+            [_BIN, "-http", f"127.0.0.1:{cls.port}", "-data", cls.datadir],
+            stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
+        )
+        cls.base = f"http://127.0.0.1:{cls.port}"
+        cls.c = RostamClient(cls.base, timeout=120)
+        deadline = time.time() + 20
+        while time.time() < deadline:
+            if cls.proc.poll() is not None:
+                raise RuntimeError("rostam-server exited during startup")
+            try:
+                if cls.c.health():
+                    break
+            except Exception:
+                time.sleep(0.1)
+        else:
+            cls.proc.kill()
+            raise RuntimeError("rostam-server did not become healthy in time")
+
+        cls.c.create_collection("q", dim=DIM, metric="l2")
+        for i in range(1, N + 1):
+            cls.c.upsert("q", i, _vec(i), content=f"doc {i}", metadata={"bucket": i % 5})
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.c.close()
+        cls.proc.terminate()
+        try:
+            cls.proc.wait(timeout=5)
+        except Exception:
+            cls.proc.kill()
+
+    def _json_client(self):
+        return RostamClient(self.base, timeout=120, binary_search=False)
+
+    def test_binary_query_matches_json_query(self):
+        q = _vec(42)
+        jc = self._json_client()
+        try:
+            bin_hits = self.c.search("q", q, k=10)
+            json_hits = jc.search("q", q, k=10)
+        finally:
+            jc.close()
+
+        self.assertTrue(bin_hits, "binary query returned no hits")
+        self.assertEqual([h.id for h in json_hits], [h.id for h in bin_hits])
+        for b, j in zip(bin_hits, json_hits):
+            self.assertEqual(j.distance, b.distance,
+                             f"distance differs for id {b.id}: binary {b.distance}, JSON {j.distance}")
+        # The nearest neighbour of a stored point is that point itself; if the
+        # framing mangled the vector this is the first thing to break.
+        self.assertEqual(42, bin_hits[0].id)
+
+    def test_binary_query_with_filter_matches_json(self):
+        q = _vec(70)
+        filt = {"op": "eq", "field": "bucket", "value": {"kind": "int", "int": 3}}
+        jc = self._json_client()
+        try:
+            bin_hits = self.c.search("q", q, k=5, filter=filt)
+            json_hits = jc.search("q", q, k=5, filter=filt)
+        finally:
+            jc.close()
+
+        self.assertTrue(bin_hits, "filtered binary query returned no hits")
+        self.assertEqual([h.id for h in json_hits], [h.id for h in bin_hits])
+        for h in bin_hits:
+            self.assertEqual(3, h.id % 5, f"filter not applied: id {h.id}")
+
+    def test_search_docs_matches_json_over_the_binary_wire(self):
+        q = _vec(99)
+        jc = self._json_client()
+        try:
+            bin_docs = self.c.search_docs("q", q, k=5)
+            json_docs = jc.search_docs("q", q, k=5)
+        finally:
+            jc.close()
+
+        self.assertEqual([d.id for d in json_docs], [d.id for d in bin_docs])
+        self.assertEqual([d.content for d in json_docs], [d.content for d in bin_docs])
+        self.assertEqual("doc 99", bin_docs[0].content)
+
+    def test_server_rejects_a_bad_k_over_the_binary_wire(self):
+        """A request error must arrive as one, not as a silent fallback to JSON."""
+        with self.assertRaises(RostamError) as caught:
+            self.c.search("q", _vec(1), k=0)
+        self.assertEqual(400, caught.exception.status)
+        # Still on the binary path — a real 400 must not disable the framing.
+        self.assertTrue(self.c._binary_search_supported)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/clients/python/tests/test_embeddings.py
+++ b/clients/python/tests/test_embeddings.py
@@ -12,6 +12,7 @@ import unittest
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 
 from rostam import FunctionEmbedder, OpenAIEmbedder, RostamClient, TextStore
+from _wire import read_body
 
 # ---- fake OpenAI-compatible embeddings endpoint ----
 
@@ -50,8 +51,7 @@ class _RostamHandler(BaseHTTPRequestHandler):
         pass
 
     def _body(self):
-        n = int(self.headers.get("Content-Length", 0))
-        return json.loads(self.rfile.read(n)) if n else None
+        return read_body(self.headers, self.rfile)
 
     def _send(self, code, obj):
         b = json.dumps(obj).encode()

--- a/clients/python/tests/test_langchain.py
+++ b/clients/python/tests/test_langchain.py
@@ -22,6 +22,7 @@ except Exception:  # pragma: no cover - exercised only without langchain
     HAVE_LC = False
 
 from rostam import RostamClient
+from _wire import read_body
 
 STORE = {}        # id -> {"content":..., "metadata": tagged}
 LAST = {"body": None, "path": None}
@@ -32,8 +33,7 @@ class _Handler(BaseHTTPRequestHandler):
         pass
 
     def _body(self):
-        n = int(self.headers.get("Content-Length", 0))
-        return json.loads(self.rfile.read(n)) if n else None
+        return read_body(self.headers, self.rfile)
 
     def _send(self, code, obj):
         b = json.dumps(obj).encode()

--- a/clients/python/tests/test_multivector.py
+++ b/clients/python/tests/test_multivector.py
@@ -11,6 +11,7 @@ import unittest
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 
 from rostam import RostamClient
+from _wire import read_body
 
 DOCS = {}   # id -> {"tokens": [[...]], "metadata": tagged}
 LAST = {}
@@ -32,8 +33,7 @@ class _Handler(BaseHTTPRequestHandler):
         pass
 
     def _body(self):
-        n = int(self.headers.get("Content-Length", 0))
-        return json.loads(self.rfile.read(n)) if n else None
+        return read_body(self.headers, self.rfile)
 
     def _send(self, code, obj):
         b = json.dumps(obj).encode()

--- a/clients/python/tests/test_transport.py
+++ b/clients/python/tests/test_transport.py
@@ -179,6 +179,109 @@ class TransportTest(unittest.TestCase):
         self.assertTrue(all(n == 2 for n in counts), "a desynchronized response would differ")
 
 
+class StaleServer(RecordingServer):
+    """Answers normally, then closes the socket without saying so.
+
+    This is what a real server's idle timeout looks like from the client: the
+    response advertises keep-alive, so the connection goes back in the pool, and
+    the close is only discovered on the *next* request — after its bytes have
+    already been written.
+    """
+
+    requests_seen = []
+
+    def _send(self, code, obj):
+        super()._send(code, obj)
+        self.close_connection = True   # no Connection: close header — that is the point
+
+
+class StaleConnectionTest(unittest.TestCase):
+    """Which requests may be replayed onto a connection that died while idle.
+
+    RemoteDisconnected surfaces from getresponse(), so the request is already on
+    the wire and the server may have executed it. A read can be repeated; a write
+    cannot, and must surface as an error the caller can act on.
+    """
+
+    def setUp(self):
+        StaleServer.content_types = []
+        StaleServer.search_bodies = []
+        StaleServer.connections = 0
+        StaleServer.requests_seen = []
+        StaleServer.fail_binary_as_old_server = False
+        StaleServer.fail_next_with = None
+        self.srv = ThreadingHTTPServer(("127.0.0.1", 0), StaleServer)
+        threading.Thread(target=self.srv.serve_forever, daemon=True).start()
+        self.url = f"http://127.0.0.1:{self.srv.server_address[1]}"
+
+    def tearDown(self):
+        self.srv.shutdown()
+        self.srv.server_close()
+
+    def test_a_search_survives_a_connection_that_died_while_idle(self):
+        c = RostamClient(self.url)
+        self.assertEqual(2, len(c.search("docs", [1.0, 2.0], k=2)))
+        # The pooled connection is now dead; the retry must make this transparent.
+        self.assertEqual(2, len(c.search("docs", [1.0, 2.0], k=2)))
+        c.close()
+
+    def test_a_write_is_not_replayed(self):
+        c = RostamClient(self.url)
+        c.search("docs", [1.0], k=1)          # leaves a dead connection pooled
+        with self.assertRaises(RostamError) as caught:
+            c.upsert("docs", 1, [1.0, 2.0])   # must fail rather than risk a double write
+        c.close()
+        self.assertEqual(0, caught.exception.status, "should surface as a transport error")
+
+
+class TimeoutTest(unittest.TestCase):
+    """A per-call timeout must reach a connection that was already open.
+
+    http.client fixes the socket timeout at connect time, so a pooled connection
+    keeps whatever its first caller asked for. bulk_build asks for 24 hours; if
+    it inherited an earlier 30-second connection the build would abort at 30
+    seconds, which the urllib code it replaced never did.
+    """
+
+    def setUp(self):
+        RecordingServer.content_types = []
+        RecordingServer.search_bodies = []
+        RecordingServer.connections = 0
+        RecordingServer.fail_binary_as_old_server = False
+        RecordingServer.fail_next_with = None
+        self.srv = ThreadingHTTPServer(("127.0.0.1", 0), RecordingServer)
+        threading.Thread(target=self.srv.serve_forever, daemon=True).start()
+        self.url = f"http://127.0.0.1:{self.srv.server_address[1]}"
+
+    def tearDown(self):
+        self.srv.shutdown()
+        self.srv.server_close()
+
+    def test_a_later_call_can_raise_the_timeout_on_a_pooled_connection(self):
+        c = RostamClient(self.url, timeout=5.0)
+        c.search("docs", [1.0], k=1)                 # pools a 5s connection
+        conn, reused = c._pool.acquire(3600.0)
+        try:
+            self.assertTrue(reused, "expected the pooled connection back")
+            self.assertEqual(3600.0, conn.timeout)
+            self.assertEqual(3600.0, conn.sock.gettimeout(),
+                             "the live socket kept the old timeout")
+        finally:
+            c._pool.discard(conn)
+            c.close()
+
+    def test_k_the_framing_cannot_express_falls_back_to_json(self):
+        """Negative k must not become a struct.error where JSON gives a 400."""
+        RecordingServer.fail_next_with = (400, "k must be between 1 and 65536")
+        c = RostamClient(self.url)
+        with self.assertRaises(RostamError) as caught:
+            c.search("docs", [1.0, 2.0], k=-1)
+        c.close()
+        self.assertEqual(400, caught.exception.status)
+        self.assertEqual(["application/json"], RecordingServer.content_types,
+                         "an unencodable k should take the JSON path, not raise struct.error")
+
+
 class ClosingServer(RecordingServer):
     """A server that closes the connection after every response (HTTP/1.0)."""
 

--- a/clients/python/tests/test_transport.py
+++ b/clients/python/tests/test_transport.py
@@ -132,6 +132,32 @@ class TransportTest(unittest.TestCase):
         self.assertIn("k must be between", str(caught.exception))
         self.assertEqual(["application/octet-stream"], RecordingServer.content_types)
 
+    def test_a_filter_too_large_for_the_framing_falls_back_to_json(self):
+        """The binary route caps a filter at 1 MiB; the JSON route allows 32 MiB.
+
+        Sending an oversized filter as RVQ1 would turn a search that used to work
+        into `filter too large` — the client picking an encoding must never
+        shrink what the API accepts.
+        """
+        big = {"op": "in", "field": "sku",
+               "value": {"kind": "strings", "strs": ["x" * 32 for _ in range(40000)]}}
+        c = RostamClient(self.url)
+        c.search("docs", [1.0, 2.0], k=1, filter=big)
+        c.close()
+        self.assertEqual(["application/json"], RecordingServer.content_types)
+        self.assertEqual(big, RecordingServer.search_bodies[0]["filter"])
+
+    def test_k_the_framing_cannot_express_falls_back_to_json(self):
+        """Negative k must not become a struct.error where JSON gives a 400."""
+        RecordingServer.fail_next_with = (400, "k must be between 1 and 65536")
+        c = RostamClient(self.url)
+        with self.assertRaises(RostamError) as caught:
+            c.search("docs", [1.0, 2.0], k=-1)
+        c.close()
+        self.assertEqual(400, caught.exception.status)
+        self.assertEqual(["application/json"], RecordingServer.content_types,
+                         "an unencodable k should take the JSON path, not raise struct.error")
+
     def test_connections_are_reused(self):
         c = RostamClient(self.url)
         for _ in range(12):
@@ -269,18 +295,6 @@ class TimeoutTest(unittest.TestCase):
         finally:
             c._pool.discard(conn)
             c.close()
-
-    def test_k_the_framing_cannot_express_falls_back_to_json(self):
-        """Negative k must not become a struct.error where JSON gives a 400."""
-        RecordingServer.fail_next_with = (400, "k must be between 1 and 65536")
-        c = RostamClient(self.url)
-        with self.assertRaises(RostamError) as caught:
-            c.search("docs", [1.0, 2.0], k=-1)
-        c.close()
-        self.assertEqual(400, caught.exception.status)
-        self.assertEqual(["application/json"], RecordingServer.content_types,
-                         "an unencodable k should take the JSON path, not raise struct.error")
-
 
 class ClosingServer(RecordingServer):
     """A server that closes the connection after every response (HTTP/1.0)."""

--- a/clients/python/tests/test_transport.py
+++ b/clients/python/tests/test_transport.py
@@ -1,0 +1,220 @@
+"""Transport-level behaviour: connection reuse, and the binary query framing.
+
+These assert on the MECHANISM, not on results. Every test here would pass on the
+old connection-per-request JSON client if it only checked that a search returned
+the right hits — which is exactly how a silently-disabled optimization survives a
+green suite.
+"""
+
+import json
+import threading
+import unittest
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+from rostam import RostamClient, RostamError
+from _wire import read_body
+
+
+class RecordingServer(BaseHTTPRequestHandler):
+    """Records how each request arrived. Set class attrs to steer responses."""
+
+    # Without this, BaseHTTPRequestHandler answers HTTP/1.0 and closes after
+    # every response — so a keep-alive test would measure the fake, not the
+    # client. ClosingServer below keeps that behaviour on purpose.
+    protocol_version = "HTTP/1.1"
+
+    content_types = []          # Content-Type of every POSTed search
+    connections = 0             # distinct TCP connections accepted
+    search_bodies = []
+    fail_binary_as_old_server = False   # answer octet-stream like a pre-RVQ1 server
+    fail_next_with = None       # (status, error) applied to the next search
+
+    def setup(self):
+        super().setup()
+        type(self).connections += 1
+
+    def log_message(self, *a):
+        pass
+
+    def _send(self, code, obj):
+        b = json.dumps(obj).encode()
+        self.send_response(code)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(b)))
+        self.end_headers()
+        self.wfile.write(b)
+
+    def do_POST(self):
+        ctype = (self.headers.get("Content-Type") or "").split(";")[0].strip()
+        cls = type(self)
+        cls.content_types.append(ctype)
+
+        if cls.fail_binary_as_old_server and ctype == "application/octet-stream":
+            # Exactly what a server without RVQ1 support does: hands the bytes to
+            # its JSON decoder, which fails on the first one.
+            n = int(self.headers.get("Content-Length", 0))
+            self.rfile.read(n)
+            return self._send(400, {"error": "invalid JSON body: invalid character 'R' looking for beginning of value"})
+
+        if cls.fail_next_with is not None:
+            status, err = cls.fail_next_with
+            cls.fail_next_with = None
+            n = int(self.headers.get("Content-Length", 0))
+            self.rfile.read(n)
+            return self._send(status, {"error": err})
+
+        body = read_body(self.headers, self.rfile)
+        cls.search_bodies.append(body)
+        k = (body or {}).get("k", 1)
+        return self._send(200, {"results": [{"id": i + 1, "distance": 0.5} for i in range(k)],
+                                "degraded": False, "missing": []})
+
+
+class TransportTest(unittest.TestCase):
+    def setUp(self):
+        RecordingServer.content_types = []
+        RecordingServer.search_bodies = []
+        RecordingServer.connections = 0
+        RecordingServer.fail_binary_as_old_server = False
+        RecordingServer.fail_next_with = None
+        self.srv = ThreadingHTTPServer(("127.0.0.1", 0), RecordingServer)
+        threading.Thread(target=self.srv.serve_forever, daemon=True).start()
+        self.url = f"http://127.0.0.1:{self.srv.server_address[1]}"
+
+    def tearDown(self):
+        self.srv.shutdown()
+        self.srv.server_close()
+
+    def test_search_is_sent_in_the_binary_framing(self):
+        c = RostamClient(self.url)
+        hits = c.search("docs", [0.25, -0.5, 1.0], k=2)
+        c.close()
+        self.assertEqual(["application/octet-stream"], RecordingServer.content_types)
+        self.assertEqual(2, len(hits))
+        # The server decoded the frame independently; the vector must survive it.
+        self.assertEqual([0.25, -0.5, 1.0], RecordingServer.search_bodies[0]["query"])
+        self.assertEqual(2, RecordingServer.search_bodies[0]["k"])
+
+    def test_filter_survives_the_binary_framing(self):
+        c = RostamClient(self.url)
+        filt = {"op": "eq", "field": "lang", "value": {"kind": "string", "str": "en"}}
+        c.search("docs", [1.0, 2.0], k=1, filter=filt)
+        c.close()
+        self.assertEqual(filt, RecordingServer.search_bodies[0]["filter"])
+
+    def test_binary_can_be_turned_off(self):
+        c = RostamClient(self.url, binary_search=False)
+        c.search("docs", [1.0], k=1)
+        c.close()
+        self.assertEqual(["application/json"], RecordingServer.content_types)
+
+    def test_falls_back_to_json_against_a_server_without_rvq1(self):
+        RecordingServer.fail_binary_as_old_server = True
+        c = RostamClient(self.url)
+        hits = c.search("docs", [1.0, 2.0], k=3)   # binary rejected, retried as JSON
+        self.assertEqual(3, len(hits))
+        self.assertEqual(["application/octet-stream", "application/json"],
+                         RecordingServer.content_types)
+
+        # ...and it must not keep paying for the discovery on every later search.
+        c.search("docs", [1.0, 2.0], k=1)
+        c.close()
+        self.assertEqual(["application/octet-stream", "application/json", "application/json"],
+                         RecordingServer.content_types)
+
+    def test_a_real_error_is_not_mistaken_for_a_missing_feature(self):
+        """A 400 about the request itself must surface, not trigger a JSON retry."""
+        RecordingServer.fail_next_with = (400, "k must be between 1 and 65536")
+        c = RostamClient(self.url)
+        with self.assertRaises(RostamError) as caught:
+            c.search("docs", [1.0], k=0)
+        c.close()
+        self.assertIn("k must be between", str(caught.exception))
+        self.assertEqual(["application/octet-stream"], RecordingServer.content_types)
+
+    def test_connections_are_reused(self):
+        c = RostamClient(self.url)
+        for _ in range(12):
+            c.search("docs", [1.0, 2.0], k=1)
+        c.close()
+        self.assertEqual(12, len(RecordingServer.content_types))
+        self.assertEqual(1, RecordingServer.connections,
+                         "12 searches should share one connection, not open one each")
+
+    def test_close_then_reuse_reconnects(self):
+        c = RostamClient(self.url)
+        c.search("docs", [1.0], k=1)
+        c.close()
+        c.search("docs", [1.0], k=1)   # the client stays usable after close()
+        c.close()
+        self.assertEqual(2, RecordingServer.connections)
+
+    def test_concurrent_searches_do_not_share_a_connection(self):
+        """The reason there is a pool and not one shared socket.
+
+        Two threads writing into one kept-alive connection interleave and
+        desynchronize the response stream; with a pool each thread holds a
+        connection for the length of its request.
+        """
+        c = RostamClient(self.url, pool_maxsize=4)
+        errors = []
+        counts = []
+
+        def worker():
+            try:
+                for _ in range(10):
+                    counts.append(len(c.search("docs", [1.0, 2.0, 3.0], k=2)))
+            except Exception as e:  # pragma: no cover - only on a real failure
+                errors.append(e)
+
+        threads = [threading.Thread(target=worker) for _ in range(8)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+        c.close()
+
+        self.assertEqual([], errors)
+        self.assertEqual(80, len(counts))
+        self.assertTrue(all(n == 2 for n in counts), "a desynchronized response would differ")
+
+
+class ClosingServer(RecordingServer):
+    """A server that closes the connection after every response (HTTP/1.0)."""
+
+    protocol_version = "HTTP/1.0"
+
+
+class ClosingServerTest(unittest.TestCase):
+    """Pooling must not become a penalty against a server that will not pool.
+
+    The first version of this client put every used connection back regardless,
+    so against a closing server each request found a dead socket, failed a write,
+    and retried — paying two round trips where the old client paid one.
+    """
+
+    def setUp(self):
+        ClosingServer.content_types = []
+        ClosingServer.search_bodies = []
+        ClosingServer.connections = 0
+        ClosingServer.fail_binary_as_old_server = False
+        ClosingServer.fail_next_with = None
+        self.srv = ThreadingHTTPServer(("127.0.0.1", 0), ClosingServer)
+        threading.Thread(target=self.srv.serve_forever, daemon=True).start()
+        self.url = f"http://127.0.0.1:{self.srv.server_address[1]}"
+
+    def tearDown(self):
+        self.srv.shutdown()
+        self.srv.server_close()
+
+    def test_works_and_opens_exactly_one_connection_per_request(self):
+        c = RostamClient(self.url)
+        for _ in range(6):
+            self.assertEqual(1, len(c.search("docs", [1.0, 2.0], k=1)))
+        c.close()
+        # One per request: the client must notice the close and not retry into it.
+        self.assertEqual(6, ClosingServer.connections)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/docs/api/http.md
+++ b/docs/api/http.md
@@ -156,6 +156,45 @@ All search bodies accept `filter` and the read options.
 
 `method` is `"rrf"` (default), `"weighted"` (with `alpha`), or `"dbsf"`.
 
+### Binary query body
+
+`/points/search` and `/points/search/docs` also accept a dense binary body,
+selected by `Content-Type: application/octet-stream` — the same selection rule as
+[binary bulk ingest](#binary-bulk-ingest), and the same guarantee: the server
+decodes it into the identical request the JSON body would have produced, then
+runs the identical validation and dispatch. Any other content type takes the
+JSON path unchanged.
+
+```
+magic      "RVQ1"                              4 bytes
+flags      u32     bit0 filter present
+k          u32
+dim        u32     length of the query vector
+rc         u8      read_consistency
+opa        u8      on_partition_unavailable
+_          u16     reserved, must be zero
+staleness  u64     max_staleness (the bound for rc=3)
+query      dim × f32
+filter     [ len u32 ][ len bytes of filter JSON ]   // only when bit0
+```
+
+**Big-endian** throughout, matching `RVB1` and the op wire.
+
+It exists because encoding the query vector dominates a small request: at
+dim=768, k=10 on a kept-alive connection, building the JSON body was 0.258 ms of
+a 0.845 ms search — 31% — against 0.011 ms to write the same vector as bytes,
+and the server's matching decode of those literals disappears with it.
+
+**Limits.** `dim` at most **65,536**, the filter blob at most **1 MiB**, the body
+at most **8 MiB**. `NaN` and `±Inf` are rejected: JSON cannot express them, and
+this body is meant to say exactly what its JSON twin can. Trailing bytes after
+the frame are rejected rather than ignored.
+
+A client that cannot assume a new enough server can simply try it: a server
+without this support hands the body to its JSON decoder and answers
+`400 invalid JSON body: ...`, which is unambiguous enough to fall back on. The
+reference Python client does this automatically.
+
 ## Partitioning (dense)
 
 | Method & path | Description |

--- a/docs/api/python.md
+++ b/docs/api/python.md
@@ -38,6 +38,12 @@ RostamClient(url, pool_maxsize=8)    # idle connections kept per client
 the next call. A server that closes the connection (HTTP/1.0, or
 `Connection: close`) is handled — the client simply does not pool those.
 
+A pooled connection can still die while idle, and that is only discovered on the
+next request — after its bytes have been sent. **Reads are retried once on a
+fresh connection; writes are not**, and surface as `RostamError` with
+`status == 0`, because replaying a write could insert twice. Retry those in the
+caller, where the intent is known.
+
 Searches are sent in the [binary query framing](http.md#binary-query-body),
 which skips encoding the query vector as text; at dim=768 that was 31% of the
 request. Against a server too old to understand it, the client detects the

--- a/docs/api/python.md
+++ b/docs/api/python.md
@@ -21,6 +21,35 @@ All errors raise `RostamError(message, status)` carrying the HTTP status.
 Metadata is plain Python dicts — the client converts to/from the server's
 tagged value encoding automatically.
 
+## Connections
+
+The client keeps a small pool of connections and reuses them, so a sequence of
+calls does not pay a TCP handshake each time. It is safe to share one client
+across threads: a connection is held by one thread for the length of a request.
+
+```python
+with RostamClient("http://localhost:8080") as c:   # or call c.close()
+    c.search("docs", q, k=10)
+
+RostamClient(url, pool_maxsize=8)    # idle connections kept per client
+```
+
+`close()` releases pooled connections; the client stays usable and reconnects on
+the next call. A server that closes the connection (HTTP/1.0, or
+`Connection: close`) is handled — the client simply does not pool those.
+
+Searches are sent in the [binary query framing](http.md#binary-query-body),
+which skips encoding the query vector as text; at dim=768 that was 31% of the
+request. Against a server too old to understand it, the client detects the
+refusal and falls back to the JSON body for the rest of its life. Pass
+`binary_search=False` to send JSON from the start.
+
+!!! note "Proxies"
+    Connection reuse is built on `http.client`, which — unlike the `urllib`
+    call it replaced — does not consult `HTTP_PROXY`/`HTTPS_PROXY`. A client
+    behind an egress proxy should point `base_url` at the proxy or at a local
+    forwarder.
+
 ## Collections
 
 ```python

--- a/httpapi/binary_search.go
+++ b/httpapi/binary_search.go
@@ -1,0 +1,214 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package httpapi
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/binary"
+	"encoding/json"
+	"errors"
+	"io"
+	"math"
+	"net/http"
+)
+
+// Binary query framing ("RVQ1") for the search routes.
+//
+// WHY: the same reason /points/bulk has one, on the other side of the workload.
+// A query vector travels as base-10 float text, and encoding it dominates the
+// request. Against a local server at dim=768, k=10, on a kept-alive connection:
+// 0.845 ms per search, of which building the JSON body is 0.258 ms — 31% of the
+// request spent turning float32s the client already holds into decimal, for the
+// server to parse straight back. The same vector encodes in 0.011 ms as bytes.
+// The server-side decode of those literals disappears along with it.
+//
+// This is a dense re-encoding of the SAME request, selected by Content-Type. It
+// adds NO new semantics: it decodes into exactly the searchReq the JSON body
+// would have produced, and then runs the identical validation and dispatch. A
+// request with a JSON content type takes the byte-identical pre-existing path.
+//
+//	magic     [4]byte  "RVQ1"
+//	flags     u32      bit0 filter present
+//	k         u32
+//	dim       u32      length of the query vector
+//	rc        u8       read_consistency
+//	opa       u8       on_partition_unavailable
+//	_         u16      reserved, must be zero
+//	staleness u64      max_staleness (the bound for rc=3)
+//	query     dim × f32
+//	filter    [len u32][len bytes of filter JSON]   (only when bit0)
+//
+// BIG-ENDIAN throughout, matching RVB1 and the op wire, so a client that
+// already byte-swaps an array to send a bulk load reuses that code here.
+//
+// The declared dim is NOT checked against the collection: this layer has no
+// local knowledge of it, and the shard that owns the config rejects a mismatch
+// for every transport at once. Same reasoning as the bulk header.
+const (
+	binarySearchMagic     = "RVQ1"
+	binarySearchHeaderLen = 28 // magic(4) flags(4) k(4) dim(4) rc(1) opa(1) pad(2) staleness(8)
+
+	binSearchFlagFilter uint32 = 1 << 0
+	binSearchKnownFlags        = binSearchFlagFilter
+)
+
+// Body bounds.
+//
+// A search request carries ONE vector, so every bound here is far tighter than
+// the JSON route it mirrors (maxJSONBody, 32 MiB). Tighter is the point: the
+// binary framing exists to make a small request cheap, so a body anywhere near
+// the JSON ceiling is not a query this path should be serving.
+//
+// maxBinarySearchDim bounds the DECLARED dimension, and is checked BEFORE it is
+// multiplied by four. That order is the whole guard: on a 32-bit build a dim of
+// 0x40000000 multiplies to exactly zero, which would allocate nothing, read
+// nothing, and hand the engine a silently empty query rather than an error.
+// Capped first, dim×4 cannot overflow on any supported word size, and the
+// largest buffer a client can make the server reserve before sending a byte is
+// 256 KiB.
+const (
+	maxBinarySearchBody   = 8 << 20 // 8 MiB, whole body
+	maxBinarySearchDim    = 1 << 16 // 65,536 floats → 256 KiB
+	maxBinarySearchFilter = 1 << 20 // 1 MiB of filter JSON
+)
+
+// isBinarySearch reports whether the request selects the binary query framing.
+// Selection is the same media-type test the bulk routes use: one binary content
+// type across the whole API, so a client sets the same header everywhere.
+func isBinarySearch(r *http.Request) bool { return isBinaryBulk(r) }
+
+// readFullQuery mirrors readFullBin rather than sharing it, only so the error
+// names this framing instead of the bulk one — a client sent an RVQ1 body and
+// should not be told its bulk body is truncated.
+func readFullQuery(w http.ResponseWriter, br *bufio.Reader, buf []byte, what string) bool {
+	if _, err := io.ReadFull(br, buf); err != nil {
+		var mbe *http.MaxBytesError
+		if errors.As(err, &mbe) {
+			writeError(w, http.StatusRequestEntityTooLarge, "request body too large")
+			return false
+		}
+		writeError(w, http.StatusBadRequest, "invalid binary query body: truncated "+what)
+		return false
+	}
+	return true
+}
+
+// decodeSearchBody decodes a search request in whichever encoding it arrived in.
+// Every search route goes through here so the two encodings cannot drift apart:
+// there is one place that produces a searchReq, and one set of validations
+// downstream of it.
+func decodeSearchBody(w http.ResponseWriter, r *http.Request, req *searchReq) bool {
+	if isBinarySearch(r) {
+		return decodeBinarySearch(w, r, req)
+	}
+	return decodeBody(w, r, req)
+}
+
+// decodeBinarySearch parses an RVQ1 body into req.
+//
+// It rejects a body with trailing bytes. A frame whose declared contents end
+// before the body does means the sender and this decoder disagree about the
+// layout, and continuing on the half they agree about is how a request comes to
+// mean something neither intended.
+func decodeBinarySearch(w http.ResponseWriter, r *http.Request, req *searchReq) bool {
+	r.Body = http.MaxBytesReader(w, r.Body, maxBinarySearchBody)
+	br := bufio.NewReaderSize(r.Body, 8<<10)
+
+	var hdr [binarySearchHeaderLen]byte
+	if !readFullQuery(w, br, hdr[:], "header") {
+		return false
+	}
+	if string(hdr[0:4]) != binarySearchMagic {
+		writeError(w, http.StatusBadRequest, "invalid binary query body: bad magic (expected "+binarySearchMagic+")")
+		return false
+	}
+	flags := binary.BigEndian.Uint32(hdr[4:8])
+	if flags&^binSearchKnownFlags != 0 {
+		// Fail loud rather than ignore: a future framing bit means the bytes
+		// after this header are shaped differently than we are about to read them.
+		writeError(w, http.StatusBadRequest, "invalid binary query body: unknown flags")
+		return false
+	}
+	if binary.BigEndian.Uint16(hdr[18:20]) != 0 {
+		writeError(w, http.StatusBadRequest, "invalid binary query body: reserved bytes must be zero")
+		return false
+	}
+
+	k := binary.BigEndian.Uint32(hdr[8:12])
+	dim := binary.BigEndian.Uint32(hdr[12:16])
+	if dim > maxBinarySearchDim {
+		writeError(w, http.StatusBadRequest, "invalid binary query body: dim exceeds 65536")
+		return false
+	}
+	// k is bounded here only against the int conversion: a k above MaxInt32 would
+	// land negative on a 32-bit build and reach validTopK as "<= 0", which is the
+	// right refusal for the wrong reason. The real ceiling stays in validTopK, so
+	// both encodings are held to one limit.
+	if k > math.MaxInt32 {
+		writeError(w, http.StatusBadRequest, "k must be between 1 and 65536")
+		return false
+	}
+
+	query := make([]float32, dim)
+	if dim > 0 {
+		raw := make([]byte, int(dim)*4) // dim is capped above, so this cannot overflow
+		if !readFullQuery(w, br, raw, "query vector") {
+			return false
+		}
+		for i := range query {
+			f := math.Float32frombits(binary.BigEndian.Uint32(raw[i*4:]))
+			// JSON cannot express NaN or ±Inf, so accepting them here would make
+			// the binary encoding mean something its JSON twin cannot say — and a
+			// NaN coordinate silently poisons every distance it touches, returning
+			// a wrong ranking rather than an error.
+			if math.IsNaN(float64(f)) || math.IsInf(float64(f), 0) {
+				writeError(w, http.StatusBadRequest, "invalid binary query body: query contains NaN or Inf")
+				return false
+			}
+			query[i] = f
+		}
+	}
+
+	if flags&binSearchFlagFilter != 0 {
+		var lenBuf [4]byte
+		if !readFullQuery(w, br, lenBuf[:], "filter length") {
+			return false
+		}
+		n := binary.BigEndian.Uint32(lenBuf[:])
+		if n > maxBinarySearchFilter {
+			writeError(w, http.StatusBadRequest, "invalid binary query body: filter too large")
+			return false
+		}
+		buf := make([]byte, n)
+		if !readFullQuery(w, br, buf, "filter") {
+			return false
+		}
+		dec := json.NewDecoder(bytes.NewReader(buf))
+		dec.DisallowUnknownFields() // the JSON route's rule, applied to the same bytes
+		if err := dec.Decode(&req.Filter); err != nil {
+			writeError(w, http.StatusBadRequest, "invalid binary query body: bad filter JSON: "+err.Error())
+			return false
+		}
+	}
+
+	if _, err := br.ReadByte(); err == nil {
+		writeError(w, http.StatusBadRequest, "invalid binary query body: trailing bytes after frame")
+		return false
+	} else if !errors.Is(err, io.EOF) {
+		var mbe *http.MaxBytesError
+		if errors.As(err, &mbe) {
+			writeError(w, http.StatusRequestEntityTooLarge, "request body too large")
+			return false
+		}
+		writeError(w, http.StatusBadRequest, "invalid binary query body: "+err.Error())
+		return false
+	}
+
+	req.Query = query
+	req.K = int(k)
+	req.ReadConsistency = hdr[16]
+	req.OnPartitionUnavailable = hdr[17]
+	req.MaxStaleness = binary.BigEndian.Uint64(hdr[20:28])
+	return true
+}

--- a/httpapi/binary_search_test.go
+++ b/httpapi/binary_search_test.go
@@ -1,0 +1,203 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package httpapi
+
+import (
+	"bytes"
+	"encoding/binary"
+	"encoding/json"
+	"fmt"
+	"math"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// buildRVQ1 assembles a binary query body. Tests mutate the result rather than
+// hand-rolling bytes, so a change to the framing breaks them at the assembler
+// instead of in fourteen byte-literals.
+func buildRVQ1(k int, query []float32, filterJSON string, rc, opa uint8, staleness uint64) []byte {
+	var flags uint32
+	if filterJSON != "" {
+		flags |= binSearchFlagFilter
+	}
+	b := make([]byte, binarySearchHeaderLen)
+	copy(b[0:4], binarySearchMagic)
+	binary.BigEndian.PutUint32(b[4:8], flags)
+	binary.BigEndian.PutUint32(b[8:12], uint32(k))
+	binary.BigEndian.PutUint32(b[12:16], uint32(len(query)))
+	b[16], b[17] = rc, opa
+	binary.BigEndian.PutUint64(b[20:28], staleness)
+	for _, f := range query {
+		b = binary.BigEndian.AppendUint32(b, math.Float32bits(f))
+	}
+	if filterJSON != "" {
+		b = binary.BigEndian.AppendUint32(b, uint32(len(filterJSON)))
+		b = append(b, filterJSON...)
+	}
+	return b
+}
+
+func decodeRVQ1(t *testing.T, body []byte) (searchReq, *httptest.ResponseRecorder, bool) {
+	t.Helper()
+	r := httptest.NewRequest(http.MethodPost, "/v1/collections/c/points/search", bytes.NewReader(body))
+	r.Header.Set("Content-Type", "application/octet-stream")
+	w := httptest.NewRecorder()
+	var req searchReq
+	ok := decodeSearchBody(w, r, &req)
+	return req, w, ok
+}
+
+// The point of the whole file: a binary body must produce exactly the searchReq
+// its JSON twin would have, field for field.
+func TestBinarySearchMatchesTheJSONBody(t *testing.T) {
+	query := []float32{0.5, -1.25, 3, 0.0009765625}
+	filter := `{"op":"eq","field":"lang","value":{"kind":"string","str":"en"}}`
+
+	bin, rec, ok := decodeRVQ1(t, buildRVQ1(7, query, filter, 1, 1, 42))
+	if !ok {
+		t.Fatalf("binary body rejected: %d %s", rec.Code, rec.Body.String())
+	}
+
+	jsonBody, err := json.Marshal(map[string]any{
+		"query": query, "k": 7, "filter": json.RawMessage(filter),
+		"read_consistency": 1, "on_partition_unavailable": 1, "max_staleness": 42,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	r := httptest.NewRequest(http.MethodPost, "/v1/collections/c/points/search", bytes.NewReader(jsonBody))
+	r.Header.Set("Content-Type", "application/json")
+	var want searchReq
+	if !decodeSearchBody(httptest.NewRecorder(), r, &want) {
+		t.Fatal("JSON body rejected")
+	}
+
+	if fmt.Sprint(bin.Query) != fmt.Sprint(want.Query) {
+		t.Errorf("query: binary %v, JSON %v", bin.Query, want.Query)
+	}
+	if bin.K != want.K || bin.ReadConsistency != want.ReadConsistency ||
+		bin.OnPartitionUnavailable != want.OnPartitionUnavailable || bin.MaxStaleness != want.MaxStaleness {
+		t.Errorf("scalars differ:\n binary %+v\n JSON   %+v", bin, want)
+	}
+	if fmt.Sprint(bin.Filter) != fmt.Sprint(want.Filter) {
+		t.Errorf("filter: binary %+v, JSON %+v", bin.Filter, want.Filter)
+	}
+}
+
+// A JSON content type must still take the JSON path, unchanged.
+func TestJSONBodyStillDecodesWhenBinaryExists(t *testing.T) {
+	r := httptest.NewRequest(http.MethodPost, "/v1/collections/c/points/search",
+		strings.NewReader(`{"query":[1,2],"k":3}`))
+	r.Header.Set("Content-Type", "application/json")
+	var req searchReq
+	if !decodeSearchBody(httptest.NewRecorder(), r, &req) {
+		t.Fatal("JSON body rejected")
+	}
+	if req.K != 3 || len(req.Query) != 2 {
+		t.Errorf("got %+v", req)
+	}
+}
+
+// The reason maxBinarySearchDim is checked BEFORE dim is multiplied by four.
+// On a 32-bit build 0x40000000*4 is exactly 0: without the cap this allocates
+// nothing, reads nothing, and hands the engine an empty query as if the client
+// had sent one.
+func TestBinarySearchRejectsDimThatOverflowsWhenWidened(t *testing.T) {
+	for _, dim := range []uint32{0x40000000, 0x80000000, 0xFFFFFFFF, maxBinarySearchDim + 1} {
+		body := buildRVQ1(1, []float32{1}, "", 0, 0, 0)
+		binary.BigEndian.PutUint32(body[12:16], dim)
+		req, w, ok := decodeRVQ1(t, body)
+		if ok {
+			t.Errorf("dim=%#x accepted, query=%v", dim, req.Query)
+			continue
+		}
+		if w.Code != http.StatusBadRequest {
+			t.Errorf("dim=%#x: status %d, want 400", dim, w.Code)
+		}
+	}
+}
+
+// k above MaxInt32 must be refused outright rather than wrapping negative and
+// arriving at validTopK as a plausible-looking "k <= 0".
+func TestBinarySearchRejectsKAboveInt32(t *testing.T) {
+	body := buildRVQ1(1, []float32{1}, "", 0, 0, 0)
+	binary.BigEndian.PutUint32(body[8:12], math.MaxInt32+1)
+	if _, w, ok := decodeRVQ1(t, body); ok || w.Code != http.StatusBadRequest {
+		t.Errorf("ok=%v status=%d, want rejected with 400", ok, w.Code)
+	}
+}
+
+// NaN and Inf are unrepresentable in the JSON body, so accepting them here would
+// let the binary encoding say something its twin cannot — and a NaN coordinate
+// poisons every distance it touches, producing a wrong ranking, not an error.
+func TestBinarySearchRejectsNonFiniteFloats(t *testing.T) {
+	for name, bits := range map[string]uint32{
+		"NaN":  math.Float32bits(float32(math.NaN())),
+		"+Inf": math.Float32bits(float32(math.Inf(1))),
+		"-Inf": math.Float32bits(float32(math.Inf(-1))),
+	} {
+		body := buildRVQ1(1, []float32{1, 2}, "", 0, 0, 0)
+		binary.BigEndian.PutUint32(body[binarySearchHeaderLen+4:], bits)
+		if _, w, ok := decodeRVQ1(t, body); ok || w.Code != http.StatusBadRequest {
+			t.Errorf("%s: ok=%v status=%d, want rejected with 400", name, ok, w.Code)
+		}
+	}
+}
+
+func TestBinarySearchRejectsMalformedFrames(t *testing.T) {
+	good := buildRVQ1(5, []float32{1, 2, 3}, "", 0, 0, 0)
+
+	cases := map[string][]byte{
+		"bad magic":       append([]byte("XXXX"), good[4:]...),
+		"short header":    good[:10],
+		"truncated body":  good[:len(good)-6],
+		"trailing bytes":  append(append([]byte{}, good...), 0x00),
+		"empty body":      {},
+		"filter len lies": buildRVQ1(5, []float32{1}, `{"op":"eq","field":"a","value":{"kind":"int","int":1}}`, 0, 0, 0)[:binarySearchHeaderLen+4+2],
+	}
+	unknownFlags := append([]byte{}, good...)
+	binary.BigEndian.PutUint32(unknownFlags[4:8], 1<<31)
+	cases["unknown flags"] = unknownFlags
+
+	reserved := append([]byte{}, good...)
+	binary.BigEndian.PutUint16(reserved[18:20], 1)
+	cases["reserved not zero"] = reserved
+
+	for name, body := range cases {
+		_, w, ok := decodeRVQ1(t, body)
+		if ok {
+			t.Errorf("%s: accepted, want rejected", name)
+			continue
+		}
+		if w.Code != http.StatusBadRequest {
+			t.Errorf("%s: status %d, want 400", name, w.Code)
+		}
+		if !strings.Contains(w.Body.String(), "binary query body") {
+			t.Errorf("%s: error does not name this framing: %s", name, w.Body.String())
+		}
+	}
+}
+
+// An oversized filter must be refused from its declared length, before the
+// server allocates for it.
+func TestBinarySearchRejectsOversizeFilter(t *testing.T) {
+	body := buildRVQ1(1, []float32{1}, `{"op":"eq","field":"a","value":{"kind":"int","int":1}}`, 0, 0, 0)
+	binary.BigEndian.PutUint32(body[binarySearchHeaderLen+4:], maxBinarySearchFilter+1)
+	if _, w, ok := decodeRVQ1(t, body); ok || w.Code != http.StatusBadRequest {
+		t.Errorf("ok=%v status=%d, want rejected with 400", ok, w.Code)
+	}
+}
+
+// A zero-dimension query is well-formed framing; it fails later, on the same
+// path the JSON body fails on, rather than here.
+func TestBinarySearchAcceptsEmptyQuery(t *testing.T) {
+	req, _, ok := decodeRVQ1(t, buildRVQ1(3, nil, "", 0, 0, 0))
+	if !ok {
+		t.Fatal("empty query rejected at the framing layer")
+	}
+	if len(req.Query) != 0 || req.K != 3 {
+		t.Errorf("got %+v", req)
+	}
+}

--- a/httpapi/vector.go
+++ b/httpapi/vector.go
@@ -1335,7 +1335,7 @@ func missingJSON(missing []uint16) []int {
 func (a *api) search(w http.ResponseWriter, r *http.Request) {
 	name := r.PathValue("name")
 	var req searchReq
-	if !decodeBody(w, r, &req) {
+	if !decodeSearchBody(w, r, &req) {
 		return
 	}
 	if !validConsistency(w, req.ReadConsistency, req.OnPartitionUnavailable) {
@@ -1362,7 +1362,7 @@ func (a *api) search(w http.ResponseWriter, r *http.Request) {
 func (a *api) searchDocs(w http.ResponseWriter, r *http.Request) {
 	name := r.PathValue("name")
 	var req searchReq
-	if !decodeBody(w, r, &req) {
+	if !decodeSearchBody(w, r, &req) {
 		return
 	}
 	if !validConsistency(w, req.ReadConsistency, req.OnPartitionUnavailable) {


### PR DESCRIPTION
Both items from the transport measurement, in order of what they buy.

## 1. The client opened a TCP connection per request

It called `urllib.request.urlopen`, which does not pool. Every search paid a handshake.

The adapter that produces our published VectorDBBench numbers uses `requests`, which **does** pool — so our own users were getting materially less than our benchmarks report, for a reason with nothing to do with the engine.

The client now keeps a small pool. Two details that are easy to get wrong, and one I did get wrong:

- `urlopen` was *accidentally* thread-safe because it shared nothing. A kept-alive connection is not: two threads writing into one socket desynchronize the response stream. So a connection is held by one thread for the length of a request and returned only once its response is fully read.
- A response that closes the connection (HTTP/1.0, `Connection: close`) must be **discarded, not pooled**. My first version pooled everything, so against a closing server every request found a dead socket, failed a write, and retried — strictly worse than no pooling. `test_connections_are_reused` caught it.

## 2. The query vector travelled as base-10 text

At dim=768, k=10 on a kept-alive connection: **0.845 ms** per search, of which building the JSON body is **0.258 ms — 31%**, spent turning float32s the client already holds into decimal so the server can parse them straight back. The same vector encodes in **0.011 ms** as bytes.

`/points/search` and `/points/search/docs` now accept a dense binary body (`RVQ1`), selected by `Content-Type`, mirroring the `RVB1` bulk framing on the other side of the workload — same big-endian layout, same rule that it decodes into *exactly* the request the JSON body would have produced and then runs the identical validation and dispatch.

**Compatibility is automatic.** A server without RVQ1 hands the body to its JSON decoder and answers `invalid JSON body: ...`; the client treats that specific reply as the signal to fall back for the rest of its life. Verified against a **real v0.1.2 binary**, not a mock of one. `binary_search=False` opts out.

## Result

Old client vs new, against the same server, five interleaved pairs at dim=768:

| | searches/s |
|---|---|
| before | 724 – 990 |
| after | 1,911 – 3,179 |

The ranges do not overlap. Per-pair ratios run 2.5×–4.4×; at dim=128, 2.1×–2.7×. This is a laptop — the non-overlap is the claim, the ratio is approximate.

## Decoder safety

Bounded the way the bulk decoder is, for the same reasons:

- `dim` is capped **before** it is multiplied by four. `0x40000000 * 4` is exactly `0` on a 32-bit build, which would allocate nothing, read nothing, and hand the engine a silently empty query instead of an error. There is a test for that shape, and the decoder tests run under `GOARCH=386`.
- `NaN`/`±Inf` are refused — JSON cannot express them, and a NaN coordinate poisons every distance it touches, producing a wrong ranking rather than an error.
- Trailing bytes after the frame are refused rather than ignored.
- `k` above `MaxInt32` is refused outright instead of wrapping negative and reaching `validTopK` as a plausible-looking `k <= 0`.

## Testing

- `httpapi`: framing tests incl. malformed frames, overflow shapes, JSON-parity. Full package green, `golangci-lint` 0 issues, also run under `GOARCH=386`.
- Python: 59 passed / 26 skipped with a real server binary. New `test_transport.py` asserts the **mechanism** — content type on the wire, connection counts, fallback latching, and 8 threads × 10 searches sharing a pool — because a test that only checks hits would pass on the old client.
- New cross-stack test drives the real Go server and asserts binary and JSON queries return identical ids **and distances**, filtered and unfiltered.
- The fakes decode RVQ1 from the *server's* spec, deliberately not by calling the client's encoder backwards: a decoder built from the encoder agrees with it by construction and would pass just as happily if both were wrong.

## Known behavioural change

`http.client` does not consult `HTTP_PROXY`/`HTTPS_PROXY` the way `urllib` did. Documented in the client README and on the docs site.

## Ordering

No version bump here — #4 already moves the client to 0.1.2 and hasn't shipped. Both should go out in that one release.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added faster binary request encoding for vector searches, with automatic JSON fallback for older servers.
  - Added connection pooling, thread-safe reuse, automatic reconnection, and configurable pool sizing.
  - Added context-manager support and an explicit client shutdown method.
  - Added binary search support for optional filters and document searches.

- **Bug Fixes**
  - Improved handling of stale or server-closed connections.
  - Added validation for malformed requests, invalid values, oversized payloads, and unsupported options.

- **Documentation**
  - Documented connection management, proxy behavior, binary request formats, validation, and fallback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->