### PR TITLE
docs: pre-release corrections — stale urllib line, and changelog entries

### DIFF
--- a/clients/python/README.md
+++ b/clients/python/README.md
@@ -16,9 +16,9 @@ pip install rostam-client[langchain] # + the LangChain VectorStore adapter
 
 ## Run a server
 
-This client speaks **HTTP** — it is built on `urllib`, so the server needs its
-`-http` listener and that is the port you point the client at. (The server also
-offers gRPC and a binary TCP protocol; this client uses neither.)
+This client speaks **HTTP** — it is built on `http.client`, so the server needs
+its `-http` listener and that is the port you point the client at. (The server
+also offers gRPC and a binary TCP protocol; this client uses neither.)
 
 Neither of these needs a Go toolchain or a checkout:
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -112,6 +112,39 @@ established. It now folds the same narrowing plan into a membership bitset and
 consults one bit per candidate instead. No API change, no configuration, and no
 change to which points a filter matches: it is the same plan, read a cheaper way.
 
+### Binary query wire
+
+`/points/search` and `/points/search/docs` now accept a dense binary body,
+selected by `Content-Type: application/octet-stream` — the ingest wire's
+counterpart on the read side. The query vector travels as raw `f32` instead of
+base-10 text, which it turns out is a large share of a small request: at dim=768,
+k=10 on a kept-alive connection, building the JSON body measured **0.258 ms of a
+0.845 ms search**, against 0.011 ms to write the same vector as bytes. The
+server's matching decode of those literals goes with it.
+
+Adds no semantics, on the same terms as the bulk wire: a binary body decodes into
+exactly the request its JSON body produces, then runs the identical validation
+and dispatch, and any other content type takes the JSON path unchanged. The
+framing, its limits (`dim` ≤ 65,536, filter ≤ 1 MiB, `NaN`/`Inf` refused) and its
+error behaviour are in [Binary query body](api/http.md#binary-query-body).
+
+Clients need no flag day. A server that predates this answers a binary body with
+`400 invalid JSON body: ...`, which is specific enough to fall back on; the
+Python client does so automatically and permanently.
+
+### The Python client reuses connections
+
+`rostam-client` opened a new TCP connection per request. It now keeps a small
+pool, and is still safe to share between threads. Combined with the binary query
+wire, repeated searches measured **724–990/s before and 1911–3179/s after** at
+dim=768 against the same server — non-overlapping ranges, on a laptop.
+
+Reads are retried once when a pooled connection turns out to have been closed
+while idle; writes are not, because that failure surfaces after the request is on
+the wire and a replayed insert is worse than an error. `close()` releases the
+pool. Note that `http.client` does not consult `HTTP_PROXY`/`HTTPS_PROXY` the way
+the previous `urllib` call did.
+
 ### Binary bulk-ingest wire
 
 `/points/bulk` and `/points/batch` now accept a dense binary body, selected by


### PR DESCRIPTION
Two documentation fixes that both block the release, caught while pre-flighting the artifacts.

## 1. The PyPI page names the wrong transport

`clients/python/README.md` says the client "is built on `urllib`". True when #4 wrote it; false once #5 replaced the transport with `http.client` in the same release. The two PRs touched different halves of one sentence's meaning, so neither review had both in view.

It matters more than an ordinary stale comment because this file is the **PyPI long description** — the copy most likely to be read by someone deciding whether the package pulls in dependencies, and least likely to be checked against the code.

Found by reading METADATA out of the built wheel rather than the source, which is also how I confirmed the rest of the page renders as intended (`docker run` first, `export PATH` present, the snippet's import present, `go build` surviving only as the contributor note).

## 2. Neither new feature was in the changelog

The binary query wire and the pooled client are both user-visible, and the changelog is where someone decides whether an upgrade is worth it. Entries added for both, including the measurements and the two caveats a reader needs: writes are not retried on a stale pooled connection, and `http.client` ignores `HTTP_PROXY`.

## Why now

Blocks `py-v0.1.2`: publishing first would put the wrong sentence on the project page, and a PyPI version can never be re-uploaded.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified that the Python client uses a modern HTTP communication approach.
  * Documented support for efficient binary vector queries in search requests, while preserving existing validation and fallback behavior.
  * Added details about connection reuse, safe retries for read operations, explicit client closing, and updated proxy behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->