### PR TITLE
fix(vector): heap mode gets a private scratch dir, not your working directory

### DIFF
--- a/heapmode_isolation_test.go
+++ b/heapmode_isolation_test.go
@@ -5,6 +5,7 @@ package rostam
 import (
 	"context"
 	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/rostamlabs/rostam/ops"
@@ -96,42 +97,46 @@ func TestHeapModeStillRejectsADuplicateInTheSameStore(t *testing.T) {
 }
 
 // The scratch directory a heap-mode store owns must not outlive it.
+//
+// This points TMPDIR at a private directory rather than counting rostam-heap-*
+// entries in the machine-wide temp dir. Counting was racy: any other process
+// creating or removing a matching directory between the snapshots could mask a
+// real leak or invent one — the exact species of flaky test this whole change
+// exists to stamp out.
 func TestHeapModeScratchDirIsRemovedOnClose(t *testing.T) {
+	tmpRoot := t.TempDir()
+	t.Setenv("TMPDIR", tmpRoot) // os.MkdirTemp("") resolves through this
 	t.Chdir(t.TempDir())
-	before, err := os.ReadDir(os.TempDir())
-	if err != nil {
-		t.Skipf("cannot list %s: %v", os.TempDir(), err)
-	}
-	count := func(es []os.DirEntry) int {
-		n := 0
-		for _, e := range es {
-			if e.IsDir() && len(e.Name()) > 12 && e.Name()[:12] == "rostam-heap-" {
-				n++
-			}
-		}
-		return n
-	}
+
 	reg := ops.NewRegistry()
 	if err := ops.RegisterBuiltins(reg); err != nil {
 		t.Fatal(err)
 	}
 	s, err := NewDirect(DirectConfig{Ops: reg})
 	if err != nil {
-		t.Fatal(err)
+		t.Fatalf("NewDirect: %v", err)
 	}
 	if err := s.CreateCollection(context.Background(), "docs", heapConfig()); err != nil {
 		t.Fatalf("CreateCollection: %v", err)
 	}
-	during, _ := os.ReadDir(os.TempDir())
-	if count(during) <= count(before) {
-		t.Skip("could not observe the scratch dir (concurrent tests may share TempDir)")
+
+	// Exactly one scratch dir, and we know which one.
+	created, err := os.ReadDir(tmpRoot)
+	if err != nil {
+		t.Fatal(err)
 	}
+	if len(created) != 1 {
+		t.Fatalf("expected one scratch dir under %s, got %d", tmpRoot, len(created))
+	}
+	scratch := filepath.Join(tmpRoot, created[0].Name())
+	if _, err := os.Stat(scratch); err != nil {
+		t.Fatalf("scratch dir %s not usable: %v", scratch, err)
+	}
+
 	if err := s.Close(); err != nil {
 		t.Fatalf("Close: %v", err)
 	}
-	after, _ := os.ReadDir(os.TempDir())
-	if count(after) != count(before) {
-		t.Errorf("scratch dirs before=%d after=%d: Close did not remove the store's own",
-			count(before), count(after))
+	if _, err := os.Stat(scratch); !os.IsNotExist(err) {
+		t.Errorf("scratch dir %s survived Close (stat err: %v)", scratch, err)
 	}
 }

--- a/heapmode_isolation_test.go
+++ b/heapmode_isolation_test.go
@@ -1,0 +1,137 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package rostam
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/rostamlabs/rostam/ops"
+	"github.com/rostamlabs/rostam/vector"
+)
+
+// An unset DataDir is documented as heap mode ("Empty = pure heap mode, no
+// persistence"). It used to mean something else entirely: every store path was
+// relative, so the store wrote ./vectors/<tenant>/ into the process's working
+// directory and read it back next time. Three consequences, all of them
+// surprising to a caller who configured nothing:
+//
+//   - files appeared next to whatever binary happened to run,
+//   - a fresh store inherited the previous run's collections, so a create
+//     returned "collection already exists" for a name never used before,
+//   - two stores in one process shared a namespace.
+//
+// It also made the test suite self-poisoning: the first run left ok_unset.json
+// behind and every later run in that checkout failed. CI never saw it, because
+// a fresh runner is always the first run.
+func heapStore(t *testing.T) Store {
+	t.Helper()
+	reg := ops.NewRegistry()
+	if err := ops.RegisterBuiltins(reg); err != nil {
+		t.Fatalf("RegisterBuiltins: %v", err)
+	}
+	s, err := NewDirect(DirectConfig{Ops: reg}) // no DataDir: heap mode
+	if err != nil {
+		t.Fatalf("NewDirect: %v", err)
+	}
+	t.Cleanup(func() { _ = s.Close() })
+	return s
+}
+
+func heapConfig() VectorConfig {
+	return VectorConfig{Dim: 4, Metric: vector.L2, M: 8, EfConstruction: 50, EfSearch: 32, Seed: 1}
+}
+
+func TestHeapModeWritesNothingToTheWorkingDirectory(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+
+	s := heapStore(t)
+	if err := s.CreateCollection(context.Background(), "docs", heapConfig()); err != nil {
+		t.Fatalf("CreateCollection: %v", err)
+	}
+
+	entries, err := os.ReadDir(".")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 0 {
+		names := make([]string, 0, len(entries))
+		for _, e := range entries {
+			names = append(names, e.Name())
+		}
+		t.Errorf("heap mode wrote into the working directory: %v", names)
+	}
+}
+
+func TestHeapModeStoresDoNotShareCollections(t *testing.T) {
+	t.Chdir(t.TempDir())
+	ctx := context.Background()
+
+	first := heapStore(t)
+	if err := first.CreateCollection(ctx, "docs", heapConfig()); err != nil {
+		t.Fatalf("first store: %v", err)
+	}
+	// A second, independent store must not see the first one's collections —
+	// which is also what a process restarting in the same directory looks like.
+	second := heapStore(t)
+	if err := second.CreateCollection(ctx, "docs", heapConfig()); err != nil {
+		t.Errorf("second store could not create \"docs\": %v", err)
+	}
+}
+
+// Creating a collection twice in ONE store is still an error — the fix must not
+// have turned a real conflict into a silent overwrite.
+func TestHeapModeStillRejectsADuplicateInTheSameStore(t *testing.T) {
+	t.Chdir(t.TempDir())
+	ctx := context.Background()
+	s := heapStore(t)
+	if err := s.CreateCollection(ctx, "docs", heapConfig()); err != nil {
+		t.Fatalf("first create: %v", err)
+	}
+	if err := s.CreateCollection(ctx, "docs", heapConfig()); err == nil {
+		t.Error("creating the same collection twice in one store was accepted; it must be refused")
+	}
+}
+
+// The scratch directory a heap-mode store owns must not outlive it.
+func TestHeapModeScratchDirIsRemovedOnClose(t *testing.T) {
+	t.Chdir(t.TempDir())
+	before, err := os.ReadDir(os.TempDir())
+	if err != nil {
+		t.Skipf("cannot list %s: %v", os.TempDir(), err)
+	}
+	count := func(es []os.DirEntry) int {
+		n := 0
+		for _, e := range es {
+			if e.IsDir() && len(e.Name()) > 12 && e.Name()[:12] == "rostam-heap-" {
+				n++
+			}
+		}
+		return n
+	}
+	reg := ops.NewRegistry()
+	if err := ops.RegisterBuiltins(reg); err != nil {
+		t.Fatal(err)
+	}
+	s, err := NewDirect(DirectConfig{Ops: reg})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := s.CreateCollection(context.Background(), "docs", heapConfig()); err != nil {
+		t.Fatalf("CreateCollection: %v", err)
+	}
+	during, _ := os.ReadDir(os.TempDir())
+	if count(during) <= count(before) {
+		t.Skip("could not observe the scratch dir (concurrent tests may share TempDir)")
+	}
+	if err := s.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	after, _ := os.ReadDir(os.TempDir())
+	if count(after) != count(before) {
+		t.Errorf("scratch dirs before=%d after=%d: Close did not remove the store's own",
+			count(before), count(after))
+	}
+}

--- a/vector/collections.go
+++ b/vector/collections.go
@@ -108,7 +108,7 @@ func OpenCollectionStore(dir string) (*CollectionStore, error) {
 // per-collection sidecar: stale on-disk vector data files are wiped at open and
 // repopulated from the Raft snapshot/log. Used by shard.New in a replicated
 // deployment (shard.Config.PersistentVectors).
-func OpenCollectionStorePersistent(dir string, persistentCluster bool) (*CollectionStore, error) {
+func OpenCollectionStorePersistent(dir string, persistentCluster bool) (store *CollectionStore, retErr error) {
 	// No directory configured means heap mode. Give the store a private temp dir
 	// rather than letting every path resolve relative to the process's working
 	// directory: the on-disk layout below is an implementation detail of the
@@ -122,6 +122,15 @@ func OpenCollectionStorePersistent(dir string, persistentCluster bool) (*Collect
 			return nil, fmt.Errorf("vector: create heap-mode scratch dir: %w", err)
 		}
 		dir, ephemeral = td, true
+		// Every failure path below this point returns without a store, so nothing
+		// will ever call Close to reclaim the directory just created. Deferring on
+		// the named error covers them all — including the ones added later by
+		// someone who never reads this comment.
+		defer func() {
+			if retErr != nil {
+				_ = os.RemoveAll(td)
+			}
+		}()
 	}
 	vd := filepath.Join(dir, "vectors")
 	if err := os.MkdirAll(vd, 0o750); err != nil {
@@ -1332,12 +1341,14 @@ func (s *CollectionStore) Close() error {
 	// Cold stubs hold no index/goroutine — just drop the catalog maps. Per-collection
 	// lastAccess lives on the Collection objects, which are dropped with s.collections.
 	s.cold = nil
-	// A heap-mode store owns its scratch dir, so it takes it with it. Failure is
-	// swallowed deliberately: the caller asked to close a store, and a leftover
-	// temp dir is not a reason to report that closing failed. It is under
-	// os.TempDir(), so the system reclaims it regardless.
+	// A heap-mode store owns its scratch dir, so it takes it with it — and says so
+	// if it cannot. Reporting success over a directory that is still on disk would
+	// make the ownership contract unobservable exactly when it has been broken,
+	// and "the OS will reclaim it" is not a guarantee any platform actually makes.
 	if s.ephemeralDir && s.dir != "" {
-		_ = os.RemoveAll(s.dir)
+		if err := os.RemoveAll(s.dir); err != nil {
+			return fmt.Errorf("vector: remove heap-mode scratch dir %s: %w", s.dir, err)
+		}
 	}
 	return nil
 }

--- a/vector/collections.go
+++ b/vector/collections.go
@@ -35,6 +35,17 @@ var ErrNoMultiVector = errors.New("vector: no multi-vector collection")
 type CollectionStore struct {
 	dir string
 
+	// ephemeralDir is set when the caller configured no directory. The store
+	// then owns a private temp dir and removes it on Close.
+	//
+	// Without this, an empty dir made every path below RELATIVE: the store wrote
+	// ./vectors/<tenant>/ into whatever working directory the process happened to
+	// have, and read it back on the next run — so a "fresh" store returned
+	// "collection already exists" for a name the caller had never used, and two
+	// independent stores in one process shared a namespace. Both contradict the
+	// documented contract that an empty DataDir means heap mode.
+	ephemeralDir bool
+
 	// persistentCluster makes every collection mmap-backed (off-heap) per node,
 	// for a replicated deployment where Raft (log + FSM snapshot) is the
 	// durability authority and the mmap is a non-authoritative memory layout.
@@ -98,11 +109,25 @@ func OpenCollectionStore(dir string) (*CollectionStore, error) {
 // repopulated from the Raft snapshot/log. Used by shard.New in a replicated
 // deployment (shard.Config.PersistentVectors).
 func OpenCollectionStorePersistent(dir string, persistentCluster bool) (*CollectionStore, error) {
+	// No directory configured means heap mode. Give the store a private temp dir
+	// rather than letting every path resolve relative to the process's working
+	// directory: the on-disk layout below is an implementation detail of the
+	// running store, not something a caller who configured nothing asked to have
+	// written next to their binary — and reading it back on the next run made a
+	// fresh store inherit a previous one's collections.
+	ephemeral := false
+	if dir == "" {
+		td, err := os.MkdirTemp("", "rostam-heap-")
+		if err != nil {
+			return nil, fmt.Errorf("vector: create heap-mode scratch dir: %w", err)
+		}
+		dir, ephemeral = td, true
+	}
 	vd := filepath.Join(dir, "vectors")
 	if err := os.MkdirAll(vd, 0o750); err != nil {
 		return nil, fmt.Errorf("vector: mkdir %s: %w", vd, err)
 	}
-	s := &CollectionStore{dir: dir, persistentCluster: persistentCluster, collections: make(map[string]*Collection), multi: make(map[string]*MultiVectorIndex), named: make(map[string]*NamedCollection)}
+	s := &CollectionStore{dir: dir, ephemeralDir: ephemeral, persistentCluster: persistentCluster, collections: make(map[string]*Collection), multi: make(map[string]*MultiVectorIndex), named: make(map[string]*NamedCollection)}
 
 	// Cluster-persistent: the mmap files are a non-authoritative cache. Wipe any
 	// left by a prior process so Raft (FSM.Restore + log replay) is the single
@@ -1307,6 +1332,13 @@ func (s *CollectionStore) Close() error {
 	// Cold stubs hold no index/goroutine — just drop the catalog maps. Per-collection
 	// lastAccess lives on the Collection objects, which are dropped with s.collections.
 	s.cold = nil
+	// A heap-mode store owns its scratch dir, so it takes it with it. Failure is
+	// swallowed deliberately: the caller asked to close a store, and a leftover
+	// temp dir is not a reason to report that closing failed. It is under
+	// os.TempDir(), so the system reclaims it regardless.
+	if s.ephemeralDir && s.dir != "" {
+		_ = os.RemoveAll(s.dir)
+	}
 	return nil
 }
 


### PR DESCRIPTION
Closes #8.

## What was happening

`DirectConfig.DataDir` documents empty as *"heap mode (no persistence)"*, and `docs/concepts/deployment-modes.md` repeats it. What actually happened is that every store path became **relative**: `OpenCollectionStorePersistent` joins the configured dir with `"vectors"` and calls `MkdirAll` on it, so an empty dir means `./vectors/<tenant>/` in whatever working directory the process happens to have — written on create, read back on the next run.

```go
s1 := NewDirect(DirectConfig{Ops: reg})
s1.CreateCollection(ctx, "uniq", cfg)   // -> nil

s2 := NewDirect(DirectConfig{Ops: reg})  // a different store
s2.CreateCollection(ctx, "uniq", cfg)   // -> vector: collection already exists
```

Three consequences a caller who configured nothing would not expect: files appear next to their binary, a fresh store inherits a previous run's collections, and two independent stores in one process share a namespace.

It is also why the root-package suite was self-poisoning — the first run left `ok_unset.json` in the checkout and every later run in that directory failed. Invisible in CI, where a fresh runner is always the first run, and doubly invisible behind `gotestsum --rerun-fails=2`.

## The fix

At the single entry point rather than the ~15 filesystem calls downstream: with no directory configured the store allocates a private temp dir and removes it on `Close`. Every path below is unchanged, which is what keeps this small enough to review.

**What it deliberately does not do:** heap mode still writes to disk — just somewhere private and short-lived. Making it genuinely filesystem-free means guarding every call site and giving `Persistent`/`WAL` collections a real error when they have nowhere to live. Worth doing; wrong thing to bundle with this.

## Verification

Each new test was confirmed to fail with the fix reverted, not merely to pass with it:

```
heap mode wrote into the working directory: [vectors]
second store could not create "docs": vector: collection already exists
```

Also pinned, because the fix could plausibly have broken them: a duplicate create in **one** store is still refused, and the scratch dir does not outlive `Close`.

The previously self-poisoning test now passes three times in a row in the same directory, and the working tree stays clean afterwards.

**Suites:** `vector` (215s), `vector/analysis`, `shard`, `shard/pbisr` all green — `shard` matters because it calls the same entry point with a configured dir and must be unaffected. The full root package is running locally as I open this; I will post the result rather than leave it implied.

## Follow-up

#9 stays open for the test-side hardening (`t.Chdir`/explicit `DataDir`) and a CI guard that fails a run if the working tree gained files — that guard is what would have caught this years earlier.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved in-memory store isolation so independent stores no longer share collections.
  * Prevented heap-mode stores from writing temporary files to the working directory.
  * Ensured temporary storage is removed when a store closes or initialization fails.
  * Preserved duplicate collection validation within a single store.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->