### PR TITLE
fix(mcp): report the binary's real version, not a literal from v0.1.0

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -34,10 +34,11 @@ builds:
       - CGO_ENABLED=0
     flags:
       - -trimpath
-    # -X main.version is what makes `rostam-server -version` report the release
+    # -X ...buildinfo.version is what makes `rostam-server -version` and the MCP
+    # server's initialize response both report the release
     # tag instead of the pseudo-version Go derives for an untagged build.
     ldflags:
-      - -s -w -X main.version={{ .Version }}
+      - -s -w -X github.com/rostamlabs/rostam/internal/buildinfo.version={{ .Version }}
     goos:
       - linux
       - darwin

--- a/cmd/rostam-server/version.go
+++ b/cmd/rostam-server/version.go
@@ -5,66 +5,19 @@ package main
 import (
 	"fmt"
 	"runtime"
-	"runtime/debug"
+
+	"github.com/rostamlabs/rostam/internal/buildinfo"
 )
-
-// version is stamped at release time with -ldflags "-X main.version=v1.2.3".
-// It stays empty for every other build, where buildVersion derives an identity
-// from what the toolchain recorded instead — so `go install ...@v0.1.0` and a
-// local `go build` both report something truthful without a release pipeline.
-var version = ""
-
-// buildVersion reports the most specific identity available, in descending
-// order of confidence:
-//
-//	v0.1.0                       a release binary (ldflags), or
-//	                             `go install ...@v0.1.0`
-//	v0.1.1-0.2026...-abc123+dirty a local build: Go derives a pseudo-version from
-//	                             the last tag, the commit time and the revision,
-//	                             and marks a modified tree
-//	devel-abc123def456           a build with VCS data but no module version
-//	(unknown)                    no build info at all (stripped/synthetic build)
-//
-// The dirty marker matters for bug reports: it is the difference between a
-// revision someone else can check out and one that exists only on one machine.
-func buildVersion() string {
-	if version != "" {
-		return version
-	}
-	info, ok := debug.ReadBuildInfo()
-	if !ok {
-		return "(unknown)"
-	}
-	// `go install module@version` records the module version. A build from a
-	// local checkout records "(devel)" here and puts the detail in Settings.
-	if v := info.Main.Version; v != "" && v != "(devel)" {
-		return v
-	}
-	var rev, suffix string
-	for _, s := range info.Settings {
-		switch s.Key {
-		case "vcs.revision":
-			rev = s.Value
-		case "vcs.modified":
-			if s.Value == "true" {
-				suffix = "-dirty"
-			}
-		}
-	}
-	if rev == "" {
-		return "(devel)"
-	}
-	if len(rev) > 12 {
-		rev = rev[:12]
-	}
-	return "devel-" + rev + suffix
-}
 
 // versionString is the one line `-version` prints. It carries the toolchain and
 // target too, because "which Go built it" and "which platform is this" are the
 // next two questions after "which version", and a downloaded binary cannot be
 // asked any other way.
+//
+// The version itself comes from internal/buildinfo rather than a var in this
+// package: the MCP server has to report the same number to its client, and two
+// copies of "what version am I" is how one of them ends up stale.
 func versionString() string {
 	return fmt.Sprintf("rostam-server %s (%s %s/%s)",
-		buildVersion(), runtime.Version(), runtime.GOOS, runtime.GOARCH)
+		buildinfo.Version(), runtime.Version(), runtime.GOOS, runtime.GOARCH)
 }

--- a/internal/buildinfo/buildinfo.go
+++ b/internal/buildinfo/buildinfo.go
@@ -1,0 +1,70 @@
+// SPDX-License-Identifier: Apache-2.0
+
+// Package buildinfo reports the binary's own version.
+//
+// This lives outside `main` because more than one place has to answer "which
+// version is this?" and they must not answer differently. The MCP server
+// reports a version to its client in `initialize`, and it used to carry a
+// literal that was written once and never updated — so a v0.2.0 binary
+// introduced itself to Claude Code as 0.1.0, and every bug report filed
+// through an MCP client named the wrong release.
+package buildinfo
+
+import "runtime/debug"
+
+// version is stamped at release time with
+// -ldflags "-X github.com/rostamlabs/rostam/internal/buildinfo.version=v1.2.3".
+// It stays empty for every other build, where Version derives an identity from
+// what the toolchain recorded instead — so `go install ...@v0.1.0` and a local
+// `go build` both report something truthful without a release pipeline.
+//
+// Note that an -X path that does not match a real package-level string is
+// silently ignored by the linker: a typo here does not fail the build, it just
+// leaves the fallback in place. TestLdflagsTargetIsReachable covers that.
+var version = ""
+
+// Version reports the most specific identity available, in descending order of
+// confidence:
+//
+//	v0.1.0                       a release binary (ldflags), or
+//	                             `go install ...@v0.1.0`
+//	v0.1.1-0.2026...-abc123+dirty a local build: Go derives a pseudo-version from
+//	                             the last tag, the commit time and the revision,
+//	                             and marks a modified tree
+//	devel-abc123def456           a build with VCS data but no module version
+//	(unknown)                    no build info at all (stripped/synthetic build)
+//
+// The dirty marker matters for bug reports: it is the difference between a
+// revision someone else can check out and one that exists only on one machine.
+func Version() string {
+	if version != "" {
+		return version
+	}
+	info, ok := debug.ReadBuildInfo()
+	if !ok {
+		return "(unknown)"
+	}
+	// `go install module@version` records the module version. A build from a
+	// local checkout records "(devel)" here and puts the detail in Settings.
+	if v := info.Main.Version; v != "" && v != "(devel)" {
+		return v
+	}
+	var rev, suffix string
+	for _, s := range info.Settings {
+		switch s.Key {
+		case "vcs.revision":
+			rev = s.Value
+		case "vcs.modified":
+			if s.Value == "true" {
+				suffix = "-dirty"
+			}
+		}
+	}
+	if rev == "" {
+		return "(devel)"
+	}
+	if len(rev) > 12 {
+		rev = rev[:12]
+	}
+	return "devel-" + rev + suffix
+}

