### PR TITLE
LLM caching proxy: point base_url at Rostam, cut the bill

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,9 +39,10 @@ reference, client config snippets, and embedder configuration.
 ## LLM response caching
 
 `rostam-server llm-proxy` is an OpenAI-compatible caching reverse proxy:
-change one line (`base_url="http://localhost:8484/v1"`) and every repeated
-chat-completions request is answered from a local semantic cache instead of
-hitting the upstream API. Exact byte-identical matching works out of the
+change one line (`base_url="http://localhost:8484/v1"`) and an eligible
+repeated chat-completions request — cacheable shape, matching scope, and a
+prompt that hits the cache — is answered from a local semantic cache instead
+of hitting the upstream API. Exact byte-identical matching works out of the
 box with no embedding key; pointing it at an OpenAI-compatible embedder
 upgrades it to matching near-duplicate prompts too.
 

--- a/README.md
+++ b/README.md
@@ -36,6 +36,22 @@ claude mcp add rostam -- rostam-server mcp
 → [MCP server](https://docs.rostamlabs.com/server/mcp/) for the full tool
 reference, client config snippets, and embedder configuration.
 
+### LLM response caching
+
+`rostam-server llm-proxy` is an OpenAI-compatible caching reverse proxy:
+change one line (`base_url="http://localhost:8484/v1"`) and every repeated
+chat-completions request is answered from a local semantic cache instead of
+hitting the upstream API. Exact byte-identical matching works out of the
+box with no embedding key; pointing it at an OpenAI-compatible embedder
+upgrades it to matching near-duplicate prompts too.
+
+```sh
+rostam-server llm-proxy
+```
+
+→ [LLM caching proxy](https://docs.rostamlabs.com/server/llm-proxy/) for
+flags, cache-scoping rules, and what's never cached.
+
 And two engines, usable together or entirely on their own:
 
 - a **vector search engine** ([`vector/`](./vector)) — HNSW, IVF and Vamana

--- a/cmd/rostam-server/llmproxy.go
+++ b/cmd/rostam-server/llmproxy.go
@@ -11,7 +11,9 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"os/signal"
 	"path/filepath"
+	"syscall"
 	"time"
 
 	rostam "github.com/rostamlabs/rostam"
@@ -142,14 +144,47 @@ func runLlmProxyCmd(args []string) {
 		Addr:    fl.listen,
 		Handler: rt.handler,
 		// ReadHeaderTimeout closes the classic slowloris window (a client that
-		// dribbles request headers). ReadTimeout/WriteTimeout are deliberately
-		// left at 0 (no limit): a streaming chat completion legitimately holds
-		// the connection open for as long as the upstream keeps producing SSE
-		// chunks, which can run well past any fixed request timeout.
+		// dribbles request headers). ReadTimeout bounds the body-read phase so
+		// a slow-body client can't hold a handler goroutine open forever; 5
+		// minutes is generous even on a poor connection for the 16 MiB
+		// chat-completions body cap (llmproxy.maxBodyBytes), and it is the
+		// only bound the uncapped passthrough routes get. IdleTimeout closes a
+		// keep-alive connection that goes quiet between requests. WriteTimeout
+		// is deliberately left at 0 (no limit): a streaming chat completion
+		// legitimately holds the connection open for as long as the upstream
+		// keeps producing SSE chunks, which can run well past any fixed
+		// timeout — bounding writes would cut off a real response, not just a
+		// slow client.
 		ReadHeaderTimeout: 10 * time.Second,
+		ReadTimeout:       5 * time.Minute,
+		IdleTimeout:       2 * time.Minute,
 	}
 	slog.Info("llm-proxy: serving", "addr", fl.listen, "upstream", fl.upstream, "mode", rt.mode, "collection", fl.collection)
-	serveErr := srv.ListenAndServe()
+
+	// Same reasoning as runMcpCmd: SIGINT/SIGTERM default to killing the
+	// process immediately, before the close below flushes engine state. An
+	// in-flight streaming relay deserves the same clean-shutdown treatment as
+	// an in-flight tool call, so Shutdown is given a bounded window to let
+	// active requests finish rather than cutting them off mid-response.
+	sigCh := make(chan os.Signal, 1)
+	signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM)
+	defer signal.Stop(sigCh)
+
+	serveDone := make(chan error, 1)
+	go func() { serveDone <- srv.ListenAndServe() }()
+
+	var serveErr error
+	select {
+	case serveErr = <-serveDone:
+	case <-sigCh:
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		if err := srv.Shutdown(shutdownCtx); err != nil {
+			slog.Error("llm-proxy: shutdown", "err", err)
+		}
+		cancel()
+		serveErr = <-serveDone
+	}
+
 	// Close before unlocking, same ordering as runMcpCmd: the store's own
 	// shutdown may still write to the data dir, so releasing the lock first
 	// would let a waiting process in mid-write.

--- a/cmd/rostam-server/llmproxy.go
+++ b/cmd/rostam-server/llmproxy.go
@@ -1,0 +1,275 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"context"
+	"errors"
+	"flag"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"net/url"
+	"os"
+	"path/filepath"
+	"time"
+
+	rostam "github.com/rostamlabs/rostam"
+	"github.com/rostamlabs/rostam/llmproxy"
+	"github.com/rostamlabs/rostam/ops"
+	"github.com/rostamlabs/rostam/semcache"
+)
+
+// llmproxyDataAuto is the -data sentinel default, mirroring mcpDataAuto:
+// "auto" resolves to ~/.rostam/llmcache (created if missing); an explicit
+// -data "" selects heap/ephemeral mode instead. See mcpDataAuto for why the
+// sentinel exists (a plain "" default would be indistinguishable from an
+// operator explicitly asking for heap mode).
+const llmproxyDataAuto = "auto"
+
+// exactThreshold is the cosine-similarity hit floor used in "exact" mode (no
+// hosted embedder configured): the stub embedder's vector for a given text is
+// deterministic, so only a byte-identical prompt should ever score this high.
+// It is not 1.0 to leave a hair of floating-point slack.
+const exactThreshold = 0.999
+
+// llmproxyFlags holds the parsed `llm-proxy` subcommand flags. It is passed
+// to llmproxySetup as plain data so setup logic is unit-testable without
+// touching flag.FlagSet or the real environment.
+type llmproxyFlags struct {
+	storeFlags
+	listen     string
+	upstream   string
+	collection string
+	threshold  float64
+	maxTemp    float64
+	ttl        time.Duration
+	insecure   bool
+}
+
+// llmproxyRuntime is what llmproxySetup produces: a ready store, the cache
+// built on top of it, and the HTTP handler runLlmProxyCmd serves.
+type llmproxyRuntime struct {
+	store   rostam.Store
+	cache   *semcache.Cache
+	handler http.Handler
+	mode    string // "exact" | "semantic"
+}
+
+// runLlmProxyCmd implements `rostam-server llm-proxy`: an OpenAI-compatible
+// caching reverse proxy backed by a rostam.Store semantic cache. Like
+// runMcpCmd, it owns its own FlagSet and process exit.
+func runLlmProxyCmd(args []string) {
+	fs := flag.NewFlagSet("llm-proxy", flag.ExitOnError)
+	var fl llmproxyFlags
+	fs.StringVar(&fl.data, "data", llmproxyDataAuto,
+		`data directory for embedded mode: "auto" (default) resolves to `+
+			`~/.rostam/llmcache (created if missing); "" runs heap/ephemeral `+
+			`(no persistence); any other value is used as given. Mutually `+
+			`exclusive with -connect`)
+	fs.StringVar(&fl.connect, "connect", "",
+		"connect to a remote rostam-server instead of running embedded (host:port); mutually exclusive with -data")
+	fs.StringVar(&fl.authToken, "auth-token", "",
+		"bearer token for -connect (PREFER the ROSTAM_AUTH_TOKEN environment variable: a flag-passed secret is visible to other local users via /proc and shell history)")
+	fs.StringVar(&fl.tlsCA, "tls-ca", "", "CA bundle PEM to verify the remote server's certificate (-connect)")
+	fs.StringVar(&fl.tlsCert, "tls-cert", "", "client certificate PEM for mTLS (-connect; requires -tls-key)")
+	fs.StringVar(&fl.tlsKey, "tls-key", "", "client private key PEM for mTLS (-connect; requires -tls-cert)")
+	fs.StringVar(&fl.tlsServer, "tls-server-name", "", "expected server certificate name (SNI + verification) for -connect")
+	fs.StringVar(&fl.listen, "listen", "127.0.0.1:8484", "HTTP listen address for the proxy")
+	fs.StringVar(&fl.upstream, "upstream", "https://api.openai.com", "upstream OpenAI-compatible API base URL")
+	fs.StringVar(&fl.collection, "collection", "llm-cache", "cache collection name (created if absent)")
+	fs.Float64Var(&fl.threshold, "threshold", 0, "cosine-similarity hit floor (0 = mode default: 0.999 in exact mode, 0.97 in semantic mode)")
+	fs.Float64Var(&fl.maxTemp, "max-temp", 1.0, "do not cache chat requests with a temperature above this")
+	fs.DurationVar(&fl.ttl, "ttl", 168*time.Hour, "per-entry cache expiry")
+	fs.BoolVar(&fl.insecure, "insecure", false, "acknowledge running with a non-loopback -listen (the proxy has no auth layer of its own); for dev/trusted-network use only")
+	if err := fs.Parse(args); err != nil {
+		os.Exit(2)
+	}
+
+	// Was -data given explicitly on the command line, as opposed to sitting
+	// at its "auto" default? Same trick as runMcpCmd: llmproxySetup's
+	// -data/-connect conflict check works on plain non-empty-string tests,
+	// and "auto" is itself non-empty, so a caller who passed ONLY -connect
+	// must not have -data resolved to a real (equally non-empty) path below.
+	dataExplicit := false
+	fs.Visit(func(f *flag.Flag) {
+		if f.Name == "data" {
+			dataExplicit = true
+		}
+	})
+
+	switch {
+	case fl.connect != "" && !dataExplicit:
+		// -data is still at its unset "auto" default; treat it as absent so
+		// the store-selection logic below cleanly picks the -connect path.
+		fl.data = ""
+	case fl.data == llmproxyDataAuto:
+		// Resolved HERE, not in llmproxySetup: llmproxySetup must stay pure
+		// (table-driven-testable with no real filesystem or HOME dependency),
+		// so home-dir resolution belongs in the subcommand entry point.
+		home, err := os.UserHomeDir()
+		if err != nil {
+			fatal("llm-proxy: resolving home directory for -data", "err", err)
+		}
+		fl.data = filepath.Join(home, ".rostam", "llmcache")
+	}
+
+	// Claim the data dir before opening it. Only embedded mode with a real
+	// directory needs this: heap mode (-data "") has nothing on disk to
+	// share, and -connect's concurrency is the remote server's problem.
+	unlock := func() error { return nil }
+	if fl.connect == "" {
+		var lerr error
+		unlock, lerr = claimDataDir(fl.data)
+		switch {
+		case errors.Is(lerr, errDataDirBusy):
+			fatal("llm-proxy: another rostam-server llm-proxy process is using this data directory; "+
+				"a data dir has one writer, so concurrent proxies must share one server over -connect "+
+				"instead of each embedding their own",
+				"dir", fl.data, "err", lerr)
+		case lerr != nil:
+			fatal("llm-proxy: claiming -data directory", "dir", fl.data, "err", lerr)
+		}
+	}
+
+	rt, err := llmproxySetup(fl, os.LookupEnv)
+	if err != nil {
+		_ = unlock()
+		fatal("llm-proxy: setup failed", "err", err)
+	}
+
+	srv := &http.Server{
+		Addr:    fl.listen,
+		Handler: rt.handler,
+		// ReadHeaderTimeout closes the classic slowloris window (a client that
+		// dribbles request headers). ReadTimeout/WriteTimeout are deliberately
+		// left at 0 (no limit): a streaming chat completion legitimately holds
+		// the connection open for as long as the upstream keeps producing SSE
+		// chunks, which can run well past any fixed request timeout.
+		ReadHeaderTimeout: 10 * time.Second,
+	}
+	slog.Info("llm-proxy: serving", "addr", fl.listen, "upstream", fl.upstream, "mode", rt.mode, "collection", fl.collection)
+	serveErr := srv.ListenAndServe()
+	// Close before unlocking, same ordering as runMcpCmd: the store's own
+	// shutdown may still write to the data dir, so releasing the lock first
+	// would let a waiting process in mid-write.
+	closeErr := rt.store.Close()
+	_ = unlock()
+	if serveErr != nil && !errors.Is(serveErr, http.ErrServerClosed) {
+		fatal("llm-proxy: serve failed", "err", serveErr)
+	}
+	if closeErr != nil {
+		fatal("llm-proxy: store close failed", "err", closeErr)
+	}
+}
+
+// llmproxySetup turns parsed flags + an environment lookup into a ready
+// llmproxyRuntime. All validation (the upstream URL, the -data/-connect
+// conflict, the embedder env combination, the exposed-listen gate) runs
+// before any I/O, so a misconfiguration is reported without ever touching
+// disk or dialing a remote server — mirrors mcpSetup.
+func llmproxySetup(fl llmproxyFlags, lookupEnv func(string) (string, bool)) (llmproxyRuntime, error) {
+	upstream, err := url.Parse(fl.upstream)
+	if err != nil || !upstream.IsAbs() || (upstream.Scheme != "http" && upstream.Scheme != "https") {
+		return llmproxyRuntime{}, fmt.Errorf("llm-proxy: -upstream must be an absolute http(s) URL, got %q", fl.upstream)
+	}
+
+	if fl.data != "" && fl.connect != "" {
+		return llmproxyRuntime{}, errors.New("llm-proxy: use -data or -connect, not both")
+	}
+
+	embedder, err := embedderFromEnv(lookupEnv)
+	if err != nil {
+		return llmproxyRuntime{}, err
+	}
+
+	// exposedBind is the SAME loopback test the main server's own -insecure
+	// gate uses (127.0.0.0/8, ::1, and the literal "localhost" are not
+	// exposed; an unparseable address or anything else is treated as exposed
+	// and refused without -insecure). Reusing it keeps the two gates from
+	// silently drifting apart, and it never resolves DNS — a hostname other
+	// than "localhost" is conservatively treated as exposed.
+	if exposedBind(fl.listen) && !fl.insecure {
+		return llmproxyRuntime{}, fmt.Errorf("llm-proxy: refusing to bind non-loopback -listen %q with no auth layer of its own; "+
+			"bind a loopback address (127.0.0.1/localhost) or pass -insecure to run open deliberately (dev/trusted-network only)", fl.listen)
+	}
+
+	mode, threshold, embedder := llmproxyModeThreshold(embedder, fl.threshold)
+
+	reg := ops.NewRegistry()
+	if err := ops.RegisterBuiltins(reg); err != nil {
+		return llmproxyRuntime{}, fmt.Errorf("llm-proxy: register ops: %w", err)
+	}
+
+	var store rostam.Store
+	if fl.connect != "" {
+		store, err = connectStore(fl.storeFlags, reg, lookupEnv)
+	} else {
+		// Same sizing precedent as mcpSetup (see its comment): this is one
+		// process's cache, reached over ordinary HTTP concurrency, not a
+		// multi-tenant server — 8 shards and a 256 MiB KV budget are ample
+		// bookkeeping headroom without the server-sized defaults (256
+		// shards, a host-RAM-fraction budget) turning a fresh -data dir into
+		// hundreds of shard directories before a single entry is cached.
+		store, err = rostam.NewDirect(rostam.DirectConfig{
+			DataDir: fl.data,
+			Ops:     reg,
+			Cache:   rostam.CacheConfig{NumShardsPerNode: 8, MaxMemoryBytes: 256 << 20},
+		})
+	}
+	if err != nil {
+		return llmproxyRuntime{}, err
+	}
+
+	cache, err := semcache.New(context.Background(), semcache.Config{
+		Store:      store,
+		Embedder:   embedder,
+		Collection: fl.collection,
+		Threshold:  threshold,
+		TTL:        fl.ttl,
+		MaxTemp:    fl.maxTemp,
+	})
+	if err != nil {
+		_ = store.Close()
+		return llmproxyRuntime{}, fmt.Errorf("llm-proxy: cache init: %w", err)
+	}
+
+	proxy, err := llmproxy.NewServer(llmproxy.Config{
+		Cache:    cache,
+		Upstream: upstream,
+		MaxTemp:  fl.maxTemp,
+		Mode:     mode,
+	})
+	if err != nil {
+		_ = store.Close()
+		return llmproxyRuntime{}, fmt.Errorf("llm-proxy: proxy init: %w", err)
+	}
+
+	return llmproxyRuntime{store: store, cache: cache, handler: proxy.Handler(), mode: mode}, nil
+}
+
+// llmproxyModeThreshold resolves the cache mode, similarity threshold, and
+// effective embedder from the (possibly nil) hosted embedder produced by
+// embedderFromEnv and the -threshold flag. Split out from llmproxySetup so
+// the defaulting rules are unit-testable without building a store:
+//   - embedder == nil (no ROSTAM_EMBED_* env): "exact" mode with a
+//     deterministic stub embedder; a zero flagThreshold defaults to
+//     exactThreshold (0.999) rather than semcache's looser default, since a
+//     stub embedder carries no real semantic meaning to compare on.
+//   - embedder != nil: "semantic" mode using the hosted embedder as given; a
+//     zero flagThreshold defaults to semcache.DefaultThreshold (0.97).
+//   - a non-zero flagThreshold always wins, in either mode.
+func llmproxyModeThreshold(embedder semcache.Embedder, flagThreshold float64) (mode string, threshold float64, resolved semcache.Embedder) {
+	if embedder != nil {
+		threshold = flagThreshold
+		if threshold == 0 {
+			threshold = semcache.DefaultThreshold
+		}
+		return "semantic", threshold, embedder
+	}
+	threshold = flagThreshold
+	if threshold == 0 {
+		threshold = exactThreshold
+	}
+	return "exact", threshold, semcache.NewStubEmbedder("exact", 64)
+}

--- a/cmd/rostam-server/llmproxy.go
+++ b/cmd/rostam-server/llmproxy.go
@@ -237,7 +237,6 @@ func llmproxySetup(fl llmproxyFlags, lookupEnv func(string) (string, bool)) (llm
 	proxy, err := llmproxy.NewServer(llmproxy.Config{
 		Cache:    cache,
 		Upstream: upstream,
-		MaxTemp:  fl.maxTemp,
 		Mode:     mode,
 	})
 	if err != nil {

--- a/cmd/rostam-server/llmproxy_signal_test.go
+++ b/cmd/rostam-server/llmproxy_signal_test.go
@@ -1,0 +1,121 @@
+// SPDX-License-Identifier: Apache-2.0
+//go:build unix
+
+package main
+
+import (
+	"net"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"syscall"
+	"testing"
+	"time"
+)
+
+// freeListenAddr picks an available loopback port for a child llm-proxy to
+// bind, closing the probe listener immediately so the child can claim it.
+// The gap between close and the child's own bind is a race in principle, but
+// negligible in practice for a short-lived local test.
+func freeListenAddr(t *testing.T) string {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("finding a free port: %v", err)
+	}
+	addr := ln.Addr().String()
+	_ = ln.Close()
+	return addr
+}
+
+// startLlmProxy starts a `rostam-server llm-proxy` child process against
+// dataDir and listen, capturing its stderr for diagnostics on failure.
+// syncBuffer and buildServer are shared with mcp_signal_test.go (same
+// package, same build tag).
+func startLlmProxy(t *testing.T, bin, dataDir, listen string) (*exec.Cmd, *syncBuffer) {
+	t.Helper()
+	cmd := exec.Command(bin, "llm-proxy", "-data", dataDir, "-listen", listen)
+	// Pin exact mode explicitly, same reasoning as startMcp: a hosted embedder
+	// configured in the developer's own environment must not change the mode
+	// this test runs in.
+	cmd.Env = append(os.Environ(), "ROSTAM_EMBED_ENDPOINT=")
+	logs := &syncBuffer{}
+	cmd.Stderr = logs
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("starting %s: %v", bin, err)
+	}
+	// Backstop: a child left running would hold the data dir lock and wedge
+	// the rest of the test. Kill is a no-op once the process has exited.
+	t.Cleanup(func() { _ = cmd.Process.Kill() })
+	return cmd, logs
+}
+
+// waitForListen polls GET /stats until the proxy answers or the deadline
+// passes, so the test never sends a signal before the server has bound its
+// listener.
+func waitForListen(t *testing.T, listen string, logs *syncBuffer) {
+	t.Helper()
+	deadline := time.Now().Add(10 * time.Second)
+	url := "http://" + listen + "/stats"
+	for time.Now().Before(deadline) {
+		resp, err := http.Get(url)
+		if err == nil {
+			_ = resp.Body.Close()
+			if resp.StatusCode == http.StatusOK {
+				return
+			}
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	t.Fatalf("llm-proxy never answered %s within the deadline\nserver log:\n%s", url, logs)
+}
+
+// TestLlmProxySIGTERMExitsCleanlyAndReleasesLock is the shutdown contract for
+// `rostam-server llm-proxy`, mirroring TestMcpSIGTERMFlushesMemory: the
+// default disposition for SIGINT/SIGTERM is to kill the process immediately,
+// before store.Close and the -data lock release run. Unlike the MCP server's
+// memory collections, the llm-proxy cache is created non-persistent
+// regardless of -data (see doc.go's "Honest limits"), so there is nothing to
+// flush across a restart — what has to hold is a clean process exit and the
+// data-dir lock actually being released, which this proves by starting a
+// second process against the same -data directory immediately afterward and
+// requiring it to come up rather than being refused with "another process is
+// using this data directory".
+//
+// This has to be a real subprocess: the behavior under test is what the OS
+// does to a process that has not installed a handler.
+func TestLlmProxySIGTERMExitsCleanlyAndReleasesLock(t *testing.T) {
+	if testing.Short() {
+		t.Skip("compiles the rostam-server binary and runs it as a subprocess")
+	}
+	bin := buildServer(t)
+	dataDir := filepath.Join(t.TempDir(), "llmcache")
+	listen := freeListenAddr(t)
+
+	cmd, logs := startLlmProxy(t, bin, dataDir, listen)
+	waitForListen(t, listen, logs)
+
+	if err := cmd.Process.Signal(syscall.SIGTERM); err != nil {
+		t.Fatalf("SIGTERM: %v", err)
+	}
+	waited := make(chan error, 1)
+	go func() { waited <- cmd.Wait() }()
+	select {
+	case err := <-waited:
+		if err != nil {
+			t.Fatalf("the server should exit cleanly on SIGTERM, got %v\nserver log:\n%s", err, logs)
+		}
+	case <-time.After(30 * time.Second):
+		t.Fatalf("the server did not exit within 30s of SIGTERM\nserver log:\n%s", logs)
+	}
+
+	// Second process over the same data directory, started right after the
+	// first exited: a leaked lock would refuse this outright, and
+	// waitForListen's own deadline would catch a process that never comes up.
+	listen2 := freeListenAddr(t)
+	cmd2, logs2 := startLlmProxy(t, bin, dataDir, listen2)
+	waitForListen(t, listen2, logs2)
+	_ = cmd2.Process.Kill()
+	_ = cmd2.Wait()
+}

--- a/cmd/rostam-server/llmproxy_test.go
+++ b/cmd/rostam-server/llmproxy_test.go
@@ -1,0 +1,215 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/rostamlabs/rostam/semcache"
+)
+
+// baseLlmproxyFlags returns a minimal valid llmproxyFlags (heap store, default
+// upstream, loopback listen) that individual test cases mutate one field at a
+// time — keeping each table entry focused on the one thing it's testing.
+func baseLlmproxyFlags() llmproxyFlags {
+	return llmproxyFlags{
+		storeFlags: storeFlags{data: ""}, // heap mode: no real filesystem touched
+		listen:     "127.0.0.1:8484",
+		upstream:   "https://api.openai.com",
+		collection: "llm-cache",
+		maxTemp:    1.0,
+		ttl:        168 * time.Hour,
+	}
+}
+
+func TestLlmproxySetup_BadUpstreamURL(t *testing.T) {
+	for _, u := range []string{
+		"not-a-url",         // no scheme: not absolute
+		"ftp://example.com", // wrong scheme
+		"://bad",            // fails url.Parse outright
+		"",                  // empty
+	} {
+		t.Run(u, func(t *testing.T) {
+			fl := baseLlmproxyFlags()
+			fl.upstream = u
+			_, err := llmproxySetup(fl, noEnv)
+			if err == nil {
+				t.Fatalf("upstream %q: expected an error", u)
+			}
+			if !strings.Contains(err.Error(), "-upstream") {
+				t.Errorf("upstream %q: error should mention -upstream, got: %v", u, err)
+			}
+		})
+	}
+}
+
+func TestLlmproxySetup_DataAndConnectConflict(t *testing.T) {
+	fl := baseLlmproxyFlags()
+	fl.data = "/some/dir"
+	fl.connect = "127.0.0.1:7000"
+	_, err := llmproxySetup(fl, noEnv)
+	if err == nil {
+		t.Fatal("expected an error when both -data and -connect are set")
+	}
+	if !strings.Contains(err.Error(), "-data") || !strings.Contains(err.Error(), "-connect") {
+		t.Errorf("error should name both -data and -connect, got: %v", err)
+	}
+}
+
+func TestLlmproxySetup_IncompleteEmbedderEnv(t *testing.T) {
+	fl := baseLlmproxyFlags()
+	_, err := llmproxySetup(fl, envMap(map[string]string{
+		"ROSTAM_EMBED_ENDPOINT": "http://localhost:11434/v1/embeddings",
+		// ROSTAM_EMBED_MODEL and ROSTAM_EMBED_DIM missing
+	}))
+	if err == nil {
+		t.Fatal("expected an error for an incomplete embedder env")
+	}
+	if !strings.Contains(err.Error(), "ROSTAM_EMBED_MODEL") {
+		t.Errorf("error should name the missing ROSTAM_EMBED_MODEL, got: %v", err)
+	}
+}
+
+func TestLlmproxySetup_ListenLoopbackGate(t *testing.T) {
+	tests := []struct {
+		name     string
+		listen   string
+		insecure bool
+		wantErr  bool
+	}{
+		{"non-loopback without insecure => error", "0.0.0.0:8484", false, true},
+		{"loopback IP => ok", "127.0.0.1:8484", false, false},
+		{"literal localhost => ok", "localhost:8484", false, false},
+		{"non-loopback with insecure => ok", "0.0.0.0:8484", true, false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			fl := baseLlmproxyFlags()
+			fl.listen = tc.listen
+			fl.insecure = tc.insecure
+			rt, err := llmproxySetup(fl, noEnv)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatal("expected an error")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			defer rt.store.Close()
+		})
+	}
+}
+
+// TestLlmproxyModeThreshold exercises the mode/threshold defaulting rules in
+// isolation (no store needed): no embedder => exact mode, 0.999 default
+// floor; an embedder => semantic mode, semcache.DefaultThreshold (0.97)
+// default floor; an explicit non-zero -threshold always wins.
+func TestLlmproxyModeThreshold(t *testing.T) {
+	tests := []struct {
+		name          string
+		embedder      semcache.Embedder
+		flagThreshold float64
+		wantMode      string
+		wantThreshold float64
+	}{
+		{"no embedder, no flag => exact, 0.999", nil, 0, "exact", exactThreshold},
+		{"embedder set, no flag => semantic, 0.97", semcache.NewStubEmbedder("hosted", 8), 0, "semantic", semcache.DefaultThreshold},
+		{"no embedder, explicit flag wins", nil, 0.5, "exact", 0.5},
+		{"embedder set, explicit flag wins", semcache.NewStubEmbedder("hosted", 8), 0.5, "semantic", 0.5},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			mode, threshold, resolved := llmproxyModeThreshold(tc.embedder, tc.flagThreshold)
+			if mode != tc.wantMode {
+				t.Errorf("mode = %q, want %q", mode, tc.wantMode)
+			}
+			if threshold != tc.wantThreshold {
+				t.Errorf("threshold = %v, want %v", threshold, tc.wantThreshold)
+			}
+			if resolved == nil {
+				t.Fatal("resolved embedder must never be nil")
+			}
+		})
+	}
+}
+
+func TestLlmproxySetup_ModeFromEnv(t *testing.T) {
+	tests := []struct {
+		name     string
+		env      map[string]string
+		wantMode string
+	}{
+		{"no env => exact", nil, "exact"},
+		{
+			"full embedder env => semantic",
+			map[string]string{
+				"ROSTAM_EMBED_ENDPOINT": "http://localhost:11434/v1/embeddings",
+				"ROSTAM_EMBED_MODEL":    "nomic-embed-text",
+				"ROSTAM_EMBED_DIM":      "768",
+			},
+			"semantic",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			fl := baseLlmproxyFlags()
+			rt, err := llmproxySetup(fl, envMap(tc.env))
+			if err != nil {
+				t.Fatalf("llmproxySetup: unexpected error: %v", err)
+			}
+			defer rt.store.Close()
+			if rt.mode != tc.wantMode {
+				t.Errorf("mode = %q, want %q", rt.mode, tc.wantMode)
+			}
+			if rt.handler == nil {
+				t.Error("handler must not be nil")
+			}
+		})
+	}
+}
+
+// TestLlmproxySetup_HeapModeCacheRoundTrip proves the built runtime is
+// actually usable: a Store/Lookup round trip through rt.cache is the only
+// reliable signal the cache (and the store underneath it) is wired up
+// correctly, not just that the constructors returned non-nil values.
+func TestLlmproxySetup_HeapModeCacheRoundTrip(t *testing.T) {
+	fl := baseLlmproxyFlags()
+	rt, err := llmproxySetup(fl, noEnv)
+	if err != nil {
+		t.Fatalf("llmproxySetup: %v", err)
+	}
+	defer rt.store.Close()
+
+	ctx := context.Background()
+	scope := semcache.Scope{Model: "gpt-4o-mini", Temperature: 0}
+	prompt := "what is the capital of France?"
+
+	if _, found, err := rt.cache.Lookup(ctx, prompt, scope); err != nil {
+		t.Fatalf("Lookup (miss): %v", err)
+	} else if found {
+		t.Fatal("expected a clean miss before any Store")
+	}
+
+	if err := rt.cache.Store(ctx, prompt, scope, "Paris", 3); err != nil {
+		t.Fatalf("Store: %v", err)
+	}
+
+	hit, found, err := rt.cache.Lookup(ctx, prompt, scope)
+	if err != nil {
+		t.Fatalf("Lookup (hit): %v", err)
+	}
+	if !found {
+		t.Fatal("expected a hit after Store")
+	}
+	if hit.Answer != "Paris" {
+		t.Errorf("Answer = %q, want %q", hit.Answer, "Paris")
+	}
+	if hit.OutTokens != 3 {
+		t.Errorf("OutTokens = %d, want 3", hit.OutTokens)
+	}
+}

--- a/cmd/rostam-server/main.go
+++ b/cmd/rostam-server/main.go
@@ -92,6 +92,10 @@ func main() {
 		runMcpCmd(os.Args[2:])
 		return
 	}
+	if len(os.Args) > 1 && os.Args[1] == "llm-proxy" {
+		runLlmProxyCmd(os.Args[2:])
+		return
+	}
 	// EXPERIMENT: debug pprof endpoint when ROSTAM_PPROF=host:port is set. Also
 	// enables block + mutex profiling (off by default) so /debug/pprof/block and
 	// /debug/pprof/mutex expose goroutine-hop waits and lock contention — the

--- a/cmd/rostam-server/mcp.go
+++ b/cmd/rostam-server/mcp.go
@@ -38,13 +38,22 @@ const mcpDataAuto = "auto"
 // each need their own copy.
 var errDataDirBusy = errors.New("data directory is held by another process")
 
+// storeFlags holds the flags common to any subcommand that connects to or
+// embeds a rostam.Store: an embedded -data directory, or -connect plus its
+// auth token and TLS options. It is shared between subcommands (mcpFlags
+// embeds it today; a future llm-proxy subcommand will too) so the
+// store-selection logic in connectStore only has to be written once.
+type storeFlags struct {
+	data, connect, authToken          string
+	tlsCA, tlsCert, tlsKey, tlsServer string
+}
+
 // mcpFlags holds the parsed `mcp` subcommand flags. It is passed to mcpSetup
 // as plain data so setup logic is unit-testable without touching flag.FlagSet
 // or the real environment.
 type mcpFlags struct {
-	data, connect, authToken          string
-	tlsCA, tlsCert, tlsKey, tlsServer string
-	destructive                       bool
+	storeFlags
+	destructive bool
 }
 
 // mcpRuntime is what mcpSetup produces: a ready store and (optionally) a
