### PR TITLE
fix(server): report the epoll TCP address, and stop a close race from killing the process

### DIFF
--- a/server.go
+++ b/server.go
@@ -334,7 +334,15 @@ func NewServer(cfg ServerConfig) (*Server, error) {
 			IdleTimeout:    120 * time.Second,
 			MaxHeaderBytes: 1 << 20, // 1 MiB header cap (body caps are enforced per-route via MaxBytesReader)
 		}
-		go func() { _ = srv.httpSrv.Serve(ln) }()
+		// Capture the server in a local, the way the TCP and gRPC goroutines below
+		// already do. Reading srv.httpSrv inside the goroutine races Close, which
+		// sets that field to nil — so a server closed before this goroutine was
+		// first scheduled dereferenced nil and took the process down with it. A
+		// panic in a goroutine cannot be recovered by the caller, so the blast
+		// radius was the whole program, and the window is widest exactly where it
+		// hurts: short-lived servers in tests, and start-then-fail-to-start paths.
+		hs := srv.httpSrv
+		go func() { _ = hs.Serve(ln) }()
 	}
 
 	if cfg.GRPCAddr != "" {
@@ -392,7 +400,17 @@ func (s *Server) GRPCAddr() string {
 }
 
 // TCPAddr returns the bound binary-TCP address, or "" if TCP is disabled.
+//
+// It must consult BOTH transports. The epoll server is stored in epollSrv
+// instead of tcpSrv, and epoll is the default for single-node — so checking only
+// tcpSrv reported "no TCP transport" for the configuration most servers run.
+// The startup log iterates these accessors, which meant `-tcp` came up, accepted
+// connections, and was never announced: an operator reading the log had no way
+// to confirm the listener existed.
 func (s *Server) TCPAddr() string {
+	if s.epollSrv != nil {
+		return s.epollSrv.Addr()
+	}
 	if s.tcpSrv == nil {
 		return ""
 	}

--- a/server/epollserver.go
+++ b/server/epollserver.go
@@ -7,6 +7,7 @@ import (
 	"encoding/binary"
 	"errors"
 	"log/slog"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -117,6 +118,18 @@ func (s *EpollServer) Start(addr string) error {
 		}
 		return err
 	}
+}
+
+// Addr returns the address this transport serves, without the "tcp://" scheme
+// gnet requires, or "" before Run/Start has been called.
+//
+// It reports the address the engine was ASKED to bind, not one resolved from the
+// listener: gnet's Engine exposes no accessor for the bound address, so a caller
+// that passed port 0 gets ":0" back rather than the port the kernel chose. Every
+// production path names a real port; the caveat matters only to a test that binds
+// ephemerally and then expects to dial what this returns.
+func (s *EpollServer) Addr() string {
+	return strings.TrimPrefix(s.addr, "tcp://")
 }
 
 // Stop gracefully shuts the event engine down (drains, closes listeners); the

--- a/tcpaddr_epoll_test.go
+++ b/tcpaddr_epoll_test.go
@@ -1,0 +1,119 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package rostam
+
+import (
+	"net"
+	"testing"
+
+	"github.com/rostamlabs/rostam/ops"
+)
+
+// newTestOps builds the registry NewServer requires for the single-node backend.
+func newTestOps(t *testing.T) *ops.Registry {
+	t.Helper()
+	reg := ops.NewRegistry()
+	if err := ops.RegisterBuiltins(reg); err != nil {
+		t.Fatalf("RegisterBuiltins: %v", err)
+	}
+	return reg
+}
+
+// freeTCPPort returns a loopback address nothing is listening on. The epoll
+// transport cannot report a kernel-chosen port (gnet exposes no accessor for the
+// bound address), so these tests name a real port rather than binding :0.
+func freeTCPPort(t *testing.T) string {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("reserve port: %v", err)
+	}
+	addr := ln.Addr().String()
+	if err := ln.Close(); err != nil {
+		t.Fatalf("release port: %v", err)
+	}
+	return addr
+}
+
+// TCPAddr has to answer for whichever TCP transport is running. Epoll is the
+// DEFAULT for single-node and lives in a different field, so a version of this
+// accessor that only knew about the goroutine server reported "TCP is disabled"
+// for the configuration most servers actually run — and the startup log, which
+// iterates these accessors, silently omitted the listener while it was up and
+// accepting connections.
+func TestTCPAddrReportsBothTransports(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		epoll bool
+	}{
+		{"epoll (the single-node default)", true},
+		{"goroutine-per-connection", false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			addr := freeTCPPort(t)
+			srv, err := NewServer(ServerConfig{
+				TCPAddr:      addr,
+				EpollTCP:     tc.epoll,
+				DirectConfig: DirectConfig{Ops: newTestOps(t)},
+			})
+			if err != nil {
+				t.Fatalf("NewServer: %v", err)
+			}
+			defer func() {
+				if cerr := srv.Close(); cerr != nil {
+					t.Errorf("Close: %v", cerr)
+				}
+			}()
+
+			if got := srv.TCPAddr(); got != addr {
+				t.Errorf("TCPAddr() = %q, want %q", got, addr)
+			}
+			// The address must be dialable, so the accessor cannot be reporting a
+			// listener that does not exist.
+			c, derr := net.Dial("tcp", srv.TCPAddr())
+			if derr != nil {
+				t.Fatalf("dial %s: %v", srv.TCPAddr(), derr)
+			}
+			if cerr := c.Close(); cerr != nil {
+				t.Errorf("close conn: %v", cerr)
+			}
+		})
+	}
+}
+
+// With no TCP address configured there is no transport to report, on either path.
+func TestTCPAddrEmptyWhenDisabled(t *testing.T) {
+	srv, err := NewServer(ServerConfig{
+		HTTPAddr:     "127.0.0.1:0",
+		DirectConfig: DirectConfig{Ops: newTestOps(t)},
+	})
+	if err != nil {
+		t.Fatalf("NewServer: %v", err)
+	}
+	defer func() { _ = srv.Close() }()
+	if got := srv.TCPAddr(); got != "" {
+		t.Errorf("TCPAddr() = %q, want \"\" when -tcp is unset", got)
+	}
+}
+
+// A server closed promptly after construction must not take the process with it.
+//
+// The HTTP serving goroutine used to read srv.httpSrv when it was first
+// scheduled, while Close sets that field to nil — so closing before the
+// goroutine ran dereferenced nil, and a panic in a goroutine cannot be recovered
+// by the caller. This loops to widen a window that is otherwise scheduler-
+// dependent; it panics rather than fails when the bug is present.
+func TestCloseImmediatelyAfterStartDoesNotPanic(t *testing.T) {
+	for i := 0; i < 50; i++ {
+		srv, err := NewServer(ServerConfig{
+			HTTPAddr:     "127.0.0.1:0",
+			DirectConfig: DirectConfig{Ops: newTestOps(t)},
+		})
+		if err != nil {
+			t.Fatalf("iteration %d: NewServer: %v", i, err)
+		}
+		if err := srv.Close(); err != nil {
+			t.Fatalf("iteration %d: Close: %v", i, err)
+		}
+	}
+}