--- a/internal/buildinfo/ldflags_test.go
+++ b/internal/buildinfo/ldflags_test.go
@@ -1,0 +1,84 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package buildinfo
+
+import (
+	"os"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// The linker silently ignores an -X flag whose target does not name a real
+// package-level string: a typo, a moved package or a renamed variable does not
+// fail the release build, it just quietly leaves the fallback in place and
+// ships binaries that report a derived version instead of the release. Nothing
+// else in CI would notice, because everything still compiles and runs.
+//
+// So this asserts the release pipeline's -X target still resolves to this
+// package's variable, by reading the target out of the release config rather
+// than restating it.
+func TestGoreleaserLdflagTargetIsThisVariable(t *testing.T) {
+	const wantPkg = "github.com/rostamlabs/rostam/internal/buildinfo"
+	const wantVar = "version"
+
+	cfg, err := os.ReadFile("../../.goreleaser.yaml")
+	if err != nil {
+		t.Fatalf("read release config: %v", err)
+	}
+
+	// -X <import/path>.<varname>=<value>
+	re := regexp.MustCompile(`-X\s+([^\s=]+)=`)
+	matches := re.FindAllStringSubmatch(string(cfg), -1)
+	if len(matches) == 0 {
+		t.Fatal("no -X ldflag found in .goreleaser.yaml; the release no longer stamps a version")
+	}
+
+	var targets []string
+	for _, m := range matches {
+		targets = append(targets, m[1])
+		dot := strings.LastIndex(m[1], ".")
+		if dot < 0 {
+			continue
+		}
+		if m[1][:dot] == wantPkg && m[1][dot+1:] == wantVar {
+			return // found it
+		}
+	}
+	t.Fatalf("release config stamps %v, but the version variable is %s.%s — "+
+		"a mismatched -X target is ignored by the linker, so releases would "+
+		"report a derived version instead of the tag", targets, wantPkg, wantVar)
+}
+
+// The variable the -X target names must actually be declared here. The test
+// above proves the config and this package agree on a name; this proves the
+// name exists.
+//
+// The case it catches is a *consistent* rename -- declaration and uses renamed
+// together, as any refactoring tool would do. That compiles cleanly and passes
+// every other test, and the only symptom is that released binaries quietly stop
+// reporting their tag. (Renaming just the declaration is caught by the compiler
+// and needs no test.)
+//
+// Matching the declaration rather than a full literal keeps this from failing
+// on a harmless change of initializer form.
+func TestVersionVariableIsDeclared(t *testing.T) {
+	src, err := os.ReadFile("buildinfo.go")
+	if err != nil {
+		t.Fatalf("read source: %v", err)
+	}
+	if !regexp.MustCompile(`(?m)^var\s+version\b`).Match(src) {
+		t.Fatal("buildinfo.go no longer declares a package-level 'version' var; " +
+			"the release ldflag targets that exact symbol, and the linker " +
+			"ignores an -X flag it cannot resolve")
+	}
+}
+
+// With no ldflag set (the normal `go test` case) Version must still answer
+// something usable rather than an empty string — the MCP server puts this
+// straight into its initialize response.
+func TestVersionIsNeverEmpty(t *testing.T) {
+	if got := Version(); got == "" {
+		t.Fatal("Version() returned an empty string")
+	}
+}

--- a/mcp/server.go
+++ b/mcp/server.go
@@ -12,6 +12,7 @@ import (
 	"sync"
 
 	"github.com/rostamlabs/rostam"
+	"github.com/rostamlabs/rostam/internal/buildinfo"
 	"github.com/rostamlabs/rostam/semcache"
 )
 
@@ -167,7 +168,9 @@ func (s *Server) dispatch(ctx context.Context, c *conn, req *request) error {
 		return c.reply(req.ID, map[string]any{
 			"protocolVersion": protocolVersion,
 			"capabilities":    map[string]any{"tools": map[string]any{}},
-			"serverInfo":      map[string]any{"name": "rostam", "version": "0.1.0"},
+			// Derived, not written down: a literal here goes stale at the
+			// next release and the client shows a version that never existed.
+			"serverInfo": map[string]any{"name": "rostam", "version": buildinfo.Version()},
 		})
 	case "ping":
 		return c.reply(req.ID, map[string]any{})

--- a/mcp/server_test.go
+++ b/mcp/server_test.go
@@ -8,6 +8,8 @@ import (
 	"io"
 	"testing"
 	"time"
+
+	"github.com/rostamlabs/rostam/internal/buildinfo"
 )
 
 func TestInitializeHandshake(t *testing.T) {
@@ -19,7 +21,8 @@ func TestInitializeHandshake(t *testing.T) {
 			Tools *struct{} `json:"tools"`
 		} `json:"capabilities"`
 		ServerInfo struct {
-			Name string `json:"name"`
+			Name    string `json:"name"`
+			Version string `json:"version"`
 		} `json:"serverInfo"`
 	}
 	if err := json.Unmarshal(res, &init); err != nil {
@@ -27,6 +30,19 @@ func TestInitializeHandshake(t *testing.T) {
 	}
 	if init.ProtocolVersion != "2025-06-18" || init.Capabilities.Tools == nil || init.ServerInfo.Name != "rostam" {
 		t.Fatalf("bad initialize result: %s", res)
+	}
+	// The version used to be a literal "0.1.0" written once and never touched,
+	// so a v0.2.0 binary introduced itself to its client as 0.1.0 and every bug
+	// report filed through an MCP client named the wrong release. This assertion
+	// existed in spirit -- the test checked Name and stopped -- which is why the
+	// stale value survived. Comparing against buildinfo rather than a literal is
+	// the point: a hardcoded expectation here would rot the same way.
+	if init.ServerInfo.Version != buildinfo.Version() {
+		t.Errorf("serverInfo.version = %q, want the binary's own version %q",
+			init.ServerInfo.Version, buildinfo.Version())
+	}
+	if init.ServerInfo.Version == "" {
+		t.Error("serverInfo.version is empty; clients display this")
 	}
 }
 


### PR DESCRIPTION
`initialize` answered `{"name":"rostam","version":"0.1.0"}` from a hardcoded literal, so v0.2.0 introduced itself to Claude Code, Cursor and every other MCP client as **0.1.0** — and would have kept saying 0.1.0 at every future release. Clients surface `serverInfo.version` in their UI and in bug reports, so the one number a user quotes back was guaranteed wrong.

Found by running the published v0.2.0 binary after release, not by reading the code.

## The fix

`cmd/rostam-server` already derived a truthful version — ldflags at release, `debug.ReadBuildInfo()` otherwise, with a documented fallback chain — but it lived in `package main`, where `mcp` could not reach it. That logic moves to `internal/buildinfo`, and both callers read it, so there is one answer to "which version is this" rather than two that can drift.

**Only one ldflag is needed, not one per package.** `debug.ReadBuildInfo()` works from any package, so only the exact release stamp involves the linker. The `-X` target moves from `main.version` to `github.com/rostamlabs/rostam/internal/buildinfo.version`; every other build keeps deriving its own identity.

## The risk this introduces, and the guards

`-X` is **silently ignored** when its target does not resolve. A moved package or renamed variable would not fail the build — it would ship binaries reporting a derived version instead of the tag, and nothing else in CI would notice. Both guards were checked against the mutation they exist for:

| Guard | Catches | Verified by |
|---|---|---|
| `TestGoreleaserLdflagTargetIsThisVariable` | `-X` target no longer names this variable | Repointed the config at `main.version` → fails with the target it found |
| `TestVersionVariableIsDeclared` | A *consistent* rename (declaration + uses) | Renamed both → still compiles, test fails |

The second one matters because a consistent rename is what a refactoring tool does, and it compiles cleanly and passes every other test. Renaming only the declaration is the compiler's job and needs no test.

`TestInitializeHandshake` asserted on `serverInfo.name` and stopped short of `version` — which is how the stale literal survived in the first place. It now compares against `buildinfo.Version()` rather than a literal, so it cannot rot the same way.

## Verification

Built with the `-X` target read out of `.goreleaser.yaml` and confirmed it reaches both consumers:

```
$ rostam-server -version
rostam-server v9.9.9-ldflagcheck (go1.26.5 linux/amd64)

$ echo '{...initialize...}' | rostam-server mcp
"serverInfo": {"name": "rostam", "version": "v9.9.9-ldflagcheck"}
```

`gofmt`, `go vet`, `golangci-lint` (0 issues), and `mcp` / `cmd/rostam-server` / `internal/buildinfo` tests all pass, including under `-short` for the race lane.

## Note

This ships in the next tag; v0.2.0 in the wild will keep reporting 0.1.0 over MCP. Not worth a re-release on its own — it is cosmetic — but worth folding into whatever goes out next.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Server and MCP initialization responses now report the application’s actual release or development version.
  * Development builds provide more informative version details, including source revision and modification status when available.

* **Bug Fixes**
  * Corrected version reporting so released binaries no longer display an outdated hard-coded version.

* **Tests**
  * Added validation to ensure version information is configured correctly and never empty.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->