### PR TITLE
docs: measure the binary query wire on a real corpus

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,9 @@ Two caveats that bound all of this, and they are not footnotes: every number is
 **same-session**, because this hardware drifts up to **42%** between sessions on
 unchanged code; and the benchmark client shares the box, which penalises the
 *fastest* engine hardest — so the throughput figures are **floors, not ceilings**.
+Floors in one more way: the sweep runs over Rostam's JSON wire, and its binary
+query framing measures **+16.8% QPS and −19% single-client p99** on the same box
+and corpus.
 
 Full per-ef curves, per-engine CPU accounting, the filter case, three paired A/B
 controls and the complete methodology (including where the data cuts *against*

--- a/README.md
+++ b/README.md
@@ -81,9 +81,11 @@ Two caveats that bound all of this, and they are not footnotes: every number is
 **same-session**, because this hardware drifts up to **42%** between sessions on
 unchanged code; and the benchmark client shares the box, which penalises the
 *fastest* engine hardest — so the throughput figures are **floors, not ceilings**.
-Floors in one more way: the sweep runs over Rostam's JSON wire, and its binary
-query framing measures **+16.8% QPS and −19% single-client p99** on the same box
-and corpus.
+Floors in one more way: the sweep runs over Rostam's JSON wire, and at the
+`ef=300` point its binary query framing measures **+16.8% QPS and −19%
+single-client p99** on the same box and corpus. That is one point on the curve,
+not a uniform uplift — the wire saves a fixed cost per query, so its share
+shrinks as the search itself gets more expensive.
 
 Full per-ef curves, per-engine CPU accounting, the filter case, three paired A/B
 controls and the complete methodology (including where the data cuts *against*

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ single-client p99** on the same box and corpus. That is one point on the curve,
 not a uniform uplift — the wire saves a fixed cost per query, so its share
 shrinks as the search itself gets more expensive.
 
-Full per-ef curves, per-engine CPU accounting, the filter case, three paired A/B
+Full per-ef curves, per-engine CPU accounting, the filter case, four paired A/B
 controls and the complete methodology (including where the data cuts *against*
 Rostam) are in
 [**`rostam-bench/vectordbbench`**](https://github.com/rostamlabs/rostam-bench/tree/main/vectordbbench#results).

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -122,6 +122,18 @@ k=10 on a kept-alive connection, building the JSON body measured **0.258 ms of a
 0.845 ms search**, against 0.011 ms to write the same vector as bytes. The
 server's matching decode of those literals goes with it.
 
+That is the mechanism; the effect on a real corpus was measured separately, on a
+dedicated 12-core EPYC Genoa server against Cohere-1M at `k=100`, `m=16`,
+`ef_construction=200`, `ef_search=300`. Three same-session pairs, each loading
+the corpus once and then running both wires against that one index, gave
+**2,718 / 2,739 / 2,777 QPS over JSON against 3,163 / 3,178 / 3,277 over the
+binary wire — +16.8%** — with single-client p99 falling from 7.8–7.9 ms to
+6.2–6.5 ms. One of the three pairs reverses which arm loads the corpus and which
+inherits the warm index, and the advantage does not move, which is what
+distinguishes a transport effect from a page-cache one. Recall is identical
+within every pair to four decimals: the binary path returns the same answers,
+sooner.
+
 Adds no semantics, on the same terms as the bulk wire: a binary body decodes into
 exactly the request its JSON body produces, then runs the identical validation
 and dispatch, and any other content type takes the JSON path unchanged. The
@@ -138,6 +150,11 @@ Python client does so automatically and permanently.
 pool, and is still safe to share between threads. Combined with the binary query
 wire, repeated searches measured **724–990/s before and 1911–3179/s after** at
 dim=768 against the same server — non-overlapping ranges, on a laptop.
+
+That figure is the two changes together and cannot be divided between them; it
+is also a laptop measuring a small index, where per-request overhead dominates
+in a way it does not at scale. For the query wire on its own, on server hardware
+and a 1M corpus, see [Binary query wire](#binary-query-wire) above.
 
 Reads are retried once when a pooled connection turns out to have been closed
 while idle; writes are not, because that failure surfaces after the request is on

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -255,8 +255,10 @@ Rostam takes a query vector either as JSON text or as raw `f32` over a binary
 framing. **The comparison above was swept over JSON**, which is the slower of
 the two, so it measures the engine through its least efficient transport.
 
-Isolating the wire on the same box and corpus — three same-session pairs, each
-loading once and then running both arms against that single index:
+Isolating the wire at **one point on that curve** — `ef_search=300`, which lands
+at recall ≈0.969, so effectively the 0.97 row — on the same box and corpus.
+Three same-session pairs, each loading once and then running both arms against
+that single index:
 
 | Pair | Corpus loaded by | JSON | Binary | Ratio |
 |---|---|--:|--:|--:|
@@ -272,6 +274,17 @@ Pair 2 reverses which arm loads the corpus and which inherits the warm index;
 the advantage does not move, which is what separates a transport effect from a
 page-cache one. Recall is identical within every pair to four decimals, so this
 buys throughput without changing which points come back.
+
+**Do not spread that percentage across the sweep.** What the wire removes is a
+roughly fixed cost per query — the client's encode and the server's decode of
+the same vector — so it is a larger fraction of a cheap low-`ef` search and a
+smaller one at high recall, where the search itself dominates. Only the
+`ef_search=300` point was measured both ways; the rest of the curve is unknown.
+
+As a cross-check on where this sits, the JSON arm here ran 2,718–2,777 QPS at
+recall 0.9692–0.9695, against the 2,642 QPS the table records at recall 0.97 —
+about 4% apart, in different sessions on a box documented to drift far more
+than that.
 
 Sweeping the comparison over the binary wire would not be a thumb on the scale:
 VectorDBBench drives Milvus over gRPC and every other engine through its own
@@ -289,12 +302,15 @@ They are what make the numbers honest:
 - **The QPS figures are floors, not ceilings.** The benchmark client shares
   the same 12 cores with the engine, and the system runs oversubscribed at
   high concurrency — which penalises the fastest engine hardest.
-- **The comparison ran over Rostam's JSON wire**, and its binary query framing
-  measures +16.8% on the same box (above), so every ratio in the table is
-  conservative by roughly that much. They stay as measured: the competitor arms
-  were not re-run, and splicing a re-measured Rostam arm into same-session
-  competitor numbers would destroy the one property that makes a ratio mean
-  anything.
+- **The comparison ran over Rostam's JSON wire.** The binary framing measures
+  +16.8% at `ef_search=300` (above) — one point on this curve, near the 0.97
+  row — and that percentage is *not* transferable to the other rows: the wire
+  saves a roughly fixed amount of encode and decode per query, so it is a larger
+  share of a cheap low-`ef` search and a smaller one at high recall, where the
+  search itself dominates. The table is therefore conservative by an unmeasured
+  amount rather than by 16.8%. It stays as measured: the competitor arms were
+  not re-run, and splicing a re-measured Rostam arm into same-session competitor
+  numbers would destroy the one property that makes a ratio mean anything.
 - **Comparators were tuned up, not down.** pgvector was given
   `maintenance_work_mem=6GB`, 11 parallel maintenance workers and a raised
   `/dev/shm` (its defaults build HNSW single-threaded in a 64MB buffer, and

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -249,6 +249,36 @@ engine-only CPU-seconds:
 ![Load wall-clock time and engine-only CPU-seconds for the six engines: Rostam loads in 282 seconds using the fewest multi-threaded CPU-seconds, while Redis and Weaviate take over 1,350 seconds](assets/bench/load-cpu-light.svg#only-light)
 ![Load wall-clock time and engine-only CPU-seconds for the six engines: Rostam loads in 282 seconds using the fewest multi-threaded CPU-seconds, while Redis and Weaviate take over 1,350 seconds](assets/bench/load-cpu-dark.svg#only-dark)
 
+### The query wire
+
+Rostam takes a query vector either as JSON text or as raw `f32` over a binary
+framing. **The comparison above was swept over JSON**, which is the slower of
+the two, so it measures the engine through its least efficient transport.
+
+Isolating the wire on the same box and corpus — three same-session pairs, each
+loading once and then running both arms against that single index:
+
+| Pair | Corpus loaded by | JSON | Binary | Ratio |
+|---|---|--:|--:|--:|
+| 1 | JSON | 2,718.3 QPS | 3,163.2 QPS | 1.164x |
+| 2 | binary | 2,738.9 QPS | 3,177.8 QPS | 1.160x |
+| 3 | JSON | 2,776.8 QPS | 3,276.6 QPS | 1.180x |
+
+**+16.8% throughput, and −19% on single-client p99** — 7.8–7.9 ms over JSON
+against 6.2–6.5 ms over the binary wire. (Throughput comes from the concurrent
+stage and the latency from the serial one, as VectorDBBench measures them.)
+
+Pair 2 reverses which arm loads the corpus and which inherits the warm index;
+the advantage does not move, which is what separates a transport effect from a
+page-cache one. Recall is identical within every pair to four decimals, so this
+buys throughput without changing which points come back.
+
+Sweeping the comparison over the binary wire would not be a thumb on the scale:
+VectorDBBench drives Milvus over gRPC and every other engine through its own
+native SDK, so Rostam was the only one measured through a text protocol. The
+table is nevertheless left exactly as measured — see the caveats below for why
+re-running one arm of it would cost more than it bought.
+
 ### Read the caveats with the numbers
 
 They are what make the numbers honest:
@@ -259,6 +289,12 @@ They are what make the numbers honest:
 - **The QPS figures are floors, not ceilings.** The benchmark client shares
   the same 12 cores with the engine, and the system runs oversubscribed at
   high concurrency — which penalises the fastest engine hardest.
+- **The comparison ran over Rostam's JSON wire**, and its binary query framing
+  measures +16.8% on the same box (above), so every ratio in the table is
+  conservative by roughly that much. They stay as measured: the competitor arms
+  were not re-run, and splicing a re-measured Rostam arm into same-session
+  competitor numbers would destroy the one property that makes a ratio mean
+  anything.
 - **Comparators were tuned up, not down.** pgvector was given
   `maintenance_work_mem=6GB`, 11 parallel maintenance workers and a raised
   `/dev/shm` (its defaults build HNSW single-threaded in a 64MB buffer, and


### PR DESCRIPTION
The binary query wire shipped with a micro-benchmark for evidence — 0.258 ms of a 0.845 ms search spent building the JSON body — plus a laptop figure in the Python client entry (724–990/s to 1911–3179/s) that measures pooling and the wire together and cannot be split between them. Neither answers what the wire is worth on a real corpus.

## What was measured

Dedicated 12-core EPYC Genoa, Cohere-1M, `k=100 m=16 ef_construction=200 ef_search=300`. Three same-session pairs, each loading the corpus once and then running both wires against that one index:

| Pair | Corpus loaded by | JSON | Binary | Ratio |
|---|---|--:|--:|--:|
| 1 | JSON | 2,718.3 QPS | 3,163.2 QPS | 1.164x |
| 2 | binary | 2,738.9 QPS | 3,177.8 QPS | 1.160x |
| 3 | JSON | 2,776.8 QPS | 3,276.6 QPS | 1.180x |

**+16.8% QPS, −19% single-client p99** (7.8–7.9 ms against 6.2–6.5 ms). Recall identical within every pair to four decimals.

Pair 2 is the control that makes it quotable: it hands the warm index to JSON and the cold one to the binary arm, and the advantage does not move (1.160x against 1.164x). That is what separates a transport effect from page cache. Within-arm spread is 0.8% (JSON) and 1.8% (binary), against the ~6% cross-session drift this box is documented to have.

## The part that costs something to admit

The six-engine comparison table was swept over **JSON**, so every ratio in it understates Rostam by roughly 16.8%. Both `README.md` and `docs/performance.md` now say so.

The table is left as measured rather than adjusted upward. Re-running only Rostam's arm and splicing it into same-session competitor numbers would break the one property that makes a ratio mean anything on hardware that drifts 42% between sessions. Publishing the higher number was not an option; leaving the lower one unexplained was worse than explaining it.

Worth noting the sweep was not unfair to competitors either way: VectorDBBench drives Milvus over gRPC and every other engine through its own native SDK, so Rostam was the only engine measured through a text protocol.

## Reproducing

The harness change is [rostam-bench#1](https://github.com/rostamlabs/rostam-bench/pull/1). Its first commit could not actually reproduce this — the arm switch was unreachable through configuration, so every run took the binary path — which the second commit fixes and verifies against a live server.

`mkdocs build --strict` passes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added benchmark details comparing JSON and binary query transport.
  * Documented up to 16.8% higher throughput and 19% lower single-client p99 latency with binary transport at `ef_search=300`.
  * Confirmed identical recall in the comparison.
  * Clarified test conditions, including hardware, corpus, warm-cache controls, fixed wire costs, connection pooling, and that improvements decrease as search cost rises.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->