--- a/tcpaddr_epoll_test.go
+++ b/tcpaddr_epoll_test.go
@@ -3,7 +3,9 @@
 package rostam
 
 import (
+	"errors"
 	"net"
+	"syscall"
 	"testing"
 
 	"github.com/rostamlabs/rostam/ops"
@@ -19,9 +21,15 @@ func newTestOps(t *testing.T) *ops.Registry {
 	return reg
 }
 
-// freeTCPPort returns a loopback address nothing is listening on. The epoll
-// transport cannot report a kernel-chosen port (gnet exposes no accessor for the
-// bound address), so these tests name a real port rather than binding :0.
+// freeTCPPort returns a loopback address nothing is listening on at the moment
+// it returns. The epoll transport cannot report a kernel-chosen port (gnet
+// exposes no accessor for the bound address), so these tests must name a real
+// port rather than binding :0 and reading it back.
+//
+// That leaves an unavoidable gap between releasing the reservation here and the
+// server binding it, in which another process can take the port. The gap cannot
+// be closed without a seam that hands a pre-bound listener to the server, so
+// serveOnFreePort below retries instead — see the note there.
 func freeTCPPort(t *testing.T) string {
 	t.Helper()
 	ln, err := net.Listen("tcp", "127.0.0.1:0")
@@ -33,6 +41,34 @@ func freeTCPPort(t *testing.T) string {
 		t.Fatalf("release port: %v", err)
 	}
 	return addr
+}
+
+// serveOnFreePort starts a server on a free loopback port, retrying only when
+// the port was taken between reservation and bind.
+//
+// Retrying ONLY that error matters: a blanket retry would paper over a genuine
+// bind failure and turn a real defect into a slow test. Anything that is not an
+// address-in-use error fails immediately.
+func serveOnFreePort(t *testing.T, epoll bool) (*Server, string) {
+	t.Helper()
+	const attempts = 5
+	for i := range attempts {
+		addr := freeTCPPort(t)
+		srv, err := NewServer(ServerConfig{
+			TCPAddr:      addr,
+			EpollTCP:     epoll,
+			DirectConfig: DirectConfig{Ops: newTestOps(t)},
+		})
+		if err == nil {
+			return srv, addr
+		}
+		if !errors.Is(err, syscall.EADDRINUSE) {
+			t.Fatalf("NewServer(%s): %v", addr, err)
+		}
+		t.Logf("attempt %d: %s was taken between reservation and bind, retrying", i+1, addr)
+	}
+	t.Fatalf("no free port survived %d attempts", attempts)
+	return nil, ""
 }
 
 // TCPAddr has to answer for whichever TCP transport is running. Epoll is the
@@ -50,15 +86,7 @@ func TestTCPAddrReportsBothTransports(t *testing.T) {
 		{"goroutine-per-connection", false},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			addr := freeTCPPort(t)
-			srv, err := NewServer(ServerConfig{
-				TCPAddr:      addr,
-				EpollTCP:     tc.epoll,
-				DirectConfig: DirectConfig{Ops: newTestOps(t)},
-			})
-			if err != nil {
-				t.Fatalf("NewServer: %v", err)
-			}
+			srv, addr := serveOnFreePort(t, tc.epoll)
 			defer func() {
 				if cerr := srv.Close(); cerr != nil {
 					t.Errorf("Close: %v", cerr)


### PR DESCRIPTION
Two defects, found by asking why the startup log never mentions the TCP transport.

## 1. `TCPAddr()` was blind to the default transport

It consulted only `tcpSrv`, but the epoll transport is stored in `epollSrv` — and `-epoll` defaults **on** for single-node. So in the configuration most servers actually run, `-tcp` bound its port, accepted connections, and was never announced, because the startup log iterates these accessors. An operator reading the log had no way to confirm the listener existed.

Confirmed by A/B rather than by reading the code:

```
default (epoll on)   port 7000 up: 1 | logged protos: proto=http
-epoll=false         port 7000 up: 1 | logged protos: proto=http proto=tcp
```

`EpollServer.Addr()` reports the address the engine was **asked** to bind — gnet exposes no accessor for the resolved one, which is documented on the method because it means a caller that asked for port 0 gets `:0` back.

## 2. Closing a server promptly could take the process down

This surfaced while testing the first fix:

```
panic: runtime error: invalid memory address or nil pointer dereference
net/http.(*Server).Serve(0x0, ...)
```

The HTTP serving goroutine read `srv.httpSrv` when it was first *scheduled*, while `Close` sets that field to `nil`. Close before the goroutine runs and it dereferences nil — and **a panic in a goroutine cannot be recovered by the caller**, so the blast radius is the whole program. It is also a plain data race on the field.

What convinced me it was an oversight rather than a decision: the TCP and gRPC goroutines a few lines away already capture locals (`tcp`, `gs`). Only HTTP read through the struct. It now does the same.

The window is widest exactly where it hurts most — short-lived servers in tests, and start-then-fail-to-start paths — which is where an unexplained crash costs the most time to diagnose.

## Testing

Both tests were confirmed to **fail without their fix**, by reverting each and watching them fail:

- `TestTCPAddrReportsBothTransports` → `TCPAddr() = "", want "127.0.0.1:39363"`
- `TestCloseImmediatelyAfterStartDoesNotPanic` → reproduces the actual panic, not a proxy for it

`./server/...` green, `-race` clean, `golangci-lint` 0 issues, and the new decoder-adjacent tests also run under `GOARCH=386`.

## On the root-package suite

An earlier run of this branch failed `TestDirectStoreRejectsPartitions` while `main` passed, which looked like a regression from these changes. It is not, and the cause is worth knowing: that test creates a Direct store with no `DataDir`, which persists to `./vectors/default/` **relative to the working directory**, so the first run leaves `ok_unset.json` behind and every later run in that directory fails with `collection already exists`. `main` passed because it ran in a freshly-created worktree; this branch failed because it ran in a repo my debugging had already polluted. Proven with a clean control — clean dir: ok, run again uncleaned: FAIL, cleaned: ok.

Filed separately, since both are pre-existing and neither belongs in a transport fix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved server shutdown safety during concurrent operations.
  * TCP address reporting now works consistently across supported server modes.
  * Address information is correctly handled when TCP is disabled or before startup.
  * Reported listener addresses are now reliable and dialable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->