### PR TITLE
docs(changelog): cover the MCP server and the LLM proxy, and cut v0.2.0

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -3,7 +3,58 @@
 Notable user-visible changes. Entries that alter existing behaviour are marked
 **Breaking** and say what to do about it.
 
-## Unreleased
+## v0.2.0 — 2026-08-15
+
+### The MCP server: agent memory with nothing to set up
+
+`rostam-server mcp` runs Rostam as a [Model Context
+Protocol](https://modelcontextprotocol.io/) server over stdio, giving Claude
+Code, Claude Desktop, Cursor or any MCP client persistent agent memory and
+generic vector-DB tools:
+
+```sh
+claude mcp add rostam -- rostam-server mcp
+```
+
+There is no daemon and no account. The process embeds the engine directly and
+persists to `~/.rostam/memory`, so the agent has durable memory seconds after
+the command above.
+
+**It works with no embedder at all.** `remember` and `recall` run on the
+built-in BM25 index, so there is no API key and no external service in the
+default path — the usual reason an agent-memory tool cannot be tried in one
+command. Setting `ROSTAM_EMBED_ENDPOINT` to any OpenAI-compatible
+`/embeddings` URL (OpenAI, Azure, Ollama, LM Studio, TEI, LiteLLM) upgrades
+recall to hybrid dense+BM25. The tools and their call shapes do not change —
+only how well results rank.
+
+Five memory tools (`remember`, `recall`, `forget`, `list_memories`,
+`list_namespaces`) and four collection tools (`create_collection`, `upsert`,
+`search`, `get`) are always registered. `delete` and `delete_by_filter` are
+**absent from `tools/list`** unless `-enable-destructive` is passed, rather
+than present and refusing — a model cannot call a tool it cannot see.
+
+`-connect host:port` runs the tools against a remote `rostam-server` over the
+binary TCP protocol instead of embedding the engine, with the usual
+token/mTLS options. Full tool reference and client config: [MCP
+server](server/mcp.md).
+
+### The LLM caching proxy
+
+`rostam-server llm-proxy` is an OpenAI-compatible caching reverse proxy: point
+an existing OpenAI SDK client at it instead of `api.openai.com` and a
+cache-eligible chat completion is answered locally, at no generation cost and
+without the round trip. Everything it cannot safely answer — every other
+`/v1/*` route, and any request whose shape or scope makes it uncacheable — is
+forwarded upstream verbatim.
+
+Like the MCP server it is useful before you configure anything: with no
+embedder, byte-identical prompts are served from cache. With one, it upgrades
+to semantic matching, so a reworded or differently-whitespaced prompt hits too.
+
+Every response carries an `x-rostam-cache` header (`hit`, `miss`,
+`uncacheable`, `bypass`) so it is visible which requests are still costing
+generation tokens. See [LLM caching proxy](server/llm-proxy.md).
 
 ### Breaking: NaN no longer matches range filters
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -23,10 +23,12 @@ the command above.
 **It works with no embedder at all.** `remember` and `recall` run on the
 built-in BM25 index, so there is no API key and no external service in the
 default path — the usual reason an agent-memory tool cannot be tried in one
-command. Setting `ROSTAM_EMBED_ENDPOINT` to any OpenAI-compatible
-`/embeddings` URL (OpenAI, Azure, Ollama, LM Studio, TEI, LiteLLM) upgrades
-recall to hybrid dense+BM25. The tools and their call shapes do not change —
-only how well results rank.
+command. Pointing it at any OpenAI-compatible `/embeddings` endpoint (OpenAI,
+Azure, Ollama, LM Studio, TEI, LiteLLM) upgrades recall to hybrid dense+BM25:
+set `ROSTAM_EMBED_ENDPOINT`, `ROSTAM_EMBED_MODEL` and `ROSTAM_EMBED_DIM`
+together — the endpoint alone is a configuration error and refuses to start,
+naming the variable it is missing. The tools and their call shapes do not
+change; only how well results rank.
 
 Five memory tools (`remember`, `recall`, `forget`, `list_memories`,
 `list_namespaces`) and four collection tools (`create_collection`, `upsert`,
@@ -42,19 +44,28 @@ server](server/mcp.md).
 ### The LLM caching proxy
 
 `rostam-server llm-proxy` is an OpenAI-compatible caching reverse proxy: point
-an existing OpenAI SDK client at it instead of `api.openai.com` and a
-cache-eligible chat completion is answered locally, at no generation cost and
-without the round trip. Everything it cannot safely answer — every other
-`/v1/*` route, and any request whose shape or scope makes it uncacheable — is
-forwarded upstream verbatim.
+an existing OpenAI SDK client at it instead of `api.openai.com`, and a chat
+completion that **hits** the cache is answered locally, at no generation cost
+and without the round trip. A cacheable request that misses is still forwarded
+and still costs what it always did — eligibility decides whether the cache is
+consulted, not whether you pay.
+
+Anything the cache cannot answer is forwarded upstream verbatim: every other
+`/v1/*` route, and any chat request whose shape or scope makes it uncacheable.
+The two exceptions are handled locally rather than passed on — a chat body over
+the size limit gets a `413`, and one that will not parse gets a `400`.
 
 Like the MCP server it is useful before you configure anything: with no
 embedder, byte-identical prompts are served from cache. With one, it upgrades
-to semantic matching, so a reworded or differently-whitespaced prompt hits too.
+to semantic matching, so a reworded or differently-whitespaced prompt *may* hit
+as well — subject to the same eligibility and cache-identity rules, and to the
+configured similarity threshold.
 
-Every response carries an `x-rostam-cache` header (`hit`, `miss`,
-`uncacheable`, `bypass`) so it is visible which requests are still costing
-generation tokens. See [LLM caching proxy](server/llm-proxy.md).
+Chat responses carry an `x-rostam-cache` header (`hit`, `miss`, `uncacheable`,
+`bypass`) so it is visible which requests are still costing generation tokens.
+Generic passthrough routes such as `/v1/models` deliberately omit it — they
+were never cache candidates, and a verdict there would be noise. See [LLM
+caching proxy](server/llm-proxy.md).
 
 ### Breaking: NaN no longer matches range filters
 


### PR DESCRIPTION
Release-blocking. Both new subcommands shipped with docs pages and mkdocs nav entries but **no changelog entry at all**, so tagging as-is would ship the two largest additions since v0.1.0 unlisted in the one place users look for what a release added.

## Added

- **`rostam-server mcp`** — the MCP server. Leads with the property that makes it evaluable in one command: no embedding API key needed, memory runs on built-in BM25, and an OpenAI-compatible endpoint upgrades it to hybrid dense+BM25. Notes that `delete`/`delete_by_filter` are absent from `tools/list` without `-enable-destructive` rather than present-and-refusing.
- **`rostam-server llm-proxy`** — the OpenAI-compatible caching proxy, including the `x-rostam-cache` header and the exact-vs-semantic distinction.

## Changed

`## Unreleased` becomes `## v0.2.0 — 2026-08-15`. That heading has survived v0.1.1 through v0.1.4 unchanged, so the changelog has been telling readers that already-shipped features are unreleased. Everything under it went public in the last five days, so dating the block as this release is more accurate than leaving it.

## Why v0.2.0 rather than v0.1.5

Two new user-facing subcommands is a feature release, not a patch. Under 0.x semantics a minor bump is the honest signal; `v0.1.5` would say "bug fixes" about the release that adds MCP.

## Why this is urgent

The README on `main` tells users to run `claude mcp add rostam -- rostam-server mcp`, but that subcommand does not exist in v0.1.4 — which is what `curl | sh` installs today. Anyone following the README right now gets an unknown-subcommand error, and it stays broken until a tag ships.

`mkdocs build --strict` passes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added release notes for version 0.2.0.
  * Documented the MCP server, LLM caching proxy, built-in BM25 fallback, optional embeddings, memory and collection tools, remote connections, and cache behavior.
  * Documented safeguards for destructive tools and cache-response headers.
  * Replaced the previous “Unreleased” section with the new release information.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->