### PR TITLE
feat(rag): RAG-in-a-box CLI (rostam-server rag ingest/ask/query)

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,24 @@ rostam-server llm-proxy
 → [LLM caching proxy](https://docs.rostamlabs.com/server/llm-proxy/) for
 flags, cache-scoping rules, and what's never cached.
 
+## RAG in a box
+
+`rostam-server rag` chunks and indexes your documents, then answers
+questions from them with cited sources — no separate vector-store setup or
+ingestion pipeline required:
+
+```sh
+rostam-server rag ingest ./docs
+rostam-server rag ask "How does the LLM proxy decide what's cacheable?"
+```
+
+Retrieval works out of the box on BM25 full-text search; pointing it at an
+OpenAI-compatible embedder upgrades it to dense vector search. `rag query`
+does retrieval alone, with no LLM required.
+
+→ [RAG CLI](https://docs.rostamlabs.com/server/rag/) for flags,
+embedded-vs-remote mode, and supported file types.
+
 And two engines, usable together or entirely on their own:
 
 - a **vector search engine** ([`vector/`](./vector)) — HNSW, IVF and Vamana

--- a/cmd/rostam-server/main.go
+++ b/cmd/rostam-server/main.go
@@ -96,6 +96,10 @@ func main() {
 		runLlmProxyCmd(os.Args[2:])
 		return
 	}
+	if len(os.Args) > 1 && os.Args[1] == "rag" {
+		runRagCmd(os.Args[2:])
+		return
+	}
 	// EXPERIMENT: debug pprof endpoint when ROSTAM_PPROF=host:port is set. Also
 	// enables block + mutex profiling (off by default) so /debug/pprof/block and
 	// /debug/pprof/mutex expose goroutine-hop waits and lock contention — the

--- a/cmd/rostam-server/rag.go
+++ b/cmd/rostam-server/rag.go
@@ -60,8 +60,8 @@ func runRagCmdE(args []string) error {
 
 	fs := flag.NewFlagSet("rag "+verb, flag.ContinueOnError)
 	var fl ragFlags
-	fs.StringVar(&fl.data, "data", ragDataDefault, "embedded data directory (mutually exclusive with -endpoint)")
-	fs.StringVar(&fl.endpoint, "endpoint", "", "connect to a remote rostam-server instead of embedding a store (host:port); mutually exclusive with -data")
+	fs.StringVar(&fl.data, "data", ragDataDefault, "embedded data directory (ignored when -endpoint is set)")
+	fs.StringVar(&fl.endpoint, "endpoint", "", "talk to a running rostam server instead of the local --data dir (host:port); -endpoint takes precedence over -data")
 	fs.StringVar(&fl.corpus, "corpus", "default", "corpus (collection) name")
 	fs.IntVar(&fl.k, "k", 5, "number of hits to retrieve")
 	fs.IntVar(&fl.chunkSize, "chunk-size", 0, "chunk size in words (0 = rag package default, 512)")

--- a/cmd/rostam-server/rag.go
+++ b/cmd/rostam-server/rag.go
@@ -1,0 +1,256 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"context"
+	"errors"
+	"flag"
+	"fmt"
+	"net/http"
+	"os"
+	"strconv"
+	"time"
+
+	"github.com/rostamlabs/rostam/rag"
+	"github.com/rostamlabs/rostam/semcache"
+)
+
+// ragDataDefault mirrors mcpDataAuto/llmproxyDataAuto in spirit, but rag has
+// no "connect to the user's existing memory" precedent to default into —
+// each corpus is its own thing, so the default is a plain relative directory
+// rather than a $HOME-rooted sentinel.
+const ragDataDefault = "./.rostam-rag"
+
+// ragFlags holds the parsed `rag` subcommand flags, shared across all three
+// sub-verbs (ingest/ask/query) so config resolution is written once.
+type ragFlags struct {
+	data         string
+	endpoint     string
+	corpus       string
+	k            int
+	chunkSize    int
+	chunkOverlap int
+	embedURL     string
+	embedModel   string
+	embedDim     int
+	llmURL       string
+	llmModel     string
+}
+
+// runRagCmd implements `rostam-server rag`: an ingest/ask/query CLI over the
+// rag package. Like runMcpCmd/runLlmProxyCmd it owns its own FlagSet and
+// process exit; runRagCmdE is the test seam that returns errors instead.
+func runRagCmd(args []string) {
+	if err := runRagCmdE(args); err != nil {
+		fatal("rag: " + err.Error())
+	}
+}
+
+// runRagCmdE is the sub-verb dispatcher. Split out from runRagCmd so tests
+// can exercise the full ingest/ask/query flow without a subprocess or
+// os.Exit — mirrors the mcpSetup/llmproxySetup test-seam pattern, but at the
+// subcommand-dispatch level since rag's sub-verbs each do real I/O (there is
+// no single "setup" step to isolate).
+func runRagCmdE(args []string) error {
+	if len(args) < 1 {
+		return errors.New("usage: rostam-server rag <ingest|ask|query> [flags] ...")
+	}
+	verb, rest := args[0], args[1:]
+
+	fs := flag.NewFlagSet("rag "+verb, flag.ContinueOnError)
+	var fl ragFlags
+	fs.StringVar(&fl.data, "data", ragDataDefault, "embedded data directory (mutually exclusive with -endpoint)")
+	fs.StringVar(&fl.endpoint, "endpoint", "", "connect to a remote rostam-server instead of embedding a store (host:port); mutually exclusive with -data")
+	fs.StringVar(&fl.corpus, "corpus", "default", "corpus (collection) name")
+	fs.IntVar(&fl.k, "k", 5, "number of hits to retrieve")
+	fs.IntVar(&fl.chunkSize, "chunk-size", 0, "chunk size in words (0 = rag package default, 512)")
+	fs.IntVar(&fl.chunkOverlap, "chunk-overlap", 0, "chunk overlap in words (0 = rag package default, 64)")
+	fs.StringVar(&fl.embedURL, "embed-url", "", "embedding endpoint URL (overrides ROSTAM_EMBED_URL); needs -embed-model and -embed-dim too, else BM25")
+	fs.StringVar(&fl.embedModel, "embed-model", "", "embedding model id (overrides ROSTAM_EMBED_MODEL)")
+	fs.IntVar(&fl.embedDim, "embed-dim", 0, "embedding vector dimension (overrides ROSTAM_EMBED_DIM)")
+	fs.StringVar(&fl.llmURL, "llm-url", "", "LLM chat-completions endpoint URL (overrides ROSTAM_LLM_URL)")
+	fs.StringVar(&fl.llmModel, "llm-model", "", "LLM model id (overrides ROSTAM_LLM_MODEL)")
+	if err := fs.Parse(rest); err != nil {
+		return err
+	}
+
+	resolveEnv(&fl, os.LookupEnv)
+	embedKey, _ := os.LookupEnv("ROSTAM_EMBED_KEY")
+	llmKey, _ := os.LookupEnv("ROSTAM_LLM_KEY")
+
+	r, err := buildRetriever(fl)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = r.Close() }()
+
+	emb := buildEmbedder(fl, embedKey)
+	ctx := context.Background()
+
+	switch verb {
+	case "ingest":
+		return runRagIngest(ctx, r, emb, fl, fs.Args())
+	case "query":
+		return runRagQuery(ctx, r, emb, fl, fs.Args())
+	case "ask":
+		return runRagAsk(ctx, r, emb, fl, llmKey, fs.Args())
+	default:
+		return fmt.Errorf("unknown rag subcommand %q (want ingest, ask, or query)", verb)
+	}
+}
+
+// resolveEnv fills any flag left at its zero value from the ROSTAM_EMBED_*/
+// ROSTAM_LLM_* environment, per the env-first config rule: flags override
+// env for every non-secret value, and API keys are read ONLY from
+// ROSTAM_EMBED_KEY/ROSTAM_LLM_KEY (never a flag, to keep secrets out of
+// /proc and shell history).
+func resolveEnv(fl *ragFlags, lookupEnv func(string) (string, bool)) {
+	if fl.embedURL == "" {
+		if v, ok := lookupEnv("ROSTAM_EMBED_URL"); ok {
+			fl.embedURL = v
+		}
+	}
+	if fl.embedModel == "" {
+		if v, ok := lookupEnv("ROSTAM_EMBED_MODEL"); ok {
+			fl.embedModel = v
+		}
+	}
+	if fl.embedDim == 0 {
+		if v, ok := lookupEnv("ROSTAM_EMBED_DIM"); ok {
+			if d, err := strconv.Atoi(v); err == nil {
+				fl.embedDim = d
+			}
+		}
+	}
+	if fl.llmURL == "" {
+		if v, ok := lookupEnv("ROSTAM_LLM_URL"); ok {
+			fl.llmURL = v
+		}
+	}
+	if fl.llmModel == "" {
+		if v, ok := lookupEnv("ROSTAM_LLM_MODEL"); ok {
+			fl.llmModel = v
+		}
+	}
+}
+
+// buildRetriever picks the Retriever backend: -endpoint (networked) wins
+// over -data (embedded), mirroring storeFlags' -connect/-data precedent.
+func buildRetriever(fl ragFlags) (rag.Retriever, error) {
+	if fl.endpoint != "" {
+		return rag.NewHTTPRetriever(fl.endpoint)
+	}
+	return rag.NewEmbeddedRetriever(fl.data)
+}
+
+// buildEmbedder constructs a hosted embedder only when URL+model+dim are ALL
+// present; otherwise nil, which every rag package entry point (Ingest,
+// Retrieve, Ask) already treats as "fall back to BM25". embedKey comes only
+// from ROSTAM_EMBED_KEY (there is no -embed-key flag — see resolveEnv's doc
+// comment), resolved by the caller so this stays a pure function of its
+// arguments.
+func buildEmbedder(fl ragFlags, embedKey string) semcache.Embedder {
+	if fl.embedURL == "" || fl.embedModel == "" || fl.embedDim <= 0 {
+		return nil
+	}
+	oe := semcache.NewOpenAIEmbedder(embedKey, fl.embedModel, fl.embedDim)
+	oe.Endpoint = fl.embedURL
+	return oe
+}
+
+func embedderDim(emb semcache.Embedder) int {
+	if emb == nil {
+		return 0
+	}
+	return emb.Dim()
+}
+
+func runRagIngest(ctx context.Context, r rag.Retriever, emb semcache.Embedder, fl ragFlags, paths []string) error {
+	if len(paths) == 0 {
+		return errors.New("usage: rostam-server rag ingest [flags] <paths...>")
+	}
+	if err := r.EnsureCorpus(ctx, fl.corpus, embedderDim(emb)); err != nil {
+		return fmt.Errorf("ensure corpus %q: %w", fl.corpus, err)
+	}
+	rep, err := rag.Ingest(ctx, r, paths, rag.IngestOptions{
+		Corpus:       fl.corpus,
+		ChunkSize:    fl.chunkSize,
+		ChunkOverlap: fl.chunkOverlap,
+		Embedder:     emb,
+	})
+	if err != nil {
+		return fmt.Errorf("ingest: %w", err)
+	}
+	fmt.Printf("ingested %d file(s), %d chunk(s), skipped %d\n", rep.Files, rep.Chunks, rep.Skipped)
+	for _, p := range rep.SkippedPaths {
+		fmt.Printf("  skipped: %s\n", p)
+	}
+	return nil
+}
+
+func runRagQuery(ctx context.Context, r rag.Retriever, emb semcache.Embedder, fl ragFlags, args []string) error {
+	if len(args) == 0 {
+		return errors.New("usage: rostam-server rag query [flags] <text>")
+	}
+	query := args[0]
+	hits, err := rag.Retrieve(ctx, r, emb, fl.corpus, query, fl.k)
+	if err != nil {
+		return fmt.Errorf("query: %w", err)
+	}
+	printHits(hits)
+	return nil
+}
+
+func runRagAsk(ctx context.Context, r rag.Retriever, emb semcache.Embedder, fl ragFlags, llmKey string, args []string) error {
+	if len(args) == 0 {
+		return errors.New("usage: rostam-server rag ask [flags] <question>")
+	}
+	question := args[0]
+	llm := rag.LLMConfig{
+		URL:        fl.llmURL,
+		APIKey:     llmKey,
+		Model:      fl.llmModel,
+		HTTPClient: &http.Client{Timeout: 5 * time.Minute},
+	}
+	res, err := rag.Ask(ctx, r, emb, llm, fl.corpus, question, fl.k)
+	if err != nil {
+		return fmt.Errorf("ask: %w", err)
+	}
+	fmt.Println(res.Answer)
+	fmt.Println()
+	fmt.Println("Sources:")
+	for i, h := range res.Hits {
+		fmt.Printf("  [%d] %s#%d\n", i+1, h.Source, h.Index)
+	}
+	return nil
+}
+
+// printHits renders query hits as `[n] source#index (score)` followed by an
+// indented content excerpt, per the brief's output format.
+func printHits(hits []rag.Hit) {
+	for i, h := range hits {
+		fmt.Printf("[%d] %s#%d (%.4f)\n", i+1, h.Source, h.Index, h.Score)
+		fmt.Printf("   %s\n", excerpt(h.Content))
+	}
+}
+
+// excerpt caps a hit's content to a single readable line for query output;
+// ask's cited answer carries the full content instead (via the LLM prompt).
+func excerpt(s string) string {
+	const maxLen = 200
+	// Collapse newlines so a multi-line chunk still prints as one indented
+	// line rather than breaking the "[n] ..." / "   ..." two-line shape.
+	r := []rune(s)
+	clean := make([]rune, 0, len(r))
+	for _, c := range r {
+		if c == '\n' || c == '\r' {
+			c = ' '
+		}
+		clean = append(clean, c)
+	}
+	if len(clean) > maxLen {
+		return string(clean[:maxLen]) + "..."
+	}
+	return string(clean)
+}

--- a/cmd/rostam-server/rag.go
+++ b/cmd/rostam-server/rag.go
@@ -54,7 +54,7 @@ func runRagCmd(args []string) {
 // no single "setup" step to isolate).
 func runRagCmdE(args []string) error {
 	if len(args) < 1 {
-		return errors.New("usage: rostam-server rag <ingest|ask|query> [flags] ...")
+		return errors.New("usage: rostam-server rag <ingest|ask|query> [flags] <args>")
 	}
 	verb, rest := args[0], args[1:]
 

--- a/cmd/rostam-server/rag_test.go
+++ b/cmd/rostam-server/rag_test.go
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// runRagCmdE is a test seam that returns an error instead of calling os.Exit.
+// runRagCmd is implemented as a thin wrapper: it calls runRagCmdE and, on
+// error, calls fatal.
+func TestRagIngestThenQuery(t *testing.T) {
+	data := t.TempDir()
+	src := t.TempDir()
+	if err := os.WriteFile(filepath.Join(src, "a.md"), []byte("epoll loop count comes from gomaxprocs"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := runRagCmdE([]string{"ingest", "--data", data, "--corpus", "docs", src}); err != nil {
+		t.Fatalf("ingest: %v", err)
+	}
+	if err := runRagCmdE([]string{"query", "--data", data, "--corpus", "docs", "epoll loop count"}); err != nil {
+		t.Fatalf("query: %v", err)
+	}
+}
+
+func TestRagAskWithoutLLMErrors(t *testing.T) {
+	data := t.TempDir()
+	err := runRagCmdE([]string{"ask", "--data", data, "--corpus", "docs", "anything"})
+	if err == nil {
+		t.Fatal("ask without an LLM configured should error")
+	}
+}

--- a/docs/server/rag.md
+++ b/docs/server/rag.md
@@ -1,0 +1,129 @@
+# RAG CLI
+
+`rostam-server rag` is a batteries-included retrieval-augmented-generation
+CLI built on the vector engine: point it at some files, ask questions, get
+cited answers. There's no separate ingestion pipeline or vector-store
+setup to wire up — `rag ingest` chunks and stores your documents, `rag ask`
+retrieves the relevant chunks and asks an LLM to answer from them (citing
+which chunk it used), and `rag query` does retrieval alone, with no LLM
+involved. It works out of the box on plain keyword (BM25) search with zero
+configuration, and upgrades to dense vector retrieval the moment you point
+it at an embedding endpoint.
+
+## Quickstart
+
+```sh
+rostam-server rag ingest ./docs
+rostam-server rag ask "How does the LLM proxy decide what's cacheable?"
+```
+
+The first command chunks and indexes every recognized file under `./docs`
+into a local corpus (default directory: `./.rostam-rag`). The second
+retrieves the most relevant chunks and asks an LLM to answer, citing the
+chunks it relied on as `[1]`, `[2]`, etc., followed by a `Sources:` list of
+`source#chunk-index` for each.
+
+To inspect retrieval without invoking an LLM at all:
+
+```sh
+rostam-server rag query "cache scoping rules"
+```
+
+This prints each hit as `[n] source#index (score)` with a one-line content
+excerpt — useful for checking what would be handed to the LLM before you
+spend a generation call on it.
+
+## Flags and environment
+
+| Flag | Env | Default | Purpose |
+|---|---|---|---|
+| `-data` | — | `./.rostam-rag` | Embedded data directory. Mutually exclusive with `-endpoint`. |
+| `-endpoint` | — | (unset) | Connect to a remote `rostam-server` (`host:port`) instead of embedding a store. Mutually exclusive with `-data`. |
+| `-corpus` | — | `default` | Corpus (collection) name — lets you keep multiple document sets side by side in one data directory. |
+| `-k` | — | `5` | Number of chunks to retrieve. |
+| `-chunk-size` | — | `512` | Chunk size in words (`0` uses the `rag` package default of 512). |
+| `-chunk-overlap` | — | `64` | Chunk overlap in words (`0` uses the `rag` package default of 64). |
+| `-embed-url` | `ROSTAM_EMBED_URL` | (unset) | Embedding endpoint URL. Needs `-embed-model` and `-embed-dim` too — with any of the three missing, retrieval falls back to BM25. |
+| `-embed-model` | `ROSTAM_EMBED_MODEL` | (unset) | Embedding model id. |
+| `-embed-dim` | `ROSTAM_EMBED_DIM` | (unset) | Embedding vector dimension. |
+| `-llm-url` | `ROSTAM_LLM_URL` | (unset) | LLM chat-completions endpoint URL (`ask` only). |
+| `-llm-model` | `ROSTAM_LLM_MODEL` | (unset) | LLM model id (`ask` only). |
+| — | `ROSTAM_EMBED_KEY` | (unset) | Bearer key for the embedding endpoint. Env-only, deliberately: there is no `-embed-key` flag, so the key never lands in `/proc` or shell history. |
+| — | `ROSTAM_LLM_KEY` | (unset) | Bearer key for the LLM endpoint. Env-only, same reasoning as `ROSTAM_EMBED_KEY`. |
+
+Every flag above has an env-variable counterpart except the two secrets and
+`-data`/`-endpoint`/`-corpus`/`-k`/`-chunk-size`/`-chunk-overlap`, which are
+flag-only. Where both a flag and an env variable are set, the flag wins.
+
+## Embedded vs. remote (`-endpoint`)
+
+By default `rag` embeds the vector engine directly and owns the `-data`
+directory — no server process required. Point it at an already-running
+`rostam-server` instead with `-endpoint`:
+
+```sh
+rostam-server rag ingest -endpoint 127.0.0.1:7000 ./docs
+rostam-server rag ask -endpoint 127.0.0.1:7000 "..."
+```
+
+This is the way to share one corpus across multiple `rag` invocations (or
+processes) without each one locking its own embedded data directory.
+
+## Retrieval: BM25 vs. dense
+
+Retrieval defaults to BM25 full-text search — no embedder configuration
+needed, works immediately after `rag ingest`. Set `-embed-url`,
+`-embed-model`, and `-embed-dim` (or the equivalent `ROSTAM_EMBED_*` env
+vars, plus `ROSTAM_EMBED_KEY` if the endpoint needs one) and retrieval
+switches to dense kNN search over the embedded vectors instead.
+
+Note that ingestion and retrieval must agree: chunks embedded at ingest
+time are only useful for dense search if the same embedder configuration
+is present at query/ask time too. Re-run `rag ingest` after changing
+embedder settings so existing chunks get fresh vectors — it's idempotent,
+so re-ingesting the same paths is safe.
+
+Combined dense+BM25 fusion (hybrid search) is a planned upgrade, not yet
+wired into the CLI — today it's one or the other, decided entirely by
+whether an embedder is configured.
+
+## Offline use with Ollama
+
+`rag ask` needs an LLM; point `-llm-url` at a local server such as
+[Ollama](https://ollama.com) to keep everything on-box:
+
+```sh
+rostam-server rag ask \
+  -llm-url http://localhost:11434/v1 \
+  -llm-model llama3.1 \
+  "How does the LLM proxy decide what's cacheable?"
+```
+
+`ROSTAM_LLM_KEY` can stay unset for local endpoints that don't require
+authentication. The same pattern works for `-embed-url` with a local
+embedding model, keeping ingestion and retrieval offline too.
+
+`rag query` never needs an LLM — it only requires `-llm-url`/`-llm-model`
+(or the env equivalents) when you run `rag ask`.
+
+## Supported file types
+
+`rag ingest` walks each given path (file or directory, recursively) and
+indexes files with these extensions, skipping everything else (and any
+file that isn't valid UTF-8):
+
+```
+.txt .md .markdown
+.go .py .js .ts .rs .java .c .h .cpp
+.json .yaml .yml .toml
+```
+
+`rag ingest` reports how many files/chunks were indexed and lists any
+skipped paths.
+
+## Re-ingesting
+
+Re-ingesting a path is idempotent: `rag ingest` deletes a source file's
+previous chunks before writing the fresh ones, so running it again after
+editing a file (or on an unchanged one) never leaves stale or duplicate
+chunks behind.

--- a/docs/server/rag.md
+++ b/docs/server/rag.md
@@ -14,14 +14,23 @@ it at an embedding endpoint.
 
 ```sh
 rostam-server rag ingest ./docs
-rostam-server rag ask "How does the LLM proxy decide what's cacheable?"
+rostam-server rag query "How does the LLM proxy decide what's cacheable?"
 ```
 
 The first command chunks and indexes every recognized file under `./docs`
 into a local corpus (default directory: `./.rostam-rag`). The second
-retrieves the most relevant chunks and asks an LLM to answer, citing the
-chunks it relied on as `[1]`, `[2]`, etc., followed by a `Sources:` list of
-`source#chunk-index` for each.
+retrieves the most relevant chunks and prints them with a
+`source#chunk-index` and score — no LLM or configuration required.
+
+Once you've configured an LLM endpoint (see [Flags and environment](#flags-and-environment)),
+`rag ask` synthesizes a cited answer from those chunks instead:
+
+```sh
+rostam-server rag ask "How does the LLM proxy decide what's cacheable?"
+```
+
+It cites the chunks it relied on as `[1]`, `[2]`, etc., followed by a
+`Sources:` list of `source#chunk-index` for each.
 
 To inspect retrieval without invoking an LLM at all:
 
@@ -120,7 +129,7 @@ embedding model, keeping ingestion and retrieval offline too.
 indexes files with these extensions, skipping everything else (and any
 file that isn't valid UTF-8):
 
-```
+```text
 .txt .md .markdown
 .go .py .js .ts .rs .java .c .h .cpp
 .json .yaml .yml .toml

--- a/docs/server/rag.md
+++ b/docs/server/rag.md
@@ -37,8 +37,8 @@ spend a generation call on it.
 
 | Flag | Env | Default | Purpose |
 |---|---|---|---|
-| `-data` | — | `./.rostam-rag` | Embedded data directory. Mutually exclusive with `-endpoint`. |
-| `-endpoint` | — | (unset) | Connect to a remote `rostam-server` (`host:port`) instead of embedding a store. Mutually exclusive with `-data`. |
+| `-data` | — | `./.rostam-rag` | Embedded data directory. Ignored when `-endpoint` is set. |
+| `-endpoint` | — | (unset) | Talk to a running `rostam-server` (`host:port`) instead of the local `-data` dir. `-endpoint` takes precedence over `-data`. |
 | `-corpus` | — | `default` | Corpus (collection) name — lets you keep multiple document sets side by side in one data directory. |
 | `-k` | — | `5` | Number of chunks to retrieve. |
 | `-chunk-size` | — | `512` | Chunk size in words (`0` uses the `rag` package default of 512). |
@@ -79,9 +79,17 @@ switches to dense kNN search over the embedded vectors instead.
 
 Note that ingestion and retrieval must agree: chunks embedded at ingest
 time are only useful for dense search if the same embedder configuration
-is present at query/ask time too. Re-run `rag ingest` after changing
-embedder settings so existing chunks get fresh vectors — it's idempotent,
-so re-ingesting the same paths is safe.
+is present at query/ask time too.
+
+A corpus's vector dimensionality is fixed the moment it's first created.
+Re-ingesting the same paths with the *same* embedder configuration (or no
+embedder at all) is idempotent and safe — see
+[Re-ingesting](#re-ingesting). But switching a corpus between BM25 and a
+dense embedder, or changing `-embed-dim`, changes the dimension a fresh
+ingest would need, and an existing corpus can't be resized in place:
+`rag ingest` refuses with an error telling you to pick a new `-corpus` (or
+wipe the `-data` dir) rather than silently leaving stale or mismatched
+vectors behind.
 
 Combined dense+BM25 fusion (hybrid search) is a planned upgrade, not yet
 wired into the CLI — today it's one or the other, decided entirely by

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -102,6 +102,7 @@ nav:
       - Monitoring: server/monitoring.md
       - MCP server: server/mcp.md
       - LLM caching proxy: server/llm-proxy.md
+      - RAG CLI: server/rag.md
   - API reference:
       - HTTP: api/http.md
       - gRPC: api/grpc.md

--- a/rag/ask.go
+++ b/rag/ask.go
@@ -1,0 +1,116 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package rag
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/rostamlabs/rostam/semcache"
+)
+
+const systemPrompt = "You answer questions using ONLY the numbered context passages provided. " +
+	"For each passage you rely on, cite its bracketed number in the form [n] (e.g. [1]). " +
+	"If the context does not contain the answer, say you don't know."
+
+// BuildPrompt returns the system+user messages: numbered context then question.
+func BuildPrompt(question string, hits []Hit) (string, string) {
+	var b strings.Builder
+	b.WriteString("Context:\n")
+	for i, h := range hits {
+		fmt.Fprintf(&b, "[%d] %s\n", i+1, h.Content)
+	}
+	if len(hits) == 0 {
+		b.WriteString("(no relevant context found)\n")
+	}
+	fmt.Fprintf(&b, "\nQuestion: %s", question)
+	return systemPrompt, b.String()
+}
+
+// LLMConfig configures an OpenAI-compatible chat completion endpoint.
+type LLMConfig struct {
+	URL        string
+	APIKey     string
+	Model      string
+	HTTPClient *http.Client
+}
+
+// AskResult is a synthesized answer plus the hits it was grounded in.
+type AskResult struct {
+	Answer string
+	Hits   []Hit
+}
+
+// Ask retrieves then synthesizes a cited answer.
+func Ask(ctx context.Context, r Retriever, emb semcache.Embedder, llm LLMConfig, corpus, question string, k int) (AskResult, error) {
+	if llm.URL == "" || llm.Model == "" {
+		return AskResult{}, fmt.Errorf("rag: ask requires an LLM URL and model (set ROSTAM_LLM_URL/ROSTAM_LLM_MODEL); use `rag query` for retrieval only")
+	}
+	hits, err := Retrieve(ctx, r, emb, corpus, question, k)
+	if err != nil {
+		return AskResult{}, err
+	}
+	sys, user := BuildPrompt(question, hits)
+	answer, err := chatComplete(ctx, llm, sys, user)
+	if err != nil {
+		return AskResult{}, err
+	}
+	return AskResult{Answer: answer, Hits: hits}, nil
+}
+
+// chatComplete posts to an OpenAI-compatible /chat/completions endpoint. URL may
+// be the base (…/v1) or the full path; we append the standard suffix if absent.
+func chatComplete(ctx context.Context, cfg LLMConfig, system, user string) (string, error) {
+	url := cfg.URL
+	if !strings.Contains(url, "/chat/completions") {
+		url = strings.TrimRight(url, "/") + "/chat/completions"
+	}
+	reqBody, err := json.Marshal(map[string]any{
+		"model": cfg.Model,
+		"messages": []map[string]string{
+			{"role": "system", "content": system},
+			{"role": "user", "content": user},
+		},
+	})
+	if err != nil {
+		return "", fmt.Errorf("rag: marshal chat request: %w", err)
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(reqBody))
+	if err != nil {
+		return "", err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	if cfg.APIKey != "" {
+		req.Header.Set("Authorization", "Bearer "+cfg.APIKey)
+	}
+	hc := cfg.HTTPClient
+	if hc == nil {
+		hc = http.DefaultClient
+	}
+	resp, err := hc.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("rag: LLM returned status %d", resp.StatusCode)
+	}
+	var out struct {
+		Choices []struct {
+			Message struct {
+				Content string `json:"content"`
+			} `json:"message"`
+		} `json:"choices"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		return "", err
+	}
+	if len(out.Choices) == 0 {
+		return "", fmt.Errorf("rag: LLM returned no choices")
+	}
+	return out.Choices[0].Message.Content, nil
+}

--- a/rag/ask_test.go
+++ b/rag/ask_test.go
@@ -1,0 +1,66 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package rag
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestBuildPromptNumbersContextAndCites(t *testing.T) {
+	hits := []Hit{
+		{Content: "epoll loop count = GOMAXPROCS", Source: "a.md", Index: 0},
+		{Content: "raft shards ~= cores", Source: "b.md", Index: 1},
+	}
+	sys, user := BuildPrompt("how many loops?", hits)
+	if !strings.Contains(sys, "[n]") && !strings.Contains(sys, "cite") {
+		t.Fatalf("system prompt should instruct citation: %q", sys)
+	}
+	if !strings.Contains(user, "[1]") || !strings.Contains(user, "[2]") {
+		t.Fatalf("user prompt should number chunks: %q", user)
+	}
+	if !strings.Contains(user, "how many loops?") {
+		t.Fatalf("user prompt should carry the question: %q", user)
+	}
+}
+
+func TestAskCallsLLMWithContext(t *testing.T) {
+	var gotBody string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		b, _ := io.ReadAll(req.Body)
+		gotBody = string(b)
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"choices": []map[string]any{{"message": map[string]any{"role": "assistant", "content": "42 loops [1]"}}},
+		})
+	}))
+	defer srv.Close()
+
+	dir := t.TempDir()
+	r, err := NewEmbeddedRetriever(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = r.Close() }()
+	ctx := context.Background()
+	_ = r.EnsureCorpus(ctx, "docs", 0)
+	_ = r.Upsert(ctx, "docs", []StoredChunk{{ID: 1, Content: "epoll loop count equals gomaxprocs", Source: "a.md", Index: 0}})
+
+	res, err := Ask(ctx, r, nil, LLMConfig{URL: srv.URL, Model: "test"}, "docs", "how many loops?", 5)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(res.Answer, "42 loops") {
+		t.Fatalf("answer=%q", res.Answer)
+	}
+	if !strings.Contains(gotBody, "epoll loop count") {
+		t.Fatalf("LLM request should include retrieved context, got %q", gotBody)
+	}
+	if len(res.Hits) != 1 || res.Hits[0].Source != "a.md" {
+		t.Fatalf("hits not returned for source mapping: %+v", res.Hits)
+	}
+}

--- a/rag/chunk.go
+++ b/rag/chunk.go
@@ -1,0 +1,87 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package rag
+
+import "strings"
+
+// Chunk is one unit of text stored as a single document in the corpus.
+type Chunk struct {
+	Content string
+	Index   int
+}
+
+// splitWords splits on any whitespace, dropping empties.
+func splitWords(s string) []string { return strings.Fields(s) }
+
+// SplitText splits s into overlapping chunks of about targetTokens words each,
+// preferring blank-line paragraph boundaries. See the interface block above.
+func SplitText(s string, targetTokens, overlap int) []Chunk {
+	if targetTokens <= 0 {
+		targetTokens = 512
+	}
+	if overlap < 0 || overlap >= targetTokens {
+		overlap = 0
+	}
+	paras := splitParagraphs(s)
+	if len(paras) == 0 {
+		return nil
+	}
+	var chunks []Chunk
+	var cur []string
+	flush := func(carryOverlap bool) {
+		if len(cur) == 0 {
+			return
+		}
+		chunks = append(chunks, Chunk{Content: strings.Join(cur, " "), Index: len(chunks)})
+		if carryOverlap && overlap > 0 && len(cur) > overlap {
+			cur = append([]string(nil), cur[len(cur)-overlap:]...)
+		} else {
+			cur = nil
+		}
+	}
+	for _, p := range paras {
+		w := splitWords(p)
+		if len(w) == 0 {
+			continue
+		}
+		// A paragraph bigger than the target: hard-split it by word count.
+		if len(w) > targetTokens {
+			flush(true)
+			for len(w) > 0 {
+				n := targetTokens - len(cur)
+				if n > len(w) {
+					n = len(w)
+				}
+				cur = append(cur, w[:n]...)
+				w = w[n:]
+				if len(cur) >= targetTokens {
+					flush(true)
+				}
+			}
+			continue
+		}
+		// Adding this paragraph would overflow: close the current chunk first,
+		// so we break on the paragraph boundary rather than mid-paragraph.
+		if len(cur)+len(w) > targetTokens {
+			flush(false)
+		}
+		cur = append(cur, w...)
+	}
+	// Final flush without carrying overlap forward.
+	if len(cur) > 0 {
+		chunks = append(chunks, Chunk{Content: strings.Join(cur, " "), Index: len(chunks)})
+	}
+	return chunks
+}
+
+// splitParagraphs splits on blank lines and trims each paragraph.
+func splitParagraphs(s string) []string {
+	raw := strings.Split(strings.ReplaceAll(s, "\r\n", "\n"), "\n\n")
+	out := make([]string, 0, len(raw))
+	for _, p := range raw {
+		if t := strings.TrimSpace(p); t != "" {
+			out = append(out, t)
+		}
+	}
+	return out
+}

--- a/rag/chunk_test.go
+++ b/rag/chunk_test.go
@@ -1,0 +1,57 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package rag
+
+import "testing"
+
+func words(s string) int {
+	n := 0
+	for _, f := range splitWords(s) {
+		_ = f
+		n++
+	}
+	return n
+}
+
+func TestSplitTextEmpty(t *testing.T) {
+	if got := SplitText("", 10, 2); got != nil {
+		t.Fatalf("empty input: got %v, want nil", got)
+	}
+	if got := SplitText("   \n\t ", 10, 2); got != nil {
+		t.Fatalf("whitespace input: got %v, want nil", got)
+	}
+}
+
+func TestSplitTextSingleShortChunk(t *testing.T) {
+	got := SplitText("hello world foo", 10, 2)
+	if len(got) != 1 || got[0].Content != "hello world foo" || got[0].Index != 0 {
+		t.Fatalf("got %+v", got)
+	}
+}
+
+func TestSplitTextOverlap(t *testing.T) {
+	// 12 words, target 5, overlap 2 => chunks advance by 3 words.
+	body := "w1 w2 w3 w4 w5 w6 w7 w8 w9 w10 w11 w12"
+	got := SplitText(body, 5, 2)
+	if len(got) < 2 {
+		t.Fatalf("want >=2 chunks, got %d (%+v)", len(got), got)
+	}
+	if got[0].Index != 0 || got[1].Index != 1 {
+		t.Fatalf("indices not sequential: %+v", got)
+	}
+	// consecutive chunks share the overlap tail/head word.
+	if last := splitWords(got[0].Content); last[len(last)-1] != splitWords(got[1].Content)[1] {
+		t.Fatalf("expected 2-word overlap between chunk 0 and 1: %q / %q", got[0].Content, got[1].Content)
+	}
+}
+
+func TestSplitTextPrefersParagraphBoundary(t *testing.T) {
+	body := "alpha beta gamma\n\ndelta epsilon zeta"
+	got := SplitText(body, 4, 1) // each paragraph is 3 words, target 4
+	if len(got) != 2 {
+		t.Fatalf("want a chunk per paragraph, got %d: %+v", len(got), got)
+	}
+	if got[0].Content != "alpha beta gamma" || got[1].Content != "delta epsilon zeta" {
+		t.Fatalf("paragraph boundaries not respected: %+v", got)
+	}
+}

--- a/rag/chunk_test.go
+++ b/rag/chunk_test.go
@@ -4,15 +4,6 @@ package rag
 
 import "testing"
 
-func words(s string) int {
-	n := 0
-	for _, f := range splitWords(s) {
-		_ = f
-		n++
-	}
-	return n
-}
-
 func TestSplitTextEmpty(t *testing.T) {
 	if got := SplitText("", 10, 2); got != nil {
 		t.Fatalf("empty input: got %v, want nil", got)

--- a/rag/doc.go
+++ b/rag/doc.go
@@ -1,0 +1,7 @@
+// SPDX-License-Identifier: Apache-2.0
+
+// Package rag turns local files into a Rostam corpus and answers questions over
+// it with grounded, cited LLM responses. It orchestrates the vector engine, an
+// optional embedder, and an OpenAI-compatible chat endpoint behind a small
+// Retriever interface with embedded and HTTP backends.
+package rag

--- a/rag/ingest.go
+++ b/rag/ingest.go
@@ -1,0 +1,145 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package rag
+
+import (
+	"context"
+	"fmt"
+	"hash/fnv"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"unicode/utf8"
+
+	"github.com/rostamlabs/rostam/semcache"
+)
+
+// IngestOptions configures a call to Ingest.
+type IngestOptions struct {
+	Corpus       string
+	ChunkSize    int               // words; default 512
+	ChunkOverlap int               // words; default 64
+	Embedder     semcache.Embedder // nil => BM25-only
+}
+
+// IngestReport summarizes the outcome of an Ingest call.
+type IngestReport struct {
+	Files        int
+	Chunks       int
+	Skipped      int
+	SkippedPaths []string
+}
+
+var textExts = map[string]bool{
+	".txt": true, ".md": true, ".markdown": true, ".go": true, ".py": true,
+	".js": true, ".ts": true, ".rs": true, ".java": true, ".c": true, ".h": true,
+	".cpp": true, ".json": true, ".yaml": true, ".yml": true, ".toml": true,
+}
+
+// Ingest walks paths (files or directories, recursively), extracts UTF-8 text
+// from recognized extensions, chunks each file, optionally embeds the chunks,
+// and upserts them into the given corpus. Re-ingesting the same source path
+// is idempotent: prior chunks for that source are deleted before the fresh
+// ones are written.
+func Ingest(ctx context.Context, r Retriever, paths []string, opts IngestOptions) (IngestReport, error) {
+	if opts.Corpus == "" {
+		opts.Corpus = "default"
+	}
+	if opts.ChunkSize <= 0 {
+		opts.ChunkSize = 512
+	}
+	if opts.ChunkOverlap <= 0 {
+		opts.ChunkOverlap = 64
+	}
+	var rep IngestReport
+	for _, p := range paths {
+		err := filepath.WalkDir(p, func(path string, d fs.DirEntry, err error) error {
+			if err != nil {
+				return err
+			}
+			if d.IsDir() {
+				return nil
+			}
+			if !textExts[strings.ToLower(filepath.Ext(path))] {
+				rep.Skipped++
+				rep.SkippedPaths = append(rep.SkippedPaths, path)
+				return nil
+			}
+			body, err := os.ReadFile(path)
+			if err != nil {
+				return err
+			}
+			if !utf8.Valid(body) {
+				rep.Skipped++
+				rep.SkippedPaths = append(rep.SkippedPaths, path)
+				return nil
+			}
+			n, err := ingestFile(ctx, r, opts, path, string(body))
+			if err != nil {
+				return err
+			}
+			rep.Files++
+			rep.Chunks += n
+			return nil
+		})
+		if err != nil {
+			return rep, err
+		}
+	}
+	return rep, nil
+}
+
+func ingestFile(ctx context.Context, r Retriever, opts IngestOptions, source, body string) (int, error) {
+	chunks := SplitText(body, opts.ChunkSize, opts.ChunkOverlap)
+	if len(chunks) == 0 {
+		return 0, nil
+	}
+	// Idempotent re-ingest: purge this file's previous chunks first.
+	if _, err := r.DeleteBySource(ctx, opts.Corpus, source); err != nil {
+		return 0, err
+	}
+	var vecs [][]float32
+	if opts.Embedder != nil {
+		texts := make([]string, len(chunks))
+		for i, c := range chunks {
+			texts[i] = c.Content
+		}
+		var err error
+		vecs, err = opts.Embedder.Embed(ctx, texts)
+		if err != nil {
+			return 0, fmt.Errorf("rag: embed %s: %w", source, err)
+		}
+	}
+	stored := make([]StoredChunk, len(chunks))
+	for i, c := range chunks {
+		sc := StoredChunk{
+			ID:      chunkID(source, c.Index),
+			Content: c.Content,
+			Source:  source,
+			Index:   c.Index,
+		}
+		if vecs != nil {
+			sc.Vector = vecs[i]
+		}
+		stored[i] = sc
+	}
+	if err := r.Upsert(ctx, opts.Corpus, stored); err != nil {
+		return 0, err
+	}
+	return len(stored), nil
+}
+
+// chunkID is deterministic in (source, index) so re-ingest overwrites in place.
+func chunkID(source string, index int) uint64 {
+	h := fnv.New64a()
+	_, _ = h.Write([]byte(source))
+	_, _ = h.Write([]byte("#"))
+	_, _ = h.Write([]byte(strconv.Itoa(index)))
+	id := h.Sum64()
+	if id == 0 {
+		id = 1 // avoid id 0 (historically special-cased in the engine)
+	}
+	return id
+}

--- a/rag/ingest.go
+++ b/rag/ingest.go
@@ -67,7 +67,7 @@ func Ingest(ctx context.Context, r Retriever, paths []string, opts IngestOptions
 				rep.SkippedPaths = append(rep.SkippedPaths, path)
 				return nil
 			}
-			body, err := os.ReadFile(path)
+			body, err := os.ReadFile(path) //nolint:gosec // G122: ingest paths are user-supplied local files for a CLI reading the user's own tree; symlink TOCTOU is out of scope
 			if err != nil {
 				return err
 			}

--- a/rag/ingest.go
+++ b/rag/ingest.go
@@ -93,12 +93,14 @@ func Ingest(ctx context.Context, r Retriever, paths []string, opts IngestOptions
 
 func ingestFile(ctx context.Context, r Retriever, opts IngestOptions, source, body string) (int, error) {
 	chunks := SplitText(body, opts.ChunkSize, opts.ChunkOverlap)
-	if len(chunks) == 0 {
-		return 0, nil
-	}
-	// Idempotent re-ingest: purge this file's previous chunks first.
+	// Idempotent re-ingest: purge this file's previous chunks first, even if
+	// the file now yields zero chunks (e.g. it was edited down to empty) —
+	// otherwise stale chunks from an earlier ingest orphan in the corpus.
 	if _, err := r.DeleteBySource(ctx, opts.Corpus, source); err != nil {
 		return 0, err
+	}
+	if len(chunks) == 0 {
+		return 0, nil
 	}
 	var vecs [][]float32
 	if opts.Embedder != nil {

--- a/rag/ingest.go
+++ b/rag/ingest.go
@@ -72,6 +72,12 @@ func Ingest(ctx context.Context, r Retriever, paths []string, opts IngestOptions
 				return err
 			}
 			if !utf8.Valid(body) {
+				// A previously-indexed source that has become invalid UTF-8
+				// must still have its stale chunks purged, or search would keep
+				// returning content no longer backed by the file.
+				if _, err := r.DeleteBySource(ctx, opts.Corpus, path); err != nil {
+					return err
+				}
 				rep.Skipped++
 				rep.SkippedPaths = append(rep.SkippedPaths, path)
 				return nil

--- a/rag/ingest_test.go
+++ b/rag/ingest_test.go
@@ -124,6 +124,53 @@ func TestIngestWithStubEmbedder(t *testing.T) {
 	}
 }
 
+// TestIngestReIngestInvalidUTF8Purges: a previously-indexed source that later
+// becomes invalid UTF-8 is skipped, but its stale chunks must still be purged
+// so search never returns content no longer backed by the file.
+func TestIngestReIngestInvalidUTF8Purges(t *testing.T) {
+	src := t.TempDir()
+	corpusDir := t.TempDir()
+	path := filepath.Join(src, "a.md")
+	writeFile(t, path, "epoll transport loop count comes from gomaxprocs and raft shards")
+
+	r, err := NewEmbeddedRetriever(corpusDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = r.Close() }()
+	ctx := context.Background()
+	if err := r.EnsureCorpus(ctx, "docs", 0); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := Ingest(ctx, r, []string{src}, IngestOptions{Corpus: "docs", ChunkSize: 8, ChunkOverlap: 2}); err != nil {
+		t.Fatal(err)
+	}
+	if hits, err := r.Search(ctx, "docs", "epoll", nil, 10); err != nil {
+		t.Fatal(err)
+	} else if len(hits) == 0 {
+		t.Fatalf("expected hits for initial content, got none")
+	}
+
+	// Overwrite a.md with invalid UTF-8 bytes: the ingester skips it, but the
+	// prior chunks for this path must be purged.
+	writeFile(t, path, "valid prefix \xff\xfe\xfa invalid tail")
+	rep, err := Ingest(ctx, r, []string{src}, IngestOptions{Corpus: "docs", ChunkSize: 8, ChunkOverlap: 2})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if rep.Skipped != 1 {
+		t.Fatalf("expected the invalid-UTF-8 file to be skipped, got report %+v", rep)
+	}
+	after, err := r.Search(ctx, "docs", "epoll", nil, 10)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(after) != 0 {
+		t.Fatalf("expected stale chunks purged after source became invalid UTF-8, got %d hits", len(after))
+	}
+}
+
 func writeFile(t *testing.T, path, body string) {
 	t.Helper()
 	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {

--- a/rag/ingest_test.go
+++ b/rag/ingest_test.go
@@ -1,0 +1,90 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package rag
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/rostamlabs/rostam/semcache"
+)
+
+func TestIngestBM25AndReIngest(t *testing.T) {
+	src := t.TempDir()
+	corpusDir := t.TempDir()
+	writeFile(t, filepath.Join(src, "a.md"), "# Title\n\nepoll transport loop count comes from gomaxprocs\n\nsecond paragraph about raft shards")
+	writeFile(t, filepath.Join(src, "skip.bin"), "\x00\x01binary")
+
+	r, err := NewEmbeddedRetriever(corpusDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = r.Close() }()
+	ctx := context.Background()
+	if err := r.EnsureCorpus(ctx, "docs", 0); err != nil {
+		t.Fatal(err)
+	}
+
+	rep, err := Ingest(ctx, r, []string{src}, IngestOptions{Corpus: "docs", ChunkSize: 8, ChunkOverlap: 2})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if rep.Files != 1 || rep.Chunks < 1 {
+		t.Fatalf("report=%+v", rep)
+	}
+	if rep.Skipped != 1 {
+		t.Fatalf("expected 1 skipped (skip.bin), got %+v", rep)
+	}
+
+	before, _ := r.Search(ctx, "docs", "epoll", nil, 10)
+	// Re-ingest the same file: chunk count in the corpus must not double.
+	if _, err := Ingest(ctx, r, []string{src}, IngestOptions{Corpus: "docs", ChunkSize: 8, ChunkOverlap: 2}); err != nil {
+		t.Fatal(err)
+	}
+	after, _ := r.Search(ctx, "docs", "epoll", nil, 10)
+	if len(after) != len(before) {
+		t.Fatalf("re-ingest duplicated chunks: before=%d after=%d", len(before), len(after))
+	}
+}
+
+func TestIngestWithStubEmbedder(t *testing.T) {
+	src := t.TempDir()
+	corpusDir := t.TempDir()
+	writeFile(t, filepath.Join(src, "a.md"), "alpha beta gamma delta epsilon")
+	emb := semcache.NewStubEmbedder("stub", 8)
+
+	r, err := NewEmbeddedRetriever(corpusDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = r.Close() }()
+	ctx := context.Background()
+	if err := r.EnsureCorpus(ctx, "docs", emb.Dim()); err != nil {
+		t.Fatal(err)
+	}
+	rep, err := Ingest(ctx, r, []string{src}, IngestOptions{Corpus: "docs", Embedder: emb})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if rep.Chunks < 1 {
+		t.Fatalf("want >=1 chunk, got %+v", rep)
+	}
+	// Dense search should return the chunk (stub vectors are deterministic).
+	qv, _ := emb.Embed(ctx, []string{"alpha"})
+	hits, err := r.Search(ctx, "docs", "alpha", qv[0], 5)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(hits) == 0 {
+		t.Fatalf("dense search returned no hits")
+	}
+}
+
+func writeFile(t *testing.T, path, body string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/rag/ingest_test.go
+++ b/rag/ingest_test.go
@@ -49,6 +49,48 @@ func TestIngestBM25AndReIngest(t *testing.T) {
 	}
 }
 
+func TestIngestReIngestEmptiedFilePurges(t *testing.T) {
+	src := t.TempDir()
+	corpusDir := t.TempDir()
+	path := filepath.Join(src, "a.md")
+	writeFile(t, path, "epoll transport loop count comes from gomaxprocs and raft shards")
+
+	r, err := NewEmbeddedRetriever(corpusDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = r.Close() }()
+	ctx := context.Background()
+	if err := r.EnsureCorpus(ctx, "docs", 0); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := Ingest(ctx, r, []string{src}, IngestOptions{Corpus: "docs", ChunkSize: 8, ChunkOverlap: 2}); err != nil {
+		t.Fatal(err)
+	}
+	hits, err := r.Search(ctx, "docs", "epoll", nil, 10)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(hits) == 0 {
+		t.Fatalf("expected hits for initial content, got none")
+	}
+
+	// Overwrite with whitespace-only content: SplitText will yield zero
+	// chunks, but the file's prior chunks must still be purged.
+	writeFile(t, path, "   \n\t ")
+	if _, err := Ingest(ctx, r, []string{src}, IngestOptions{Corpus: "docs", ChunkSize: 8, ChunkOverlap: 2}); err != nil {
+		t.Fatal(err)
+	}
+	after, err := r.Search(ctx, "docs", "epoll", nil, 10)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(after) != 0 {
+		t.Fatalf("expected stale chunks purged after re-ingesting emptied file, got %d hits", len(after))
+	}
+}
+
 func TestIngestWithStubEmbedder(t *testing.T) {
 	src := t.TempDir()
 	corpusDir := t.TempDir()

--- a/rag/retrieve.go
+++ b/rag/retrieve.go
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package rag
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/rostamlabs/rostam/semcache"
+)
+
+func Retrieve(ctx context.Context, r Retriever, emb semcache.Embedder, corpus, query string, k int) ([]Hit, error) {
+	if k <= 0 {
+		k = 5
+	}
+	var qv []float32
+	if emb != nil {
+		vecs, err := emb.Embed(ctx, []string{query})
+		if err != nil {
+			return nil, fmt.Errorf("rag: embed query: %w", err)
+		}
+		if len(vecs) != 1 {
+			return nil, fmt.Errorf("rag: embedder returned %d vectors for 1 query", len(vecs))
+		}
+		qv = vecs[0]
+	}
+	return r.Search(ctx, corpus, query, qv, k)
+}

--- a/rag/retrieve_test.go
+++ b/rag/retrieve_test.go
@@ -1,0 +1,51 @@
+package rag
+
+import (
+	"context"
+	"testing"
+
+	"github.com/rostamlabs/rostam/semcache"
+)
+
+func TestRetrieveBM25(t *testing.T) {
+	dir := t.TempDir()
+	r, err := NewEmbeddedRetriever(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = r.Close() }()
+	ctx := context.Background()
+	_ = r.EnsureCorpus(ctx, "docs", 0)
+	_ = r.Upsert(ctx, "docs", []StoredChunk{
+		{ID: 1, Content: "epoll event loop transport", Source: "a.md", Index: 0},
+		{ID: 2, Content: "raft shard core count tuning", Source: "b.md", Index: 0},
+	})
+	hits, err := Retrieve(ctx, r, nil, "docs", "epoll transport", 5)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(hits) == 0 || hits[0].Source != "a.md" {
+		t.Fatalf("got %+v", hits)
+	}
+}
+
+func TestRetrieveDenseUsesEmbedder(t *testing.T) {
+	dir := t.TempDir()
+	r, err := NewEmbeddedRetriever(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = r.Close() }()
+	ctx := context.Background()
+	emb := semcache.NewStubEmbedder("stub", 8)
+	_ = r.EnsureCorpus(ctx, "docs", emb.Dim())
+	vecs, _ := emb.Embed(ctx, []string{"alpha beta"})
+	_ = r.Upsert(ctx, "docs", []StoredChunk{{ID: 1, Content: "alpha beta", Vector: vecs[0], Source: "a.md", Index: 0}})
+	hits, err := Retrieve(ctx, r, emb, "docs", "alpha beta", 5)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(hits) == 0 {
+		t.Fatalf("dense retrieve returned nothing")
+	}
+}

--- a/rag/store.go
+++ b/rag/store.go
@@ -73,8 +73,16 @@ func (e *EmbeddedRetriever) EnsureCorpus(_ context.Context, name string, dim int
 		FullText: &vector.FullTextConfig{},
 	}
 	if err := e.store.CreateCollection(name, cfg); err != nil {
-		// Treat "already exists" as success so re-ingest is idempotent.
+		// Treat "already exists" as success so re-ingest is idempotent — but
+		// only when the dimension matches. A corpus's Dim is fixed at
+		// creation, so a stale corpus (e.g. one created BM25-only at the
+		// dim=1 placeholder, now being re-ingested with a real embedder)
+		// would otherwise slip through here and fail later, deep inside
+		// Upsert, as an unhelpful raw vector.ErrDimMismatch.
 		if errors.Is(err, vector.ErrCollectionExists) {
+			if existing, ok := e.store.Get(name); ok && existing.Config().Dim != d {
+				return fmt.Errorf("rag: corpus %q already exists with dimension %d, but this run needs %d; use a different --corpus or wipe the --data dir to recreate it", name, existing.Config().Dim, d)
+			}
 			return nil
 		}
 		return err
@@ -154,6 +162,14 @@ func (h *HTTPRetriever) EnsureCorpus(ctx context.Context, name string, dim int) 
 	// Mirrors EmbeddedRetriever.EnsureCorpus: BM25-only corpora still need a
 	// collection; give it dim=1 so no real vectors are ever inserted but the
 	// full-text index is live.
+	//
+	// Unlike EmbeddedRetriever, this does NOT guard against a dim mismatch on
+	// an already-existing corpus: the rostam.Store client interface exposes
+	// CreateCollection (write) but no read RPC to fetch an existing
+	// collection's configured Dim, so there is nothing here to compare
+	// against without a fragile ad hoc fetch. A dim mismatch over -endpoint
+	// still surfaces later as a raw error out of Upsert, same as before this
+	// fix; closing that gap is a fast-follow.
 	d := dim
 	if d <= 0 {
 		d = 1

--- a/rag/store.go
+++ b/rag/store.go
@@ -6,7 +6,9 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 
+	"github.com/rostamlabs/rostam"
 	"github.com/rostamlabs/rostam/vector"
 )
 
@@ -126,6 +128,95 @@ func (e *EmbeddedRetriever) DeleteBySource(_ context.Context, corpus, source str
 }
 
 func (e *EmbeddedRetriever) Close() error { return e.store.Close() }
+
+// HTTPRetriever talks to a running rostam server over the network (the
+// client package's wire protocol — NOT plain HTTP, despite the endpoint
+// flag's name) via the root rostam.Store interface, for the CLI's
+// --endpoint mode.
+type HTTPRetriever struct {
+	store rostam.Store
+	dim   int // 0 => BM25-only; used to size a placeholder vector-less collection
+}
+
+// NewHTTPRetriever constructs a client pointed at endpoint (a "host:port"
+// bootstrap server address; the smart client discovers the rest of the
+// cluster's topology from there).
+func NewHTTPRetriever(endpoint string) (*HTTPRetriever, error) {
+	s, err := rostam.NewClient(rostam.ClientConfig{Servers: []string{endpoint}})
+	if err != nil {
+		return nil, err
+	}
+	return &HTTPRetriever{store: s}, nil
+}
+
+func (h *HTTPRetriever) EnsureCorpus(ctx context.Context, name string, dim int) error {
+	h.dim = dim
+	// Mirrors EmbeddedRetriever.EnsureCorpus: BM25-only corpora still need a
+	// collection; give it dim=1 so no real vectors are ever inserted but the
+	// full-text index is live.
+	d := dim
+	if d <= 0 {
+		d = 1
+	}
+	cfg := rostam.VectorConfig{
+		Dim: d, Metric: vector.Cosine, M: 16, EfConstruction: 200, EfSearch: 64, Seed: 1,
+		FullText: &vector.FullTextConfig{},
+	}
+	if err := h.store.CreateCollection(ctx, name, cfg); err != nil {
+		// Treat "already exists" as success so re-ingest is idempotent. Over the
+		// wire the error is a reconstructed value whose chain does not survive
+		// the RPC round trip, so errors.Is alone won't match a networked
+		// CreateCollection failure — fall back to the message the server sends,
+		// mirroring mcp.isCollectionExists.
+		if errors.Is(err, vector.ErrCollectionExists) || strings.Contains(err.Error(), "collection already exists") {
+			return nil
+		}
+		return err
+	}
+	return nil
+}
+
+func (h *HTTPRetriever) Upsert(ctx context.Context, corpus string, chunks []StoredChunk) error {
+	for _, c := range chunks {
+		meta := rostam.VectorMetadata{
+			"source": vector.NewString(c.Source),
+			"chunk":  vector.NewInt(int64(c.Index)),
+		}
+		vec := c.Vector
+		if vec == nil && h.dim <= 0 {
+			// BM25-only corpora are sized Dim=1; pad with a zero vector so the
+			// engine's length check (len(vec) != Dim) doesn't reject the write.
+			vec = make([]float32, 1)
+		}
+		if err := h.store.VectorUpsert(ctx, corpus, c.ID, vec, c.Content, rostam.VectorInsertOpts{Metadata: meta}); err != nil {
+			return fmt.Errorf("rag: upsert id %d: %w", c.ID, err)
+		}
+	}
+	// Unlike EmbeddedRetriever there is no local Flush: durability of a
+	// networked write is the server's concern (Raft/WAL), not the client's.
+	return nil
+}
+
+func (h *HTTPRetriever) Search(ctx context.Context, corpus, queryText string, queryVec []float32, k int) ([]Hit, error) {
+	var docs []rostam.VectorDocument
+	var err error
+	if len(queryVec) > 0 {
+		docs, _, err = h.store.VectorSearchDocs(ctx, corpus, queryVec, k, rostam.VectorSearchOpts{})
+	} else {
+		docs, _, err = h.store.VectorSearchText(ctx, corpus, queryText, k, rostam.VectorSearchOpts{})
+	}
+	if err != nil {
+		return nil, err
+	}
+	return docsToHits(docs), nil
+}
+
+func (h *HTTPRetriever) DeleteBySource(ctx context.Context, corpus, source string) (int, error) {
+	f := rostam.VectorFilter{Op: vector.FilterEq, Field: "source", Value: vector.NewString(source)}
+	return h.store.VectorDeleteByFilter(ctx, corpus, f)
+}
+
+func (h *HTTPRetriever) Close() error { return h.store.Close() }
 
 // docsToHits maps engine documents to Hits, pulling source/chunk back out of
 // metadata (both were written as tagged values in Upsert).

--- a/rag/store.go
+++ b/rag/store.go
@@ -1,0 +1,145 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package rag
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/rostamlabs/rostam/vector"
+)
+
+// Hit is one retrieved chunk with its provenance.
+type Hit struct {
+	Content string
+	Source  string
+	Index   int
+	Score   float32
+}
+
+// StoredChunk is a chunk ready to persist. Vector is nil for BM25-only corpora.
+type StoredChunk struct {
+	ID      uint64
+	Content string
+	Vector  []float32
+	Source  string
+	Index   int
+}
+
+// Retriever is the storage backend the rag package talks to.
+type Retriever interface {
+	// EnsureCorpus creates the named corpus if it does not already exist.
+	// dim<=0 means BM25-only (no vectors are ever inserted).
+	EnsureCorpus(ctx context.Context, name string, dim int) error
+	Upsert(ctx context.Context, corpus string, chunks []StoredChunk) error
+	// Search runs a vector search when queryVec is non-nil, else BM25 full text.
+	Search(ctx context.Context, corpus, queryText string, queryVec []float32, k int) ([]Hit, error)
+	DeleteBySource(ctx context.Context, corpus, source string) (int, error)
+	Close() error
+}
+
+// EmbeddedRetriever runs the vector engine in-process against a local data dir.
+type EmbeddedRetriever struct {
+	store *vector.CollectionStore
+	dim   int // 0 => BM25-only; used to size a placeholder vector-less collection
+}
+
+// NewEmbeddedRetriever opens (or creates) a corpus store rooted at dir.
+func NewEmbeddedRetriever(dir string) (*EmbeddedRetriever, error) {
+	s, err := vector.OpenCollectionStore(dir)
+	if err != nil {
+		return nil, err
+	}
+	return &EmbeddedRetriever{store: s}, nil
+}
+
+func (e *EmbeddedRetriever) EnsureCorpus(_ context.Context, name string, dim int) error {
+	e.dim = dim
+	// BM25-only corpora still need a collection; give it dim=1 so no real
+	// vectors are ever inserted but the full-text index is live. Upsert pads
+	// with a zero vector of this length (CollectionStore.Upsert rejects a
+	// length mismatch against the collection's Dim, so nil alone won't do).
+	d := dim
+	if d <= 0 {
+		d = 1
+	}
+	cfg := vector.Config{
+		Dim: d, Metric: vector.Cosine, M: 16, EfConstruction: 200, EfSearch: 64, Seed: 1,
+		// Always on: BM25-only corpora need it for Search, and a vector corpus
+		// still wants full-text as a fallback lane (queryVec == nil).
+		FullText: &vector.FullTextConfig{},
+	}
+	if err := e.store.CreateCollection(name, cfg); err != nil {
+		// Treat "already exists" as success so re-ingest is idempotent.
+		if errors.Is(err, vector.ErrCollectionExists) {
+			return nil
+		}
+		return err
+	}
+	return nil
+}
+
+func (e *EmbeddedRetriever) Upsert(_ context.Context, corpus string, chunks []StoredChunk) error {
+	for _, c := range chunks {
+		meta := vector.Metadata{
+			"source": vector.NewString(c.Source),
+			"chunk":  vector.NewInt(int64(c.Index)),
+		}
+		vec := c.Vector
+		if vec == nil && e.dim <= 0 {
+			// BM25-only corpora are sized Dim=1; pad with a zero vector so the
+			// engine's length check (len(vec) != Dim) doesn't reject the write.
+			vec = make([]float32, 1)
+		}
+		if err := e.store.Upsert(corpus, c.ID, vec, c.Content, 0, meta, nil); err != nil {
+			return fmt.Errorf("rag: upsert id %d: %w", c.ID, err)
+		}
+	}
+	return e.store.Flush(corpus)
+}
+
+func (e *EmbeddedRetriever) Search(_ context.Context, corpus, queryText string, queryVec []float32, k int) ([]Hit, error) {
+	var docs []vector.Document
+	var err error
+	if len(queryVec) > 0 {
+		docs, err = e.store.SearchDocs(corpus, queryVec, k, vector.Filter{})
+	} else {
+		docs, err = e.store.SearchText(corpus, queryText, k, vector.Filter{})
+	}
+	if err != nil {
+		return nil, err
+	}
+	return docsToHits(docs), nil
+}
+
+func (e *EmbeddedRetriever) DeleteBySource(_ context.Context, corpus, source string) (int, error) {
+	f := vector.Filter{Op: vector.FilterEq, Field: "source", Value: vector.NewString(source)}
+	n, err := e.store.DeleteByFilter(corpus, f)
+	if err != nil {
+		return 0, err
+	}
+	if err := e.store.Flush(corpus); err != nil {
+		return n, err
+	}
+	return n, nil
+}
+
+func (e *EmbeddedRetriever) Close() error { return e.store.Close() }
+
+// docsToHits maps engine documents to Hits, pulling source/chunk back out of
+// metadata (both were written as tagged values in Upsert).
+func docsToHits(docs []vector.Document) []Hit {
+	hits := make([]Hit, 0, len(docs))
+	for _, d := range docs {
+		h := Hit{Content: d.Content, Score: d.Score}
+		if v, ok := d.Metadata["source"]; ok {
+			h.Source = v.Str
+		}
+		if v, ok := d.Metadata["chunk"]; ok {
+			h.Index = int(v.Int)
+		}
+		hits = append(hits, h)
+	}
+	return hits
+}

--- a/rag/store_test.go
+++ b/rag/store_test.go
@@ -4,7 +4,13 @@ package rag
 
 import (
 	"context"
+	"errors"
+	"net"
+	"syscall"
 	"testing"
+
+	"github.com/rostamlabs/rostam"
+	"github.com/rostamlabs/rostam/ops"
 )
 
 func TestEmbeddedRetrieverRoundtripBM25(t *testing.T) {
@@ -59,6 +65,110 @@ func TestEmbeddedRetrieverDeleteBySource(t *testing.T) {
 		t.Fatalf("deleted %d, want 1", n)
 	}
 	hits, _ := r.Search(ctx, "docs", "alpha", nil, 5)
+	for _, h := range hits {
+		if h.Source == "a.md" {
+			t.Fatalf("a.md should be gone: %+v", hits)
+		}
+	}
+}
+
+func TestHTTPRetrieverImplementsInterface(t *testing.T) {
+	var _ Retriever = (*HTTPRetriever)(nil) // compile-time interface check
+}
+
+// freeTCPPort returns a loopback address nothing is listening on at the
+// moment it returns. Mirrors mcp.freeTCPPort: there's an unavoidable gap
+// between releasing the reservation and the server binding it, so the caller
+// retries on EADDRINUSE.
+func freeTCPPort(t *testing.T) string {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("reserve port: %v", err)
+	}
+	addr := ln.Addr().String()
+	if err := ln.Close(); err != nil {
+		t.Fatalf("release port: %v", err)
+	}
+	return addr
+}
+
+// startRemoteServer boots an in-process rostam.NewServer on a free loopback
+// TCP port (the wire protocol HTTPRetriever's client actually speaks — this
+// package has no HTTP/httptest server to reuse), retrying only when the port
+// was taken between reservation and bind. Mirrors mcp.startRemoteServer.
+func startRemoteServer(t *testing.T) (*rostam.Server, string) {
+	t.Helper()
+	const attempts = 5
+	for i := 0; i < attempts; i++ {
+		addr := freeTCPPort(t)
+		reg := ops.NewRegistry()
+		if err := ops.RegisterBuiltins(reg); err != nil {
+			t.Fatalf("ops: %v", err)
+		}
+		srv, err := rostam.NewServer(rostam.ServerConfig{
+			TCPAddr:      addr,
+			DirectConfig: rostam.DirectConfig{Ops: reg},
+		})
+		if err == nil {
+			return srv, addr
+		}
+		if !errors.Is(err, syscall.EADDRINUSE) {
+			t.Fatalf("NewServer(%s): %v", addr, err)
+		}
+		t.Logf("attempt %d: %s was taken between reservation and bind, retrying", i+1, addr)
+	}
+	t.Fatalf("no free port survived %d attempts", attempts)
+	return nil, ""
+}
+
+// TestHTTPRetrieverRoundtripBM25 runs the same assertions as
+// TestEmbeddedRetrieverRoundtripBM25 but against NewHTTPRetriever talking to
+// an in-process rostam.NewServer, proving behavioral parity between the two
+// Retriever backends over the wire (not just the shared interface).
+func TestHTTPRetrieverRoundtripBM25(t *testing.T) {
+	srv, addr := startRemoteServer(t)
+	defer func() { _ = srv.Close() }()
+
+	r, err := NewHTTPRetriever(addr)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = r.Close() }()
+	ctx := context.Background()
+
+	if err := r.EnsureCorpus(ctx, "docs", 0); err != nil { // BM25-only
+		t.Fatal(err)
+	}
+	chunks := []StoredChunk{
+		{ID: 1, Content: "the epoll transport picks its loop count from GOMAXPROCS", Source: "a.md", Index: 0},
+		{ID: 2, Content: "raft shards should roughly equal core count", Source: "b.md", Index: 0},
+	}
+	if err := r.Upsert(ctx, "docs", chunks); err != nil {
+		t.Fatal(err)
+	}
+	hits, err := r.Search(ctx, "docs", "epoll loop count", nil, 5)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(hits) == 0 || hits[0].Source != "a.md" {
+		t.Fatalf("expected a.md top hit, got %+v", hits)
+	}
+	if hits[0].Content == "" {
+		t.Fatalf("hit content should be populated: %+v", hits[0])
+	}
+
+	n, err := r.DeleteBySource(ctx, "docs", "a.md")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if n != 1 {
+		t.Fatalf("deleted %d, want 1", n)
+	}
+	hits, err = r.Search(ctx, "docs", "epoll loop count", nil, 5)
+	if err != nil {
+		t.Fatal(err)
+	}
 	for _, h := range hits {
 		if h.Source == "a.md" {
 			t.Fatalf("a.md should be gone: %+v", hits)

--- a/rag/store_test.go
+++ b/rag/store_test.go
@@ -6,11 +6,13 @@ import (
 	"context"
 	"errors"
 	"net"
+	"strings"
 	"syscall"
 	"testing"
 
 	"github.com/rostamlabs/rostam"
 	"github.com/rostamlabs/rostam/ops"
+	"github.com/rostamlabs/rostam/vector"
 )
 
 func TestEmbeddedRetrieverRoundtripBM25(t *testing.T) {
@@ -69,6 +71,37 @@ func TestEmbeddedRetrieverDeleteBySource(t *testing.T) {
 		if h.Source == "a.md" {
 			t.Fatalf("a.md should be gone: %+v", hits)
 		}
+	}
+}
+
+// TestEmbeddedRetrieverEnsureCorpusDimMismatch covers Finding 1 from the
+// whole-branch review: a corpus's Dim is fixed at creation, so re-ingesting
+// the same --corpus with a different dimension (e.g. BM25's dim=1
+// placeholder, then a dense embedder) must refuse cleanly instead of
+// silently succeeding and failing later, deep inside Upsert, as a raw
+// vector.ErrDimMismatch.
+func TestEmbeddedRetrieverEnsureCorpusDimMismatch(t *testing.T) {
+	dir := t.TempDir()
+	r, err := NewEmbeddedRetriever(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = r.Close() }()
+	ctx := context.Background()
+
+	if err := r.EnsureCorpus(ctx, "docs", 0); err != nil { // BM25-only: dim=1 placeholder
+		t.Fatal(err)
+	}
+
+	err = r.EnsureCorpus(ctx, "docs", 8) // now ask for a dense embedder's real dim
+	if err == nil {
+		t.Fatal("expected a dimension-mismatch error, got nil (silent success)")
+	}
+	if !strings.Contains(err.Error(), "dimension") {
+		t.Fatalf("expected an error mentioning the dimension mismatch, got: %v", err)
+	}
+	if errors.Is(err, vector.ErrDimMismatch) {
+		t.Fatalf("expected EnsureCorpus's own actionable error, not a raw vector.ErrDimMismatch: %v", err)
 	}
 }
 

--- a/rag/store_test.go
+++ b/rag/store_test.go
@@ -1,0 +1,67 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package rag
+
+import (
+	"context"
+	"testing"
+)
+
+func TestEmbeddedRetrieverRoundtripBM25(t *testing.T) {
+	dir := t.TempDir() // allocate BEFORE Close cleanup is registered
+	r, err := NewEmbeddedRetriever(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = r.Close() }()
+	ctx := context.Background()
+
+	if err := r.EnsureCorpus(ctx, "docs", 0); err != nil { // BM25-only
+		t.Fatal(err)
+	}
+	chunks := []StoredChunk{
+		{ID: 1, Content: "the epoll transport picks its loop count from GOMAXPROCS", Source: "a.md", Index: 0},
+		{ID: 2, Content: "raft shards should roughly equal core count", Source: "b.md", Index: 0},
+	}
+	if err := r.Upsert(ctx, "docs", chunks); err != nil {
+		t.Fatal(err)
+	}
+	hits, err := r.Search(ctx, "docs", "epoll loop count", nil, 5)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(hits) == 0 || hits[0].Source != "a.md" {
+		t.Fatalf("expected a.md top hit, got %+v", hits)
+	}
+	if hits[0].Content == "" {
+		t.Fatalf("hit content should be populated: %+v", hits[0])
+	}
+}
+
+func TestEmbeddedRetrieverDeleteBySource(t *testing.T) {
+	dir := t.TempDir()
+	r, err := NewEmbeddedRetriever(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = r.Close() }()
+	ctx := context.Background()
+	_ = r.EnsureCorpus(ctx, "docs", 0)
+	_ = r.Upsert(ctx, "docs", []StoredChunk{
+		{ID: 1, Content: "alpha", Source: "a.md", Index: 0},
+		{ID: 2, Content: "beta", Source: "b.md", Index: 0},
+	})
+	n, err := r.DeleteBySource(ctx, "docs", "a.md")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if n != 1 {
+		t.Fatalf("deleted %d, want 1", n)
+	}
+	hits, _ := r.Search(ctx, "docs", "alpha", nil, 5)
+	for _, h := range hits {
+		if h.Source == "a.md" {
+			t.Fatalf("a.md should be gone: %+v", hits)
+		}
+	}
+}


### PR DESCRIPTION
## RAG-in-a-box CLI

A single-binary retrieval-augmented-generation CLI over the existing Rostam engine:

```
rostam-server rag ingest ./docs
rostam-server rag ask "how does the epoll transport pick its loop count?"
rostam-server rag query "epoll loop count"   # retrieval only, no LLM
```

`ask` retrieves the most relevant chunks and calls an LLM to synthesize a grounded, cited answer. `query` returns ranked chunks (no LLM). Built as roadmap **option C** on top of the merged MCP server (#12) and LLM proxy (#14).

### Design (Approach A — thin orchestrator over the existing engine)
- New `rag/` package: `chunk` → `store` (a `Retriever` interface with an in-process embedded backend and an HTTP `--endpoint` backend) → `ingest` → `retrieve` → `ask`. All engine coupling is isolated in `store.go`; the rest is backend-agnostic.
- Reuses `vector.CollectionStore` (`SearchDocs`/`SearchText`/`Upsert`/`DeleteByFilter`), the `semcache` embedder abstraction, and a small self-contained OpenAI-compatible chat client (no `llmproxy` coupling).
- **Embedded by default** (local `--data` dir, nothing to run); `--endpoint` targets a running server.
- **Retrieval:** BM25 when no embedder is configured; dense KNN when one is. (Dense+BM25 *fusion* is an intentional fast-follow — see below.)
- **Secrets are env-only** (`ROSTAM_EMBED_KEY` / `ROSTAM_LLM_KEY`), never flags, matching the repo convention.
- Ingest is **idempotent per source file** (delete-then-upsert with deterministic chunk IDs); re-ingesting an emptied file purges its stale chunks; a dim-change re-ingest is refused with an actionable message rather than a raw engine error.

### Scope
- 17 files, +1594 lines. Blast radius outside the new package/docs is **4 lines** in `cmd/rostam-server/main.go` (one dispatch clause matching the existing `mcp`/`llm-proxy` shape).
- Docs: `docs/server/rag.md` (+ mkdocs nav) and a README section.

### Testing
- `go build ./...`, `go vet`, and `go test ./rag/ ./cmd/rostam-server/` all green.
- Backend parity is covered by a real over-the-wire test that stands up an in-process `rostam.NewServer` and runs the same assertions as the embedded backend (not just a compile-time interface check).

### Fast-follow (not blockers, tracked)
- Dense+BM25 fusion (`HybridText` returns content-less results — needs a content-by-id fetch).
- HTTP-side `EnsureCorpus` dim guard (the client has no read-collection-dim RPC today; embedded path guards, HTTP surfaces the raw error).
- `HTTPRetriever` discards `FanMeta` (partial fan-out signal — only relevant to partitioned collections via `--endpoint`).
- Minor polish: structured-slog shape in one `fatal`, include the LLM error-response body on non-200, a couple of extra edge-case tests.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a RAG command for document ingestion, passage retrieval, and cited question answering.
  - Supports BM25 and dense retrieval, local or remote operation, configurable chunking, embeddings, and LLM providers.
  - Added recursive ingestion for supported text files with idempotent re-ingestion.
  - Added local and HTTP-backed retrieval options.

- **Documentation**
  - Added comprehensive RAG CLI documentation, configuration guidance, supported file types, and offline usage instructions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->