@@ -120,7 +129,7 @@ func runMcpCmd(args []string) {
 	unlock := func() error { return nil }
 	if fl.connect == "" {
 		var lerr error
-		unlock, lerr = mcpClaimDataDir(fl.data)
+		unlock, lerr = claimDataDir(fl.data)
 		switch {
 		case errors.Is(lerr, errDataDirBusy):
 			fatal("mcp: another rostam-server mcp process is using this data directory; "+
@@ -171,9 +180,10 @@ func runMcpCmd(args []string) {
 	}
 }
 
-// mcpClaimDataDir creates the embedded data directory and takes the
-// single-writer lock on it, returning the closer that releases it. A "" dir is
-// heap mode: nothing on disk to create or claim, so the closer is a no-op.
+// claimDataDir creates an embedded data directory and takes the single-writer
+// lock on it, returning the closer that releases it. A "" dir is heap mode:
+// nothing on disk to create or claim, so the closer is a no-op. Shared by any
+// subcommand that can embed a store (mcp today; llm-proxy will too).
 //
 // The directory has to be created here rather than being left to the engine
 // further down, because the lock file lives INSIDE it and is opened first —
@@ -185,7 +195,7 @@ func runMcpCmd(args []string) {
 // It returns its errors instead of calling fatal so both paths are testable
 // without a subprocess, the same reason the tiering validation is a returning
 // function. Only a real lock conflict carries errDataDirBusy.
-func mcpClaimDataDir(dir string) (func() error, error) {
+func claimDataDir(dir string) (func() error, error) {
 	noop := func() error { return nil }
 	if dir == "" {
 		return noop, nil
@@ -207,7 +217,7 @@ func mcpSetup(fl mcpFlags, lookupEnv func(string) (string, bool)) (mcpRuntime, e
 		return mcpRuntime{}, errors.New("mcp: use -data or -connect, not both")
 	}
 
-	embedder, err := mcpEmbedderFromEnv(lookupEnv)
+	embedder, err := embedderFromEnv(lookupEnv)
 	if err != nil {
 		return mcpRuntime{}, err
 	}
@@ -219,7 +229,7 @@ func mcpSetup(fl mcpFlags, lookupEnv func(string) (string, bool)) (mcpRuntime, e
 
 	var store rostam.Store
 	if fl.connect != "" {
-		store, err = mcpConnectStore(fl, reg, lookupEnv)
+		store, err = connectStore(fl.storeFlags, reg, lookupEnv)
 	} else {
 		// Size the cache for what this actually is: one person's memory store,
 		// reached one tool call at a time over a pipe. The defaults are sized for a
@@ -243,28 +253,29 @@ func mcpSetup(fl mcpFlags, lookupEnv func(string) (string, bool)) (mcpRuntime, e
 	return mcpRuntime{store: store, embedder: embedder}, nil
 }
 
-// mcpEmbedderFromEnv reads the ROSTAM_EMBED_* variables and builds a hosted
+// embedderFromEnv reads the ROSTAM_EMBED_* variables and builds a hosted
 // embedder, or nil for BM25-only mode. ROSTAM_EMBED_ENDPOINT is the trigger:
 // unset (along with everything else) means BM25-only; set without a valid
 // ROSTAM_EMBED_MODEL/ROSTAM_EMBED_DIM is a configuration error naming the
 // exact missing/invalid variable, so a typo'd env var fails loud at startup
-// rather than silently falling back to BM25-only.
-func mcpEmbedderFromEnv(lookupEnv func(string) (string, bool)) (semcache.Embedder, error) {
+// rather than silently falling back to BM25-only. Shared by any subcommand
+// that wants a hosted embedder (mcp today; llm-proxy will too).
+func embedderFromEnv(lookupEnv func(string) (string, bool)) (semcache.Embedder, error) {
 	endpoint, _ := lookupEnv("ROSTAM_EMBED_ENDPOINT")
 	if endpoint == "" {
 		return nil, nil
 	}
 	model, _ := lookupEnv("ROSTAM_EMBED_MODEL")
 	if model == "" {
-		return nil, errors.New("mcp: ROSTAM_EMBED_ENDPOINT is set but ROSTAM_EMBED_MODEL is missing")
+		return nil, errors.New("rostam-server: ROSTAM_EMBED_ENDPOINT is set but ROSTAM_EMBED_MODEL is missing")
 	}
 	dimStr, _ := lookupEnv("ROSTAM_EMBED_DIM")
 	if dimStr == "" {
-		return nil, errors.New("mcp: ROSTAM_EMBED_ENDPOINT is set but ROSTAM_EMBED_DIM is missing")
+		return nil, errors.New("rostam-server: ROSTAM_EMBED_ENDPOINT is set but ROSTAM_EMBED_DIM is missing")
 	}
 	dim, err := strconv.Atoi(dimStr)
 	if err != nil {
-		return nil, fmt.Errorf("mcp: ROSTAM_EMBED_DIM=%q is not a valid integer: %w", dimStr, err)
+		return nil, fmt.Errorf("rostam-server: ROSTAM_EMBED_DIM=%q is not a valid integer: %w", dimStr, err)
 	}
 	apiKey, _ := lookupEnv("ROSTAM_EMBED_API_KEY")
 	oe := semcache.NewOpenAIEmbedder(apiKey, model, dim)
@@ -277,11 +288,12 @@ func mcpEmbedderFromEnv(lookupEnv func(string) (string, bool)) (semcache.Embedde
 	return oe, nil
 }
 
-// mcpConnectStore builds the remote-mode Store for -connect: the auth token
+// connectStore builds the remote-mode Store for -connect: the auth token
 // (flag, else ROSTAM_AUTH_TOKEN) and TLS config (built only when any -tls-*
 // flag is set, so plaintext stays the zero-config default) feed
-// rostam.NewClient.
-func mcpConnectStore(fl mcpFlags, reg *ops.Registry, lookupEnv func(string) (string, bool)) (rostam.Store, error) {
+// rostam.NewClient. Shared by any subcommand that offers -connect (mcp
+// today; llm-proxy will too).
+func connectStore(fl storeFlags, reg *ops.Registry, lookupEnv func(string) (string, bool)) (rostam.Store, error) {
 	token := fl.authToken
 	if token == "" {
 		if v, ok := lookupEnv("ROSTAM_AUTH_TOKEN"); ok {
@@ -293,7 +305,7 @@ func mcpConnectStore(fl mcpFlags, reg *ops.Registry, lookupEnv func(string) (str
 	if fl.tlsCA != "" || fl.tlsCert != "" || fl.tlsKey != "" || fl.tlsServer != "" {
 		cfg, err := tlsutil.ClientTLS(fl.tlsCA, fl.tlsCert, fl.tlsKey, fl.tlsServer)
 		if err != nil {
-			return nil, fmt.Errorf("mcp: -connect TLS config: %w", err)
+			return nil, fmt.Errorf("rostam-server: -connect TLS config: %w", err)
 		}
 		tlsCfg = cfg
 	}
@@ -305,7 +317,7 @@ func mcpConnectStore(fl mcpFlags, reg *ops.Registry, lookupEnv func(string) (str
 		TLSConfig: tlsCfg,
 	})
 	if err != nil {
-		return nil, fmt.Errorf("mcp: connect to %q: %w", fl.connect, err)
+		return nil, fmt.Errorf("rostam-server: connect to %q: %w", fl.connect, err)
 	}
 	return store, nil
 }

--- a/cmd/rostam-server/mcp_test.go
+++ b/cmd/rostam-server/mcp_test.go
@@ -24,7 +24,7 @@ func envMap(m map[string]string) func(string) (string, bool) {
 }
 
 func TestMcpSetup_DataAndConnectConflict(t *testing.T) {
-	fl := mcpFlags{data: "/some/dir", connect: "127.0.0.1:7000"}
+	fl := mcpFlags{storeFlags: storeFlags{data: "/some/dir", connect: "127.0.0.1:7000"}}
 	_, err := mcpSetup(fl, noEnv)
 	if err == nil {
 		t.Fatal("expected an error when both -data and -connect are set")
@@ -86,7 +86,7 @@ func TestMcpSetup_Embedder(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			fl := mcpFlags{data: ""} // heap mode so the store side never fails
+			fl := mcpFlags{storeFlags: storeFlags{data: ""}} // heap mode so the store side never fails
 			rt, err := mcpSetup(fl, envMap(tc.env))
 			if tc.wantErr != "" {
 				if err == nil {
@@ -132,7 +132,7 @@ func TestMcpSetup_Embedder(t *testing.T) {
 // working store: a Put/Get round trip is the only reliable signal the store
 // is actually usable, not just a non-nil interface value.
 func TestMcpSetup_HeapMode(t *testing.T) {
-	rt, err := mcpSetup(mcpFlags{data: ""}, noEnv)
+	rt, err := mcpSetup(mcpFlags{storeFlags: storeFlags{data: ""}}, noEnv)
 	if err != nil {
 		t.Fatalf("mcpSetup: %v", err)
 	}

--- a/cmd/rostam-server/mcplock_test.go
+++ b/cmd/rostam-server/mcplock_test.go
@@ -99,7 +99,7 @@ func TestLockDataDirConflictIsBusy(t *testing.T) {
 func TestClaimDataDirCreatesMissingPath(t *testing.T) {
 	dir := filepath.Join(t.TempDir(), "nested", "does-not-exist-yet")
 
-	unlock, err := mcpClaimDataDir(dir)
+	unlock, err := claimDataDir(dir)
 	if err != nil {
 		t.Fatalf("claiming a not-yet-existing -data path: %v", err)
 	}
@@ -114,7 +114,7 @@ func TestClaimDataDirCreatesMissingPath(t *testing.T) {
 // lock file anywhere and still returns a usable closer -- heap mode has no
 // directory to be a second writer to.
 func TestClaimDataDirHeapModeClaimsNothing(t *testing.T) {
-	unlock, err := mcpClaimDataDir("")
+	unlock, err := claimDataDir("")
 	if err != nil {
 		t.Fatalf("heap mode should claim nothing and succeed: %v", err)
 	}
@@ -127,18 +127,18 @@ func TestClaimDataDirHeapModeClaimsNothing(t *testing.T) {
 }
 
 // TestClaimDataDirConflictSurvivesTheHelper makes sure the sentinel is not lost
-// on the way through mcpClaimDataDir: runMcpCmd switches on it, so a wrapper
+// on the way through claimDataDir: runMcpCmd switches on it, so a wrapper
 // that flattened it would silently downgrade the actionable message.
 func TestClaimDataDirConflictSurvivesTheHelper(t *testing.T) {
 	dir := t.TempDir()
-	unlock, err := mcpClaimDataDir(dir)
+	unlock, err := claimDataDir(dir)
 	if err != nil {
 		t.Fatalf("first claim: %v", err)
 	}
 	defer func() { _ = unlock() }()
 
-	if _, err := mcpClaimDataDir(dir); !errors.Is(err, errDataDirBusy) {
-		t.Fatalf("conflict through mcpClaimDataDir must stay errDataDirBusy, got %v", err)
+	if _, err := claimDataDir(dir); !errors.Is(err, errDataDirBusy) {
+		t.Fatalf("conflict through claimDataDir must stay errDataDirBusy, got %v", err)
 	}
 }
 
@@ -152,7 +152,7 @@ func TestClaimDataDirUncreatablePathIsNotBusy(t *testing.T) {
 		t.Fatalf("write blocker: %v", err)
 	}
 
-	_, err := mcpClaimDataDir(filepath.Join(blocker, "under-a-file"))
+	_, err := claimDataDir(filepath.Join(blocker, "under-a-file"))
 	if err == nil {
 		t.Fatal("creating a directory under a regular file should fail")
 	}

--- a/cmd/rostam-server/mcplock_unix.go
+++ b/cmd/rostam-server/mcplock_unix.go
@@ -11,9 +11,11 @@ import (
 	"golang.org/x/sys/unix"
 )
 
-// mcpLockName is the lock file an embedded `mcp` session holds inside its data
-// directory for the lifetime of the process.
-const mcpLockName = ".mcp.lock"
+// dataDirLockName is the lock file an embedded session (mcp today; llm-proxy
+// will too) holds inside its data directory for the lifetime of the process.
+// The name is kept as ".mcp.lock" for compatibility: existing user data dirs
+// already contain a lock file with this name.
+const dataDirLockName = ".mcp.lock"
 
 // lockDataDir takes an exclusive advisory lock on dir, and returns the closer
 // that releases it.
@@ -31,7 +33,7 @@ const mcpLockName = ".mcp.lock"
 // protect against the same process opening the dir twice; that isn't a case
 // runMcpCmd can produce.
 func lockDataDir(dir string) (func() error, error) {
-	path := filepath.Join(dir, mcpLockName)
+	path := filepath.Join(dir, dataDirLockName)
 	f, err := os.OpenFile(path, os.O_RDWR|os.O_CREATE, 0o600)
 	if err != nil {
 		return nil, fmt.Errorf("opening lock file %s: %w", path, err)

--- a/cmd/rostam-server/usage.go
+++ b/cmd/rostam-server/usage.go
@@ -163,7 +163,7 @@ func printGroupedUsage(w io.Writer, fs *flag.FlagSet, helpAll bool) {
 	p := func(format string, a ...any) { _, _ = fmt.Fprintf(w, format, a...) }
 
 	p("rostam-server — a vector database and key-value store over REST, gRPC and TCP.\n\n")
-	p("Usage:\n  rostam-server [flags]\n  rostam-server keys <add|revoke|list> [flags]\n  rostam-server mcp [flags]\n\n")
+	p("Usage:\n  rostam-server [flags]\n  rostam-server keys <add|revoke|list> [flags]\n  rostam-server mcp [flags]\n  rostam-server llm-proxy [flags]\n\n")
 
 	if helpAll {
 		fs.SetOutput(w)

--- a/docs/server/llm-proxy.md
+++ b/docs/server/llm-proxy.md
@@ -1,0 +1,223 @@
+# LLM caching proxy
+
+`rostam-server llm-proxy` runs Rostam as an OpenAI-compatible caching reverse
+proxy: point your existing OpenAI SDK or `curl` calls at it instead of
+`api.openai.com`, and every chat-completions request that repeats a prior
+prompt is answered from a local semantic cache instead of hitting the
+upstream API — zero generation cost, no round trip. Everything else (every
+other `/v1/*` route, and any chat request the cache can't safely answer) is
+forwarded to the real upstream verbatim.
+
+With no embedding endpoint configured it still does useful work out of the
+box: exact byte-identical prompts are cached and served locally, no API key
+or embedding model required. Point it at an embedder and it upgrades to
+semantic matching — near-duplicate prompts (different whitespace, minor
+rewording) hit the cache too.
+
+## Quickstart
+
+Change one line in the OpenAI Python SDK:
+
+```python
+from openai import OpenAI
+
+client = OpenAI(base_url="http://localhost:8484/v1", api_key="sk-...")
+resp = client.chat.completions.create(
+    model="gpt-4o-mini",
+    messages=[{"role": "user", "content": "What is the capital of France?"}],
+)
+```
+
+Or with `curl`:
+
+```sh
+rostam-server llm-proxy &
+
+curl http://localhost:8484/v1/chat/completions \
+  -H "Authorization: Bearer $OPENAI_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"model":"gpt-4o-mini","messages":[{"role":"user","content":"What is the capital of France?"}]}'
+```
+
+The response carries an `x-rostam-cache` header (`hit`, `miss`, or `bypass`)
+so you can see, at a glance, which requests are actually costing you
+generation tokens.
+
+## Exact vs. semantic mode
+
+The mode is decided at startup from whether an embedder is configured — see
+[Embedder configuration](#embedder-configuration-environment-only) below:
+
+- **Exact mode** (default, no `ROSTAM_EMBED_*` env set): prompts are matched
+  with a deterministic stub embedder at a `0.999` cosine-similarity floor, so
+  only a byte-identical prompt (within the same scope) is ever treated as a
+  hit.
+- **Semantic mode** (`ROSTAM_EMBED_ENDPOINT` set): prompts are matched with a
+  real hosted embedder at a `0.97` floor by default, so a paraphrased or
+  lightly-edited prompt can still hit the cache.
+
+`-threshold` overrides either mode's default floor.
+
+### What forms the cache key
+
+A cache entry is scoped to more than just the prompt text. Two requests only
+match if **both** their prompt and their scope agree:
+
+- **Prompt**: every non-system message's role and content, concatenated in
+  order. Only the plain-string form of `content` is used — a multimodal
+  message (the array-of-parts form: images, etc.) can't be reduced to text,
+  so it's never cached.
+- **Scope**: `model`, the concatenated `system` message(s), the requested
+  `tools`' names, the effective `temperature`, `max_tokens`, a hash of the
+  `Authorization` header (tenancy — see below), and the embedder identity (so
+  switching embedders never mixes cached answers from a different embedding
+  space).
+
+Two prompts that are textually identical but differ in model, system prompt,
+tools, temperature, `max_tokens`, or caller never share a cache entry.
+
+## Flags
+
+| Flag | Default | Meaning |
+|---|---|---|
+| `-listen` | `127.0.0.1:8484` | HTTP listen address for the proxy. |
+| `-upstream` | `https://api.openai.com` | Upstream OpenAI-compatible API base URL. |
+| `-collection` | `llm-cache` | Cache collection name (created if absent). |
+| `-threshold` | `0` | Cosine-similarity hit floor. `0` = mode default: `0.999` in exact mode, `0.97` in semantic mode. |
+| `-max-temp` | `1.0` | Do not cache chat requests with a temperature above this. |
+| `-ttl` | `168h` | Per-entry cache expiry. |
+| `-data` | `auto` | Embedded data directory. `auto` resolves to `~/.rostam/llmcache` (created if missing); `""` runs heap/ephemeral mode; any other value is used as given. Mutually exclusive with `-connect`. |
+| `-connect` | disabled | Connect to a remote `rostam-server` instead of embedding the engine (`host:port`). Mutually exclusive with `-data`. |
+| `-auth-token` | — | Bearer token for `-connect`. Prefer `ROSTAM_AUTH_TOKEN` — a flag-passed secret is visible to other local users via `/proc` and shell history. |
+| `-tls-ca` | — | CA bundle PEM to verify the remote server's certificate (`-connect`). |
+| `-tls-cert` / `-tls-key` | — | Client certificate/key PEM for mTLS (`-connect`; both required together). |
+| `-tls-server-name` | — | Expected server certificate name (SNI + verification) for `-connect`. |
+| `-insecure` | `false` | Acknowledge running with a non-loopback `-listen`. The proxy has no auth layer of its own (it relays whatever `Authorization` header the client sends straight to upstream), so binding it to a reachable address without this flag is refused at startup. Dev/trusted-network use only. |
+
+`-data` and `-connect` are mutually exclusive: pass one or the other, never
+both.
+
+## Embedder configuration (environment only)
+
+Like the [MCP server](mcp.md#embedder-configuration-environment-only), the
+embedder is configured entirely through environment variables, using the
+same `ROSTAM_EMBED_*` variables:
+
+| Variable | Required | Meaning |
+|---|---|---|
+| `ROSTAM_EMBED_ENDPOINT` | trigger | OpenAI-compatible `/embeddings` URL. Unset (with the other three also unset) means exact-match mode. |
+| `ROSTAM_EMBED_MODEL` | if endpoint set | Model id sent to the endpoint. |
+| `ROSTAM_EMBED_DIM` | if endpoint set | Output embedding dimension, as an integer. |
+| `ROSTAM_EMBED_API_KEY` | optional | Bearer token for the endpoint (local endpoints like Ollama typically don't need one). |
+
+All four unset is the zero-config default: exact-match caching, no embedding
+API key required. Setting `ROSTAM_EMBED_ENDPOINT` without
+`ROSTAM_EMBED_MODEL` or `ROSTAM_EMBED_DIM` fails at startup naming the exact
+missing variable.
+
+Example: a local Ollama embedding model for semantic matching:
+
+```sh
+ROSTAM_EMBED_ENDPOINT=http://localhost:11434/v1/embeddings \
+ROSTAM_EMBED_MODEL=nomic-embed-text \
+ROSTAM_EMBED_DIM=768 \
+rostam-server llm-proxy
+```
+
+## What's never cached
+
+The following requests are always forwarded to upstream and never answered
+from (or written to) the cache:
+
+- A response with `tool_calls` present.
+- `n` greater than 1 (multiple choices can't be represented by one cached
+  answer).
+- Non-string message content — the array-of-parts (multimodal) form.
+- A response whose `finish_reason` isn't `"stop"` (truncated, length-limited,
+  content-filtered, etc.).
+- A streamed response that aborts mid-stream (never reaches a clean
+  `[DONE]`).
+
+## Temperature and cacheability
+
+OpenAI treats an omitted `temperature` field as `1.0`, and the proxy follows
+the same rule for cache scoping. Combined with the default `-max-temp 1.0`,
+that means a typical request with no explicit `temperature` **is cached by
+default** — high-temperature, "creative" requests are exactly the ones most
+API traffic sends without setting the field at all.
+
+If you only want to cache fully-deterministic requests, tighten the ceiling:
+
+```sh
+rostam-server llm-proxy -max-temp 0
+```
+
+With `-max-temp 0`, only requests that explicitly set `"temperature": 0`
+are cached; anything with a higher (or omitted, i.e. `1.0`) temperature
+always passes through.
+
+## Tenancy
+
+Cache entries are scoped by caller: the proxy hashes the request's
+`Authorization` header (never storing it raw) and includes that hash in the
+scope key, so one client's cached answers are never served to another client
+using a different API key. Requests with no `Authorization` header share one
+"no auth" tenant scope.
+
+## `/stats`
+
+`GET /stats` returns the proxy's running counters as JSON:
+
+```json
+{
+  "hits": 42,
+  "misses": 130,
+  "stored": 118,
+  "uncacheable": 9,
+  "tokens_saved": 15872,
+  "mode": "exact"
+}
+```
+
+`tokens_saved` sums the completion-token count of every cache hit — the
+generation cost you didn't pay. `mode` is `"exact"` or `"semantic"`, fixed
+for the life of the process.
+
+## Remote mode
+
+By default `rostam-server llm-proxy` embeds the engine and owns a local data
+directory. Point it at an already-running server instead with `-connect`,
+the same way as the [MCP server](mcp.md#remote-mode):
+
+```sh
+rostam-server llm-proxy -connect 127.0.0.1:7000 -auth-token "$ROSTAM_AUTH_TOKEN"
+```
+
+This is also how multiple proxy processes share one cache: a `-data`
+directory has a single writer (see below), so concurrent proxies sharing a
+cache must all `-connect` to one `rostam-server` rather than each embedding
+their own.
+
+## Honest limits
+
+- **Cache entries do not survive a proxy restart in v1.** The semantic-cache
+  collection backing the proxy is created as an in-memory (non-persistent)
+  vector collection regardless of `-data` — a real `-data` directory still
+  claims the directory and persists other engine state, but the cache itself
+  starts empty on every restart. Don't rely on it as a durable answer store.
+- **One `-data` directory, one writer.** Embedded mode locks the data
+  directory (the same mechanism the MCP server uses); a second `llm-proxy`
+  process pointed at the same directory is refused at startup. Run one
+  process per `-data` directory, or share a cache across processes with
+  `-connect` instead.
+- **OpenAI-compatible surface only.** The proxy understands the
+  `/v1/chat/completions` request/response shape (including its streaming SSE
+  variant) well enough to cache it; every other route is opaque passthrough.
+  It does not cache `/v1/embeddings`, `/v1/completions`, or any
+  provider-specific endpoint.
+- **Streaming replay doesn't preserve upstream cadence.** A cache hit on a
+  `stream: true` request is replayed as a synthetic SSE stream with a fixed
+  three-chunk shape (role, content, finish) — fewer, larger chunks than the
+  original upstream stream produced. A client reading only the assembled
+  content sees the same answer; a client sensitive to chunk-by-chunk timing
+  or granularity will notice the difference.

--- a/docs/server/llm-proxy.md
+++ b/docs/server/llm-proxy.md
@@ -158,11 +158,14 @@ always passes through.
 
 ## Tenancy
 
-Cache entries are scoped by caller: the proxy hashes the request's
-`Authorization` header (never storing it raw) and includes that hash in the
-scope key, so one client's cached answers are never served to another client
-using a different API key. Requests with no `Authorization` header share one
-"no auth" tenant scope.
+Cache entries are scoped by caller: the proxy hashes the request's credential
+headers — `Authorization`, `api-key` (Azure OpenAI) and `x-api-key` — never
+storing any of them raw, and includes that hash in the scope key, so one
+client's cached answers are never served to another client using a different
+key. All three are covered because an OpenAI-compatible surface is not only
+OpenAI: a proxy that looked at `Authorization` alone would put every Azure
+caller in the same tenant. Requests carrying none of the three share one "no
+auth" tenant scope.
 
 ## `/stats`
 

--- a/docs/server/llm-proxy.md
+++ b/docs/server/llm-proxy.md
@@ -2,11 +2,14 @@
 
 `rostam-server llm-proxy` runs Rostam as an OpenAI-compatible caching reverse
 proxy: point your existing OpenAI SDK or `curl` calls at it instead of
-`api.openai.com`, and every chat-completions request that repeats a prior
-prompt is answered from a local semantic cache instead of hitting the
-upstream API — zero generation cost, no round trip. Everything else (every
-other `/v1/*` route, and any chat request the cache can't safely answer) is
-forwarded to the real upstream verbatim.
+`api.openai.com`, and an **eligible** chat-completions request — one with a
+cacheable shape, a matching [scope](#what-forms-the-cache-key), and a prompt
+that hits the cache (byte-identical to a prior prompt in exact mode; a
+near-duplicate within the configured threshold in semantic mode) — is
+answered from a local semantic cache instead of hitting the upstream API —
+zero generation cost, no round trip. Everything else (every other `/v1/*`
+route, and any chat request the cache can't safely answer or that doesn't
+match) is forwarded to the real upstream verbatim.
 
 With no embedding endpoint configured it still does useful work out of the
 box: exact byte-identical prompts are cached and served locally, no API key

--- a/docs/server/llm-proxy.md
+++ b/docs/server/llm-proxy.md
@@ -39,9 +39,9 @@ curl http://localhost:8484/v1/chat/completions \
   -d '{"model":"gpt-4o-mini","messages":[{"role":"user","content":"What is the capital of France?"}]}'
 ```
 
-The response carries an `x-rostam-cache` header (`hit`, `miss`, or `bypass`)
-so you can see, at a glance, which requests are actually costing you
-generation tokens.
+The response carries an `x-rostam-cache` header (`hit`, `miss`, `uncacheable`,
+or `bypass`) so you can see, at a glance, which requests are actually costing
+you generation tokens.
 
 ## Exact vs. semantic mode
 
@@ -69,12 +69,20 @@ match if **both** their prompt and their scope agree:
   so it's never cached.
 - **Scope**: `model`, the concatenated `system` message(s), the requested
   `tools`' names, the effective `temperature`, `max_tokens`, a hash of the
-  `Authorization` header (tenancy — see below), and the embedder identity (so
+  caller's credential headers (tenancy — see below), the embedder identity (so
   switching embedders never mixes cached answers from a different embedding
-  space).
+  space), and a hash of **every remaining field in the request body**.
+
+That last part matters: `response_format`, `seed`, `top_p`, `stop`,
+`frequency_penalty` and anything else a provider adds all partition the cache,
+so a request asking for JSON is never answered with prose cached from the
+identical messages. Only `messages` (that's the prompt) and `stream` /
+`stream_options` are excluded — the streaming and non-streaming forms of one
+call deliberately share an answer. The hash is computed over the parsed body,
+so key order and whitespace don't matter.
 
 Two prompts that are textually identical but differ in model, system prompt,
-tools, temperature, `max_tokens`, or caller never share a cache entry.
+tools, any sampling parameter, or caller never share a cache entry.
 
 ## Flags
 
@@ -132,6 +140,8 @@ from (or written to) the cache:
 - A response with `tool_calls` present.
 - `n` greater than 1 (multiple choices can't be represented by one cached
   answer).
+- `stream_options` (e.g. `{"include_usage": true}`) — it asks for a stream
+  shape a cache replay cannot reproduce.
 - Non-string message content — the array-of-parts (multimodal) form.
 - A response whose `finish_reason` isn't `"stop"` (truncated, length-limited,
   content-filtered, etc.).
@@ -218,6 +228,10 @@ their own.
   variant) well enough to cache it; every other route is opaque passthrough.
   It does not cache `/v1/embeddings`, `/v1/completions`, or any
   provider-specific endpoint.
+- **No single-flight.** Concurrent identical requests that all arrive before
+  the first one's answer is stored each reach the upstream once — the cache
+  deduplicates across time, not within a burst. A cold start that fans out N
+  copies of the same prompt pays for N generations.
 - **Streaming replay doesn't preserve upstream cadence.** A cache hit on a
   `stream: true` request is replayed as a synthetic SSE stream with a fixed
   three-chunk shape (role, content, finish) — fewer, larger chunks than the

--- a/llmproxy/doc.go
+++ b/llmproxy/doc.go
@@ -1,10 +1,29 @@
 // SPDX-License-Identifier: Apache-2.0
 
 // Package llmproxy implements an OpenAI-compatible chat-completions reverse
-// proxy that caches answers in semcache. Requests that hit the cache are
-// answered locally (no upstream call, no cost); everything else — streaming,
-// uncacheable request shapes, cache misses — is forwarded to the configured
-// upstream and, on a miss, the answer is stored for next time. Like the rest
-// of the repository's protocol code, the OpenAI wire format is hand-rolled
-// against stdlib net/http and encoding/json — no SDK, no new dependency.
+// proxy that caches answers in semcache.
+//
+// POST /v1/chat/completions is the cache path. A request whose identity
+// (prompt plus scope: model, system prompt, tools, sampling parameters,
+// caller) matches a stored answer is served locally — no upstream call, no
+// generation cost — and everything else is forwarded upstream and stored on
+// the way back. Streaming is cached too: a stream:true miss is relayed to the
+// client live while the answer is assembled from the SSE chunks, and a
+// subsequent hit is replayed as a synthetic SSE stream, in either direction
+// between the streaming and non-streaming forms of the same call.
+//
+// Requests the cache cannot stand in for — n > 1, stream_options, multimodal
+// (array-form) message content, a temperature above the configured ceiling —
+// are forwarded as uncacheable passthrough, as is every route other than
+// /v1/chat/completions. Responses that would be unsafe to replay (tool calls,
+// a finish_reason other than "stop", a stream that never reaches [DONE]) are
+// relayed to the client but never stored.
+//
+// Every chat response carries an x-rostam-cache header: hit, miss,
+// uncacheable, or bypass (a cache lookup that errored and fell through to
+// upstream). GET /stats reports the running counters.
+//
+// Like the rest of the repository's protocol code, the OpenAI wire format is
+// hand-rolled against stdlib net/http and encoding/json — no SDK, no new
+// dependency.
 package llmproxy

--- a/llmproxy/doc.go
+++ b/llmproxy/doc.go
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: Apache-2.0
+
+// Package llmproxy implements an OpenAI-compatible chat-completions reverse
+// proxy that caches answers in semcache. Requests that hit the cache are
+// answered locally (no upstream call, no cost); everything else — streaming,
+// uncacheable request shapes, cache misses — is forwarded to the configured
+// upstream and, on a miss, the answer is stored for next time. Like the rest
+// of the repository's protocol code, the OpenAI wire format is hand-rolled
+// against stdlib net/http and encoding/json — no SDK, no new dependency.
+package llmproxy

--- a/llmproxy/harness_test.go
+++ b/llmproxy/harness_test.go
@@ -211,7 +211,6 @@ func newProxy(t *testing.T, upstream *fakeUpstream, embedder semcache.Embedder) 
 	srv, err := NewServer(Config{
 		Cache:    cache,
 		Upstream: upstreamURL,
-		MaxTemp:  1.0,
 		Mode:     "exact",
 	})
 	if err != nil {

--- a/llmproxy/harness_test.go
+++ b/llmproxy/harness_test.go
@@ -1,0 +1,266 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package llmproxy
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/rostamlabs/rostam"
+	"github.com/rostamlabs/rostam/ops"
+	"github.com/rostamlabs/rostam/semcache"
+)
+
+// capturedRequest records what fakeUpstream saw for a single request, so
+// tests can assert on routing (path, method, headers) without the fake
+// server needing to understand OpenAI's wire format itself.
+type capturedRequest struct {
+	Method  string
+	Path    string
+	Headers http.Header
+	Body    []byte
+}
+
+// scriptedResponse is one canned reply fakeUpstream serves for a path: either
+// a plain JSON/status response, or a scripted SSE body written line-by-line
+// with a flush after each line (abort stops mid-script, simulating a
+// connection drop).
+type scriptedResponse struct {
+	status  int
+	body    []byte // used when sseLines is nil
+	headers map[string]string
+	sse     bool
+	lines   []string // raw SSE lines (including "\n"), written+flushed one at a time
+	abort   bool     // stop after writing lines without a clean close (Task 6 use)
+}
+
+// fakeUpstream is a scriptable stand-in for the real OpenAI-compatible
+// upstream: tests register a canned response per path, then assert on what
+// the proxy forwarded (method, headers, body) via Requests.
+type fakeUpstream struct {
+	srv *httptest.Server
+
+	mu       sync.Mutex
+	scripts  map[string]scriptedResponse
+	requests []capturedRequest
+}
+
+// newFakeUpstream starts the fake server. Callers script responses with
+// script() before pointing a proxy at it.
+func newFakeUpstream(t *testing.T) *fakeUpstream {
+	t.Helper()
+	fu := &fakeUpstream{scripts: make(map[string]scriptedResponse)}
+	fu.srv = httptest.NewServer(http.HandlerFunc(fu.handle))
+	t.Cleanup(fu.srv.Close)
+	return fu
+}
+
+// script registers the canned response fakeUpstream serves for path,
+// overwriting any previous script for that path.
+func (fu *fakeUpstream) script(path string, resp scriptedResponse) {
+	fu.mu.Lock()
+	defer fu.mu.Unlock()
+	fu.scripts[path] = resp
+}
+
+// requestCount returns how many requests fakeUpstream has received for path,
+// so tests can assert a cache hit never touched upstream.
+func (fu *fakeUpstream) requestCount(path string) int {
+	fu.mu.Lock()
+	defer fu.mu.Unlock()
+	n := 0
+	for _, r := range fu.requests {
+		if r.Path == path {
+			n++
+		}
+	}
+	return n
+}
+
+// lastRequest returns the most recently captured request for path, or nil.
+func (fu *fakeUpstream) lastRequest(path string) *capturedRequest {
+	fu.mu.Lock()
+	defer fu.mu.Unlock()
+	for i := len(fu.requests) - 1; i >= 0; i-- {
+		if fu.requests[i].Path == path {
+			r := fu.requests[i]
+			return &r
+		}
+	}
+	return nil
+}
+
+func (fu *fakeUpstream) handle(w http.ResponseWriter, r *http.Request) {
+	body, _ := io.ReadAll(r.Body)
+
+	fu.mu.Lock()
+	fu.requests = append(fu.requests, capturedRequest{
+		Method:  r.Method,
+		Path:    r.URL.Path,
+		Headers: r.Header.Clone(),
+		Body:    body,
+	})
+	resp, ok := fu.scripts[r.URL.Path]
+	fu.mu.Unlock()
+
+	if !ok {
+		w.WriteHeader(http.StatusNotFound)
+		return
+	}
+
+	for k, v := range resp.headers {
+		w.Header().Set(k, v)
+	}
+
+	if resp.sse {
+		w.Header().Set("Content-Type", "text/event-stream")
+		status := resp.status
+		if status == 0 {
+			status = http.StatusOK
+		}
+		w.WriteHeader(status)
+		fl, _ := w.(http.Flusher)
+		for _, line := range resp.lines {
+			_, _ = io.WriteString(w, line)
+			if fl != nil {
+				fl.Flush()
+			}
+		}
+		if resp.abort {
+			// Simulate a dropped connection: close the underlying conn
+			// without writing a clean terminator.
+			if hj, ok := w.(http.Hijacker); ok {
+				conn, _, err := hj.Hijack()
+				if err == nil {
+					_ = conn.Close()
+				}
+			}
+		}
+		return
+	}
+
+	status := resp.status
+	if status == 0 {
+		status = http.StatusOK
+	}
+	w.WriteHeader(status)
+	_, _ = w.Write(resp.body)
+}
+
+// newProxy builds a proxy.Server backed by a heap Direct store and a
+// semcache.Cache pointed at upstream, and returns it as an httptest.Server
+// along with the fakeUpstream it targets. embedder nil selects the
+// deterministic stub embedder ("exact" mode, dim 64) used by default across
+// Tasks 5-6's tests.
+func newProxy(t *testing.T, upstream *fakeUpstream, embedder semcache.Embedder) *httptest.Server {
+	t.Helper()
+
+	if embedder == nil {
+		embedder = semcache.NewStubEmbedder("exact", 64)
+	}
+
+	reg := ops.NewRegistry()
+	if err := ops.RegisterBuiltins(reg); err != nil {
+		t.Fatalf("RegisterBuiltins: %v", err)
+	}
+	store, err := rostam.NewDirect(rostam.DirectConfig{Ops: reg})
+	if err != nil {
+		t.Fatalf("NewDirect: %v", err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+
+	cache, err := semcache.New(context.Background(), semcache.Config{
+		Store:      store,
+		Embedder:   embedder,
+		Collection: "llm-cache",
+		Threshold:  0.999,
+		MaxTemp:    1.0,
+	})
+	if err != nil {
+		t.Fatalf("semcache.New: %v", err)
+	}
+
+	upstreamURL, err := url.Parse(upstream.srv.URL)
+	if err != nil {
+		t.Fatalf("parse upstream URL: %v", err)
+	}
+
+	srv, err := NewServer(Config{
+		Cache:    cache,
+		Upstream: upstreamURL,
+		MaxTemp:  1.0,
+		Mode:     "exact",
+	})
+	if err != nil {
+		t.Fatalf("NewServer: %v", err)
+	}
+
+	proxy := httptest.NewServer(srv.Handler())
+	t.Cleanup(proxy.Close)
+	return proxy
+}
+
+// postChat POSTs body to proxyURL+"/v1/chat/completions" with headers merged
+// on top of a default Content-Type, and returns the response plus its fully
+// read body.
+func postChat(t *testing.T, proxyURL, body string, headers map[string]string) (*http.Response, []byte) {
+	t.Helper()
+
+	req, err := http.NewRequest(http.MethodPost, proxyURL+"/v1/chat/completions", strings.NewReader(body))
+	if err != nil {
+		t.Fatalf("NewRequest: %v", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	for k, v := range headers {
+		req.Header.Set(k, v)
+	}
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("Do: %v", err)
+	}
+	defer resp.Body.Close()
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("ReadAll: %v", err)
+	}
+	return resp, respBody
+}
+
+// chatCompletionJSON builds a canned non-streaming chat-completions upstream
+// response body with the given content, finish reason and completion-token
+// count, for use with fakeUpstream.script.
+func chatCompletionJSON(t *testing.T, content, finishReason string, completionTokens int) []byte {
+	t.Helper()
+	resp := map[string]any{
+		"id":     "chatcmpl-fake",
+		"object": "chat.completion",
+		"model":  "gpt-4",
+		"choices": []map[string]any{
+			{
+				"index": 0,
+				"message": map[string]any{
+					"role":    "assistant",
+					"content": content,
+				},
+				"finish_reason": finishReason,
+			},
+		},
+		"usage": map[string]any{
+			"completion_tokens": completionTokens,
+		},
+	}
+	b, err := json.Marshal(resp)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	return b
+}

--- a/llmproxy/harness_test.go
+++ b/llmproxy/harness_test.go
@@ -177,6 +177,16 @@ func (fu *fakeUpstream) handle(w http.ResponseWriter, r *http.Request) {
 // Tasks 5-6's tests.
 func newProxy(t *testing.T, upstream *fakeUpstream, embedder semcache.Embedder) *httptest.Server {
 	t.Helper()
+	proxy := httptest.NewServer(newProxyServer(t, upstream, embedder).Handler())
+	t.Cleanup(proxy.Close)
+	return proxy
+}
+
+// newProxyServer is newProxy without the http listener, for a test that needs
+// to drive Handler() with its own ResponseWriter (to observe flushes, say)
+// rather than talk to it over a real socket.
+func newProxyServer(t *testing.T, upstream *fakeUpstream, embedder semcache.Embedder) *Server {
+	t.Helper()
 
 	if embedder == nil {
 		embedder = semcache.NewStubEmbedder("exact", 64)
@@ -216,10 +226,7 @@ func newProxy(t *testing.T, upstream *fakeUpstream, embedder semcache.Embedder) 
 	if err != nil {
 		t.Fatalf("NewServer: %v", err)
 	}
-
-	proxy := httptest.NewServer(srv.Handler())
-	t.Cleanup(proxy.Close)
-	return proxy
+	return srv
 }
 
 // postChat POSTs body to proxyURL+"/v1/chat/completions" with headers merged

--- a/llmproxy/harness_test.go
+++ b/llmproxy/harness_test.go
@@ -3,6 +3,7 @@
 package llmproxy
 
 import (
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"io"
@@ -39,6 +40,11 @@ type scriptedResponse struct {
 	sse     bool
 	lines   []string // raw SSE lines (including "\n"), written+flushed one at a time
 	abort   bool     // stop after writing lines without a clean close (Task 6 use)
+	// gzipIfAccepted makes the fake behave like every real OpenAI-compatible
+	// endpoint: compress body whenever the request says it accepts gzip. Only
+	// a fake that does this can catch a proxy that reads a compressed body as
+	// if it were JSON.
+	gzipIfAccepted bool
 }
 
 // fakeUpstream is a scriptable stand-in for the real OpenAI-compatible
@@ -150,6 +156,16 @@ func (fu *fakeUpstream) handle(w http.ResponseWriter, r *http.Request) {
 	if status == 0 {
 		status = http.StatusOK
 	}
+
+	if resp.gzipIfAccepted && strings.Contains(r.Header.Get("Accept-Encoding"), "gzip") {
+		w.Header().Set("Content-Encoding", "gzip")
+		w.WriteHeader(status)
+		zw := gzip.NewWriter(w)
+		_, _ = zw.Write(resp.body)
+		_ = zw.Close()
+		return
+	}
+
 	w.WriteHeader(status)
 	_, _ = w.Write(resp.body)
 }

--- a/llmproxy/openai.go
+++ b/llmproxy/openai.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/cespare/xxhash/v2"
 
@@ -187,12 +188,16 @@ func extraDiscriminator(raw json.RawMessage) string {
 // synthesizeResponse builds a non-streaming chat-completions response body
 // for a cache hit, in the exact shape a real OpenAI response would have so
 // clients can't tell the difference. prompt_tokens is always 0 because the
-// prompt was never sent upstream on a hit.
+// prompt was never sent upstream on a hit. created is the synthesis time
+// (Unix seconds), not the original completion's — OpenAI's SDKs treat a
+// missing created as an error-shaped response, so a synthesized reply needs
+// *a* timestamp even though the real one was never recorded.
 func synthesizeResponse(model, answer string, outTokens int) []byte {
 	resp := map[string]any{
-		"id":     "rostam-cache",
-		"object": "chat.completion",
-		"model":  model,
+		"id":      "rostam-cache",
+		"object":  "chat.completion",
+		"created": time.Now().Unix(),
+		"model":   model,
 		"choices": []map[string]any{
 			{
 				"index": 0,

--- a/llmproxy/openai.go
+++ b/llmproxy/openai.go
@@ -218,13 +218,18 @@ func synthesizeResponse(model, answer string, outTokens int) []byte {
 	return b
 }
 
-// tenantOf derives a cache-scope tenant identity from a request's
-// Authorization header, so one client's cached answers are never served to
-// another. The header is hashed rather than stored raw — the tenant value
-// ends up in cache metadata, and a credential doesn't belong there.
-func tenantOf(authHeader string) string {
-	if authHeader == "" {
+// tenantOf derives a cache-scope tenant identity from a request's credential
+// headers, so one client's cached answers are never served to another.
+//
+// All three headers are covered because an OpenAI-compatible surface is not
+// only OpenAI: Azure OpenAI authenticates with "api-key" and Anthropic with
+// "x-api-key", and hashing Authorization alone collapsed every such caller
+// into the single empty "no auth" tenant — every Azure user on one proxy
+// sharing one cache. The values are hashed, never stored raw: the tenant ends
+// up in cache metadata, which is no place for a credential.
+func tenantOf(authHeader, apiKeyHeader, xAPIKeyHeader string) string {
+	if authHeader == "" && apiKeyHeader == "" && xAPIKeyHeader == "" {
 		return ""
 	}
-	return strconv.FormatUint(xxhash.Sum64String(authHeader), 16)
+	return strconv.FormatUint(xxhash.Sum64String(authHeader+"\x00"+apiKeyHeader+"\x00"+xAPIKeyHeader), 16)
 }

--- a/llmproxy/openai.go
+++ b/llmproxy/openai.go
@@ -17,14 +17,19 @@ import (
 // original body so it can be forwarded verbatim on a miss or passthrough —
 // the proxy never needs to re-encode a request it didn't answer itself.
 type chatRequest struct {
-	Model       string          `json:"model"`
-	Messages    []chatMessage   `json:"messages"`
-	Temperature *float64        `json:"temperature,omitempty"` // nil => 1.0 (OpenAI default)
-	MaxTokens   int             `json:"max_tokens,omitempty"`
-	N           int             `json:"n,omitempty"`
-	Stream      bool            `json:"stream,omitempty"`
-	Tools       []chatTool      `json:"tools,omitempty"`
-	Raw         json.RawMessage `json:"-"` // original body, forwarded verbatim on miss/passthrough
+	Model       string        `json:"model"`
+	Messages    []chatMessage `json:"messages"`
+	Temperature *float64      `json:"temperature,omitempty"` // nil => 1.0 (OpenAI default)
+	MaxTokens   int           `json:"max_tokens,omitempty"`
+	N           int           `json:"n,omitempty"`
+	Stream      bool          `json:"stream,omitempty"`
+	// StreamOptions (e.g. {"include_usage":true}) changes the SHAPE of the
+	// stream the client expects, which a cache replay cannot reproduce: the
+	// replay emits a fixed three-chunk stream with no usage chunk. Present
+	// (and non-null) => uncacheable passthrough.
+	StreamOptions json.RawMessage `json:"stream_options,omitempty"`
+	Tools         []chatTool      `json:"tools,omitempty"`
+	Raw           json.RawMessage `json:"-"` // original body, forwarded verbatim on miss/passthrough
 }
 
 // chatMessage holds Content undecoded because OpenAI allows either a plain
@@ -94,10 +99,14 @@ func (m chatMessage) contentString() (string, bool) {
 
 // cacheIdentity reduces a request to the prompt text and scope semcache needs
 // to look up or store an answer. It returns ok=false when the request shape
-// isn't safely reducible to text: any message with array-form content, or
-// n > 1 (multiple choices can't be represented by a single cached answer).
+// isn't safely reducible to text: any message with array-form content, n > 1
+// (multiple choices can't be represented by a single cached answer), or
+// stream_options (whose stream shape a replay can't reproduce).
 func (r *chatRequest) cacheIdentity(tenant string) (prompt string, scope semcache.Scope, ok bool) {
 	if r.N > 1 {
+		return "", semcache.Scope{}, false
+	}
+	if rawFieldPresent(r.StreamOptions) {
 		return "", semcache.Scope{}, false
 	}
 
@@ -133,8 +142,46 @@ func (r *chatRequest) cacheIdentity(tenant string) (prompt string, scope semcach
 		Temperature: r.temperature(),
 		MaxTokens:   r.MaxTokens,
 		Tenant:      tenant,
+		Extra:       extraDiscriminator(r.Raw),
 	}
 	return promptBuf.String(), scope, true
+}
+
+// extraDiscriminator hashes everything in the request body that isn't already
+// part of the prompt or the stream decision, so any request knob the proxy
+// doesn't model by name still partitions the cache. Without it, a
+// response_format:json_object request happily received prose cached from the
+// same messages, and seed / top_p / stop / frequency_penalty all silently
+// shared one entry.
+//
+// messages is removed because it IS the prompt; stream and stream_options
+// because a cached answer is deliberately shared between the streaming and
+// non-streaming forms of the same call. Everything else — including fields
+// already in the scope, harmlessly counted twice — is hashed from the
+// unmarshaled map, so two byte-different but semantically equal bodies (key
+// order, whitespace) still agree: Go marshals map keys in sorted order.
+func extraDiscriminator(raw json.RawMessage) string {
+	if len(raw) == 0 {
+		return ""
+	}
+	var m map[string]any
+	if err := json.Unmarshal(raw, &m); err != nil {
+		// Unreachable for a body that parsed as a chat request (that needs a
+		// JSON object), but if it ever happens, partition on the raw bytes
+		// rather than let two unrelated requests share a cache entry.
+		return strconv.FormatUint(xxhash.Sum64String(string(raw)), 16)
+	}
+	delete(m, "messages")
+	delete(m, "stream")
+	delete(m, "stream_options")
+	if len(m) == 0 {
+		return ""
+	}
+	canonical, err := json.Marshal(m)
+	if err != nil {
+		return strconv.FormatUint(xxhash.Sum64String(string(raw)), 16)
+	}
+	return strconv.FormatUint(xxhash.Sum64String(string(canonical)), 16)
 }
 
 // synthesizeResponse builds a non-streaming chat-completions response body

--- a/llmproxy/openai.go
+++ b/llmproxy/openai.go
@@ -1,0 +1,183 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package llmproxy
+
+import (
+	"encoding/json"
+	"strconv"
+	"strings"
+
+	"github.com/cespare/xxhash/v2"
+
+	"github.com/rostamlabs/rostam/semcache"
+)
+
+// chatRequest is the subset of the OpenAI chat-completions request body the
+// proxy needs to judge cacheability and derive a cache key. Raw holds the
+// original body so it can be forwarded verbatim on a miss or passthrough —
+// the proxy never needs to re-encode a request it didn't answer itself.
+type chatRequest struct {
+	Model       string          `json:"model"`
+	Messages    []chatMessage   `json:"messages"`
+	Temperature *float64        `json:"temperature,omitempty"` // nil => 1.0 (OpenAI default)
+	MaxTokens   int             `json:"max_tokens,omitempty"`
+	N           int             `json:"n,omitempty"`
+	Stream      bool            `json:"stream,omitempty"`
+	Tools       []chatTool      `json:"tools,omitempty"`
+	Raw         json.RawMessage `json:"-"` // original body, forwarded verbatim on miss/passthrough
+}
+
+// chatMessage holds Content undecoded because OpenAI allows either a plain
+// string or an array of typed parts (text/image/etc). Only the string form is
+// cacheable — an array means we cannot safely reduce the message to text.
+type chatMessage struct {
+	Role    string          `json:"role"`
+	Content json.RawMessage `json:"content"` // string OR array; array => uncacheable
+}
+
+// chatTool is the minimal shape needed to pull a tool name out of the
+// request's tool list; everything else in the tool definition is irrelevant
+// to cache scoping.
+type chatTool struct {
+	Function struct {
+		Name string `json:"name"`
+	} `json:"function"`
+}
+
+// chatResponse is decode-tolerant on purpose: it captures just enough of an
+// upstream response to decide whether the call is cacheable and to store the
+// answer, without choking on fields OpenAI adds over time.
+type chatResponse struct {
+	Choices []struct {
+		Message struct {
+			Content   string          `json:"content"`
+			ToolCalls json.RawMessage `json:"tool_calls,omitempty"`
+		} `json:"message"`
+		FinishReason string `json:"finish_reason"`
+	} `json:"choices"`
+	Usage struct {
+		CompletionTokens int `json:"completion_tokens"`
+	} `json:"usage"`
+}
+
+// parseChatRequest decodes a chat-completions request body and stashes the
+// original bytes in Raw for verbatim forwarding.
+func parseChatRequest(body []byte) (*chatRequest, error) {
+	var req chatRequest
+	if err := json.Unmarshal(body, &req); err != nil {
+		return nil, err
+	}
+	req.Raw = body
+	return &req, nil
+}
+
+// temperature returns the effective sampling temperature, applying OpenAI's
+// default of 1.0 when the client omitted the field. A caller cannot
+// distinguish "not sent" from "sent as 0" without the pointer, and the two
+// mean different things for cache scoping.
+func (r *chatRequest) temperature() float64 {
+	if r.Temperature == nil {
+		return 1.0
+	}
+	return *r.Temperature
+}
+
+// contentString returns the message content as a string, and false if the
+// content is not a JSON string (i.e. it's the array-of-parts form).
+func (m chatMessage) contentString() (string, bool) {
+	var s string
+	if err := json.Unmarshal(m.Content, &s); err != nil {
+		return "", false
+	}
+	return s, true
+}
+
+// cacheIdentity reduces a request to the prompt text and scope semcache needs
+// to look up or store an answer. It returns ok=false when the request shape
+// isn't safely reducible to text: any message with array-form content, or
+// n > 1 (multiple choices can't be represented by a single cached answer).
+func (r *chatRequest) cacheIdentity(tenant string) (prompt string, scope semcache.Scope, ok bool) {
+	if r.N > 1 {
+		return "", semcache.Scope{}, false
+	}
+
+	var promptBuf strings.Builder
+	var systemParts []string
+
+	for _, msg := range r.Messages {
+		content, isString := msg.contentString()
+		if !isString {
+			return "", semcache.Scope{}, false
+		}
+
+		if msg.Role == "system" {
+			systemParts = append(systemParts, content)
+			continue
+		}
+
+		promptBuf.WriteString(msg.Role)
+		promptBuf.WriteByte('\x00')
+		promptBuf.WriteString(content)
+		promptBuf.WriteByte('\x1e')
+	}
+
+	tools := make([]string, 0, len(r.Tools))
+	for _, t := range r.Tools {
+		tools = append(tools, t.Function.Name)
+	}
+
+	scope = semcache.Scope{
+		Model:       r.Model,
+		System:      strings.Join(systemParts, "\n"),
+		Tools:       tools,
+		Temperature: r.temperature(),
+		MaxTokens:   r.MaxTokens,
+		Tenant:      tenant,
+	}
+	return promptBuf.String(), scope, true
+}
+
+// synthesizeResponse builds a non-streaming chat-completions response body
+// for a cache hit, in the exact shape a real OpenAI response would have so
+// clients can't tell the difference. prompt_tokens is always 0 because the
+// prompt was never sent upstream on a hit.
+func synthesizeResponse(model, answer string, outTokens int) []byte {
+	resp := map[string]any{
+		"id":     "rostam-cache",
+		"object": "chat.completion",
+		"model":  model,
+		"choices": []map[string]any{
+			{
+				"index": 0,
+				"message": map[string]any{
+					"role":    "assistant",
+					"content": answer,
+				},
+				"finish_reason": "stop",
+			},
+		},
+		"usage": map[string]any{
+			"prompt_tokens":     0,
+			"completion_tokens": outTokens,
+			"total_tokens":      outTokens,
+		},
+	}
+	// The shape above is fixed and always marshals cleanly; an error here
+	// would mean a bug in this function, not bad input.
+	b, err := json.Marshal(resp)
+	if err != nil {
+		panic("llmproxy: synthesizeResponse: " + err.Error())
+	}
+	return b
+}
+
+// tenantOf derives a cache-scope tenant identity from a request's
+// Authorization header, so one client's cached answers are never served to
+// another. The header is hashed rather than stored raw — the tenant value
+// ends up in cache metadata, and a credential doesn't belong there.
+func tenantOf(authHeader string) string {
+	if authHeader == "" {
+		return ""
+	}
+	return strconv.FormatUint(xxhash.Sum64String(authHeader), 16)
+}

--- a/llmproxy/openai_test.go
+++ b/llmproxy/openai_test.go
@@ -319,15 +319,15 @@ func TestSynthesizeResponse_RoundTrips(t *testing.T) {
 	}
 }
 
-func TestTenantOf_EmptyHeaderYieldsEmptyTenant(t *testing.T) {
-	if got := tenantOf(""); got != "" {
-		t.Fatalf("tenantOf(\"\") = %q, want empty", got)
+func TestTenantOf_EmptyHeadersYieldEmptyTenant(t *testing.T) {
+	if got := tenantOf("", "", ""); got != "" {
+		t.Fatalf("tenantOf with no credential headers = %q, want empty", got)
 	}
 }
 
 func TestTenantOf_DifferingHeadersDiffer(t *testing.T) {
-	a := tenantOf("Bearer sk-aaaa")
-	b := tenantOf("Bearer sk-bbbb")
+	a := tenantOf("Bearer sk-aaaa", "", "")
+	b := tenantOf("Bearer sk-bbbb", "", "")
 	if a == "" || b == "" {
 		t.Fatalf("tenantOf returned empty for non-empty header: a=%q b=%q", a, b)
 	}
@@ -337,9 +337,41 @@ func TestTenantOf_DifferingHeadersDiffer(t *testing.T) {
 }
 
 func TestTenantOf_SameHeaderSameTenant(t *testing.T) {
-	a := tenantOf("Bearer sk-aaaa")
-	b := tenantOf("Bearer sk-aaaa")
+	a := tenantOf("Bearer sk-aaaa", "", "")
+	b := tenantOf("Bearer sk-aaaa", "", "")
 	if a != b {
 		t.Fatalf("tenantOf(same) = %q vs %q, want equal", a, b)
+	}
+}
+
+// Azure OpenAI sends "api-key" and Anthropic-style surfaces send "x-api-key";
+// neither sets Authorization. Hashing only Authorization put all of them in
+// the one empty "no auth" tenant, so every such caller shared a cache.
+func TestTenantOf_AlternateCredentialHeadersIsolate(t *testing.T) {
+	for name, pair := range map[string][2]string{
+		"api-key":   {"azure-key-a", "azure-key-b"},
+		"x-api-key": {"anthropic-key-a", "anthropic-key-b"},
+	} {
+		var a, b string
+		if name == "api-key" {
+			a, b = tenantOf("", pair[0], ""), tenantOf("", pair[1], "")
+		} else {
+			a, b = tenantOf("", "", pair[0]), tenantOf("", "", pair[1])
+		}
+		if a == "" || b == "" {
+			t.Errorf("%s: tenantOf returned empty for a set credential header: a=%q b=%q", name, a, b)
+		}
+		if a == b {
+			t.Errorf("%s: two different keys share tenant %q", name, a)
+		}
+	}
+
+	// The three headers must not be interchangeable: the same secret in a
+	// different header is a different caller.
+	if tenantOf("k", "", "") == tenantOf("", "k", "") {
+		t.Fatal("Authorization and api-key with the same value share a tenant")
+	}
+	if tenantOf("", "k", "") == tenantOf("", "", "k") {
+		t.Fatal("api-key and x-api-key with the same value share a tenant")
 	}
 }

--- a/llmproxy/openai_test.go
+++ b/llmproxy/openai_test.go
@@ -310,6 +310,9 @@ func TestSynthesizeResponse_RoundTrips(t *testing.T) {
 	if raw["model"] != "gpt-4" {
 		t.Fatalf("model = %v, want gpt-4", raw["model"])
 	}
+	if created, ok := raw["created"].(float64); !ok || created == 0 {
+		t.Fatalf("created = %v, want a non-zero Unix timestamp", raw["created"])
+	}
 	usage, _ := raw["usage"].(map[string]any)
 	if usage["prompt_tokens"] != float64(0) {
 		t.Fatalf("prompt_tokens = %v, want 0", usage["prompt_tokens"])

--- a/llmproxy/openai_test.go
+++ b/llmproxy/openai_test.go
@@ -197,6 +197,85 @@ func TestCacheIdentity_ScopeFieldsPopulated(t *testing.T) {
 	}
 }
 
+func TestCacheIdentity_StreamOptionsUncacheable(t *testing.T) {
+	for name, body := range map[string]string{
+		"include_usage": `{"model":"gpt-4","messages":[{"role":"user","content":"hi"}],"stream":true,"stream_options":{"include_usage":true}}`,
+		"empty object":  `{"model":"gpt-4","messages":[{"role":"user","content":"hi"}],"stream":true,"stream_options":{}}`,
+	} {
+		req, err := parseChatRequest([]byte(body))
+		if err != nil {
+			t.Fatalf("%s: parseChatRequest: %v", name, err)
+		}
+		if _, _, ok := req.cacheIdentity(""); ok {
+			t.Errorf("%s: cacheIdentity ok = true, want false (a replay can't reproduce the requested stream shape)", name)
+		}
+	}
+
+	// An explicit null is the same as absent — several OpenAI-compatible
+	// backends send it — and must stay cacheable.
+	req, err := parseChatRequest([]byte(`{"model":"gpt-4","messages":[{"role":"user","content":"hi"}],"stream_options":null}`))
+	if err != nil {
+		t.Fatalf("parseChatRequest: %v", err)
+	}
+	if _, _, ok := req.cacheIdentity(""); !ok {
+		t.Fatalf("cacheIdentity ok = false for stream_options:null, want true")
+	}
+}
+
+// extraOf is a test shorthand: parse a body and return the Extra
+// discriminator its scope carries.
+func extraOf(t *testing.T, body string) string {
+	t.Helper()
+	req, err := parseChatRequest([]byte(body))
+	if err != nil {
+		t.Fatalf("parseChatRequest(%s): %v", body, err)
+	}
+	_, scope, ok := req.cacheIdentity("")
+	if !ok {
+		t.Fatalf("cacheIdentity ok = false for %s", body)
+	}
+	return scope.Extra
+}
+
+func TestCacheIdentity_ExtraPartitionsOnSamplingParams(t *testing.T) {
+	const base = `{"model":"gpt-4","messages":[{"role":"user","content":"hi"}]}`
+	baseExtra := extraOf(t, base)
+
+	for name, body := range map[string]string{
+		"response_format":   `{"model":"gpt-4","messages":[{"role":"user","content":"hi"}],"response_format":{"type":"json_object"}}`,
+		"seed":              `{"model":"gpt-4","messages":[{"role":"user","content":"hi"}],"seed":7}`,
+		"top_p":             `{"model":"gpt-4","messages":[{"role":"user","content":"hi"}],"top_p":0.1}`,
+		"stop":              `{"model":"gpt-4","messages":[{"role":"user","content":"hi"}],"stop":["\n"]}`,
+		"frequency_penalty": `{"model":"gpt-4","messages":[{"role":"user","content":"hi"}],"frequency_penalty":1.5}`,
+	} {
+		if got := extraOf(t, body); got == baseExtra {
+			t.Errorf("%s: Extra = %q, same as the base request — the two must not share a cache entry", name, got)
+		}
+	}
+}
+
+func TestCacheIdentity_ExtraIgnoresKeyOrderAndPromptOnlyFields(t *testing.T) {
+	// Byte-different, semantically equal: reordered keys and extra whitespace.
+	a := extraOf(t, `{"model":"gpt-4","seed":7,"messages":[{"role":"user","content":"hi"}],"top_p":0.5}`)
+	b := extraOf(t, `{ "top_p": 0.5, "messages":[{"role":"user","content":"hi"}], "model":"gpt-4",  "seed":7 }`)
+	if a != b {
+		t.Fatalf("Extra = %q vs %q, want equal (key order and whitespace are not request surface)", a, b)
+	}
+
+	// stream and messages are deliberately excluded: the streaming and
+	// non-streaming forms of one call share a cached answer, and the messages
+	// ARE the prompt.
+	plain := extraOf(t, `{"model":"gpt-4","messages":[{"role":"user","content":"hi"}]}`)
+	streamed := extraOf(t, `{"model":"gpt-4","stream":true,"messages":[{"role":"user","content":"hi"}]}`)
+	if plain != streamed {
+		t.Fatalf("Extra = %q (plain) vs %q (stream:true), want equal", plain, streamed)
+	}
+	differentPrompt := extraOf(t, `{"model":"gpt-4","messages":[{"role":"user","content":"something else"}]}`)
+	if plain != differentPrompt {
+		t.Fatalf("Extra = %q vs %q, want equal (messages belong to the prompt, not the discriminator)", plain, differentPrompt)
+	}
+}
+
 func TestSynthesizeResponse_RoundTrips(t *testing.T) {
 	body := synthesizeResponse("gpt-4", "the answer", 42)
 

--- a/llmproxy/openai_test.go
+++ b/llmproxy/openai_test.go
@@ -1,0 +1,266 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package llmproxy
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestParseChatRequest_StringContent(t *testing.T) {
+	body := []byte(`{"model":"gpt-4","messages":[{"role":"user","content":"hi"}]}`)
+	req, err := parseChatRequest(body)
+	if err != nil {
+		t.Fatalf("parseChatRequest: %v", err)
+	}
+	if req.Model != "gpt-4" {
+		t.Fatalf("Model = %q, want gpt-4", req.Model)
+	}
+	if len(req.Messages) != 1 {
+		t.Fatalf("len(Messages) = %d, want 1", len(req.Messages))
+	}
+
+	_, _, ok := req.cacheIdentity("")
+	if !ok {
+		t.Fatalf("cacheIdentity ok = false, want true for string content")
+	}
+}
+
+func TestParseChatRequest_StashesRawBody(t *testing.T) {
+	body := []byte(`{"model":"gpt-4","messages":[{"role":"user","content":"hi"}]}`)
+	req, err := parseChatRequest(body)
+	if err != nil {
+		t.Fatalf("parseChatRequest: %v", err)
+	}
+	if string(req.Raw) != string(body) {
+		t.Fatalf("Raw = %q, want %q", req.Raw, body)
+	}
+}
+
+func TestCacheIdentity_ArrayContentUncacheable(t *testing.T) {
+	body := []byte(`{"model":"gpt-4","messages":[{"role":"user","content":[{"type":"text","text":"hi"}]}]}`)
+	req, err := parseChatRequest(body)
+	if err != nil {
+		t.Fatalf("parseChatRequest: %v", err)
+	}
+
+	_, _, ok := req.cacheIdentity("")
+	if ok {
+		t.Fatalf("cacheIdentity ok = true, want false for array content")
+	}
+}
+
+func TestTemperature_NilDefaultsToOne(t *testing.T) {
+	req := &chatRequest{}
+	if got := req.temperature(); got != 1.0 {
+		t.Fatalf("temperature() = %v, want 1.0", got)
+	}
+}
+
+func TestTemperature_ExplicitZeroStaysZero(t *testing.T) {
+	zero := 0.0
+	req := &chatRequest{Temperature: &zero}
+	if got := req.temperature(); got != 0.0 {
+		t.Fatalf("temperature() = %v, want 0.0", got)
+	}
+}
+
+func TestTemperature_ExplicitValuePreserved(t *testing.T) {
+	half := 0.5
+	req := &chatRequest{Temperature: &half}
+	if got := req.temperature(); got != 0.5 {
+		t.Fatalf("temperature() = %v, want 0.5", got)
+	}
+}
+
+func TestCacheIdentity_PromptSerializationExact(t *testing.T) {
+	body := []byte(`{"model":"gpt-4","messages":[
+		{"role":"system","content":"be terse"},
+		{"role":"user","content":"hello"},
+		{"role":"assistant","content":"hi there"},
+		{"role":"user","content":"bye"}
+	]}`)
+	req, err := parseChatRequest(body)
+	if err != nil {
+		t.Fatalf("parseChatRequest: %v", err)
+	}
+
+	prompt, scope, ok := req.cacheIdentity("")
+	if !ok {
+		t.Fatalf("cacheIdentity ok = false, want true")
+	}
+
+	want := "user\x00hello\x1eassistant\x00hi there\x1euser\x00bye\x1e"
+	if prompt != want {
+		t.Fatalf("prompt = %q, want %q", prompt, want)
+	}
+	if scope.System != "be terse" {
+		t.Fatalf("Scope.System = %q, want %q", scope.System, "be terse")
+	}
+}
+
+func TestCacheIdentity_SystemMessagesExcludedAndJoined(t *testing.T) {
+	body := []byte(`{"model":"gpt-4","messages":[
+		{"role":"system","content":"first"},
+		{"role":"user","content":"q"},
+		{"role":"system","content":"second"}
+	]}`)
+	req, err := parseChatRequest(body)
+	if err != nil {
+		t.Fatalf("parseChatRequest: %v", err)
+	}
+
+	prompt, scope, ok := req.cacheIdentity("")
+	if !ok {
+		t.Fatalf("cacheIdentity ok = false, want true")
+	}
+
+	wantPrompt := "user\x00q\x1e"
+	if prompt != wantPrompt {
+		t.Fatalf("prompt = %q, want %q", prompt, wantPrompt)
+	}
+
+	wantSystem := "first\nsecond"
+	if scope.System != wantSystem {
+		t.Fatalf("Scope.System = %q, want %q", scope.System, wantSystem)
+	}
+}
+
+func TestCacheIdentity_ToolNamesExtracted(t *testing.T) {
+	body := []byte(`{"model":"gpt-4","messages":[{"role":"user","content":"hi"}],
+		"tools":[{"function":{"name":"get_weather"}},{"function":{"name":"search"}}]}`)
+	req, err := parseChatRequest(body)
+	if err != nil {
+		t.Fatalf("parseChatRequest: %v", err)
+	}
+
+	_, scope, ok := req.cacheIdentity("")
+	if !ok {
+		t.Fatalf("cacheIdentity ok = false, want true")
+	}
+
+	want := []string{"get_weather", "search"}
+	if len(scope.Tools) != len(want) {
+		t.Fatalf("Tools = %v, want %v", scope.Tools, want)
+	}
+	for i := range want {
+		if scope.Tools[i] != want[i] {
+			t.Fatalf("Tools[%d] = %q, want %q", i, scope.Tools[i], want[i])
+		}
+	}
+}
+
+func TestCacheIdentity_NGreaterThanOneUncacheable(t *testing.T) {
+	body := []byte(`{"model":"gpt-4","messages":[{"role":"user","content":"hi"}],"n":2}`)
+	req, err := parseChatRequest(body)
+	if err != nil {
+		t.Fatalf("parseChatRequest: %v", err)
+	}
+
+	_, _, ok := req.cacheIdentity("")
+	if ok {
+		t.Fatalf("cacheIdentity ok = true, want false when n=2")
+	}
+}
+
+func TestCacheIdentity_ScopeFieldsPopulated(t *testing.T) {
+	half := 0.5
+	body, err := json.Marshal(chatRequest{
+		Model:       "gpt-4o",
+		Messages:    []chatMessage{{Role: "user", Content: json.RawMessage(`"hi"`)}},
+		Temperature: &half,
+		MaxTokens:   256,
+	})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	req, err := parseChatRequest(body)
+	if err != nil {
+		t.Fatalf("parseChatRequest: %v", err)
+	}
+
+	_, scope, ok := req.cacheIdentity("tenant-a")
+	if !ok {
+		t.Fatalf("cacheIdentity ok = false, want true")
+	}
+	if scope.Model != "gpt-4o" {
+		t.Fatalf("Scope.Model = %q, want gpt-4o", scope.Model)
+	}
+	if scope.Temperature != 0.5 {
+		t.Fatalf("Scope.Temperature = %v, want 0.5", scope.Temperature)
+	}
+	if scope.MaxTokens != 256 {
+		t.Fatalf("Scope.MaxTokens = %d, want 256", scope.MaxTokens)
+	}
+	if scope.Tenant != "tenant-a" {
+		t.Fatalf("Scope.Tenant = %q, want tenant-a", scope.Tenant)
+	}
+}
+
+func TestSynthesizeResponse_RoundTrips(t *testing.T) {
+	body := synthesizeResponse("gpt-4", "the answer", 42)
+
+	var resp chatResponse
+	if err := json.Unmarshal(body, &resp); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	if len(resp.Choices) != 1 {
+		t.Fatalf("len(Choices) = %d, want 1", len(resp.Choices))
+	}
+	if resp.Choices[0].Message.Content != "the answer" {
+		t.Fatalf("Content = %q, want %q", resp.Choices[0].Message.Content, "the answer")
+	}
+	if resp.Choices[0].FinishReason != "stop" {
+		t.Fatalf("FinishReason = %q, want stop", resp.Choices[0].FinishReason)
+	}
+	if resp.Usage.CompletionTokens != 42 {
+		t.Fatalf("CompletionTokens = %d, want 42", resp.Usage.CompletionTokens)
+	}
+
+	// Also check the raw JSON shape for the fields not carried by chatResponse.
+	var raw map[string]any
+	if err := json.Unmarshal(body, &raw); err != nil {
+		t.Fatalf("Unmarshal raw: %v", err)
+	}
+	if raw["id"] != "rostam-cache" {
+		t.Fatalf("id = %v, want rostam-cache", raw["id"])
+	}
+	if raw["object"] != "chat.completion" {
+		t.Fatalf("object = %v, want chat.completion", raw["object"])
+	}
+	if raw["model"] != "gpt-4" {
+		t.Fatalf("model = %v, want gpt-4", raw["model"])
+	}
+	usage, _ := raw["usage"].(map[string]any)
+	if usage["prompt_tokens"] != float64(0) {
+		t.Fatalf("prompt_tokens = %v, want 0", usage["prompt_tokens"])
+	}
+	if usage["total_tokens"] != float64(42) {
+		t.Fatalf("total_tokens = %v, want 42", usage["total_tokens"])
+	}
+}
+
+func TestTenantOf_EmptyHeaderYieldsEmptyTenant(t *testing.T) {
+	if got := tenantOf(""); got != "" {
+		t.Fatalf("tenantOf(\"\") = %q, want empty", got)
+	}
+}
+
+func TestTenantOf_DifferingHeadersDiffer(t *testing.T) {
+	a := tenantOf("Bearer sk-aaaa")
+	b := tenantOf("Bearer sk-bbbb")
+	if a == "" || b == "" {
+		t.Fatalf("tenantOf returned empty for non-empty header: a=%q b=%q", a, b)
+	}
+	if a == b {
+		t.Fatalf("tenantOf(a) == tenantOf(b) = %q, want distinct hashes", a)
+	}
+}
+
+func TestTenantOf_SameHeaderSameTenant(t *testing.T) {
+	a := tenantOf("Bearer sk-aaaa")
+	b := tenantOf("Bearer sk-aaaa")
+	if a != b {
+		t.Fatalf("tenantOf(same) = %q vs %q, want equal", a, b)
+	}
+}

--- a/llmproxy/proxy.go
+++ b/llmproxy/proxy.go
@@ -266,13 +266,13 @@ func (s *Server) forwardAndMaybeStore(w http.ResponseWriter, r *http.Request, re
 		return
 	}
 
-	resp, err := s.client.Do(upstreamReq)
+	resp, err := s.client.Do(upstreamReq) //nolint:gosec // G704: upstream host comes only from the operator-pinned -upstream flag (validated absolute http/https at startup); the client controls only path/query/body
 	if err != nil {
 		s.log.Error("llmproxy: upstream request failed", "err", err)
 		writeOpenAIError(w, http.StatusBadGateway, "upstream request failed: "+err.Error(), "upstream_error")
 		return
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	respBody, err := io.ReadAll(resp.Body)
 	if err != nil {
@@ -341,13 +341,13 @@ func (s *Server) forwardStreamAndMaybeStore(w http.ResponseWriter, r *http.Reque
 		return
 	}
 
-	resp, err := s.client.Do(upstreamReq)
+	resp, err := s.client.Do(upstreamReq) //nolint:gosec // G704: upstream host comes only from the operator-pinned -upstream flag (validated absolute http/https at startup); the client controls only path/query/body
 	if err != nil {
 		s.log.Error("llmproxy: upstream request failed", "err", err)
 		writeOpenAIError(w, http.StatusBadGateway, "upstream request failed: "+err.Error(), "upstream_error")
 		return
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	copyHeadersExceptHopByHop(w.Header(), resp.Header)
 	w.Header().Set("x-rostam-cache", cacheStatus)
@@ -395,13 +395,13 @@ func (s *Server) passthroughRequest(w http.ResponseWriter, r *http.Request, body
 		return
 	}
 
-	resp, err := s.client.Do(upstreamReq)
+	resp, err := s.client.Do(upstreamReq) //nolint:gosec // G704: upstream host comes only from the operator-pinned -upstream flag (validated absolute http/https at startup); the client controls only path/query/body
 	if err != nil {
 		s.log.Error("llmproxy: upstream request failed", "err", err)
 		writeOpenAIError(w, http.StatusBadGateway, "upstream request failed: "+err.Error(), "upstream_error")
 		return
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	copyHeadersExceptHopByHop(w.Header(), resp.Header)
 	if cacheStatus != "" {

--- a/llmproxy/proxy.go
+++ b/llmproxy/proxy.go
@@ -149,9 +149,9 @@ func writeOpenAIError(w http.ResponseWriter, status int, message, errType string
 
 // handleChatCompletions implements the cache path for POST
 // /v1/chat/completions: parse, check cacheability, look up, answer from
-// cache or forward and store. Stream:true requests take the passthrough
-// (uncached) branch in this task — a later task replaces that branch with
-// real streaming-cache support; see the SEAM comment below.
+// cache or forward and store. Stream:true requests are cacheable exactly like
+// non-streaming ones but take a separate path (handleStreamingChat) because
+// their hit and miss responses are SSE rather than a single JSON body.
 func (s *Server) handleChatCompletions(w http.ResponseWriter, r *http.Request) {
 	r.Body = http.MaxBytesReader(w, r.Body, maxBodyBytes)
 	body, err := io.ReadAll(r.Body)

--- a/llmproxy/proxy.go
+++ b/llmproxy/proxy.go
@@ -175,7 +175,7 @@ func (s *Server) handleChatCompletions(w http.ResponseWriter, r *http.Request) {
 	prompt, scope, ok := req.cacheIdentity(tenant)
 	if !ok || !s.cache.Cacheable(req.temperature()) {
 		s.stats.uncacheable.Add(1)
-		s.passthroughRequest(w, r, bytes.NewReader(body), int64(len(body)))
+		s.passthroughRequest(w, r, bytes.NewReader(body), int64(len(body)), "uncacheable")
 		return
 	}
 
@@ -358,7 +358,7 @@ func (s *Server) forwardStreamAndMaybeStore(w http.ResponseWriter, r *http.Reque
 
 	isSSE := strings.HasPrefix(resp.Header.Get("Content-Type"), "text/event-stream")
 	if resp.StatusCode != http.StatusOK || !isSSE {
-		if _, err := io.Copy(w, resp.Body); err != nil {
+		if _, err := io.Copy(newFlushWriter(w), resp.Body); err != nil {
 			s.logRelayError("llmproxy: relaying non-SSE stream response", err)
 		}
 		return
@@ -385,8 +385,13 @@ func (s *Server) forwardStreamAndMaybeStore(w http.ResponseWriter, r *http.Reque
 // rather than buffering either — a passthrough route has no chat-completions
 // body cap, so buffering here would let a single client exhaust memory with
 // an arbitrarily large body. contentLength mirrors http.Request.ContentLength
-// (-1 when unknown).
-func (s *Server) passthroughRequest(w http.ResponseWriter, r *http.Request, body io.Reader, contentLength int64) {
+// (-1 when unknown). cacheStatus, when non-empty, is reported to the client as
+// x-rostam-cache; a chat request the cache declined passes "uncacheable" so
+// every chat response carries a cache verdict, while the generic passthrough
+// routes pass "" — they were never cache candidates and claiming a verdict on
+// /v1/models would be noise.
+func (s *Server) passthroughRequest(w http.ResponseWriter, r *http.Request, body io.Reader, contentLength int64,
+	cacheStatus string) {
 	upstreamReq, err := s.newUpstreamRequest(r, body, contentLength)
 	if err != nil {
 		writeOpenAIError(w, http.StatusBadGateway, "building upstream request: "+err.Error(), "upstream_error")
@@ -402,11 +407,14 @@ func (s *Server) passthroughRequest(w http.ResponseWriter, r *http.Request, body
 	defer resp.Body.Close()
 
 	copyHeadersExceptHopByHop(w.Header(), resp.Header)
+	if cacheStatus != "" {
+		w.Header().Set("x-rostam-cache", cacheStatus)
+	}
 	w.WriteHeader(resp.StatusCode)
 	// Stream rather than buffer: passthrough also carries SSE bodies (a
 	// stream:true request that took this branch), and buffering the whole
 	// response would defeat the point of a stream.
-	if _, err := io.Copy(w, resp.Body); err != nil {
+	if _, err := io.Copy(newFlushWriter(w), resp.Body); err != nil {
 		s.logRelayError("llmproxy: relaying passthrough response body", err)
 	}
 }
@@ -418,7 +426,7 @@ func (s *Server) passthroughRequest(w http.ResponseWriter, r *http.Request, body
 // route carries no chat-completions-style size cap, so reading it fully here
 // would be an unbounded allocation driven by whatever the client sends.
 func (s *Server) handlePassthrough(w http.ResponseWriter, r *http.Request) {
-	s.passthroughRequest(w, r, r.Body, r.ContentLength)
+	s.passthroughRequest(w, r, r.Body, r.ContentLength, "")
 }
 
 // newUpstreamRequest builds the request the proxy sends to Upstream for an
@@ -442,6 +450,38 @@ func (s *Server) newUpstreamRequest(r *http.Request, body io.Reader, contentLeng
 	upstreamReq.Host = s.upstream.Host
 	upstreamReq.ContentLength = contentLength
 	return upstreamReq, nil
+}
+
+// flushWriter flushes the destination after every Write. io.Copy on its own
+// hands the http.ResponseWriter 32 KiB at a time and never flushes, so an SSE
+// body relayed through it sits in the response buffer until the copy finishes
+// — the client gets the whole "stream" at the end, which is exactly what a
+// streaming client asked not to happen. Uncacheable and non-SSE relays take
+// that path, so they need the flush too.
+//
+// The flusher is resolved once, at construction, and a writer that cannot
+// flush degrades to a plain copy rather than an error: these relays must keep
+// working on any ResponseWriter.
+type flushWriter struct {
+	w  io.Writer
+	fl http.Flusher
+}
+
+// newFlushWriter wraps w, flushing after each Write when w can flush.
+func newFlushWriter(w io.Writer) *flushWriter {
+	fw := &flushWriter{w: w}
+	if fl, ok := w.(http.Flusher); ok {
+		fw.fl = fl
+	}
+	return fw
+}
+
+func (f *flushWriter) Write(p []byte) (int, error) {
+	n, err := f.w.Write(p)
+	if n > 0 && f.fl != nil {
+		f.fl.Flush()
+	}
+	return n, err
 }
 
 // newChatUpstreamRequest builds the upstream request for a chat-completions

--- a/llmproxy/proxy.go
+++ b/llmproxy/proxy.go
@@ -171,7 +171,7 @@ func (s *Server) handleChatCompletions(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	tenant := tenantOf(r.Header.Get("Authorization"))
+	tenant := tenantOf(r.Header.Get("Authorization"), r.Header.Get("api-key"), r.Header.Get("x-api-key"))
 	prompt, scope, ok := req.cacheIdentity(tenant)
 	if !ok || !s.cache.Cacheable(req.temperature()) {
 		s.stats.uncacheable.Add(1)

--- a/llmproxy/proxy.go
+++ b/llmproxy/proxy.go
@@ -179,11 +179,8 @@ func (s *Server) handleChatCompletions(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// SEAM: Stream:true requests are uncached passthrough here; a later task
-	// replaces this branch with a caching-aware SSE relay (cache hit -> replay
-	// as SSE, miss -> relay + capture via relayAndCapture).
 	if req.Stream {
-		s.passthroughRequest(w, r, bytes.NewReader(body), int64(len(body)))
+		s.handleStreamingChat(w, r, req, prompt, scope)
 		return
 	}
 
@@ -203,6 +200,35 @@ func (s *Server) handleChatCompletions(w http.ResponseWriter, r *http.Request) {
 		_, _ = w.Write(synthesizeResponse(req.Model, hit.Answer, hit.OutTokens))
 	default:
 		s.forwardAndMaybeStore(w, r, req, prompt, scope, "miss")
+	}
+}
+
+// handleStreamingChat implements the cache path for a Stream:true request
+// already judged cacheable: a hit replays the cached answer as a synthetic
+// SSE stream without touching upstream; a miss (or a lookup error, treated as
+// a bypass) forwards the request and relays upstream's stream live via
+// forwardStreamAndMaybeStore.
+func (s *Server) handleStreamingChat(w http.ResponseWriter, r *http.Request, req *chatRequest,
+	prompt string, scope semcache.Scope) {
+	hit, found, err := s.cache.Lookup(r.Context(), prompt, scope)
+	switch {
+	case err != nil:
+		// Lookup errored: treat as a miss but tell the client the cache was
+		// bypassed rather than claiming a clean miss it didn't get.
+		s.log.Error("llmproxy: cache lookup failed", "err", err)
+		s.forwardStreamAndMaybeStore(w, r, req, prompt, scope, "bypass")
+	case found:
+		s.stats.hits.Add(1)
+		s.stats.tokensSaved.Add(int64(hit.OutTokens))
+		// The header must land before replayAsSSE's first write, which
+		// implicitly sends the response headers (no explicit WriteHeader for
+		// an SSE stream — replayAsSSE never calls it).
+		w.Header().Set("x-rostam-cache", "hit")
+		if err := replayAsSSE(w, req.Model, hit.Answer); err != nil {
+			s.log.Error("llmproxy: replaying cached stream", "err", err)
+		}
+	default:
+		s.forwardStreamAndMaybeStore(w, r, req, prompt, scope, "miss")
 	}
 }
 
@@ -283,6 +309,58 @@ func (s *Server) maybeStore(ctx context.Context, prompt string, scope semcache.S
 	}
 
 	if err := s.cache.Store(ctx, prompt, scope, choice.Message.Content, resp.Usage.CompletionTokens); err != nil {
+		s.log.Error("llmproxy: cache store failed", "err", err)
+		return
+	}
+	s.stats.stored.Add(1)
+}
+
+// forwardStreamAndMaybeStore forwards req.Raw upstream for a Stream:true
+// request. A 200 response with an SSE content type is relayed live via
+// relayAndCapture, and the assembled answer is stored on a clean single-choice
+// completion; anything else (non-200, or a 200 that isn't SSE — e.g. an
+// upstream that doesn't honor stream:true) is relayed as-is and never cached,
+// since relayAndCapture's accumulation logic assumes an SSE body.
+func (s *Server) forwardStreamAndMaybeStore(w http.ResponseWriter, r *http.Request, req *chatRequest,
+	prompt string, scope semcache.Scope, cacheStatus string) {
+	s.stats.misses.Add(1)
+
+	upstreamReq, err := s.newUpstreamRequest(r, bytes.NewReader(req.Raw), int64(len(req.Raw)))
+	if err != nil {
+		writeOpenAIError(w, http.StatusBadGateway, "building upstream request: "+err.Error(), "upstream_error")
+		return
+	}
+
+	resp, err := s.client.Do(upstreamReq)
+	if err != nil {
+		s.log.Error("llmproxy: upstream request failed", "err", err)
+		writeOpenAIError(w, http.StatusBadGateway, "upstream request failed: "+err.Error(), "upstream_error")
+		return
+	}
+	defer resp.Body.Close()
+
+	copyHeadersExceptHopByHop(w.Header(), resp.Header)
+	w.Header().Set("x-rostam-cache", cacheStatus)
+	w.WriteHeader(resp.StatusCode)
+
+	isSSE := strings.HasPrefix(resp.Header.Get("Content-Type"), "text/event-stream")
+	if resp.StatusCode != http.StatusOK || !isSSE {
+		if _, err := io.Copy(w, resp.Body); err != nil {
+			s.log.Error("llmproxy: relaying non-SSE stream response", "err", err)
+		}
+		return
+	}
+
+	result, err := relayAndCapture(w, resp.Body)
+	if err != nil {
+		s.log.Error("llmproxy: relaying streamed response", "err", err)
+		return
+	}
+	if !result.clean || result.finishReason != "stop" || result.sawToolCalls || result.content.Len() == 0 {
+		return
+	}
+
+	if err := s.cache.Store(r.Context(), prompt, scope, result.content.String(), result.completionTokens); err != nil {
 		s.log.Error("llmproxy: cache store failed", "err", err)
 		return
 	}

--- a/llmproxy/proxy.go
+++ b/llmproxy/proxy.go
@@ -44,7 +44,6 @@ var hopByHopHeaders = []string{
 type Config struct {
 	Cache    *semcache.Cache // required
 	Upstream *url.URL        // required
-	MaxTemp  float64         // cacheability ceiling (proxy-level; also set on the semcache Config by the caller)
 	Mode     string          // "exact" | "semantic" — surfaced verbatim in /stats, not otherwise used here
 	Logger   *slog.Logger
 	Client   *http.Client // nil => &http.Client{Timeout: 5 * time.Minute}
@@ -65,7 +64,6 @@ type stats struct {
 type Server struct {
 	cache    *semcache.Cache
 	upstream *url.URL
-	maxTemp  float64
 	mode     string
 	log      *slog.Logger
 	client   *http.Client
@@ -93,7 +91,6 @@ func NewServer(cfg Config) (*Server, error) {
 	return &Server{
 		cache:    cfg.Cache,
 		upstream: cfg.Upstream,
-		maxTemp:  cfg.MaxTemp,
 		mode:     cfg.Mode,
 		log:      log,
 		client:   client,

--- a/llmproxy/proxy.go
+++ b/llmproxy/proxy.go
@@ -1,0 +1,390 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package llmproxy
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/url"
+	"strings"
+	"sync/atomic"
+	"time"
+
+	"github.com/rostamlabs/rostam/semcache"
+)
+
+// maxBodyBytes bounds a chat-completions request body the proxy will parse
+// for cache scoping. 16 MiB is generous for any real chat prompt; without a
+// cap a client could make the proxy buffer an unbounded body in memory
+// before it ever gets to json.Unmarshal.
+const maxBodyBytes = 16 << 20
+
+// hopByHopHeaders are stripped when relaying a request or response between
+// the proxy and upstream/client, per RFC 7230 §6.1 — they describe THIS hop's
+// connection, not the message, and forwarding them verbatim would leak or
+// corrupt the next hop's own connection handling.
+var hopByHopHeaders = []string{
+	"Connection",
+	"Keep-Alive",
+	"Proxy-Authenticate",
+	"Proxy-Authorization",
+	"TE",
+	"Trailer",
+	"Transfer-Encoding",
+	"Upgrade",
+}
+
+// Config configures a Server.
+type Config struct {
+	Cache    *semcache.Cache // required
+	Upstream *url.URL        // required
+	MaxTemp  float64         // cacheability ceiling (proxy-level; also set on the semcache Config by the caller)
+	Mode     string          // "exact" | "semantic" — surfaced verbatim in /stats, not otherwise used here
+	Logger   *slog.Logger
+	Client   *http.Client // nil => &http.Client{Timeout: 5 * time.Minute}
+}
+
+// stats holds the proxy's request counters, exposed as JSON at GET /stats.
+// Fields are atomic because requests are served concurrently.
+type stats struct {
+	hits        atomic.Int64
+	misses      atomic.Int64
+	stored      atomic.Int64
+	uncacheable atomic.Int64
+	tokensSaved atomic.Int64
+}
+
+// Server is the OpenAI-compatible caching reverse proxy. Safe for concurrent
+// use (http.Handler is called concurrently by net/http already).
+type Server struct {
+	cache    *semcache.Cache
+	upstream *url.URL
+	maxTemp  float64
+	mode     string
+	log      *slog.Logger
+	client   *http.Client
+	stats    stats
+}
+
+// NewServer validates cfg and builds a Server.
+func NewServer(cfg Config) (*Server, error) {
+	if cfg.Cache == nil {
+		return nil, errors.New("llmproxy: Config.Cache is required")
+	}
+	if cfg.Upstream == nil {
+		return nil, errors.New("llmproxy: Config.Upstream is required")
+	}
+
+	log := cfg.Logger
+	if log == nil {
+		log = slog.Default()
+	}
+	client := cfg.Client
+	if client == nil {
+		client = &http.Client{Timeout: 5 * time.Minute}
+	}
+
+	return &Server{
+		cache:    cfg.Cache,
+		upstream: cfg.Upstream,
+		maxTemp:  cfg.MaxTemp,
+		mode:     cfg.Mode,
+		log:      log,
+		client:   client,
+	}, nil
+}
+
+// Handler returns the proxy's http.Handler. Routing: POST
+// /v1/chat/completions goes through the cache path; GET /stats returns
+// counters; everything else is passed through to Upstream verbatim.
+func (s *Server) Handler() http.Handler {
+	mux := http.NewServeMux()
+	mux.HandleFunc("POST /v1/chat/completions", s.handleChatCompletions)
+	mux.HandleFunc("GET /stats", s.handleStats)
+	mux.HandleFunc("/", s.handlePassthrough)
+	return mux
+}
+
+// handleStats serves the current counters as JSON.
+func (s *Server) handleStats(w http.ResponseWriter, r *http.Request) {
+	body := map[string]any{
+		"hits":         s.stats.hits.Load(),
+		"misses":       s.stats.misses.Load(),
+		"stored":       s.stats.stored.Load(),
+		"uncacheable":  s.stats.uncacheable.Load(),
+		"tokens_saved": s.stats.tokensSaved.Load(),
+		"mode":         s.mode,
+	}
+	w.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w).Encode(body); err != nil {
+		s.log.Error("llmproxy: encode /stats response", "err", err)
+	}
+}
+
+// writeOpenAIError writes an OpenAI-shaped error body: clients of an
+// OpenAI-compatible API expect {"error":{"message":...,"type":...}} even
+// from proxy-local failures, not a bare status code or plain text.
+func writeOpenAIError(w http.ResponseWriter, status int, message, errType string) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	body := map[string]any{
+		"error": map[string]any{
+			"message": message,
+			"type":    errType,
+		},
+	}
+	// The shape above is fixed and always marshals cleanly.
+	b, err := json.Marshal(body)
+	if err != nil {
+		panic("llmproxy: writeOpenAIError: " + err.Error())
+	}
+	_, _ = w.Write(b)
+}
+
+// handleChatCompletions implements the cache path for POST
+// /v1/chat/completions: parse, check cacheability, look up, answer from
+// cache or forward and store. Stream:true requests take the passthrough
+// (uncached) branch in this task — a later task replaces that branch with
+// real streaming-cache support; see the SEAM comment below.
+func (s *Server) handleChatCompletions(w http.ResponseWriter, r *http.Request) {
+	r.Body = http.MaxBytesReader(w, r.Body, maxBodyBytes)
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		if isMaxBytesError(err) {
+			writeOpenAIError(w, http.StatusRequestEntityTooLarge,
+				"request body exceeds the maximum allowed size", "invalid_request_error")
+			return
+		}
+		writeOpenAIError(w, http.StatusBadRequest, err.Error(), "invalid_request_error")
+		return
+	}
+
+	req, err := parseChatRequest(body)
+	if err != nil {
+		writeOpenAIError(w, http.StatusBadRequest, "invalid JSON: "+err.Error(), "invalid_request_error")
+		return
+	}
+
+	tenant := tenantOf(r.Header.Get("Authorization"))
+	prompt, scope, ok := req.cacheIdentity(tenant)
+	if !ok || !s.cache.Cacheable(req.temperature()) {
+		s.stats.uncacheable.Add(1)
+		s.passthroughRequest(w, r, body)
+		return
+	}
+
+	// SEAM: Stream:true requests are uncached passthrough here; a later task
+	// replaces this branch with a caching-aware SSE relay (cache hit -> replay
+	// as SSE, miss -> relay + capture via relayAndCapture).
+	if req.Stream {
+		s.passthroughRequest(w, r, body)
+		return
+	}
+
+	hit, found, err := s.cache.Lookup(r.Context(), prompt, scope)
+	switch {
+	case err != nil:
+		// Lookup errored: treat as a miss but tell the client the cache was
+		// bypassed rather than claiming a clean miss it didn't get.
+		s.log.Error("llmproxy: cache lookup failed", "err", err)
+		s.forwardAndMaybeStore(w, r, req, prompt, scope, "bypass")
+	case found:
+		s.stats.hits.Add(1)
+		s.stats.tokensSaved.Add(int64(hit.OutTokens))
+		w.Header().Set("x-rostam-cache", "hit")
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(synthesizeResponse(req.Model, hit.Answer, hit.OutTokens))
+	default:
+		s.forwardAndMaybeStore(w, r, req, prompt, scope, "miss")
+	}
+}
+
+// isMaxBytesError reports whether err came from http.MaxBytesReader's limit,
+// across Go versions that either expose *http.MaxBytesError or a plain
+// "http: request body too large" message.
+func isMaxBytesError(err error) bool {
+	var mbErr *http.MaxBytesError
+	if errors.As(err, &mbErr) {
+		return true
+	}
+	return strings.Contains(err.Error(), "request body too large")
+}
+
+// forwardAndMaybeStore forwards req.Raw upstream, relays the response
+// verbatim to the client with the given cache-status header, and — for a
+// cacheable-shaped success — stores the answer for next time.
+func (s *Server) forwardAndMaybeStore(w http.ResponseWriter, r *http.Request, req *chatRequest,
+	prompt string, scope semcache.Scope, cacheStatus string) {
+	s.stats.misses.Add(1)
+
+	upstreamReq, err := s.newUpstreamRequest(r, req.Raw)
+	if err != nil {
+		writeOpenAIError(w, http.StatusBadGateway, "building upstream request: "+err.Error(), "upstream_error")
+		return
+	}
+
+	resp, err := s.client.Do(upstreamReq)
+	if err != nil {
+		s.log.Error("llmproxy: upstream request failed", "err", err)
+		writeOpenAIError(w, http.StatusBadGateway, "upstream request failed: "+err.Error(), "upstream_error")
+		return
+	}
+	defer resp.Body.Close()
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		s.log.Error("llmproxy: reading upstream response", "err", err)
+		writeOpenAIError(w, http.StatusBadGateway, "reading upstream response: "+err.Error(), "upstream_error")
+		return
+	}
+
+	copyHeadersExceptHopByHop(w.Header(), resp.Header)
+	w.Header().Set("x-rostam-cache", cacheStatus)
+	w.WriteHeader(resp.StatusCode)
+	_, _ = w.Write(respBody)
+
+	if resp.StatusCode == http.StatusOK {
+		s.maybeStore(r.Context(), req.Model, prompt, scope, respBody)
+	}
+}
+
+// maybeStore decodes an upstream chat-completions response and stores it in
+// the cache if it has the shape a cached answer can safely stand in for:
+// exactly one choice, finish_reason "stop", no tool calls, non-empty
+// content. Anything else (multiple choices already excluded upstream by
+// cacheIdentity's n>1 check, but a defensively-checked finish reason or a
+// tool call) means the response isn't a plain completion a synthesized reply
+// could faithfully replay.
+func (s *Server) maybeStore(ctx context.Context, model, prompt string, scope semcache.Scope, respBody []byte) {
+	var resp chatResponse
+	if err := json.Unmarshal(respBody, &resp); err != nil {
+		s.log.Error("llmproxy: decode upstream response for cache store", "err", err)
+		return
+	}
+	if len(resp.Choices) != 1 {
+		return
+	}
+	choice := resp.Choices[0]
+	if choice.FinishReason != "stop" {
+		return
+	}
+	if toolCallsPresent(choice.Message.ToolCalls) {
+		return
+	}
+	if choice.Message.Content == "" {
+		return
+	}
+
+	if err := s.cache.Store(ctx, prompt, scope, choice.Message.Content, resp.Usage.CompletionTokens); err != nil {
+		s.log.Error("llmproxy: cache store failed", "err", err)
+		return
+	}
+	s.stats.stored.Add(1)
+}
+
+// passthroughRequest relays r to Upstream verbatim, streaming the response
+// body back to the client. body is the already-read request body (the
+// caller has consumed r.Body via io.ReadAll for size-capping/parsing, so it
+// can't be read from r again).
+func (s *Server) passthroughRequest(w http.ResponseWriter, r *http.Request, body []byte) {
+	upstreamReq, err := s.newUpstreamRequest(r, body)
+	if err != nil {
+		writeOpenAIError(w, http.StatusBadGateway, "building upstream request: "+err.Error(), "upstream_error")
+		return
+	}
+
+	resp, err := s.client.Do(upstreamReq)
+	if err != nil {
+		s.log.Error("llmproxy: upstream request failed", "err", err)
+		writeOpenAIError(w, http.StatusBadGateway, "upstream request failed: "+err.Error(), "upstream_error")
+		return
+	}
+	defer resp.Body.Close()
+
+	copyHeadersExceptHopByHop(w.Header(), resp.Header)
+	w.WriteHeader(resp.StatusCode)
+	// Stream rather than buffer: passthrough also carries SSE bodies (a
+	// stream:true request that took this branch), and buffering the whole
+	// response would defeat the point of a stream.
+	if _, err := io.Copy(w, resp.Body); err != nil {
+		s.log.Error("llmproxy: relaying passthrough response body", "err", err)
+	}
+}
+
+// handlePassthrough relays any request not matched by a more specific route
+// to Upstream verbatim: method, path, query, headers (minus hop-by-hop) and
+// body all preserved, response streamed back unmodified.
+func (s *Server) handlePassthrough(w http.ResponseWriter, r *http.Request) {
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		writeOpenAIError(w, http.StatusBadRequest, err.Error(), "invalid_request_error")
+		return
+	}
+	s.passthroughRequest(w, r, body)
+}
+
+// newUpstreamRequest builds the request the proxy sends to Upstream for an
+// incoming client request r, rebuilding the URL on Upstream's scheme/host
+// while keeping r's path and query, and copying method/headers (minus
+// hop-by-hop) with the given body.
+func (s *Server) newUpstreamRequest(r *http.Request, body []byte) (*http.Request, error) {
+	u := *s.upstream
+	u.Path = singleJoiningSlash(s.upstream.Path, r.URL.Path)
+	u.RawQuery = r.URL.RawQuery
+
+	upstreamReq, err := http.NewRequestWithContext(r.Context(), r.Method, u.String(), bytes.NewReader(body))
+	if err != nil {
+		return nil, fmt.Errorf("llmproxy: new upstream request: %w", err)
+	}
+	copyHeadersExceptHopByHop(upstreamReq.Header, r.Header)
+	upstreamReq.Host = s.upstream.Host
+	upstreamReq.ContentLength = int64(len(body))
+	return upstreamReq, nil
+}
+
+// singleJoiningSlash joins a base path and a request path with exactly one
+// slash between them, mirroring net/http/httputil.ReverseProxy's helper —
+// Upstream is typically bare ("https://api.openai.com", empty Path) but
+// mustn't produce a doubled or missing slash if it ever carries one.
+func singleJoiningSlash(base, ref string) string {
+	baseSlash := strings.HasSuffix(base, "/")
+	refSlash := strings.HasPrefix(ref, "/")
+	switch {
+	case baseSlash && refSlash:
+		return base + ref[1:]
+	case !baseSlash && !refSlash:
+		return base + "/" + ref
+	default:
+		return base + ref
+	}
+}
+
+// copyHeadersExceptHopByHop copies every header from src to dst except the
+// hop-by-hop set, which describes the connection between two specific peers
+// and must not be forwarded to the next hop.
+func copyHeadersExceptHopByHop(dst, src http.Header) {
+	for k, vv := range src {
+		if isHopByHop(k) {
+			continue
+		}
+		for _, v := range vv {
+			dst.Add(k, v)
+		}
+	}
+}
+
+func isHopByHop(header string) bool {
+	for _, h := range hopByHopHeaders {
+		if strings.EqualFold(h, header) {
+			return true
+		}
+	}
+	return false
+}

--- a/llmproxy/proxy.go
+++ b/llmproxy/proxy.go
@@ -175,7 +175,7 @@ func (s *Server) handleChatCompletions(w http.ResponseWriter, r *http.Request) {
 	prompt, scope, ok := req.cacheIdentity(tenant)
 	if !ok || !s.cache.Cacheable(req.temperature()) {
 		s.stats.uncacheable.Add(1)
-		s.passthroughRequest(w, r, body)
+		s.passthroughRequest(w, r, bytes.NewReader(body), int64(len(body)))
 		return
 	}
 
@@ -183,7 +183,7 @@ func (s *Server) handleChatCompletions(w http.ResponseWriter, r *http.Request) {
 	// replaces this branch with a caching-aware SSE relay (cache hit -> replay
 	// as SSE, miss -> relay + capture via relayAndCapture).
 	if req.Stream {
-		s.passthroughRequest(w, r, body)
+		s.passthroughRequest(w, r, bytes.NewReader(body), int64(len(body)))
 		return
 	}
 
@@ -224,7 +224,7 @@ func (s *Server) forwardAndMaybeStore(w http.ResponseWriter, r *http.Request, re
 	prompt string, scope semcache.Scope, cacheStatus string) {
 	s.stats.misses.Add(1)
 
-	upstreamReq, err := s.newUpstreamRequest(r, req.Raw)
+	upstreamReq, err := s.newUpstreamRequest(r, bytes.NewReader(req.Raw), int64(len(req.Raw)))
 	if err != nil {
 		writeOpenAIError(w, http.StatusBadGateway, "building upstream request: "+err.Error(), "upstream_error")
 		return
@@ -251,7 +251,7 @@ func (s *Server) forwardAndMaybeStore(w http.ResponseWriter, r *http.Request, re
 	_, _ = w.Write(respBody)
 
 	if resp.StatusCode == http.StatusOK {
-		s.maybeStore(r.Context(), req.Model, prompt, scope, respBody)
+		s.maybeStore(r.Context(), prompt, scope, respBody)
 	}
 }
 
@@ -262,7 +262,7 @@ func (s *Server) forwardAndMaybeStore(w http.ResponseWriter, r *http.Request, re
 // cacheIdentity's n>1 check, but a defensively-checked finish reason or a
 // tool call) means the response isn't a plain completion a synthesized reply
 // could faithfully replay.
-func (s *Server) maybeStore(ctx context.Context, model, prompt string, scope semcache.Scope, respBody []byte) {
+func (s *Server) maybeStore(ctx context.Context, prompt string, scope semcache.Scope, respBody []byte) {
 	var resp chatResponse
 	if err := json.Unmarshal(respBody, &resp); err != nil {
 		s.log.Error("llmproxy: decode upstream response for cache store", "err", err)
@@ -289,12 +289,14 @@ func (s *Server) maybeStore(ctx context.Context, model, prompt string, scope sem
 	s.stats.stored.Add(1)
 }
 
-// passthroughRequest relays r to Upstream verbatim, streaming the response
-// body back to the client. body is the already-read request body (the
-// caller has consumed r.Body via io.ReadAll for size-capping/parsing, so it
-// can't be read from r again).
-func (s *Server) passthroughRequest(w http.ResponseWriter, r *http.Request, body []byte) {
-	upstreamReq, err := s.newUpstreamRequest(r, body)
+// passthroughRequest relays r to Upstream verbatim, streaming both the
+// request body (to upstream) and the response body (back to the client)
+// rather than buffering either — a passthrough route has no chat-completions
+// body cap, so buffering here would let a single client exhaust memory with
+// an arbitrarily large body. contentLength mirrors http.Request.ContentLength
+// (-1 when unknown).
+func (s *Server) passthroughRequest(w http.ResponseWriter, r *http.Request, body io.Reader, contentLength int64) {
+	upstreamReq, err := s.newUpstreamRequest(r, body, contentLength)
 	if err != nil {
 		writeOpenAIError(w, http.StatusBadGateway, "building upstream request: "+err.Error(), "upstream_error")
 		return
@@ -320,32 +322,34 @@ func (s *Server) passthroughRequest(w http.ResponseWriter, r *http.Request, body
 
 // handlePassthrough relays any request not matched by a more specific route
 // to Upstream verbatim: method, path, query, headers (minus hop-by-hop) and
-// body all preserved, response streamed back unmodified.
+// body all preserved, response streamed back unmodified. r.Body is handed
+// straight to the upstream request rather than read into memory first — this
+// route carries no chat-completions-style size cap, so reading it fully here
+// would be an unbounded allocation driven by whatever the client sends.
 func (s *Server) handlePassthrough(w http.ResponseWriter, r *http.Request) {
-	body, err := io.ReadAll(r.Body)
-	if err != nil {
-		writeOpenAIError(w, http.StatusBadRequest, err.Error(), "invalid_request_error")
-		return
-	}
-	s.passthroughRequest(w, r, body)
+	s.passthroughRequest(w, r, r.Body, r.ContentLength)
 }
 
 // newUpstreamRequest builds the request the proxy sends to Upstream for an
 // incoming client request r, rebuilding the URL on Upstream's scheme/host
 // while keeping r's path and query, and copying method/headers (minus
-// hop-by-hop) with the given body.
-func (s *Server) newUpstreamRequest(r *http.Request, body []byte) (*http.Request, error) {
+// hop-by-hop). body is streamed through as given — contentLength mirrors
+// http.Request.ContentLength semantics (-1 when unknown, e.g. a chunked
+// passthrough body), so a caller with a small already-read []byte can pass
+// bytes.NewReader plus its exact length, and a caller streaming r.Body
+// straight through can pass r.ContentLength unchanged.
+func (s *Server) newUpstreamRequest(r *http.Request, body io.Reader, contentLength int64) (*http.Request, error) {
 	u := *s.upstream
 	u.Path = singleJoiningSlash(s.upstream.Path, r.URL.Path)
 	u.RawQuery = r.URL.RawQuery
 
-	upstreamReq, err := http.NewRequestWithContext(r.Context(), r.Method, u.String(), bytes.NewReader(body))
+	upstreamReq, err := http.NewRequestWithContext(r.Context(), r.Method, u.String(), body)
 	if err != nil {
 		return nil, fmt.Errorf("llmproxy: new upstream request: %w", err)
 	}
 	copyHeadersExceptHopByHop(upstreamReq.Header, r.Header)
 	upstreamReq.Host = s.upstream.Host
-	upstreamReq.ContentLength = int64(len(body))
+	upstreamReq.ContentLength = contentLength
 	return upstreamReq, nil
 }
 

--- a/llmproxy/proxy.go
+++ b/llmproxy/proxy.go
@@ -274,10 +274,22 @@ func (s *Server) forwardAndMaybeStore(w http.ResponseWriter, r *http.Request, re
 	}
 	defer func() { _ = resp.Body.Close() }()
 
-	respBody, err := io.ReadAll(resp.Body)
+	// Bounded the same way the incoming request body is (maxBodyBytes): this
+	// path buffers the whole response to decode and cache it, so an unbounded
+	// ReadAll here would let a misbehaving or compromised upstream make the
+	// proxy allocate without limit. Read one byte past the cap so an
+	// exactly-at-the-limit body isn't mistaken for an oversized one.
+	respBody, err := io.ReadAll(io.LimitReader(resp.Body, maxBodyBytes+1))
 	if err != nil {
 		s.logRelayError("llmproxy: reading upstream response", err)
 		writeOpenAIError(w, http.StatusBadGateway, "reading upstream response: "+err.Error(), "upstream_error")
+		return
+	}
+	if len(respBody) > maxBodyBytes {
+		// Nothing has been written to w yet, so this is still a clean error
+		// response rather than a truncated one.
+		s.log.Error("llmproxy: upstream response exceeds the maximum allowed size", "limit", maxBodyBytes)
+		writeOpenAIError(w, http.StatusBadGateway, "upstream response exceeds the maximum allowed size", "upstream_error")
 		return
 	}
 
@@ -287,7 +299,15 @@ func (s *Server) forwardAndMaybeStore(w http.ResponseWriter, r *http.Request, re
 	_, _ = w.Write(respBody)
 
 	if resp.StatusCode == http.StatusOK {
-		s.maybeStore(r.Context(), prompt, scope, respBody)
+		// Store on a context decoupled from the client's: net/http cancels
+		// r.Context() once the client disconnects, which can race the write
+		// above (a client that hangs up the instant it has its answer), and a
+		// canceled Store call would silently drop an otherwise-good cache
+		// entry. WithoutCancel keeps any request-scoped values while shedding
+		// the cancellation; the 30s timeout is its own independent bound.
+		sctx, cancel := context.WithTimeout(context.WithoutCancel(r.Context()), 30*time.Second)
+		s.maybeStore(sctx, prompt, scope, respBody)
+		cancel()
 	}
 }
 
@@ -370,7 +390,14 @@ func (s *Server) forwardStreamAndMaybeStore(w http.ResponseWriter, r *http.Reque
 		return
 	}
 
-	if err := s.cache.Store(r.Context(), prompt, scope, result.content.String(), result.completionTokens); err != nil {
+	// Same reasoning as forwardAndMaybeStore: decouple Store from the
+	// client's request context, worst here of all — a streaming client
+	// routinely closes its connection the instant it reads [DONE], right as
+	// this call is about to run.
+	sctx, cancel := context.WithTimeout(context.WithoutCancel(r.Context()), 30*time.Second)
+	err = s.cache.Store(sctx, prompt, scope, result.content.String(), result.completionTokens)
+	cancel()
+	if err != nil {
 		s.log.Error("llmproxy: cache store failed", "err", err)
 		return
 	}

--- a/llmproxy/proxy.go
+++ b/llmproxy/proxy.go
@@ -232,6 +232,19 @@ func (s *Server) handleStreamingChat(w http.ResponseWriter, r *http.Request, req
 	}
 }
 
+// logRelayError reports a failure while relaying bytes between upstream and
+// the client. A canceled context means the client hung up mid-response —
+// pressing stop in a chat UI does exactly that, and on a streaming proxy it
+// is routine, not a fault — so it is logged at Debug rather than filling an
+// operator's error stream with normal user behavior.
+func (s *Server) logRelayError(msg string, err error) {
+	if errors.Is(err, context.Canceled) {
+		s.log.Debug(msg, "err", err)
+		return
+	}
+	s.log.Error(msg, "err", err)
+}
+
 // isMaxBytesError reports whether err came from http.MaxBytesReader's limit,
 // across Go versions that either expose *http.MaxBytesError or a plain
 // "http: request body too large" message.
@@ -250,7 +263,7 @@ func (s *Server) forwardAndMaybeStore(w http.ResponseWriter, r *http.Request, re
 	prompt string, scope semcache.Scope, cacheStatus string) {
 	s.stats.misses.Add(1)
 
-	upstreamReq, err := s.newUpstreamRequest(r, bytes.NewReader(req.Raw), int64(len(req.Raw)))
+	upstreamReq, err := s.newChatUpstreamRequest(r, bytes.NewReader(req.Raw), int64(len(req.Raw)))
 	if err != nil {
 		writeOpenAIError(w, http.StatusBadGateway, "building upstream request: "+err.Error(), "upstream_error")
 		return
@@ -266,7 +279,7 @@ func (s *Server) forwardAndMaybeStore(w http.ResponseWriter, r *http.Request, re
 
 	respBody, err := io.ReadAll(resp.Body)
 	if err != nil {
-		s.log.Error("llmproxy: reading upstream response", "err", err)
+		s.logRelayError("llmproxy: reading upstream response", err)
 		writeOpenAIError(w, http.StatusBadGateway, "reading upstream response: "+err.Error(), "upstream_error")
 		return
 	}
@@ -325,7 +338,7 @@ func (s *Server) forwardStreamAndMaybeStore(w http.ResponseWriter, r *http.Reque
 	prompt string, scope semcache.Scope, cacheStatus string) {
 	s.stats.misses.Add(1)
 
-	upstreamReq, err := s.newUpstreamRequest(r, bytes.NewReader(req.Raw), int64(len(req.Raw)))
+	upstreamReq, err := s.newChatUpstreamRequest(r, bytes.NewReader(req.Raw), int64(len(req.Raw)))
 	if err != nil {
 		writeOpenAIError(w, http.StatusBadGateway, "building upstream request: "+err.Error(), "upstream_error")
 		return
@@ -346,14 +359,14 @@ func (s *Server) forwardStreamAndMaybeStore(w http.ResponseWriter, r *http.Reque
 	isSSE := strings.HasPrefix(resp.Header.Get("Content-Type"), "text/event-stream")
 	if resp.StatusCode != http.StatusOK || !isSSE {
 		if _, err := io.Copy(w, resp.Body); err != nil {
-			s.log.Error("llmproxy: relaying non-SSE stream response", "err", err)
+			s.logRelayError("llmproxy: relaying non-SSE stream response", err)
 		}
 		return
 	}
 
 	result, err := relayAndCapture(w, resp.Body)
 	if err != nil {
-		s.log.Error("llmproxy: relaying streamed response", "err", err)
+		s.logRelayError("llmproxy: relaying streamed response", err)
 		return
 	}
 	if !result.clean || result.finishReason != "stop" || result.sawToolCalls || result.content.Len() == 0 {
@@ -394,7 +407,7 @@ func (s *Server) passthroughRequest(w http.ResponseWriter, r *http.Request, body
 	// stream:true request that took this branch), and buffering the whole
 	// response would defeat the point of a stream.
 	if _, err := io.Copy(w, resp.Body); err != nil {
-		s.log.Error("llmproxy: relaying passthrough response body", "err", err)
+		s.logRelayError("llmproxy: relaying passthrough response body", err)
 	}
 }
 
@@ -428,6 +441,29 @@ func (s *Server) newUpstreamRequest(r *http.Request, body io.Reader, contentLeng
 	copyHeadersExceptHopByHop(upstreamReq.Header, r.Header)
 	upstreamReq.Host = s.upstream.Host
 	upstreamReq.ContentLength = contentLength
+	return upstreamReq, nil
+}
+
+// newChatUpstreamRequest builds the upstream request for a chat-completions
+// call whose response the proxy has to READ (to cache it), which the client's
+// own Accept-Encoding must not govern.
+//
+// Go's transport adds "Accept-Encoding: gzip" and transparently decompresses
+// the reply ONLY when it set that header itself. Forwarding the client's
+// header suppresses that, so the proxy would be handed raw compressed bytes —
+// and every openai-python call sends "Accept-Encoding: gzip, deflate", making
+// the JSON decode fail and nothing ever get cached for the clients that
+// matter most. Dropping the header lets the transport negotiate and
+// decompress; the response relayed onward is then plain (Go strips
+// Content-Encoding and Content-Length when it decompresses), which any client
+// accepts. The generic passthrough route keeps the header verbatim: nothing
+// there is parsed or cached, so the bytes should stay exactly as negotiated.
+func (s *Server) newChatUpstreamRequest(r *http.Request, body io.Reader, contentLength int64) (*http.Request, error) {
+	upstreamReq, err := s.newUpstreamRequest(r, body, contentLength)
+	if err != nil {
+		return nil, err
+	}
+	upstreamReq.Header.Del("Accept-Encoding")
 	return upstreamReq, nil
 }
 

--- a/llmproxy/proxy_test.go
+++ b/llmproxy/proxy_test.go
@@ -332,6 +332,39 @@ func TestProxy_StreamOptionsPassesThroughUncacheable(t *testing.T) {
 	}
 }
 
+// Azure-style tenancy: two callers that differ only in their "api-key" header
+// must not share a cache. Hashing Authorization alone put both in the empty
+// "no auth" tenant, so the second caller was served the first one's answers.
+func TestProxy_AzureAPIKeyTenantIsolation(t *testing.T) {
+	upstream := newFakeUpstream(t)
+	upstream.script(chatPath, scriptedResponse{
+		body: chatCompletionJSON(t, "answer", "stop", 3),
+	})
+	proxy := newProxy(t, upstream, nil)
+
+	body := `{"model":"gpt-4","messages":[{"role":"user","content":"shared prompt"}]}`
+
+	resp1, _ := postChat(t, proxy.URL, body, map[string]string{"api-key": "azure-tenant-a"})
+	if got := resp1.Header.Get("x-rostam-cache"); got != "miss" {
+		t.Fatalf("first api-key request x-rostam-cache = %q, want miss", got)
+	}
+
+	resp2, _ := postChat(t, proxy.URL, body, map[string]string{"api-key": "azure-tenant-b"})
+	if got := resp2.Header.Get("x-rostam-cache"); got != "miss" {
+		t.Fatalf("second api-key request x-rostam-cache = %q, want miss (a different api-key must not see the first caller's cache)", got)
+	}
+
+	// The same api-key still gets its own hit — isolation must not disable
+	// caching for these callers.
+	resp3, _ := postChat(t, proxy.URL, body, map[string]string{"api-key": "azure-tenant-a"})
+	if got := resp3.Header.Get("x-rostam-cache"); got != "hit" {
+		t.Fatalf("repeat for api-key tenant-a x-rostam-cache = %q, want hit", got)
+	}
+	if n := upstream.requestCount(chatPath); n != 2 {
+		t.Fatalf("upstream requests = %d, want 2", n)
+	}
+}
+
 // (d) temperature above MaxTemp is uncacheable: the request passes through
 // to upstream and the uncacheable counter grows, but nothing is stored or
 // looked up.

--- a/llmproxy/proxy_test.go
+++ b/llmproxy/proxy_test.go
@@ -1,0 +1,352 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package llmproxy
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"testing"
+)
+
+const chatPath = "/v1/chat/completions"
+
+// (a) miss -> store -> hit: identical body twice. First request is a miss
+// that reaches upstream and gets stored; the second is a hit answered
+// entirely from the cache, without touching upstream again.
+func TestProxy_MissThenHit(t *testing.T) {
+	upstream := newFakeUpstream(t)
+	upstream.script(chatPath, scriptedResponse{
+		body: chatCompletionJSON(t, "the answer", "stop", 7),
+	})
+	proxy := newProxy(t, upstream, nil)
+
+	body := `{"model":"gpt-4","messages":[{"role":"user","content":"what is 2+2"}]}`
+
+	resp1, body1 := postChat(t, proxy.URL, body, nil)
+	if resp1.StatusCode != http.StatusOK {
+		t.Fatalf("first request status = %d, want 200", resp1.StatusCode)
+	}
+	if got := resp1.Header.Get("x-rostam-cache"); got != "miss" {
+		t.Fatalf("first request x-rostam-cache = %q, want miss", got)
+	}
+	if n := upstream.requestCount(chatPath); n != 1 {
+		t.Fatalf("upstream requests after first call = %d, want 1", n)
+	}
+
+	resp2, body2 := postChat(t, proxy.URL, body, nil)
+	if resp2.StatusCode != http.StatusOK {
+		t.Fatalf("second request status = %d, want 200", resp2.StatusCode)
+	}
+	if got := resp2.Header.Get("x-rostam-cache"); got != "hit" {
+		t.Fatalf("second request x-rostam-cache = %q, want hit", got)
+	}
+	if n := upstream.requestCount(chatPath); n != 1 {
+		t.Fatalf("upstream requests after second call = %d, want still 1 (cache hit must not call upstream)", n)
+	}
+
+	var decoded chatResponse
+	if err := json.Unmarshal(body2, &decoded); err != nil {
+		t.Fatalf("unmarshal cached response: %v", err)
+	}
+	if len(decoded.Choices) != 1 || decoded.Choices[0].Message.Content != "the answer" {
+		t.Fatalf("cached response content = %+v, want %q", decoded.Choices, "the answer")
+	}
+	_ = body1
+}
+
+// (b) a one-character-different body must miss under the exact-mode stub
+// embedder (threshold 0.999) — near-identical text is not close enough.
+func TestProxy_OneCharDifferentBodyMisses(t *testing.T) {
+	upstream := newFakeUpstream(t)
+	upstream.script(chatPath, scriptedResponse{
+		body: chatCompletionJSON(t, "answer", "stop", 3),
+	})
+	proxy := newProxy(t, upstream, nil)
+
+	body1 := `{"model":"gpt-4","messages":[{"role":"user","content":"what is 2+2a"}]}`
+	body2 := `{"model":"gpt-4","messages":[{"role":"user","content":"what is 2+2b"}]}`
+
+	resp1, _ := postChat(t, proxy.URL, body1, nil)
+	if got := resp1.Header.Get("x-rostam-cache"); got != "miss" {
+		t.Fatalf("first request x-rostam-cache = %q, want miss", got)
+	}
+
+	resp2, _ := postChat(t, proxy.URL, body2, nil)
+	if got := resp2.Header.Get("x-rostam-cache"); got != "miss" {
+		t.Fatalf("second (one-char-different) request x-rostam-cache = %q, want miss", got)
+	}
+	if n := upstream.requestCount(chatPath); n != 2 {
+		t.Fatalf("upstream requests = %d, want 2 (both should miss)", n)
+	}
+}
+
+// (c) tenant isolation: the same prompt under two different Authorization
+// headers must miss both times — one tenant never sees another's cache.
+func TestProxy_TenantIsolation(t *testing.T) {
+	upstream := newFakeUpstream(t)
+	upstream.script(chatPath, scriptedResponse{
+		body: chatCompletionJSON(t, "answer", "stop", 3),
+	})
+	proxy := newProxy(t, upstream, nil)
+
+	body := `{"model":"gpt-4","messages":[{"role":"user","content":"shared prompt"}]}`
+
+	resp1, _ := postChat(t, proxy.URL, body, map[string]string{"Authorization": "Bearer tenant-a"})
+	if got := resp1.Header.Get("x-rostam-cache"); got != "miss" {
+		t.Fatalf("tenant-a request x-rostam-cache = %q, want miss", got)
+	}
+
+	resp2, _ := postChat(t, proxy.URL, body, map[string]string{"Authorization": "Bearer tenant-b"})
+	if got := resp2.Header.Get("x-rostam-cache"); got != "miss" {
+		t.Fatalf("tenant-b request x-rostam-cache = %q, want miss (different tenant must not see tenant-a's cache)", got)
+	}
+	if n := upstream.requestCount(chatPath); n != 2 {
+		t.Fatalf("upstream requests = %d, want 2", n)
+	}
+}
+
+// (d) temperature above MaxTemp is uncacheable: the request passes through
+// to upstream and the uncacheable counter grows, but nothing is stored or
+// looked up.
+func TestProxy_HighTemperaturePassesThroughUncacheable(t *testing.T) {
+	upstream := newFakeUpstream(t)
+	upstream.script(chatPath, scriptedResponse{
+		body: chatCompletionJSON(t, "answer", "stop", 3),
+	})
+	proxy := newProxy(t, upstream, nil)
+
+	body := `{"model":"gpt-4","temperature":1.5,"messages":[{"role":"user","content":"hi"}]}`
+
+	resp, _ := postChat(t, proxy.URL, body, nil)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+	if n := upstream.requestCount(chatPath); n != 1 {
+		t.Fatalf("upstream requests = %d, want 1", n)
+	}
+
+	statsResp, statsBody := getStats(t, proxy.URL)
+	if statsResp.StatusCode != http.StatusOK {
+		t.Fatalf("/stats status = %d, want 200", statsResp.StatusCode)
+	}
+	var st map[string]any
+	if err := json.Unmarshal(statsBody, &st); err != nil {
+		t.Fatalf("unmarshal /stats: %v", err)
+	}
+	if got := st["uncacheable"]; got != float64(1) {
+		t.Fatalf("/stats uncacheable = %v, want 1", got)
+	}
+}
+
+// (e) an upstream response carrying tool_calls is relayed to the client but
+// must not be stored: a repeat of the same request misses again.
+func TestProxy_ToolCallsResponseNotStored(t *testing.T) {
+	upstream := newFakeUpstream(t)
+	toolResp := map[string]any{
+		"id":     "chatcmpl-fake",
+		"object": "chat.completion",
+		"model":  "gpt-4",
+		"choices": []map[string]any{
+			{
+				"index": 0,
+				"message": map[string]any{
+					"role": "assistant",
+					"tool_calls": []map[string]any{
+						{"id": "call_1", "type": "function", "function": map[string]any{"name": "get_weather", "arguments": "{}"}},
+					},
+				},
+				"finish_reason": "tool_calls",
+			},
+		},
+		"usage": map[string]any{"completion_tokens": 5},
+	}
+	toolBody, err := json.Marshal(toolResp)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	upstream.script(chatPath, scriptedResponse{body: toolBody})
+	proxy := newProxy(t, upstream, nil)
+
+	body := `{"model":"gpt-4","messages":[{"role":"user","content":"what's the weather"}],
+		"tools":[{"function":{"name":"get_weather"}}]}`
+
+	resp1, _ := postChat(t, proxy.URL, body, nil)
+	if resp1.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200", resp1.StatusCode)
+	}
+	if got := resp1.Header.Get("x-rostam-cache"); got != "miss" {
+		t.Fatalf("x-rostam-cache = %q, want miss", got)
+	}
+
+	resp2, _ := postChat(t, proxy.URL, body, nil)
+	if got := resp2.Header.Get("x-rostam-cache"); got != "miss" {
+		t.Fatalf("repeat request x-rostam-cache = %q, want miss (tool_calls responses must not be stored)", got)
+	}
+	if n := upstream.requestCount(chatPath); n != 2 {
+		t.Fatalf("upstream requests = %d, want 2 (both should reach upstream)", n)
+	}
+}
+
+// (f) a non-chat-completions path (e.g. GET /v1/models) passes through
+// verbatim, preserving path and the Authorization header at upstream.
+func TestProxy_PassthroughPreservesPathAndAuth(t *testing.T) {
+	upstream := newFakeUpstream(t)
+	upstream.script("/v1/models", scriptedResponse{
+		body: []byte(`{"object":"list","data":[]}`),
+	})
+	proxy := newProxy(t, upstream, nil)
+
+	req, err := http.NewRequest(http.MethodGet, proxy.URL+"/v1/models", nil)
+	if err != nil {
+		t.Fatalf("NewRequest: %v", err)
+	}
+	req.Header.Set("Authorization", "Bearer sk-passthrough")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("Do: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+
+	captured := upstream.lastRequest("/v1/models")
+	if captured == nil {
+		t.Fatalf("upstream never saw /v1/models")
+	}
+	if captured.Method != http.MethodGet {
+		t.Fatalf("upstream method = %q, want GET", captured.Method)
+	}
+	if got := captured.Headers.Get("Authorization"); got != "Bearer sk-passthrough" {
+		t.Fatalf("upstream Authorization = %q, want %q", got, "Bearer sk-passthrough")
+	}
+}
+
+// (g) malformed JSON on the cache path returns an OpenAI-shaped 400 error.
+func TestProxy_MalformedJSONReturns400(t *testing.T) {
+	upstream := newFakeUpstream(t)
+	proxy := newProxy(t, upstream, nil)
+
+	resp, body := postChat(t, proxy.URL, `{not valid json`, nil)
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400", resp.StatusCode)
+	}
+
+	var errBody struct {
+		Error struct {
+			Message string `json:"message"`
+			Type    string `json:"type"`
+		} `json:"error"`
+	}
+	if err := json.Unmarshal(body, &errBody); err != nil {
+		t.Fatalf("unmarshal error body: %v; body=%s", err, body)
+	}
+	if errBody.Error.Type != "invalid_request_error" {
+		t.Fatalf("error.type = %q, want invalid_request_error", errBody.Error.Type)
+	}
+	if errBody.Error.Message == "" {
+		t.Fatalf("error.message is empty")
+	}
+}
+
+// (h) an upstream 500 is relayed untouched to the client and not cached.
+func TestProxy_Upstream500RelayedNotCached(t *testing.T) {
+	upstream := newFakeUpstream(t)
+	upstream.script(chatPath, scriptedResponse{
+		status: http.StatusInternalServerError,
+		body:   []byte(`{"error":{"message":"boom","type":"server_error"}}`),
+	})
+	proxy := newProxy(t, upstream, nil)
+
+	body := `{"model":"gpt-4","messages":[{"role":"user","content":"trigger a 500"}]}`
+
+	resp1, body1 := postChat(t, proxy.URL, body, nil)
+	if resp1.StatusCode != http.StatusInternalServerError {
+		t.Fatalf("status = %d, want 500", resp1.StatusCode)
+	}
+	if got := string(body1); got != `{"error":{"message":"boom","type":"server_error"}}` {
+		t.Fatalf("relayed body = %q, want upstream body verbatim", got)
+	}
+
+	// A repeat of the same request must miss again: a 500 must never be
+	// stored as a cached answer.
+	resp2, _ := postChat(t, proxy.URL, body, nil)
+	if resp2.StatusCode != http.StatusInternalServerError {
+		t.Fatalf("second status = %d, want 500 again (nothing cached)", resp2.StatusCode)
+	}
+	if n := upstream.requestCount(chatPath); n != 2 {
+		t.Fatalf("upstream requests = %d, want 2", n)
+	}
+}
+
+// (i) /stats reflects hits, misses, stored, uncacheable and tokens_saved
+// across a mixed sequence of the scenarios above, plus the configured mode.
+func TestProxy_StatsAggregatesAcrossRequests(t *testing.T) {
+	upstream := newFakeUpstream(t)
+	upstream.script(chatPath, scriptedResponse{
+		body: chatCompletionJSON(t, "cacheable answer", "stop", 11),
+	})
+	proxy := newProxy(t, upstream, nil)
+
+	cacheableBody := `{"model":"gpt-4","messages":[{"role":"user","content":"cacheable prompt"}]}`
+	uncacheableBody := `{"model":"gpt-4","temperature":2.0,"messages":[{"role":"user","content":"loud prompt"}]}`
+
+	// miss, then store
+	postChat(t, proxy.URL, cacheableBody, nil)
+	// hit
+	postChat(t, proxy.URL, cacheableBody, nil)
+	// uncacheable passthrough
+	postChat(t, proxy.URL, uncacheableBody, nil)
+
+	statsResp, statsBody := getStats(t, proxy.URL)
+	if statsResp.StatusCode != http.StatusOK {
+		t.Fatalf("/stats status = %d, want 200", statsResp.StatusCode)
+	}
+
+	var st struct {
+		Hits        float64 `json:"hits"`
+		Misses      float64 `json:"misses"`
+		Stored      float64 `json:"stored"`
+		Uncacheable float64 `json:"uncacheable"`
+		TokensSaved float64 `json:"tokens_saved"`
+		Mode        string  `json:"mode"`
+	}
+	if err := json.Unmarshal(statsBody, &st); err != nil {
+		t.Fatalf("unmarshal /stats: %v; body=%s", err, statsBody)
+	}
+	if st.Hits != 1 {
+		t.Fatalf("hits = %v, want 1", st.Hits)
+	}
+	if st.Misses != 1 {
+		t.Fatalf("misses = %v, want 1", st.Misses)
+	}
+	if st.Stored != 1 {
+		t.Fatalf("stored = %v, want 1", st.Stored)
+	}
+	if st.Uncacheable != 1 {
+		t.Fatalf("uncacheable = %v, want 1", st.Uncacheable)
+	}
+	if st.TokensSaved != 11 {
+		t.Fatalf("tokens_saved = %v, want 11", st.TokensSaved)
+	}
+	if st.Mode != "exact" {
+		t.Fatalf("mode = %q, want exact", st.Mode)
+	}
+}
+
+// getStats GETs /stats on the proxy and returns the response plus its body.
+func getStats(t *testing.T, proxyURL string) (*http.Response, []byte) {
+	t.Helper()
+	resp, err := http.Get(proxyURL + "/stats")
+	if err != nil {
+		t.Fatalf("GET /stats: %v", err)
+	}
+	defer resp.Body.Close()
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("ReadAll: %v", err)
+	}
+	return resp, body
+}

--- a/llmproxy/proxy_test.go
+++ b/llmproxy/proxy_test.go
@@ -12,9 +12,15 @@ import (
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"strconv"
 	"strings"
+	"sync"
 	"testing"
+
+	"github.com/rostamlabs/rostam"
+	"github.com/rostamlabs/rostam/ops"
+	"github.com/rostamlabs/rostam/semcache"
 )
 
 const chatPath = "/v1/chat/completions"
@@ -571,6 +577,51 @@ func TestProxy_OversizedChatBodyReturns413(t *testing.T) {
 	}
 }
 
+// An upstream response over the 16 MiB cap is refused with an OpenAI-shaped
+// 502 rather than buffered without bound: the non-streaming cache path reads
+// the whole response to decode and cache it, so nothing bounded the read
+// before this — a misbehaving or compromised upstream could make the proxy
+// allocate arbitrarily. Nothing must reach the client (the response is
+// refused before any header or body is written) and nothing must be cached.
+func TestProxy_OversizedUpstreamResponseReturns502(t *testing.T) {
+	upstream := newFakeUpstream(t)
+	oversized := bytes.Repeat([]byte("x"), maxBodyBytes+1024)
+	upstream.script(chatPath, scriptedResponse{body: oversized})
+	proxy := newProxy(t, upstream, nil)
+
+	body := `{"model":"gpt-4","messages":[{"role":"user","content":"trigger an oversized reply"}]}`
+
+	resp, respBody := postChat(t, proxy.URL, body, nil)
+	if resp.StatusCode != http.StatusBadGateway {
+		t.Fatalf("status = %d, want 502", resp.StatusCode)
+	}
+
+	var errBody struct {
+		Error struct {
+			Message string `json:"message"`
+			Type    string `json:"type"`
+		} `json:"error"`
+	}
+	if err := json.Unmarshal(respBody, &errBody); err != nil {
+		t.Fatalf("unmarshal error body: %v; body=%s", err, respBody)
+	}
+	if errBody.Error.Type != "upstream_error" {
+		t.Fatalf("error.type = %q, want upstream_error", errBody.Error.Type)
+	}
+	if errBody.Error.Message == "" {
+		t.Fatalf("error.message is empty")
+	}
+
+	// A repeat must still miss: nothing from the oversized response was cached.
+	resp2, _ := postChat(t, proxy.URL, body, nil)
+	if resp2.StatusCode != http.StatusBadGateway {
+		t.Fatalf("second status = %d, want 502 again (nothing cached)", resp2.StatusCode)
+	}
+	if n := upstream.requestCount(chatPath); n != 2 {
+		t.Fatalf("upstream requests = %d, want 2", n)
+	}
+}
+
 // n > 1 asks for several completions, which one cached answer cannot stand in
 // for: the request passes through uncacheable and nothing is stored.
 func TestProxy_NGreaterThanOnePassesThroughUncacheable(t *testing.T) {
@@ -877,4 +928,162 @@ func getStats(t *testing.T, proxyURL string) (*http.Response, []byte) {
 		t.Fatalf("ReadAll: %v", err)
 	}
 	return resp, body
+}
+
+// ctxCapturingStore wraps a real rostam.Store and, on VectorUpsert, fires
+// triggerCancel (when set) BEFORE inspecting ctx — simulating the client
+// disconnecting at the exact instant the proxy is about to write to the
+// cache, which is the actual race the fix has to survive. Checking
+// cancellation any later than that (e.g. once the whole request has
+// finished) can't tell a real leak apart from a context being canceled
+// afterward simply because it is no longer needed, which the fix does
+// deliberately to release its own timer promptly. Embedding rostam.Store
+// promotes every other method unchanged; only VectorUpsert is intercepted.
+type ctxCapturingStore struct {
+	rostam.Store
+	triggerCancel context.CancelFunc // invoked once, from inside VectorUpsert, before it looks at ctx.Err()
+
+	mu     sync.Mutex
+	called bool
+	ctxErr error // ctx.Err(), observed inside VectorUpsert right after triggerCancel fires
+}
+
+func (s *ctxCapturingStore) VectorUpsert(ctx context.Context, collection string, id uint64, vec []float32, content string, opts rostam.VectorInsertOpts) error {
+	if s.triggerCancel != nil {
+		s.triggerCancel()
+	}
+	s.mu.Lock()
+	s.called = true
+	s.ctxErr = ctx.Err()
+	s.mu.Unlock()
+	return s.Store.VectorUpsert(ctx, collection, id, vec, content, opts)
+}
+
+// wasCalled reports whether VectorUpsert ran, and the ctx.Err() observed at
+// the moment it did (immediately after triggerCancel, if any).
+func (s *ctxCapturingStore) wasCalled() (bool, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.called, s.ctxErr
+}
+
+// newProxyServerCtxCapturing is newProxyServer with the backing store swapped
+// for a ctxCapturingStore, so a test can inspect what context a cache Store
+// call actually received rather than only its success/failure — heap-mode
+// VectorUpsert ignores its ctx argument entirely, so success/failure alone
+// can't distinguish a decoupled context from the request's own.
+func newProxyServerCtxCapturing(t *testing.T, upstream *fakeUpstream) (*Server, *ctxCapturingStore) {
+	t.Helper()
+
+	reg := ops.NewRegistry()
+	if err := ops.RegisterBuiltins(reg); err != nil {
+		t.Fatalf("RegisterBuiltins: %v", err)
+	}
+	backing, err := rostam.NewDirect(rostam.DirectConfig{Ops: reg})
+	if err != nil {
+		t.Fatalf("NewDirect: %v", err)
+	}
+	t.Cleanup(func() { _ = backing.Close() })
+	wrapped := &ctxCapturingStore{Store: backing}
+
+	cache, err := semcache.New(context.Background(), semcache.Config{
+		Store:      wrapped,
+		Embedder:   semcache.NewStubEmbedder("exact", 64),
+		Collection: "llm-cache",
+		Threshold:  0.999,
+		MaxTemp:    1.0,
+	})
+	if err != nil {
+		t.Fatalf("semcache.New: %v", err)
+	}
+
+	upstreamURL, err := url.Parse(upstream.srv.URL)
+	if err != nil {
+		t.Fatalf("parse upstream URL: %v", err)
+	}
+
+	srv, err := NewServer(Config{Cache: cache, Upstream: upstreamURL, Mode: "exact"})
+	if err != nil {
+		t.Fatalf("NewServer: %v", err)
+	}
+	return srv, wrapped
+}
+
+// A client disconnecting right as the proxy is about to write the cache
+// entry must not silently lose that write. net/http cancels r.Context() when
+// the client goes away, and the store call runs after the response is
+// already written to the client, so a context taken straight from
+// r.Context() would race the client's own cancel — exactly the moment
+// ctxCapturingStore's triggerCancel simulates by canceling the request's
+// context from inside VectorUpsert, immediately before it looks at ctx.Err().
+func TestProxy_StoreContextSurvivesClientCancel(t *testing.T) {
+	upstream := newFakeUpstream(t)
+	upstream.script(chatPath, scriptedResponse{body: chatCompletionJSON(t, "the answer", "stop", 5)})
+	srv, wrapped := newProxyServerCtxCapturing(t, upstream)
+
+	body := `{"model":"gpt-4","messages":[{"role":"user","content":"disconnect right as it stores"}]}`
+	ctx, cancel := context.WithCancel(context.Background())
+	wrapped.triggerCancel = cancel
+	req := httptest.NewRequest(http.MethodPost, chatPath, strings.NewReader(body)).WithContext(ctx)
+	req.Header.Set("Content-Type", "application/json")
+
+	w := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", w.Code)
+	}
+
+	called, ctxErr := wrapped.wasCalled()
+	if !called {
+		t.Fatal("VectorUpsert was never called: a clean miss must be stored")
+	}
+	if ctxErr != nil {
+		t.Fatalf("ctx.Err() inside VectorUpsert = %v, want nil: the request's own context was canceled at the same instant, so a context taken straight from it would report this error", ctxErr)
+	}
+
+	// And the entry is actually there: a follow-up identical request hits.
+	req2 := httptest.NewRequest(http.MethodPost, chatPath, strings.NewReader(body))
+	req2.Header.Set("Content-Type", "application/json")
+	w2 := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(w2, req2)
+	if got := w2.Header().Get("x-rostam-cache"); got != "hit" {
+		t.Fatalf("follow-up x-rostam-cache = %q, want hit (the store must have survived the client's cancel)", got)
+	}
+}
+
+// The streaming counterpart: a streaming client routinely closes its
+// connection the instant it reads [DONE], right as forwardStreamAndMaybeStore
+// is about to call Store — the case the fix's rationale calls out as worst.
+func TestProxy_StreamingStoreContextSurvivesClientCancel(t *testing.T) {
+	upstream := newFakeUpstream(t)
+	upstream.script(chatPath, scriptedResponse{sse: true, lines: basicStreamLines})
+	srv, wrapped := newProxyServerCtxCapturing(t, upstream)
+
+	body := `{"model":"gpt-4","stream":true,"messages":[{"role":"user","content":"stream then disconnect at [DONE]"}]}`
+	ctx, cancel := context.WithCancel(context.Background())
+	wrapped.triggerCancel = cancel
+	req := httptest.NewRequest(http.MethodPost, chatPath, strings.NewReader(body)).WithContext(ctx)
+	req.Header.Set("Content-Type", "application/json")
+
+	w := &countingResponseWriter{ResponseRecorder: httptest.NewRecorder()}
+	srv.Handler().ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", w.Code)
+	}
+
+	called, ctxErr := wrapped.wasCalled()
+	if !called {
+		t.Fatal("VectorUpsert was never called: a clean stream to [DONE] must be stored")
+	}
+	if ctxErr != nil {
+		t.Fatalf("ctx.Err() inside VectorUpsert = %v, want nil: the request's own context was canceled at the same instant, so a context taken straight from it would report this error", ctxErr)
+	}
+
+	req2 := httptest.NewRequest(http.MethodPost, chatPath, strings.NewReader(body))
+	req2.Header.Set("Content-Type", "application/json")
+	w2 := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(w2, req2)
+	if got := w2.Header().Get("x-rostam-cache"); got != "hit" {
+		t.Fatalf("follow-up x-rostam-cache = %q, want hit (the store must have survived the client's cancel)", got)
+	}
 }

--- a/llmproxy/proxy_test.go
+++ b/llmproxy/proxy_test.go
@@ -3,10 +3,16 @@
 package llmproxy
 
 import (
+	"bytes"
+	"context"
 	"encoding/json"
+	"errors"
+	"fmt"
 	"io"
+	"log/slog"
 	"net/http"
 	"strconv"
+	"strings"
 	"testing"
 )
 
@@ -143,6 +149,61 @@ func TestProxy_ThirtyTwoBitCollidingPromptsDoNotCrossHit(t *testing.T) {
 	}
 	if n := upstream.requestCount(chatPath); n != 2 {
 		t.Fatalf("upstream requests = %d, want 2 (both prompts must reach upstream)", n)
+	}
+}
+
+// A client that advertises gzip must still get its answers cached. The proxy
+// used to forward the client's Accept-Encoding, which suppressed Go's
+// transparent decompression, so maybeStore was handed raw gzip bytes and the
+// JSON decode failed on every single response — and openai-python sends
+// "Accept-Encoding: gzip, deflate" by default, so that was the common case.
+func TestProxy_GzipAcceptingClientStillGetsCached(t *testing.T) {
+	upstream := newFakeUpstream(t)
+	upstream.script(chatPath, scriptedResponse{
+		body:           chatCompletionJSON(t, "compressed answer", "stop", 6),
+		gzipIfAccepted: true,
+	})
+	proxy := newProxy(t, upstream, nil)
+
+	body := `{"model":"gpt-4","messages":[{"role":"user","content":"compress me"}]}`
+	headers := map[string]string{"Accept-Encoding": "gzip, deflate"}
+
+	resp1, body1 := postChat(t, proxy.URL, body, headers)
+	if resp1.StatusCode != http.StatusOK {
+		t.Fatalf("first request status = %d, want 200", resp1.StatusCode)
+	}
+	if got := resp1.Header.Get("x-rostam-cache"); got != "miss" {
+		t.Fatalf("first request x-rostam-cache = %q, want miss", got)
+	}
+	// The client must receive decodable JSON, not the gzip frame.
+	var decoded1 chatResponse
+	if err := json.Unmarshal(body1, &decoded1); err != nil {
+		t.Fatalf("client could not decode the relayed body: %v; body=%q", err, body1)
+	}
+
+	// The upstream must have been asked with the transport's OWN gzip header,
+	// not the client's — that is what buys transparent decompression.
+	captured := upstream.lastRequest(chatPath)
+	if captured == nil {
+		t.Fatalf("upstream never saw %s", chatPath)
+	}
+	if got := captured.Headers.Get("Accept-Encoding"); got != "gzip" {
+		t.Fatalf("upstream Accept-Encoding = %q, want %q (the client's header must not be forwarded on a cached path)", got, "gzip")
+	}
+
+	resp2, body2 := postChat(t, proxy.URL, body, headers)
+	if got := resp2.Header.Get("x-rostam-cache"); got != "hit" {
+		t.Fatalf("second request x-rostam-cache = %q, want hit (a gzip-accepting client's response must still be stored)", got)
+	}
+	if n := upstream.requestCount(chatPath); n != 1 {
+		t.Fatalf("upstream requests = %d, want 1 (the second request must be served from the cache)", n)
+	}
+	var decoded2 chatResponse
+	if err := json.Unmarshal(body2, &decoded2); err != nil {
+		t.Fatalf("unmarshal cached response: %v", err)
+	}
+	if len(decoded2.Choices) != 1 || decoded2.Choices[0].Message.Content != "compressed answer" {
+		t.Fatalf("cached response content = %+v, want %q", decoded2.Choices, "compressed answer")
 	}
 }
 
@@ -447,6 +508,28 @@ func TestProxy_StatsAggregatesAcrossRequests(t *testing.T) {
 	}
 	if st.Mode != "exact" {
 		t.Fatalf("mode = %q, want exact", st.Mode)
+	}
+}
+
+// A client hanging up mid-response (context.Canceled, however wrapped) is
+// normal traffic on a streaming proxy, so it must not be logged as an ERROR;
+// anything else still is.
+func TestLogRelayError_ClientCancelLogsAtDebug(t *testing.T) {
+	var buf bytes.Buffer
+	s := &Server{log: slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug}))}
+
+	for _, err := range []error{context.Canceled, fmt.Errorf("llmproxy: relay: %w", context.Canceled)} {
+		buf.Reset()
+		s.logRelayError("llmproxy: relaying", err)
+		if got := buf.String(); !strings.Contains(got, "level=DEBUG") || strings.Contains(got, "level=ERROR") {
+			t.Fatalf("logRelayError(%v) logged %q, want DEBUG", err, got)
+		}
+	}
+
+	buf.Reset()
+	s.logRelayError("llmproxy: relaying", errors.New("connection reset by peer"))
+	if got := buf.String(); !strings.Contains(got, "level=ERROR") {
+		t.Fatalf("logRelayError(real failure) logged %q, want ERROR", got)
 	}
 }
 

--- a/llmproxy/proxy_test.go
+++ b/llmproxy/proxy_test.go
@@ -232,6 +232,106 @@ func TestProxy_TenantIsolation(t *testing.T) {
 	}
 }
 
+// Same messages, different sampling/formatting surface: the proxy used to
+// scope only on temperature and max_tokens, so a response_format:json_object
+// request was answered with prose cached from the identical messages. Each
+// variation must reach upstream on its own.
+func TestProxy_SamplingParamsPartitionTheCache(t *testing.T) {
+	upstream := newFakeUpstream(t)
+	upstream.script(chatPath, scriptedResponse{
+		body: chatCompletionJSON(t, "an answer", "stop", 4),
+	})
+	proxy := newProxy(t, upstream, nil)
+
+	const messages = `"model":"gpt-4","messages":[{"role":"user","content":"list three colors"}]`
+	bodies := []string{
+		`{` + messages + `}`,
+		`{` + messages + `,"response_format":{"type":"json_object"}}`,
+		`{` + messages + `,"seed":7}`,
+		`{` + messages + `,"top_p":0.1}`,
+		`{` + messages + `,"stop":["\n"]}`,
+		`{` + messages + `,"frequency_penalty":1.5}`,
+	}
+
+	for i, body := range bodies {
+		resp, _ := postChat(t, proxy.URL, body, nil)
+		if got := resp.Header.Get("x-rostam-cache"); got != "miss" {
+			t.Fatalf("body %d (%s) x-rostam-cache = %q, want miss (it must not be served another variant's answer)", i, body, got)
+		}
+	}
+	if n := upstream.requestCount(chatPath); n != len(bodies) {
+		t.Fatalf("upstream requests = %d, want %d (every variant must reach upstream)", n, len(bodies))
+	}
+
+	// A repeat of a variant still hits: partitioning must not break caching.
+	resp, _ := postChat(t, proxy.URL, bodies[1], nil)
+	if got := resp.Header.Get("x-rostam-cache"); got != "hit" {
+		t.Fatalf("repeat of the json_object variant x-rostam-cache = %q, want hit", got)
+	}
+
+	// Same request surface, written differently (key order, whitespace) —
+	// still the same cache entry.
+	reordered := `{"response_format":{"type":"json_object"}, "messages":[{"role":"user","content":"list three colors"}] , "model":"gpt-4"}`
+	resp, _ = postChat(t, proxy.URL, reordered, nil)
+	if got := resp.Header.Get("x-rostam-cache"); got != "hit" {
+		t.Fatalf("key-reordered json_object variant x-rostam-cache = %q, want hit (key order is not request surface)", got)
+	}
+	if n := upstream.requestCount(chatPath); n != len(bodies) {
+		t.Fatalf("upstream requests = %d, want still %d", n, len(bodies))
+	}
+}
+
+// stream_options asks for a stream shape a cache replay cannot produce (an
+// extra usage chunk), so such a request is uncacheable passthrough: counted
+// uncacheable, and never stored — a later request without it still misses.
+func TestProxy_StreamOptionsPassesThroughUncacheable(t *testing.T) {
+	upstream := newFakeUpstream(t)
+	upstream.script(chatPath, scriptedResponse{sse: true, lines: basicStreamLines})
+	proxy := newProxy(t, upstream, nil)
+
+	withOptions := `{"model":"gpt-4","stream":true,"stream_options":{"include_usage":true},` +
+		`"messages":[{"role":"user","content":"count my tokens"}]}`
+
+	resp1, body1 := postChat(t, proxy.URL, withOptions, nil)
+	if resp1.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200", resp1.StatusCode)
+	}
+	if got := resp1.Header.Get("x-rostam-cache"); got != "uncacheable" {
+		t.Fatalf("x-rostam-cache = %q, want uncacheable", got)
+	}
+	if got := string(body1); got != strings.Join(basicStreamLines, "") {
+		t.Fatalf("relayed body = %q, want the upstream stream verbatim", got)
+	}
+
+	// Repeat it: still uncacheable, still reaching upstream.
+	postChat(t, proxy.URL, withOptions, nil)
+	if n := upstream.requestCount(chatPath); n != 2 {
+		t.Fatalf("upstream requests = %d, want 2", n)
+	}
+
+	statsResp, statsBody := getStats(t, proxy.URL)
+	if statsResp.StatusCode != http.StatusOK {
+		t.Fatalf("/stats status = %d, want 200", statsResp.StatusCode)
+	}
+	var st struct {
+		Uncacheable float64 `json:"uncacheable"`
+		Stored      float64 `json:"stored"`
+		Misses      float64 `json:"misses"`
+	}
+	if err := json.Unmarshal(statsBody, &st); err != nil {
+		t.Fatalf("unmarshal /stats: %v; body=%s", err, statsBody)
+	}
+	if st.Uncacheable != 2 {
+		t.Fatalf("uncacheable = %v, want 2", st.Uncacheable)
+	}
+	if st.Stored != 0 {
+		t.Fatalf("stored = %v, want 0 (a stream_options request must never be stored)", st.Stored)
+	}
+	if st.Misses != 0 {
+		t.Fatalf("misses = %v, want 0 (an uncacheable request is not a cache miss)", st.Misses)
+	}
+}
+
 // (d) temperature above MaxTemp is uncacheable: the request passes through
 // to upstream and the uncacheable counter grows, but nothing is stored or
 // looked up.
@@ -508,6 +608,78 @@ func TestProxy_StatsAggregatesAcrossRequests(t *testing.T) {
 	}
 	if st.Mode != "exact" {
 		t.Fatalf("mode = %q, want exact", st.Mode)
+	}
+}
+
+// flushCounter is a writer that records how many times it was flushed, so a
+// relay can be checked for incremental delivery without timing anything.
+type flushCounter struct {
+	bytes.Buffer
+	flushes int
+}
+
+func (f *flushCounter) Flush() { f.flushes++ }
+
+// io.Copy hands the destination 32 KiB at a time and never flushes, so a
+// relay built on it alone buffers a "stream" until the copy finishes. The
+// wrapper must flush after every write instead.
+func TestFlushWriter_FlushesAfterEveryWrite(t *testing.T) {
+	fc := &flushCounter{}
+	fw := newFlushWriter(fc)
+
+	chunks := []string{"data: one\n\n", "data: two\n\n", "data: [DONE]\n\n"}
+	for _, c := range chunks {
+		if _, err := io.WriteString(fw, c); err != nil {
+			t.Fatalf("Write: %v", err)
+		}
+	}
+
+	if fc.flushes != len(chunks) {
+		t.Fatalf("flushes = %d, want %d (one per write)", fc.flushes, len(chunks))
+	}
+	if got, want := fc.String(), strings.Join(chunks, ""); got != want {
+		t.Fatalf("relayed bytes = %q, want %q", got, want)
+	}
+}
+
+// A destination that can't flush must still be written to, not rejected:
+// these relays have to work on any writer.
+func TestFlushWriter_NonFlusherStillCopies(t *testing.T) {
+	var buf bytes.Buffer
+	if _, err := io.WriteString(newFlushWriter(&buf), "payload"); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	if buf.String() != "payload" {
+		t.Fatalf("wrote %q, want %q", buf.String(), "payload")
+	}
+}
+
+// An uncacheable STREAMING request (temperature above the ceiling) takes the
+// passthrough relay, which must still deliver a real SSE stream — flushed
+// chunk by chunk — and label the response uncacheable.
+func TestProxy_UncacheableStreamingRelaysSSE(t *testing.T) {
+	upstream := newFakeUpstream(t)
+	upstream.script(chatPath, scriptedResponse{sse: true, lines: basicStreamLines})
+	proxy := newProxy(t, upstream, nil)
+
+	body := `{"model":"gpt-4","stream":true,"temperature":1.5,` +
+		`"messages":[{"role":"user","content":"be creative"}]}`
+
+	resp, respBody := postChat(t, proxy.URL, body, nil)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+	if got := resp.Header.Get("x-rostam-cache"); got != "uncacheable" {
+		t.Fatalf("x-rostam-cache = %q, want uncacheable", got)
+	}
+	if got := resp.Header.Get("Content-Type"); got != "text/event-stream" {
+		t.Fatalf("Content-Type = %q, want text/event-stream", got)
+	}
+	if got := string(respBody); got != strings.Join(basicStreamLines, "") {
+		t.Fatalf("relayed body = %q, want the upstream stream verbatim", got)
+	}
+	if got := assembleSSEContent(t, string(respBody)); got != "Hello, world" {
+		t.Fatalf("assembled answer = %q, want %q", got, "Hello, world")
 	}
 }
 

--- a/llmproxy/proxy_test.go
+++ b/llmproxy/proxy_test.go
@@ -11,6 +11,7 @@ import (
 	"io"
 	"log/slog"
 	"net/http"
+	"net/http/httptest"
 	"strconv"
 	"strings"
 	"testing"
@@ -793,6 +794,51 @@ func TestProxy_UncacheableStreamingRelaysSSE(t *testing.T) {
 	}
 	if got := assembleSSEContent(t, string(respBody)); got != "Hello, world" {
 		t.Fatalf("assembled answer = %q, want %q", got, "Hello, world")
+	}
+}
+
+// countingResponseWriter is a real http.ResponseWriter (recorder) that also
+// counts how many times the handler flushed it, so a test can see the relay's
+// delivery behavior from where the client sits.
+type countingResponseWriter struct {
+	*httptest.ResponseRecorder
+	flushes int
+}
+
+func (c *countingResponseWriter) Flush() {
+	c.flushes++
+	c.ResponseRecorder.Flush()
+}
+
+// The flush WIRING, not just the wrapper: drive the uncacheable-streaming
+// path through the real handler and require that the client's writer was
+// flushed. Without newFlushWriter at the relay call sites this counts zero —
+// every chunk would sit in the response buffer until the handler returned,
+// which for a stream:true request is the whole response arriving at once.
+func TestProxy_UncacheableStreamFlushesToTheClient(t *testing.T) {
+	upstream := newFakeUpstream(t)
+	upstream.script(chatPath, scriptedResponse{sse: true, lines: basicStreamLines})
+	srv := newProxyServer(t, upstream, nil)
+
+	body := `{"model":"gpt-4","stream":true,"temperature":1.5,` +
+		`"messages":[{"role":"user","content":"be creative"}]}`
+	req := httptest.NewRequest(http.MethodPost, chatPath, strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+
+	w := &countingResponseWriter{ResponseRecorder: httptest.NewRecorder()}
+	srv.Handler().ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", w.Code)
+	}
+	if got := w.Header().Get("x-rostam-cache"); got != "uncacheable" {
+		t.Fatalf("x-rostam-cache = %q, want uncacheable", got)
+	}
+	if w.flushes == 0 {
+		t.Fatalf("the relay never flushed: the client would get the whole stream at once, when the handler returns")
+	}
+	if got, want := w.Body.String(), strings.Join(basicStreamLines, ""); got != want {
+		t.Fatalf("relayed body = %q, want %q", got, want)
 	}
 }
 

--- a/llmproxy/proxy_test.go
+++ b/llmproxy/proxy_test.go
@@ -532,6 +532,86 @@ func (zeroReader) Read(p []byte) (int, error) {
 	return len(p), nil
 }
 
+// A chat-completions body over the 16 MiB cap is refused with an
+// OpenAI-shaped 413 and never reaches upstream: the cache path buffers the
+// whole body to parse it, so the cap is what keeps a single client from
+// making the proxy allocate without bound.
+func TestProxy_OversizedChatBodyReturns413(t *testing.T) {
+	upstream := newFakeUpstream(t)
+	upstream.script(chatPath, scriptedResponse{body: chatCompletionJSON(t, "never reached", "stop", 1)})
+	proxy := newProxy(t, upstream, nil)
+
+	// A valid JSON body whose padding pushes it past maxBodyBytes.
+	filler := strings.Repeat("x", maxBodyBytes+1024)
+	body := `{"model":"gpt-4","messages":[{"role":"user","content":"` + filler + `"}]}`
+
+	resp, respBody := postChat(t, proxy.URL, body, nil)
+	if resp.StatusCode != http.StatusRequestEntityTooLarge {
+		t.Fatalf("status = %d, want 413", resp.StatusCode)
+	}
+
+	var errBody struct {
+		Error struct {
+			Message string `json:"message"`
+			Type    string `json:"type"`
+		} `json:"error"`
+	}
+	if err := json.Unmarshal(respBody, &errBody); err != nil {
+		t.Fatalf("unmarshal error body: %v; body=%s", err, respBody)
+	}
+	if errBody.Error.Type != "invalid_request_error" {
+		t.Fatalf("error.type = %q, want invalid_request_error", errBody.Error.Type)
+	}
+	if errBody.Error.Message == "" {
+		t.Fatalf("error.message is empty")
+	}
+	if n := upstream.requestCount(chatPath); n != 0 {
+		t.Fatalf("upstream requests = %d, want 0 (an oversized body must be refused locally)", n)
+	}
+}
+
+// n > 1 asks for several completions, which one cached answer cannot stand in
+// for: the request passes through uncacheable and nothing is stored.
+func TestProxy_NGreaterThanOnePassesThroughUncacheable(t *testing.T) {
+	upstream := newFakeUpstream(t)
+	upstream.script(chatPath, scriptedResponse{body: chatCompletionJSON(t, "one of two", "stop", 3)})
+	proxy := newProxy(t, upstream, nil)
+
+	body := `{"model":"gpt-4","n":2,"messages":[{"role":"user","content":"give me two answers"}]}`
+
+	resp1, _ := postChat(t, proxy.URL, body, nil)
+	if resp1.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200", resp1.StatusCode)
+	}
+	if got := resp1.Header.Get("x-rostam-cache"); got != "uncacheable" {
+		t.Fatalf("x-rostam-cache = %q, want uncacheable", got)
+	}
+
+	// Repeat: still uncacheable, still reaching upstream.
+	postChat(t, proxy.URL, body, nil)
+	if n := upstream.requestCount(chatPath); n != 2 {
+		t.Fatalf("upstream requests = %d, want 2", n)
+	}
+
+	statsResp, statsBody := getStats(t, proxy.URL)
+	if statsResp.StatusCode != http.StatusOK {
+		t.Fatalf("/stats status = %d, want 200", statsResp.StatusCode)
+	}
+	var st struct {
+		Uncacheable float64 `json:"uncacheable"`
+		Stored      float64 `json:"stored"`
+	}
+	if err := json.Unmarshal(statsBody, &st); err != nil {
+		t.Fatalf("unmarshal /stats: %v; body=%s", err, statsBody)
+	}
+	if st.Uncacheable != 2 {
+		t.Fatalf("uncacheable = %v, want 2", st.Uncacheable)
+	}
+	if st.Stored != 0 {
+		t.Fatalf("stored = %v, want 0 (an n>1 request must never be stored)", st.Stored)
+	}
+}
+
 // (g) malformed JSON on the cache path returns an OpenAI-shaped 400 error.
 func TestProxy_MalformedJSONReturns400(t *testing.T) {
 	upstream := newFakeUpstream(t)

--- a/llmproxy/proxy_test.go
+++ b/llmproxy/proxy_test.go
@@ -224,6 +224,55 @@ func TestProxy_PassthroughPreservesPathAndAuth(t *testing.T) {
 	}
 }
 
+// A passthrough body must be streamed through to upstream rather than
+// buffered in the proxy: a 20 MiB body (well over the 16 MiB chat-completions
+// cap, which does not apply to passthrough routes) must reach upstream
+// intact and get a normal 200, never a 413. The request body is sourced from
+// an io.Reader rather than a pre-built []byte so the test itself can't
+// accidentally hide a proxy-side buffering bug behind its own buffering.
+func TestProxy_PassthroughStreamsLargeBody(t *testing.T) {
+	upstream := newFakeUpstream(t)
+	upstream.script("/v1/embeddings", scriptedResponse{body: []byte(`{"ok":true}`)})
+	proxy := newProxy(t, upstream, nil)
+
+	const size = 20 << 20 // 20 MiB
+
+	req, err := http.NewRequest(http.MethodPost, proxy.URL+"/v1/embeddings", io.LimitReader(zeroReader{}, size))
+	if err != nil {
+		t.Fatalf("NewRequest: %v", err)
+	}
+	req.ContentLength = size
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("Do: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200 (not 413 — passthrough has no chat-completions body cap)", resp.StatusCode)
+	}
+
+	captured := upstream.lastRequest("/v1/embeddings")
+	if captured == nil {
+		t.Fatalf("upstream never saw /v1/embeddings")
+	}
+	if len(captured.Body) != size {
+		t.Fatalf("upstream received body length = %d, want %d (body must reach upstream intact)", len(captured.Body), size)
+	}
+}
+
+// zeroReader is an endless source of zero bytes, used with io.LimitReader to
+// produce a large test request body without ever holding it as a single
+// in-memory []byte.
+type zeroReader struct{}
+
+func (zeroReader) Read(p []byte) (int, error) {
+	for i := range p {
+		p[i] = 0
+	}
+	return len(p), nil
+}
+
 // (g) malformed JSON on the cache path returns an OpenAI-shaped 400 error.
 func TestProxy_MalformedJSONReturns400(t *testing.T) {
 	upstream := newFakeUpstream(t)

--- a/llmproxy/proxy_test.go
+++ b/llmproxy/proxy_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"io"
 	"net/http"
+	"strconv"
 	"testing"
 )
 
@@ -78,6 +79,70 @@ func TestProxy_OneCharDifferentBodyMisses(t *testing.T) {
 	}
 	if n := upstream.requestCount(chatPath); n != 2 {
 		t.Fatalf("upstream requests = %d, want 2 (both should miss)", n)
+	}
+}
+
+// fnv32a is the 32-bit hash the stub embedder used to seed itself with,
+// reproduced here to manufacture the prompt pair that used to cross-hit.
+func fnv32a(s string) uint32 {
+	h := uint32(2166136261)
+	for _, b := range []byte(s) {
+		h = (h ^ uint32(b)) * 16777619
+	}
+	return h
+}
+
+// colliding32BitPair finds two distinct user-message contents whose SERIALIZED
+// prompts (what cacheIdentity actually hands the embedder, role and separators
+// included) share a 32-bit FNV-1a hash, by birthday search over a 2^32 space.
+// Colliding the bare content instead would prove nothing: the embedder never
+// sees it.
+func colliding32BitPair(t *testing.T) (string, string) {
+	t.Helper()
+	const maxCandidates = 500_000 // P(no collision) < 1e-6
+
+	seen := make(map[uint32]string, maxCandidates)
+	for i := 0; i < maxCandidates; i++ {
+		s := "collide-" + strconv.Itoa(i)
+		h := fnv32a("user\x00" + s + "\x1e")
+		if prev, ok := seen[h]; ok {
+			return prev, s
+		}
+		seen[h] = s
+	}
+	t.Skip("no 32-bit FNV-1a collision found in the candidate budget")
+	return "", ""
+}
+
+// (b2) two prompts that collide in 32-bit FNV-1a must still miss each other
+// end to end. The stub embedder used to derive every dimension from that
+// 32-bit hash, so this pair embedded identically and the second prompt was
+// answered with the first prompt's completion — a wrong answer, served with
+// x-rostam-cache: hit.
+func TestProxy_ThirtyTwoBitCollidingPromptsDoNotCrossHit(t *testing.T) {
+	promptA, promptB := colliding32BitPair(t)
+
+	upstream := newFakeUpstream(t)
+	upstream.script(chatPath, scriptedResponse{
+		body: chatCompletionJSON(t, "answer for A", "stop", 5),
+	})
+	proxy := newProxy(t, upstream, nil)
+
+	bodyA := `{"model":"gpt-4","messages":[{"role":"user","content":"` + promptA + `"}]}`
+	bodyB := `{"model":"gpt-4","messages":[{"role":"user","content":"` + promptB + `"}]}`
+
+	resp1, _ := postChat(t, proxy.URL, bodyA, nil)
+	if got := resp1.Header.Get("x-rostam-cache"); got != "miss" {
+		t.Fatalf("first request x-rostam-cache = %q, want miss", got)
+	}
+
+	resp2, _ := postChat(t, proxy.URL, bodyB, nil)
+	if got := resp2.Header.Get("x-rostam-cache"); got != "miss" {
+		t.Fatalf("32-bit-colliding prompt %q x-rostam-cache = %q, want miss (it must not be answered with %q's cached completion)",
+			promptB, got, promptA)
+	}
+	if n := upstream.requestCount(chatPath); n != 2 {
+		t.Fatalf("upstream requests = %d, want 2 (both prompts must reach upstream)", n)
 	}
 }
 

--- a/llmproxy/sse.go
+++ b/llmproxy/sse.go
@@ -207,10 +207,16 @@ func relayAndCapture(dst http.ResponseWriter, src io.Reader) (streamResult, erro
 		fl.Flush()
 
 		line := bytes.TrimRight(raw, "\r\n")
-		data, isData := strings.CutPrefix(string(line), "data: ")
+		data, isData := strings.CutPrefix(string(line), "data:")
 		if !isData {
 			continue
 		}
+		// Per the SSE spec a single space after the colon is optional
+		// padding, not part of the value. OpenAI sends it; other
+		// OpenAI-compatible servers write "data:{...}" and used to be
+		// captured as nothing at all — the client still got the stream
+		// relayed verbatim above, but the answer was never cached.
+		data = strings.TrimPrefix(data, " ")
 		if data == "[DONE]" {
 			result.clean = true
 			continue

--- a/llmproxy/sse.go
+++ b/llmproxy/sse.go
@@ -11,6 +11,7 @@ import (
 	"io"
 	"net/http"
 	"strings"
+	"time"
 )
 
 // sseMaxLine bounds a single upstream SSE line, matching mcp/jsonrpc.go's
@@ -74,27 +75,35 @@ func replayAsSSE(w http.ResponseWriter, model, answer string) error {
 		return err
 	}
 
+	// One timestamp shared across every chunk in the stream, the way a real
+	// upstream stream carries the same created value from its first chunk to
+	// its last — one call to time.Now, not one per chunk.
+	created := time.Now().Unix()
+
 	chunks := []map[string]any{
 		{
-			"id":     "rostam-cache",
-			"object": "chat.completion.chunk",
-			"model":  model,
+			"id":      "rostam-cache",
+			"object":  "chat.completion.chunk",
+			"created": created,
+			"model":   model,
 			"choices": []map[string]any{
 				{"index": 0, "delta": map[string]any{"role": "assistant"}},
 			},
 		},
 		{
-			"id":     "rostam-cache",
-			"object": "chat.completion.chunk",
-			"model":  model,
+			"id":      "rostam-cache",
+			"object":  "chat.completion.chunk",
+			"created": created,
+			"model":   model,
 			"choices": []map[string]any{
 				{"index": 0, "delta": map[string]any{"content": answer}},
 			},
 		},
 		{
-			"id":     "rostam-cache",
-			"object": "chat.completion.chunk",
-			"model":  model,
+			"id":      "rostam-cache",
+			"object":  "chat.completion.chunk",
+			"created": created,
+			"model":   model,
 			"choices": []map[string]any{
 				{"index": 0, "delta": map[string]any{}, "finish_reason": "stop"},
 			},

--- a/llmproxy/sse.go
+++ b/llmproxy/sse.go
@@ -131,17 +131,24 @@ type sseChunk struct {
 	} `json:"usage"`
 }
 
-// toolCallsPresent reports whether a decoded delta.tool_calls field actually
-// carries tool calls. Several OpenAI-compatible backends (vLLM, Azure) emit
-// "tool_calls": null on ordinary content deltas, and json.RawMessage
-// captures that literal — a bare len(raw) > 0 check would misclassify every
-// such delta as carrying tool calls, wrongly marking plain-text answers
-// uncacheable downstream.
-func toolCallsPresent(raw json.RawMessage) bool {
+// rawFieldPresent reports whether a captured json.RawMessage field carries a
+// value. Absent (len 0) and an explicit null both count as absent: several
+// OpenAI-compatible backends (vLLM, Azure) send "field": null where OpenAI
+// omits the field, and json.RawMessage captures that literal, so a bare
+// len(raw) > 0 check would read every such request or chunk as carrying
+// something it doesn't.
+func rawFieldPresent(raw json.RawMessage) bool {
 	if len(raw) == 0 {
 		return false
 	}
 	return string(bytes.TrimSpace(raw)) != "null"
+}
+
+// toolCallsPresent reports whether a decoded delta.tool_calls field actually
+// carries tool calls — see rawFieldPresent for why an explicit null matters
+// here: misreading it would wrongly mark plain-text answers uncacheable.
+func toolCallsPresent(raw json.RawMessage) bool {
+	return rawFieldPresent(raw)
 }
 
 // scanRawLines is like bufio.ScanLines but keeps each line's terminator

--- a/llmproxy/sse.go
+++ b/llmproxy/sse.go
@@ -4,6 +4,7 @@ package llmproxy
 
 import (
 	"bufio"
+	"bytes"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -130,6 +131,38 @@ type sseChunk struct {
 	} `json:"usage"`
 }
 
+// toolCallsPresent reports whether a decoded delta.tool_calls field actually
+// carries tool calls. Several OpenAI-compatible backends (vLLM, Azure) emit
+// "tool_calls": null on ordinary content deltas, and json.RawMessage
+// captures that literal — a bare len(raw) > 0 check would misclassify every
+// such delta as carrying tool calls, wrongly marking plain-text answers
+// uncacheable downstream.
+func toolCallsPresent(raw json.RawMessage) bool {
+	if len(raw) == 0 {
+		return false
+	}
+	return string(bytes.TrimSpace(raw)) != "null"
+}
+
+// scanRawLines is like bufio.ScanLines but keeps each line's terminator
+// (LF or CRLF) attached to the returned token instead of stripping it. A
+// relay that re-appends its own "\n" after ScanLines strips \r silently
+// turns CRLF upstream input into LF-only output; returning the terminator
+// verbatim lets the caller forward exactly the bytes it read.
+func scanRawLines(data []byte, atEOF bool) (advance int, token []byte, err error) {
+	if atEOF && len(data) == 0 {
+		return 0, nil, nil
+	}
+	if i := bytes.IndexByte(data, '\n'); i >= 0 {
+		return i + 1, data[0 : i+1], nil
+	}
+	if atEOF {
+		return len(data), data, nil
+	}
+	// Request more data.
+	return 0, nil, nil
+}
+
 // streamResult accumulates what the cache needs from an upstream SSE stream
 // as it's relayed to the client.
 type streamResult struct {
@@ -157,17 +190,16 @@ func relayAndCapture(dst http.ResponseWriter, src io.Reader) (streamResult, erro
 
 	sc := bufio.NewScanner(src)
 	sc.Buffer(make([]byte, 64<<10), sseMaxLine)
+	sc.Split(scanRawLines)
 
 	for sc.Scan() {
-		line := sc.Bytes()
-		if _, err := dst.Write(line); err != nil {
-			return result, err
-		}
-		if _, err := dst.Write([]byte("\n")); err != nil {
+		raw := sc.Bytes() // includes its original terminator (LF or CRLF), or none at EOF
+		if _, err := dst.Write(raw); err != nil {
 			return result, err
 		}
 		fl.Flush()
 
+		line := bytes.TrimRight(raw, "\r\n")
 		data, isData := strings.CutPrefix(string(line), "data: ")
 		if !isData {
 			continue
@@ -186,7 +218,7 @@ func relayAndCapture(dst http.ResponseWriter, src io.Reader) (streamResult, erro
 		}
 		for _, ch := range chunk.Choices {
 			result.content.WriteString(ch.Delta.Content)
-			if len(ch.Delta.ToolCalls) > 0 {
+			if toolCallsPresent(ch.Delta.ToolCalls) {
 				result.sawToolCalls = true
 			}
 			if ch.FinishReason != "" {

--- a/llmproxy/sse.go
+++ b/llmproxy/sse.go
@@ -1,0 +1,204 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package llmproxy
+
+import (
+	"bufio"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+)
+
+// sseMaxLine bounds a single upstream SSE line, matching mcp/jsonrpc.go's
+// maxLine so an upstream that never terminates a line cannot make the proxy
+// buffer unboundedly.
+const sseMaxLine = 16 << 20
+
+// sseWriter emits Server-Sent Events to an http.ResponseWriter, flushing
+// after every event so the client sees each chunk as it's produced rather
+// than the whole response buffered until the handler returns.
+type sseWriter struct {
+	w  http.ResponseWriter
+	fl http.Flusher
+}
+
+// newSSEWriter sets the SSE response headers and returns a writer. It errors
+// if w cannot flush — without that, a "stream" would just buffer behind
+// whatever the transport does by default and defeat the point of SSE.
+func newSSEWriter(w http.ResponseWriter) (*sseWriter, error) {
+	fl, ok := w.(http.Flusher)
+	if !ok {
+		return nil, errors.New("llmproxy: response writer does not support flushing")
+	}
+	w.Header().Set("Content-Type", "text/event-stream")
+	w.Header().Set("Cache-Control", "no-cache")
+	return &sseWriter{w: w, fl: fl}, nil
+}
+
+// event writes one SSE data frame and flushes it to the client immediately.
+func (s *sseWriter) event(data []byte) error {
+	if _, err := s.w.Write([]byte("data: ")); err != nil {
+		return err
+	}
+	if _, err := s.w.Write(data); err != nil {
+		return err
+	}
+	if _, err := s.w.Write([]byte("\n\n")); err != nil {
+		return err
+	}
+	s.fl.Flush()
+	return nil
+}
+
+// done writes the terminal [DONE] sentinel OpenAI-compatible clients expect
+// to see before they stop reading the stream.
+func (s *sseWriter) done() error {
+	if _, err := s.w.Write([]byte("data: [DONE]\n\n")); err != nil {
+		return err
+	}
+	s.fl.Flush()
+	return nil
+}
+
+// replayAsSSE writes a cached answer back as a minimal valid chat-completions
+// stream, so a client that requested stream=true can't tell a cache hit from
+// a real upstream stream. Three chunks (role, content, finish) mirror the
+// smallest shape a real OpenAI stream ever produces.
+func replayAsSSE(w http.ResponseWriter, model, answer string) error {
+	sw, err := newSSEWriter(w)
+	if err != nil {
+		return err
+	}
+
+	chunks := []map[string]any{
+		{
+			"id":     "rostam-cache",
+			"object": "chat.completion.chunk",
+			"model":  model,
+			"choices": []map[string]any{
+				{"index": 0, "delta": map[string]any{"role": "assistant"}},
+			},
+		},
+		{
+			"id":     "rostam-cache",
+			"object": "chat.completion.chunk",
+			"model":  model,
+			"choices": []map[string]any{
+				{"index": 0, "delta": map[string]any{"content": answer}},
+			},
+		},
+		{
+			"id":     "rostam-cache",
+			"object": "chat.completion.chunk",
+			"model":  model,
+			"choices": []map[string]any{
+				{"index": 0, "delta": map[string]any{}, "finish_reason": "stop"},
+			},
+		},
+	}
+
+	for _, c := range chunks {
+		// The shapes above are fixed and always marshal cleanly; an error
+		// here would mean a bug in this function, not bad input.
+		b, err := json.Marshal(c)
+		if err != nil {
+			panic("llmproxy: replayAsSSE: " + err.Error())
+		}
+		if err := sw.event(b); err != nil {
+			return err
+		}
+	}
+	return sw.done()
+}
+
+// sseChunk is the tolerant decode shape for one upstream chat-completions
+// stream chunk: just enough to update streamResult without choking on fields
+// OpenAI adds over time.
+type sseChunk struct {
+	Choices []struct {
+		Delta struct {
+			Content   string          `json:"content"`
+			ToolCalls json.RawMessage `json:"tool_calls,omitempty"`
+		} `json:"delta"`
+		FinishReason string `json:"finish_reason"`
+	} `json:"choices"`
+	Usage struct {
+		CompletionTokens int `json:"completion_tokens"`
+	} `json:"usage"`
+}
+
+// streamResult accumulates what the cache needs from an upstream SSE stream
+// as it's relayed to the client.
+type streamResult struct {
+	content          strings.Builder
+	finishReason     string
+	sawToolCalls     bool
+	completionTokens int  // from a usage-bearing chunk when present; else 0
+	clean            bool // saw [DONE] with no relay error
+}
+
+// relayAndCapture relays an upstream SSE body to the client line-for-line
+// while accumulating the assembled answer, so a streamed response can still
+// be cached without buffering the whole thing in memory before forwarding
+// it. Every raw line is forwarded verbatim — comments, event: lines, and
+// blank separators included — the proxy doesn't get to decide which SSE
+// fields the client cares about; only data: lines are decoded, and
+// tolerantly, for capture.
+func relayAndCapture(dst http.ResponseWriter, src io.Reader) (streamResult, error) {
+	var result streamResult
+
+	fl, ok := dst.(http.Flusher)
+	if !ok {
+		return result, errors.New("llmproxy: response writer does not support flushing")
+	}
+
+	sc := bufio.NewScanner(src)
+	sc.Buffer(make([]byte, 64<<10), sseMaxLine)
+
+	for sc.Scan() {
+		line := sc.Bytes()
+		if _, err := dst.Write(line); err != nil {
+			return result, err
+		}
+		if _, err := dst.Write([]byte("\n")); err != nil {
+			return result, err
+		}
+		fl.Flush()
+
+		data, isData := strings.CutPrefix(string(line), "data: ")
+		if !isData {
+			continue
+		}
+		if data == "[DONE]" {
+			result.clean = true
+			continue
+		}
+
+		var chunk sseChunk
+		if err := json.Unmarshal([]byte(data), &chunk); err != nil {
+			// Capture is best-effort: the client already got the raw bytes
+			// above, so a chunk shape we don't recognize just doesn't
+			// contribute to the accumulated result.
+			continue
+		}
+		for _, ch := range chunk.Choices {
+			result.content.WriteString(ch.Delta.Content)
+			if len(ch.Delta.ToolCalls) > 0 {
+				result.sawToolCalls = true
+			}
+			if ch.FinishReason != "" {
+				result.finishReason = ch.FinishReason
+			}
+		}
+		if chunk.Usage.CompletionTokens > 0 {
+			result.completionTokens = chunk.Usage.CompletionTokens
+		}
+	}
+	if err := sc.Err(); err != nil {
+		return result, fmt.Errorf("llmproxy: relay: %w", err)
+	}
+	return result, nil
+}

--- a/llmproxy/sse_test.go
+++ b/llmproxy/sse_test.go
@@ -69,6 +69,7 @@ type chunkChoice struct {
 type chunk struct {
 	ID      string        `json:"id"`
 	Object  string        `json:"object"`
+	Created int64         `json:"created"`
 	Model   string        `json:"model"`
 	Choices []chunkChoice `json:"choices"`
 }
@@ -97,6 +98,9 @@ func TestReplayAsSSE_ParsesAsThreeChunksThenDone(t *testing.T) {
 	if roleChunk.Object != "chat.completion.chunk" {
 		t.Fatalf("chunk 0 object = %q, want chat.completion.chunk", roleChunk.Object)
 	}
+	if roleChunk.Created == 0 {
+		t.Fatalf("chunk 0 created = %d, want a non-zero Unix timestamp", roleChunk.Created)
+	}
 	if roleChunk.Model != "gpt-4" {
 		t.Fatalf("chunk 0 model = %q, want gpt-4", roleChunk.Model)
 	}
@@ -111,6 +115,9 @@ func TestReplayAsSSE_ParsesAsThreeChunksThenDone(t *testing.T) {
 	if content, _ := contentChunk.Choices[0].Delta["content"].(string); content != "hello world" {
 		t.Fatalf("chunk 1 delta.content = %q, want hello world", content)
 	}
+	if contentChunk.Created != roleChunk.Created {
+		t.Fatalf("chunk 1 created = %d, want %d (same as chunk 0 — one timestamp for the whole stream)", contentChunk.Created, roleChunk.Created)
+	}
 
 	var finishChunk chunk
 	if err := json.Unmarshal([]byte(events[2]), &finishChunk); err != nil {
@@ -118,6 +125,9 @@ func TestReplayAsSSE_ParsesAsThreeChunksThenDone(t *testing.T) {
 	}
 	if finishChunk.Choices[0].FinishReason != "stop" {
 		t.Fatalf("chunk 2 finish_reason = %q, want stop", finishChunk.Choices[0].FinishReason)
+	}
+	if finishChunk.Created != roleChunk.Created {
+		t.Fatalf("chunk 2 created = %d, want %d (same as chunk 0 — one timestamp for the whole stream)", finishChunk.Created, roleChunk.Created)
 	}
 }
 

--- a/llmproxy/sse_test.go
+++ b/llmproxy/sse_test.go
@@ -1,0 +1,216 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package llmproxy
+
+import (
+	"bufio"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// nonFlushingWriter satisfies http.ResponseWriter but deliberately does not
+// implement http.Flusher, so it exercises newSSEWriter's rejection path.
+type nonFlushingWriter struct {
+	header http.Header
+}
+
+func (w *nonFlushingWriter) Header() http.Header         { return w.header }
+func (w *nonFlushingWriter) Write(b []byte) (int, error) { return len(b), nil }
+func (w *nonFlushingWriter) WriteHeader(int)             {}
+
+func TestNewSSEWriter_RejectsNonFlusher(t *testing.T) {
+	w := &nonFlushingWriter{header: http.Header{}}
+	_, err := newSSEWriter(w)
+	if err == nil {
+		t.Fatalf("newSSEWriter err = nil, want error for non-Flusher writer")
+	}
+}
+
+func TestNewSSEWriter_SetsHeaders(t *testing.T) {
+	rec := httptest.NewRecorder()
+	if _, err := newSSEWriter(rec); err != nil {
+		t.Fatalf("newSSEWriter: %v", err)
+	}
+	if got := rec.Header().Get("Content-Type"); got != "text/event-stream" {
+		t.Fatalf("Content-Type = %q, want text/event-stream", got)
+	}
+	if got := rec.Header().Get("Cache-Control"); got != "no-cache" {
+		t.Fatalf("Cache-Control = %q, want no-cache", got)
+	}
+}
+
+// dataEvents splits an SSE body into the payloads of its "data: " lines, in
+// order, matching how a real client would parse the stream.
+func dataEvents(t *testing.T, body string) []string {
+	t.Helper()
+	var events []string
+	sc := bufio.NewScanner(strings.NewReader(body))
+	for sc.Scan() {
+		line := sc.Text()
+		if data, ok := strings.CutPrefix(line, "data: "); ok {
+			events = append(events, data)
+		}
+	}
+	if err := sc.Err(); err != nil {
+		t.Fatalf("scan body: %v", err)
+	}
+	return events
+}
+
+type chunkChoice struct {
+	Index        int            `json:"index"`
+	Delta        map[string]any `json:"delta"`
+	FinishReason string         `json:"finish_reason"`
+}
+
+type chunk struct {
+	ID      string        `json:"id"`
+	Object  string        `json:"object"`
+	Model   string        `json:"model"`
+	Choices []chunkChoice `json:"choices"`
+}
+
+func TestReplayAsSSE_ParsesAsThreeChunksThenDone(t *testing.T) {
+	rec := httptest.NewRecorder()
+	if err := replayAsSSE(rec, "gpt-4", "hello world"); err != nil {
+		t.Fatalf("replayAsSSE: %v", err)
+	}
+
+	events := dataEvents(t, rec.Body.String())
+	if len(events) != 4 {
+		t.Fatalf("len(events) = %d, want 4 (3 chunks + [DONE])", len(events))
+	}
+	if events[3] != "[DONE]" {
+		t.Fatalf("last event = %q, want [DONE]", events[3])
+	}
+
+	var roleChunk chunk
+	if err := json.Unmarshal([]byte(events[0]), &roleChunk); err != nil {
+		t.Fatalf("unmarshal chunk 0: %v", err)
+	}
+	if roleChunk.ID != "rostam-cache" {
+		t.Fatalf("chunk 0 id = %q, want rostam-cache", roleChunk.ID)
+	}
+	if roleChunk.Object != "chat.completion.chunk" {
+		t.Fatalf("chunk 0 object = %q, want chat.completion.chunk", roleChunk.Object)
+	}
+	if roleChunk.Model != "gpt-4" {
+		t.Fatalf("chunk 0 model = %q, want gpt-4", roleChunk.Model)
+	}
+	if role, _ := roleChunk.Choices[0].Delta["role"].(string); role != "assistant" {
+		t.Fatalf("chunk 0 delta.role = %q, want assistant", role)
+	}
+
+	var contentChunk chunk
+	if err := json.Unmarshal([]byte(events[1]), &contentChunk); err != nil {
+		t.Fatalf("unmarshal chunk 1: %v", err)
+	}
+	if content, _ := contentChunk.Choices[0].Delta["content"].(string); content != "hello world" {
+		t.Fatalf("chunk 1 delta.content = %q, want hello world", content)
+	}
+
+	var finishChunk chunk
+	if err := json.Unmarshal([]byte(events[2]), &finishChunk); err != nil {
+		t.Fatalf("unmarshal chunk 2: %v", err)
+	}
+	if finishChunk.Choices[0].FinishReason != "stop" {
+		t.Fatalf("chunk 2 finish_reason = %q, want stop", finishChunk.Choices[0].FinishReason)
+	}
+}
+
+// scriptedStream is a realistic upstream chat-completions SSE body: a role
+// chunk, three content deltas, a finish chunk, a usage chunk, and [DONE],
+// with a comment line and an event: line mixed in to exercise pass-through
+// of non-data SSE fields.
+const scriptedStream = ": ping\n" +
+	"data: {\"choices\":[{\"index\":0,\"delta\":{\"role\":\"assistant\"},\"finish_reason\":null}]}\n\n" +
+	"event: message\n" +
+	"data: {\"choices\":[{\"index\":0,\"delta\":{\"content\":\"Hel\"},\"finish_reason\":null}]}\n\n" +
+	"data: {\"choices\":[{\"index\":0,\"delta\":{\"content\":\"lo, \"},\"finish_reason\":null}]}\n\n" +
+	"data: {\"choices\":[{\"index\":0,\"delta\":{\"content\":\"world\"},\"finish_reason\":null}]}\n\n" +
+	"data: {\"choices\":[{\"index\":0,\"delta\":{},\"finish_reason\":\"stop\"}]}\n\n" +
+	"data: {\"choices\":[],\"usage\":{\"completion_tokens\":42}}\n\n" +
+	"data: [DONE]\n\n"
+
+func TestRelayAndCapture_ForwardsByteIdenticalAndAssembles(t *testing.T) {
+	rec := httptest.NewRecorder()
+	result, err := relayAndCapture(rec, strings.NewReader(scriptedStream))
+	if err != nil {
+		t.Fatalf("relayAndCapture: %v", err)
+	}
+
+	if got := rec.Body.String(); got != scriptedStream {
+		t.Fatalf("relayed body = %q, want %q", got, scriptedStream)
+	}
+	if got := result.content.String(); got != "Hello, world" {
+		t.Fatalf("content = %q, want %q", got, "Hello, world")
+	}
+	if result.finishReason != "stop" {
+		t.Fatalf("finishReason = %q, want stop", result.finishReason)
+	}
+	if result.completionTokens != 42 {
+		t.Fatalf("completionTokens = %d, want 42", result.completionTokens)
+	}
+	if !result.clean {
+		t.Fatalf("clean = false, want true ([DONE] was present)")
+	}
+	if result.sawToolCalls {
+		t.Fatalf("sawToolCalls = true, want false")
+	}
+}
+
+func TestRelayAndCapture_ToolCallsSetsFlag(t *testing.T) {
+	stream := "data: {\"choices\":[{\"index\":0,\"delta\":{\"tool_calls\":[{\"index\":0,\"id\":\"call_1\"}]},\"finish_reason\":null}]}\n\n" +
+		"data: {\"choices\":[{\"index\":0,\"delta\":{},\"finish_reason\":\"tool_calls\"}]}\n\n" +
+		"data: [DONE]\n\n"
+
+	rec := httptest.NewRecorder()
+	result, err := relayAndCapture(rec, strings.NewReader(stream))
+	if err != nil {
+		t.Fatalf("relayAndCapture: %v", err)
+	}
+	if !result.sawToolCalls {
+		t.Fatalf("sawToolCalls = false, want true")
+	}
+	if result.finishReason != "tool_calls" {
+		t.Fatalf("finishReason = %q, want tool_calls", result.finishReason)
+	}
+	if !result.clean {
+		t.Fatalf("clean = false, want true")
+	}
+}
+
+func TestRelayAndCapture_TruncatedStreamNotClean(t *testing.T) {
+	stream := "data: {\"choices\":[{\"index\":0,\"delta\":{\"content\":\"partial\"},\"finish_reason\":null}]}\n\n"
+
+	rec := httptest.NewRecorder()
+	result, err := relayAndCapture(rec, strings.NewReader(stream))
+	if err != nil {
+		t.Fatalf("relayAndCapture: %v", err)
+	}
+	if result.clean {
+		t.Fatalf("clean = true, want false (no [DONE] in stream)")
+	}
+	if result.content.String() != "partial" {
+		t.Fatalf("content = %q, want partial", result.content.String())
+	}
+}
+
+func TestRelayAndCapture_NonDataLinesForwardedUntouched(t *testing.T) {
+	stream := ": keep-alive\n" +
+		"event: ping\n" +
+		"id: 123\n\n" +
+		"data: [DONE]\n\n"
+
+	rec := httptest.NewRecorder()
+	_, err := relayAndCapture(rec, strings.NewReader(stream))
+	if err != nil {
+		t.Fatalf("relayAndCapture: %v", err)
+	}
+	if got := rec.Body.String(); got != stream {
+		t.Fatalf("relayed body = %q, want %q", got, stream)
+	}
+}

--- a/llmproxy/sse_test.go
+++ b/llmproxy/sse_test.go
@@ -183,6 +183,26 @@ func TestRelayAndCapture_ToolCallsSetsFlag(t *testing.T) {
 	}
 }
 
+func TestRelayAndCapture_NullToolCallsNotFlagged(t *testing.T) {
+	// vLLM/Azure and other OpenAI-compatible backends emit "tool_calls":
+	// null on ordinary content deltas; that must not be misread as tool
+	// calls present.
+	stream := "data: {\"choices\":[{\"index\":0,\"delta\":{\"content\":\"hi\",\"tool_calls\":null},\"finish_reason\":null}]}\n\n" +
+		"data: [DONE]\n\n"
+
+	rec := httptest.NewRecorder()
+	result, err := relayAndCapture(rec, strings.NewReader(stream))
+	if err != nil {
+		t.Fatalf("relayAndCapture: %v", err)
+	}
+	if result.sawToolCalls {
+		t.Fatalf("sawToolCalls = true, want false (tool_calls: null is not tool calls)")
+	}
+	if result.content.String() != "hi" {
+		t.Fatalf("content = %q, want hi", result.content.String())
+	}
+}
+
 func TestRelayAndCapture_TruncatedStreamNotClean(t *testing.T) {
 	stream := "data: {\"choices\":[{\"index\":0,\"delta\":{\"content\":\"partial\"},\"finish_reason\":null}]}\n\n"
 
@@ -212,5 +232,35 @@ func TestRelayAndCapture_NonDataLinesForwardedUntouched(t *testing.T) {
 	}
 	if got := rec.Body.String(); got != stream {
 		t.Fatalf("relayed body = %q, want %q", got, stream)
+	}
+}
+
+func TestRelayAndCapture_CRLFForwardedByteIdentical(t *testing.T) {
+	stream := "data: {\"choices\":[{\"index\":0,\"delta\":{\"content\":\"hi\"},\"finish_reason\":null}]}\r\n\r\n" +
+		"data: [DONE]\r\n\r\n"
+
+	rec := httptest.NewRecorder()
+	result, err := relayAndCapture(rec, strings.NewReader(stream))
+	if err != nil {
+		t.Fatalf("relayAndCapture: %v", err)
+	}
+	if got := rec.Body.String(); got != stream {
+		t.Fatalf("relayed body = %q, want %q (CRLF terminators must be preserved)", got, stream)
+	}
+	if result.content.String() != "hi" {
+		t.Fatalf("content = %q, want hi", result.content.String())
+	}
+	if !result.clean {
+		t.Fatalf("clean = false, want true")
+	}
+}
+
+func TestRelayAndCapture_OversizedLineErrors(t *testing.T) {
+	huge := strings.Repeat("a", sseMaxLine+1) // one line, no newline, past the scanner bound
+
+	rec := httptest.NewRecorder()
+	_, err := relayAndCapture(rec, strings.NewReader(huge))
+	if err == nil {
+		t.Fatalf("relayAndCapture err = nil, want error for an oversized line")
 	}
 }

--- a/llmproxy/stream_test.go
+++ b/llmproxy/stream_test.go
@@ -1,0 +1,289 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package llmproxy
+
+import (
+	"bufio"
+	"encoding/json"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+// assembleSSEContent decodes an SSE chat-completions-chunk body (as produced
+// by either relayAndCapture's live relay or replayAsSSE's cache replay) and
+// concatenates every delta.content field in order, the way a real client
+// would reconstruct the answer.
+func assembleSSEContent(t *testing.T, body string) string {
+	t.Helper()
+	var sb strings.Builder
+	sc := bufio.NewScanner(strings.NewReader(body))
+	for sc.Scan() {
+		data, ok := strings.CutPrefix(sc.Text(), "data: ")
+		if !ok || data == "[DONE]" {
+			continue
+		}
+		var c sseChunk
+		if err := json.Unmarshal([]byte(data), &c); err != nil {
+			t.Fatalf("unmarshal chunk: %v; data=%s", err, data)
+		}
+		for _, ch := range c.Choices {
+			sb.WriteString(ch.Delta.Content)
+		}
+	}
+	if err := sc.Err(); err != nil {
+		t.Fatalf("scan SSE body: %v", err)
+	}
+	return sb.String()
+}
+
+// basicStreamLines is a realistic upstream chat-completions SSE script: role
+// chunk, two content deltas, a finish chunk, a usage chunk, then [DONE].
+var basicStreamLines = []string{
+	"data: {\"choices\":[{\"index\":0,\"delta\":{\"role\":\"assistant\"},\"finish_reason\":null}]}\n\n",
+	"data: {\"choices\":[{\"index\":0,\"delta\":{\"content\":\"Hello, \"},\"finish_reason\":null}]}\n\n",
+	"data: {\"choices\":[{\"index\":0,\"delta\":{\"content\":\"world\"},\"finish_reason\":null}]}\n\n",
+	"data: {\"choices\":[{\"index\":0,\"delta\":{},\"finish_reason\":\"stop\"}]}\n\n",
+	"data: {\"choices\":[],\"usage\":{\"completion_tokens\":9}}\n\n",
+	"data: [DONE]\n\n",
+}
+
+// (a) streaming miss: scripted upstream SSE relayed to the client byte-for-
+// byte. Then an identical streaming request is served from the cache as a
+// valid SSE stream without a second upstream call, and the assembled answer
+// from the cached replay matches the deltas assembled from the live relay.
+func TestProxy_StreamingMissThenHit(t *testing.T) {
+	upstream := newFakeUpstream(t)
+	upstream.script(chatPath, scriptedResponse{sse: true, lines: basicStreamLines})
+	proxy := newProxy(t, upstream, nil)
+
+	body := `{"model":"gpt-4","stream":true,"messages":[{"role":"user","content":"say hello"}]}`
+
+	resp1, body1 := postChat(t, proxy.URL, body, nil)
+	if resp1.StatusCode != http.StatusOK {
+		t.Fatalf("first request status = %d, want 200", resp1.StatusCode)
+	}
+	if got := resp1.Header.Get("x-rostam-cache"); got != "miss" {
+		t.Fatalf("first request x-rostam-cache = %q, want miss", got)
+	}
+	wantBody := strings.Join(basicStreamLines, "")
+	if got := string(body1); got != wantBody {
+		t.Fatalf("relayed body = %q, want %q (byte-for-byte)", got, wantBody)
+	}
+	if n := upstream.requestCount(chatPath); n != 1 {
+		t.Fatalf("upstream requests after first call = %d, want 1", n)
+	}
+	firstAnswer := assembleSSEContent(t, string(body1))
+	if firstAnswer != "Hello, world" {
+		t.Fatalf("assembled answer from relay = %q, want %q", firstAnswer, "Hello, world")
+	}
+
+	resp2, body2 := postChat(t, proxy.URL, body, nil)
+	if resp2.StatusCode != http.StatusOK {
+		t.Fatalf("second request status = %d, want 200", resp2.StatusCode)
+	}
+	if got := resp2.Header.Get("x-rostam-cache"); got != "hit" {
+		t.Fatalf("second request x-rostam-cache = %q, want hit", got)
+	}
+	if n := upstream.requestCount(chatPath); n != 1 {
+		t.Fatalf("upstream requests after second call = %d, want still 1 (cache hit must not call upstream)", n)
+	}
+	if got := resp2.Header.Get("Content-Type"); got != "text/event-stream" {
+		t.Fatalf("second request Content-Type = %q, want text/event-stream", got)
+	}
+	secondAnswer := assembleSSEContent(t, string(body2))
+	if secondAnswer != firstAnswer {
+		t.Fatalf("assembled answer from cache replay = %q, want %q (concatenated deltas from the miss)", secondAnswer, firstAnswer)
+	}
+}
+
+// (b1) cross-mode hit: cache populated via a NON-streaming request, then a
+// streaming request for the same identity replays from the cache.
+func TestProxy_NonStreamingPopulatesThenStreamingHits(t *testing.T) {
+	upstream := newFakeUpstream(t)
+	upstream.script(chatPath, scriptedResponse{
+		body: chatCompletionJSON(t, "the answer", "stop", 7),
+	})
+	proxy := newProxy(t, upstream, nil)
+
+	nonStreamBody := `{"model":"gpt-4","messages":[{"role":"user","content":"cross mode prompt"}]}`
+	streamBody := `{"model":"gpt-4","stream":true,"messages":[{"role":"user","content":"cross mode prompt"}]}`
+
+	resp1, _ := postChat(t, proxy.URL, nonStreamBody, nil)
+	if got := resp1.Header.Get("x-rostam-cache"); got != "miss" {
+		t.Fatalf("non-streaming request x-rostam-cache = %q, want miss", got)
+	}
+	if n := upstream.requestCount(chatPath); n != 1 {
+		t.Fatalf("upstream requests after non-streaming miss = %d, want 1", n)
+	}
+
+	resp2, body2 := postChat(t, proxy.URL, streamBody, nil)
+	if resp2.StatusCode != http.StatusOK {
+		t.Fatalf("streaming request status = %d, want 200", resp2.StatusCode)
+	}
+	if got := resp2.Header.Get("x-rostam-cache"); got != "hit" {
+		t.Fatalf("streaming request x-rostam-cache = %q, want hit", got)
+	}
+	if n := upstream.requestCount(chatPath); n != 1 {
+		t.Fatalf("upstream requests after streaming hit = %d, want still 1", n)
+	}
+	if got := assembleSSEContent(t, string(body2)); got != "the answer" {
+		t.Fatalf("streaming hit assembled answer = %q, want %q", got, "the answer")
+	}
+}
+
+// (b2) the reverse cross-mode direction: cache populated via a STREAMING
+// request, then a non-streaming request for the same identity serves a hit.
+func TestProxy_StreamingPopulatesThenNonStreamingHits(t *testing.T) {
+	upstream := newFakeUpstream(t)
+	upstream.script(chatPath, scriptedResponse{sse: true, lines: basicStreamLines})
+	proxy := newProxy(t, upstream, nil)
+
+	streamBody := `{"model":"gpt-4","stream":true,"messages":[{"role":"user","content":"reverse cross mode"}]}`
+	nonStreamBody := `{"model":"gpt-4","messages":[{"role":"user","content":"reverse cross mode"}]}`
+
+	resp1, _ := postChat(t, proxy.URL, streamBody, nil)
+	if got := resp1.Header.Get("x-rostam-cache"); got != "miss" {
+		t.Fatalf("streaming request x-rostam-cache = %q, want miss", got)
+	}
+	if n := upstream.requestCount(chatPath); n != 1 {
+		t.Fatalf("upstream requests after streaming miss = %d, want 1", n)
+	}
+
+	resp2, body2 := postChat(t, proxy.URL, nonStreamBody, nil)
+	if resp2.StatusCode != http.StatusOK {
+		t.Fatalf("non-streaming request status = %d, want 200", resp2.StatusCode)
+	}
+	if got := resp2.Header.Get("x-rostam-cache"); got != "hit" {
+		t.Fatalf("non-streaming request x-rostam-cache = %q, want hit", got)
+	}
+	if n := upstream.requestCount(chatPath); n != 1 {
+		t.Fatalf("upstream requests after non-streaming hit = %d, want still 1", n)
+	}
+
+	var decoded chatResponse
+	if err := json.Unmarshal(body2, &decoded); err != nil {
+		t.Fatalf("unmarshal cached response: %v", err)
+	}
+	if len(decoded.Choices) != 1 || decoded.Choices[0].Message.Content != "Hello, world" {
+		t.Fatalf("cached response content = %+v, want %q", decoded.Choices, "Hello, world")
+	}
+}
+
+// (c) mid-stream abort: upstream cuts the connection before writing [DONE].
+// The client still sees whatever was relayed before the drop, but nothing is
+// stored, so a repeat of the same request misses again.
+func TestProxy_StreamingMidStreamAbortNotStored(t *testing.T) {
+	partialLines := []string{
+		"data: {\"choices\":[{\"index\":0,\"delta\":{\"role\":\"assistant\"},\"finish_reason\":null}]}\n\n",
+		"data: {\"choices\":[{\"index\":0,\"delta\":{\"content\":\"partial\"},\"finish_reason\":null}]}\n\n",
+	}
+	upstream := newFakeUpstream(t)
+	upstream.script(chatPath, scriptedResponse{sse: true, lines: partialLines, abort: true})
+	proxy := newProxy(t, upstream, nil)
+
+	body := `{"model":"gpt-4","stream":true,"messages":[{"role":"user","content":"abort mid stream"}]}`
+
+	resp1, body1 := postChat(t, proxy.URL, body, nil)
+	if resp1.StatusCode != http.StatusOK {
+		t.Fatalf("first request status = %d, want 200", resp1.StatusCode)
+	}
+	if got := resp1.Header.Get("x-rostam-cache"); got != "miss" {
+		t.Fatalf("first request x-rostam-cache = %q, want miss", got)
+	}
+	wantBody := strings.Join(partialLines, "")
+	if got := string(body1); got != wantBody {
+		t.Fatalf("relayed (truncated) body = %q, want %q", got, wantBody)
+	}
+	if strings.Contains(string(body1), "[DONE]") {
+		t.Fatalf("relayed body contains [DONE], want a truncated stream")
+	}
+
+	resp2, _ := postChat(t, proxy.URL, body, nil)
+	if got := resp2.Header.Get("x-rostam-cache"); got != "miss" {
+		t.Fatalf("repeat request x-rostam-cache = %q, want miss (aborted stream must not be stored)", got)
+	}
+	if n := upstream.requestCount(chatPath); n != 2 {
+		t.Fatalf("upstream requests = %d, want 2 (both should reach upstream)", n)
+	}
+}
+
+// (d) a streamed response carrying tool_calls is relayed to the client but
+// must not be stored: a repeat of the same request misses again.
+func TestProxy_StreamingToolCallsNotStored(t *testing.T) {
+	lines := []string{
+		"data: {\"choices\":[{\"index\":0,\"delta\":{\"tool_calls\":[{\"index\":0,\"id\":\"call_1\"}]},\"finish_reason\":null}]}\n\n",
+		"data: {\"choices\":[{\"index\":0,\"delta\":{},\"finish_reason\":\"tool_calls\"}]}\n\n",
+		"data: [DONE]\n\n",
+	}
+	upstream := newFakeUpstream(t)
+	upstream.script(chatPath, scriptedResponse{sse: true, lines: lines})
+	proxy := newProxy(t, upstream, nil)
+
+	body := `{"model":"gpt-4","stream":true,"messages":[{"role":"user","content":"what's the weather"}],
+		"tools":[{"function":{"name":"get_weather"}}]}`
+
+	resp1, body1 := postChat(t, proxy.URL, body, nil)
+	if resp1.StatusCode != http.StatusOK {
+		t.Fatalf("first request status = %d, want 200", resp1.StatusCode)
+	}
+	if got := resp1.Header.Get("x-rostam-cache"); got != "miss" {
+		t.Fatalf("first request x-rostam-cache = %q, want miss", got)
+	}
+	wantBody := strings.Join(lines, "")
+	if got := string(body1); got != wantBody {
+		t.Fatalf("relayed body = %q, want %q (byte-for-byte)", got, wantBody)
+	}
+
+	resp2, _ := postChat(t, proxy.URL, body, nil)
+	if got := resp2.Header.Get("x-rostam-cache"); got != "miss" {
+		t.Fatalf("repeat request x-rostam-cache = %q, want miss (tool_calls responses must not be stored)", got)
+	}
+	if n := upstream.requestCount(chatPath); n != 2 {
+		t.Fatalf("upstream requests = %d, want 2 (both should reach upstream)", n)
+	}
+}
+
+// (e) usage-chunk completion_tokens land in tokens_saved once the answer is
+// served from a subsequent cache hit, and /stats counts streaming hits and
+// misses exactly like non-streaming ones (a gap Task 5 left open).
+func TestProxy_StreamingStatsAndTokensSaved(t *testing.T) {
+	upstream := newFakeUpstream(t)
+	upstream.script(chatPath, scriptedResponse{sse: true, lines: basicStreamLines})
+	proxy := newProxy(t, upstream, nil)
+
+	body := `{"model":"gpt-4","stream":true,"messages":[{"role":"user","content":"count my tokens"}]}`
+
+	// miss, then store
+	postChat(t, proxy.URL, body, nil)
+	// hit
+	postChat(t, proxy.URL, body, nil)
+
+	statsResp, statsBody := getStats(t, proxy.URL)
+	if statsResp.StatusCode != http.StatusOK {
+		t.Fatalf("/stats status = %d, want 200", statsResp.StatusCode)
+	}
+	var st struct {
+		Hits        float64 `json:"hits"`
+		Misses      float64 `json:"misses"`
+		Stored      float64 `json:"stored"`
+		TokensSaved float64 `json:"tokens_saved"`
+	}
+	if err := json.Unmarshal(statsBody, &st); err != nil {
+		t.Fatalf("unmarshal /stats: %v; body=%s", err, statsBody)
+	}
+	if st.Hits != 1 {
+		t.Fatalf("hits = %v, want 1", st.Hits)
+	}
+	if st.Misses != 1 {
+		t.Fatalf("misses = %v, want 1", st.Misses)
+	}
+	if st.Stored != 1 {
+		t.Fatalf("stored = %v, want 1", st.Stored)
+	}
+	// basicStreamLines' usage chunk carries completion_tokens: 9, captured by
+	// relayAndCapture and stored; the subsequent hit credits it as saved.
+	if st.TokensSaved != 9 {
+		t.Fatalf("tokens_saved = %v, want 9", st.TokensSaved)
+	}
+}

--- a/llmproxy/stream_test.go
+++ b/llmproxy/stream_test.go
@@ -244,6 +244,87 @@ func TestProxy_StreamingToolCallsNotStored(t *testing.T) {
 	}
 }
 
+// (f) a Stream:true request whose upstream response is 200 but not SSE (an
+// upstream that doesn't honor stream:true) is relayed to the client as-is and
+// never cached: a repeat of the same request misses again, and each request
+// is counted as exactly one miss.
+func TestProxy_StreamingRequestNonSSEUpstreamResponseRelayedNotCached(t *testing.T) {
+	upstream := newFakeUpstream(t)
+	upstream.script(chatPath, scriptedResponse{
+		body: chatCompletionJSON(t, "plain json despite stream:true", "stop", 4),
+	})
+	proxy := newProxy(t, upstream, nil)
+
+	body := `{"model":"gpt-4","stream":true,"messages":[{"role":"user","content":"upstream ignores stream"}]}`
+
+	resp1, body1 := postChat(t, proxy.URL, body, nil)
+	if resp1.StatusCode != http.StatusOK {
+		t.Fatalf("first request status = %d, want 200", resp1.StatusCode)
+	}
+	if got := resp1.Header.Get("x-rostam-cache"); got != "miss" {
+		t.Fatalf("first request x-rostam-cache = %q, want miss", got)
+	}
+	wantBody := chatCompletionJSON(t, "plain json despite stream:true", "stop", 4)
+	if string(body1) != string(wantBody) {
+		t.Fatalf("relayed body = %s, want %s (upstream JSON relayed verbatim)", body1, wantBody)
+	}
+
+	resp2, _ := postChat(t, proxy.URL, body, nil)
+	if got := resp2.Header.Get("x-rostam-cache"); got != "miss" {
+		t.Fatalf("repeat request x-rostam-cache = %q, want miss (non-SSE upstream response must not be cached)", got)
+	}
+	if n := upstream.requestCount(chatPath); n != 2 {
+		t.Fatalf("upstream requests = %d, want 2 (both should reach upstream)", n)
+	}
+
+	statsResp, statsBody := getStats(t, proxy.URL)
+	if statsResp.StatusCode != http.StatusOK {
+		t.Fatalf("/stats status = %d, want 200", statsResp.StatusCode)
+	}
+	var st struct {
+		Misses float64 `json:"misses"`
+		Stored float64 `json:"stored"`
+	}
+	if err := json.Unmarshal(statsBody, &st); err != nil {
+		t.Fatalf("unmarshal /stats: %v; body=%s", err, statsBody)
+	}
+	if st.Misses != 2 {
+		t.Fatalf("misses = %v, want 2 (each request counted exactly once)", st.Misses)
+	}
+	if st.Stored != 0 {
+		t.Fatalf("stored = %v, want 0 (non-SSE response must never be stored)", st.Stored)
+	}
+}
+
+// (g) a Stream:true request whose upstream response is a non-200 error is
+// relayed untouched and never cached.
+func TestProxy_StreamingRequestUpstream500RelayedNotCached(t *testing.T) {
+	upstream := newFakeUpstream(t)
+	upstream.script(chatPath, scriptedResponse{
+		status: http.StatusInternalServerError,
+		body:   []byte(`{"error":{"message":"boom","type":"server_error"}}`),
+	})
+	proxy := newProxy(t, upstream, nil)
+
+	body := `{"model":"gpt-4","stream":true,"messages":[{"role":"user","content":"trigger a 500"}]}`
+
+	resp1, body1 := postChat(t, proxy.URL, body, nil)
+	if resp1.StatusCode != http.StatusInternalServerError {
+		t.Fatalf("status = %d, want 500", resp1.StatusCode)
+	}
+	if got := string(body1); got != `{"error":{"message":"boom","type":"server_error"}}` {
+		t.Fatalf("relayed body = %q, want upstream body verbatim", got)
+	}
+
+	resp2, _ := postChat(t, proxy.URL, body, nil)
+	if resp2.StatusCode != http.StatusInternalServerError {
+		t.Fatalf("second status = %d, want 500 again (nothing cached)", resp2.StatusCode)
+	}
+	if n := upstream.requestCount(chatPath); n != 2 {
+		t.Fatalf("upstream requests = %d, want 2", n)
+	}
+}
+
 // (e) usage-chunk completion_tokens land in tokens_saved once the answer is
 // served from a subsequent cache hit, and /stats counts streaming hits and
 // misses exactly like non-streaming ones (a gap Task 5 left open).

--- a/llmproxy/stream_test.go
+++ b/llmproxy/stream_test.go
@@ -325,6 +325,53 @@ func TestProxy_StreamingRequestUpstream500RelayedNotCached(t *testing.T) {
 	}
 }
 
+// (h) the space after "data:" is optional padding in the SSE spec, and
+// several OpenAI-compatible servers omit it. The capture side required it, so
+// against those upstreams every chunk decoded as nothing: the client got its
+// stream (relayed verbatim), but the answer was never cached and every
+// request paid full price.
+func TestProxy_StreamingSpacelessDataPrefixIsCaptured(t *testing.T) {
+	lines := []string{
+		"data:{\"choices\":[{\"index\":0,\"delta\":{\"role\":\"assistant\"},\"finish_reason\":null}]}\n\n",
+		"data:{\"choices\":[{\"index\":0,\"delta\":{\"content\":\"space\"},\"finish_reason\":null}]}\n\n",
+		"data:{\"choices\":[{\"index\":0,\"delta\":{\"content\":\"less\"},\"finish_reason\":null}]}\n\n",
+		"data:{\"choices\":[{\"index\":0,\"delta\":{},\"finish_reason\":\"stop\"}]}\n\n",
+		"data:[DONE]\n\n",
+	}
+	upstream := newFakeUpstream(t)
+	upstream.script(chatPath, scriptedResponse{sse: true, lines: lines})
+	proxy := newProxy(t, upstream, nil)
+
+	streamBody := `{"model":"gpt-4","stream":true,"messages":[{"role":"user","content":"no padding please"}]}`
+	nonStreamBody := `{"model":"gpt-4","messages":[{"role":"user","content":"no padding please"}]}`
+
+	resp1, body1 := postChat(t, proxy.URL, streamBody, nil)
+	if got := resp1.Header.Get("x-rostam-cache"); got != "miss" {
+		t.Fatalf("streaming request x-rostam-cache = %q, want miss", got)
+	}
+	// The relay stays byte-for-byte: the proxy re-pads nothing.
+	if got, want := string(body1), strings.Join(lines, ""); got != want {
+		t.Fatalf("relayed body = %q, want %q (verbatim)", got, want)
+	}
+
+	// Read the captured answer back through a non-streaming request for the
+	// same identity: a hit proves the space-less chunks were decoded.
+	resp2, body2 := postChat(t, proxy.URL, nonStreamBody, nil)
+	if got := resp2.Header.Get("x-rostam-cache"); got != "hit" {
+		t.Fatalf("follow-up x-rostam-cache = %q, want hit (space-less data: lines must still be captured)", got)
+	}
+	var decoded chatResponse
+	if err := json.Unmarshal(body2, &decoded); err != nil {
+		t.Fatalf("unmarshal cached response: %v", err)
+	}
+	if len(decoded.Choices) != 1 || decoded.Choices[0].Message.Content != "spaceless" {
+		t.Fatalf("cached content = %+v, want %q", decoded.Choices, "spaceless")
+	}
+	if n := upstream.requestCount(chatPath); n != 1 {
+		t.Fatalf("upstream requests = %d, want 1", n)
+	}
+}
+
 // (e) usage-chunk completion_tokens land in tokens_saved once the answer is
 // served from a subsequent cache hit, and /stats counts streaming hits and
 // misses exactly like non-streaming ones (a gap Task 5 left open).

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -101,6 +101,7 @@ nav:
       - Backups & cold tier: server/backups.md
       - Monitoring: server/monitoring.md
       - MCP server: server/mcp.md
+      - LLM caching proxy: server/llm-proxy.md
   - API reference:
       - HTTP: api/http.md
       - gRPC: api/grpc.md

--- a/semcache/cache_test.go
+++ b/semcache/cache_test.go
@@ -117,6 +117,48 @@ func TestLookupHitMissAndScope(t *testing.T) {
 	}
 }
 
+func TestTenantIsolation(t *testing.T) {
+	c := newTestCache(t)
+	ctx := context.Background()
+	scopeA := Scope{Model: "m", Temperature: 0, Tenant: "alice"}
+	scopeB := Scope{Model: "m", Temperature: 0, Tenant: "bob"}
+
+	// Store under tenant A.
+	if err := c.Store(ctx, "hello", scopeA, "answer_for_alice", 5); err != nil {
+		t.Fatalf("Store under tenant A: %v", err)
+	}
+
+	// Lookup with tenant B must miss.
+	if _, ok, err := c.Lookup(ctx, "hello", scopeB); err != nil || ok {
+		t.Fatalf("tenant B must not see tenant A's cache, got ok=%v err=%v", ok, err)
+	}
+
+	// Lookup with tenant A must hit.
+	hit, ok, err := c.Lookup(ctx, "hello", scopeA)
+	if err != nil || !ok {
+		t.Fatalf("tenant A must hit its own cache, got ok=%v err=%v", ok, err)
+	}
+	if hit.Answer != "answer_for_alice" {
+		t.Fatalf("wrong answer for tenant A: %v", hit.Answer)
+	}
+
+	// Store a different answer under tenant B.
+	if err := c.Store(ctx, "hello", scopeB, "answer_for_bob", 7); err != nil {
+		t.Fatalf("Store under tenant B: %v", err)
+	}
+
+	// Both should now hit with their respective answers.
+	hitA, ok, err := c.Lookup(ctx, "hello", scopeA)
+	if err != nil || !ok || hitA.Answer != "answer_for_alice" {
+		t.Fatalf("tenant A after B's store: ok=%v err=%v answer=%v", ok, err, hitA.Answer)
+	}
+
+	hitB, ok, err := c.Lookup(ctx, "hello", scopeB)
+	if err != nil || !ok || hitB.Answer != "answer_for_bob" {
+		t.Fatalf("tenant B after store: ok=%v err=%v answer=%v", ok, err, hitB.Answer)
+	}
+}
+
 func TestCacheableHonorsMaxTemp(t *testing.T) {
 	c := newTestCache(t) // MaxTemp defaults to 0
 	if !c.Cacheable(0) {

--- a/semcache/embedder.go
+++ b/semcache/embedder.go
@@ -9,6 +9,8 @@ import (
 	"fmt"
 	"math"
 	"net/http"
+
+	"github.com/cespare/xxhash/v2"
 )
 
 // Embedder turns text into vectors. The SAME embedder (model+version) must be
@@ -43,6 +45,12 @@ func normalizeVec(v []float32) {
 // NewStubEmbedder returns a deterministic, dependency-free Embedder for tests
 // and local demos: it hashes text into a normalized vector of length dim. NOT
 // for production (no semantic meaning) — use OpenAIEmbedder there.
+//
+// Two different texts produce the same vector only if they collide in the
+// 64-bit seed hash (collision space 2^64), which is the same budget the cache
+// already spends on entry ids. A narrower hash would not do: the proxy's
+// "exact" mode treats a vector match as proof the prompts are identical, so a
+// collision there is a wrong answer served to a user, not just a wasted slot.
 func NewStubEmbedder(model string, dim int) Embedder {
 	return stubEmbedder{model: model, dim: dim}
 }
@@ -55,17 +63,31 @@ type stubEmbedder struct {
 func (s stubEmbedder) Model() string { return s.model }
 func (s stubEmbedder) Dim() int      { return s.dim }
 
+// splitmix64Gamma and the two multipliers below are the standard splitmix64
+// constants: one increment of the golden-ratio gamma plus two xor-shift
+// multiply rounds turn a counter into a well-distributed 64-bit value. Used
+// here to expand one 64-bit seed into dim per-dimension values without ever
+// narrowing the state to 32 bits.
+const (
+	splitmix64Gamma = 0x9e3779b97f4a7c15
+	splitmix64Mix1  = 0xbf58476d1ce4e5b9
+	splitmix64Mix2  = 0x94d049bb133111eb
+	// int64Scale maps a signed 64-bit value into roughly [-1, 1).
+	int64Scale = 1 << 63
+)
+
 func (s stubEmbedder) Embed(_ context.Context, texts []string) ([][]float32, error) {
 	out := make([][]float32, len(texts))
 	for i, t := range texts {
 		v := make([]float32, s.dim)
-		h := uint32(2166136261)
-		for _, b := range []byte(t) {
-			h = (h ^ uint32(b)) * 16777619
-		}
+		state := xxhash.Sum64String(t)
 		for j := 0; j < s.dim; j++ {
-			h = (h ^ uint32(j)) * 16777619
-			v[j] = float32(int32(h)) / 2147483647.0
+			state += splitmix64Gamma
+			z := state
+			z = (z ^ (z >> 30)) * splitmix64Mix1
+			z = (z ^ (z >> 27)) * splitmix64Mix2
+			z ^= z >> 31
+			v[j] = float32(float64(int64(z)) / float64(int64Scale))
 		}
 		normalizeVec(v)
 		out[i] = v

--- a/semcache/embedder_test.go
+++ b/semcache/embedder_test.go
@@ -8,6 +8,7 @@ import (
 	"math"
 	"net/http"
 	"net/http/httptest"
+	"strconv"
 	"testing"
 )
 
@@ -49,6 +50,89 @@ func TestFakeEmbedderIsNormalizedAndDeterministic(t *testing.T) {
 	b, _ := e.Embed(context.Background(), []string{"hello"})
 	if a[0][0] != b[0][0] {
 		t.Fatalf("embedder not deterministic")
+	}
+	var sum float64
+	for _, x := range a[0] {
+		sum += float64(x) * float64(x)
+	}
+	if math.Abs(sum-1.0) > 1e-4 {
+		t.Fatalf("not unit-normalized: |v|^2=%v", sum)
+	}
+}
+
+// fnv32a is the 32-bit hash the stub embedder used to seed itself with. It
+// lives here, in the test, purely to manufacture the collision that made that
+// choice unsafe.
+func fnv32a(s string) uint32 {
+	h := uint32(2166136261)
+	for _, b := range []byte(s) {
+		h = (h ^ uint32(b)) * 16777619
+	}
+	return h
+}
+
+// TestStubEmbedderSurvivesA32BitCollision finds a real pair of distinct
+// strings sharing a 32-bit FNV-1a hash (a birthday search over 2^32 needs
+// only ~100k candidates) and asserts the stub embedder still separates them.
+// The stub used to derive every dimension from exactly that 32-bit hash, so
+// such a pair produced identical vectors — cosine 1.0, an exact-mode cache
+// hit, and one prompt answered with another prompt's completion.
+func TestStubEmbedderSurvivesA32BitCollision(t *testing.T) {
+	const maxCandidates = 500_000 // P(no collision) < 1e-6
+
+	seen := make(map[uint32]string, maxCandidates)
+	var a, b string
+	for i := 0; i < maxCandidates && a == ""; i++ {
+		s := "collide-" + strconv.Itoa(i)
+		h := fnv32a(s)
+		if prev, ok := seen[h]; ok {
+			a, b = prev, s
+			break
+		}
+		seen[h] = s
+	}
+	if a == "" {
+		t.Skip("no 32-bit FNV-1a collision found in the candidate budget")
+	}
+	if a == b {
+		t.Fatalf("collision search returned the same string twice: %q", a)
+	}
+	t.Logf("colliding pair: %q / %q (fnv32a=%d)", a, b, fnv32a(a))
+
+	e := NewStubEmbedder("stub-1", 64)
+	vecs, err := e.Embed(context.Background(), []string{a, b})
+	if err != nil {
+		t.Fatalf("Embed: %v", err)
+	}
+
+	var dot float64
+	for i := range vecs[0] {
+		dot += float64(vecs[0][i]) * float64(vecs[1][i])
+	}
+	// The exact-mode threshold is 0.999; anything at or above it would be
+	// served as a hit.
+	if dot >= 0.999 {
+		t.Fatalf("32-bit-colliding prompts embed to cosine %v, want well below the 0.999 exact-mode floor", dot)
+	}
+}
+
+func TestStubEmbedderDeterministicAndNormalized(t *testing.T) {
+	e := NewStubEmbedder("stub-1", 32)
+	a, err := e.Embed(context.Background(), []string{"hello"})
+	if err != nil {
+		t.Fatalf("Embed: %v", err)
+	}
+	b, err := e.Embed(context.Background(), []string{"hello"})
+	if err != nil {
+		t.Fatalf("Embed: %v", err)
+	}
+	for i := range a[0] {
+		if a[0][i] != b[0][i] {
+			t.Fatalf("stub embedder not deterministic at dim %d: %v vs %v", i, a[0][i], b[0][i])
+		}
+	}
+	if len(a[0]) != 32 {
+		t.Fatalf("dim = %d, want 32", len(a[0]))
 	}
 	var sum float64
 	for _, x := range a[0] {

--- a/semcache/scope.go
+++ b/semcache/scope.go
@@ -21,6 +21,15 @@ type Scope struct {
 	Temperature float64  // sampling temperature
 	MaxTokens   int      // max output tokens
 	Tenant      string   // caller identity hash (prevents one client's cached answers from being served to another; never a raw credential)
+	// Extra is an opaque discriminator: callers fold in any request surface
+	// that must partition the cache but has no named field here. The fields
+	// above cover what a semantic cache always cares about, and no fixed list
+	// can keep up with a provider's sampling and formatting knobs
+	// (response_format, seed, top_p, stop, frequency_penalty, …) — a request
+	// asking for JSON must not be answered with prose cached from the same
+	// messages. Same contract as Tenant: a hash or short tag, never a raw
+	// credential, since the value rides in cache metadata.
+	Extra string
 }
 
 // key returns a stable hex digest of the scope plus the embedding model. Tool
@@ -46,6 +55,8 @@ func (s Scope) key(embedModel string) string {
 	b.WriteString(strconv.Itoa(s.MaxTokens))
 	b.WriteString("\x00ten=")
 	b.WriteString(s.Tenant)
+	b.WriteString("\x00extra=")
+	b.WriteString(s.Extra)
 
 	return strconv.FormatUint(xxhash.Sum64String(b.String()), 16)
 }

--- a/semcache/scope.go
+++ b/semcache/scope.go
@@ -20,6 +20,7 @@ type Scope struct {
 	Tools       []string // tool names available to the call (order-independent)
 	Temperature float64  // sampling temperature
 	MaxTokens   int      // max output tokens
+	Tenant      string   // caller identity hash (prevents one client's cached answers from being served to another; never a raw credential)
 }
 
 // key returns a stable hex digest of the scope plus the embedding model. Tool
@@ -43,6 +44,8 @@ func (s Scope) key(embedModel string) string {
 	b.WriteString(strconv.FormatFloat(s.Temperature, 'g', 6, 64))
 	b.WriteString("\x00maxtok=")
 	b.WriteString(strconv.Itoa(s.MaxTokens))
+	b.WriteString("\x00ten=")
+	b.WriteString(s.Tenant)
 
 	return strconv.FormatUint(xxhash.Sum64String(b.String()), 16)
 }

--- a/semcache/scope_test.go
+++ b/semcache/scope_test.go
@@ -26,6 +26,7 @@ func TestScopeKeyStableAndSensitive(t *testing.T) {
 		"temperature": func(s Scope) Scope { s.Temperature = 0.7; return s },
 		"max-tokens":  func(s Scope) Scope { s.MaxTokens = 2048; return s },
 		"tenant":      func(s Scope) Scope { s.Tenant = "bob"; return s },
+		"extra":       func(s Scope) Scope { s.Extra = "json-mode"; return s },
 	} {
 		if name == "embed-model" {
 			if base.key("emb-1") == base.key("emb-2") {
@@ -47,5 +48,19 @@ func TestScopeKeyTenantIsolates(t *testing.T) {
 	}
 	if a.key("e") != (Scope{Model: "m", Tenant: "alice"}).key("e") {
 		t.Fatal("equal scopes must produce equal keys")
+	}
+}
+
+func TestScopeKeyExtraIsolates(t *testing.T) {
+	a := Scope{Model: "m", Extra: "json-mode"}
+	b := Scope{Model: "m", Extra: "prose-mode"}
+	if a.key("e") == b.key("e") {
+		t.Fatal("Extra must partition the scope key")
+	}
+	if a.key("e") != (Scope{Model: "m", Extra: "json-mode"}).key("e") {
+		t.Fatal("equal scopes must produce equal keys")
+	}
+	if (Scope{Model: "m"}).key("e") != (Scope{Model: "m", Extra: ""}).key("e") {
+		t.Fatal("an empty Extra must not change the key")
 	}
 }

--- a/semcache/scope_test.go
+++ b/semcache/scope_test.go
@@ -25,6 +25,7 @@ func TestScopeKeyStableAndSensitive(t *testing.T) {
 		"tools":       func(s Scope) Scope { s.Tools = []string{"a"}; return s },
 		"temperature": func(s Scope) Scope { s.Temperature = 0.7; return s },
 		"max-tokens":  func(s Scope) Scope { s.MaxTokens = 2048; return s },
+		"tenant":      func(s Scope) Scope { s.Tenant = "bob"; return s },
 	} {
 		if name == "embed-model" {
 			if base.key("emb-1") == base.key("emb-2") {
@@ -35,5 +36,16 @@ func TestScopeKeyStableAndSensitive(t *testing.T) {
 		if base.key("emb-1") == mut(base).key("emb-1") {
 			t.Errorf("key insensitive to %s", name)
 		}
+	}
+}
+
+func TestScopeKeyTenantIsolates(t *testing.T) {
+	a := Scope{Model: "m", Tenant: "alice"}
+	b := Scope{Model: "m", Tenant: "bob"}
+	if a.key("e") == b.key("e") {
+		t.Fatal("tenant must partition the scope key")
+	}
+	if a.key("e") != (Scope{Model: "m", Tenant: "alice"}).key("e") {
+		t.Fatal("equal scopes must produce equal keys")
 	}
 }


### PR DESCRIPTION
## What

A new \`rostam-server llm-proxy\` subcommand: an OpenAI-compatible caching reverse proxy built on the \`semcache\` package. Point any client's \`base_url\` at it — identical (zero config) or semantically similar (with an embedder) chat-completions requests are served from a local Rostam-backed cache instead of the upstream.

> Stacked on #12 (it reuses that branch's shared cmd helpers); this PR targets \`feat/mcp-server\` and can retarget \`main\` once #12 merges.

\`\`\`python
client = OpenAI(base_url="http://localhost:8484/v1")  # that's the whole integration
\`\`\`

## Highlights

- **Zero-config exact-match mode**: no embedding key needed — identical requests hit, everything else misses (64-bit deterministic hashing; collision space 2^64). \`ROSTAM_EMBED_*\` env upgrades to semantic similarity at semcache's conservative 0.97 floor.
- **Full streaming both directions**: cache hits replay as SSE; misses stream through to the client chunk-by-chunk (flush-per-event) while being captured, and only clean \`finish_reason:"stop"\` completions are stored.
- **Correct cache identity**: scope = model + system prompt + tool names + temperature + max_tokens + a tenant hash of the caller's credential headers (Authorization/api-key/x-api-key) + a discriminator over every other body field — so \`response_format\`, \`seed\`, \`top_p\`, etc. all partition the cache. Never cached: tool calls, \`n>1\`, multimodal content, \`stream_options\`, aborted streams.
- **Transparent passthrough** for every other \`/v1/*\` route (bodies stream, nothing buffers), \`/stats\` savings counters (\`tokens_saved\` from upstream usage), \`x-rostam-cache: hit|miss|bypass|uncacheable\` on every chat response.
- **Safe by default**: loopback-only listen unless \`-insecure\`; the proxy never holds an upstream key (client credentials forwarded verbatim); cache failures degrade to a plain reverse proxy rather than breaking traffic.

## Review hardening

The whole-branch review drove end-to-end fixes verified on the real binary: 64-bit stub hashing (32-bit collisions could serve another prompt's answer), Accept-Encoding no longer forwarded on cached paths (default openai-python headers silently defeated caching), flush-preserving relays for uncacheable streams, and per-credential tenancy.

## Docs

\`docs/server/llm-proxy.md\` (quickstart, modes, cache-key semantics, honest limits — cache entries don't survive restarts in v1, no single-flight) + mkdocs nav + README section.

## Testing

TDD throughout; 60 proxy tests incl. byte-identical SSE relay, mid-stream abort, tenant isolation, gzip clients, big-body streaming; \`-race -short\` green across all touched packages; live smoke on the built binary.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an OpenAI-compatible `llm-proxy` command with exact and semantic response caching.
  * Supports streaming responses, cache statistics, embedded or remote storage, TLS, and configurable embedders.
  * Isolates cached responses by caller and request parameters.
  * Transparently forwards unsupported or uncacheable requests to the upstream service.
  * Supports clean shutdown and data-directory lock release.

* **Documentation**
  * Added setup, configuration, caching behavior, operational limitations, and usage guidance.
  * Added the proxy to server command help and documentation navigation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->