### PR TITLE
feat(mcp): self-teaching memory — initialize instructions + tool-description nudges

### DIFF
--- a/mcp/memory.go
+++ b/mcp/memory.go
@@ -240,7 +240,7 @@ type memoryHit struct {
 func (s *Server) registerMemoryTools() {
 	s.register(toolDef{
 		Name:        "remember",
-		Description: "Store a fact in persistent memory for later recall.",
+		Description: `Store a fact in persistent memory for later recall. Store ONE self-contained, durable fact per call (a decision, gotcha, command, or finding), phrased so it stands alone when recalled later — not transient chatter, and never secrets. Pass namespace = the project directory name so facts stay project-scoped.`,
 		InputSchema: map[string]any{
 			"type": "object",
 			"properties": map[string]any{
@@ -254,7 +254,7 @@ func (s *Server) registerMemoryTools() {
 	})
 	s.register(toolDef{
 		Name:        "recall",
-		Description: "Search stored memories by relevance to a query, scoped to a namespace.",
+		Description: `Search stored memories by relevance to a query, scoped to a namespace. Call this at the START of a task, before re-reading large files or re-exploring a codebase — it's cheaper than rediscovering what you already know. Pass namespace = the project directory name.`,
 		InputSchema: map[string]any{
 			"type": "object",
 			"properties": map[string]any{

--- a/mcp/server.go
+++ b/mcp/server.go
@@ -18,6 +18,18 @@ import (
 
 const protocolVersion = "2025-06-18"
 
+// instructions is the MCP top-level `instructions` string returned from
+// initialize. Clients inject it into the model's context, so it is how the
+// server teaches an agent WHEN to use the memory tools — the tools alone don't
+// convey that. Keep it short, imperative, and client-agnostic.
+const instructions = `Rostam is persistent, namespaced memory for carrying facts across sessions so you don't re-derive what you already know. Use it well:
+- At the start of a nontrivial task, call recall with the task's keywords BEFORE re-reading large files or re-exploring a codebase — recall is cheaper than rediscovery.
+- Namespace per project: pass namespace = the project/repo directory name (not "default") so facts stay scoped and don't collide across projects.
+- When you learn a durable fact (a decision, a gotcha, a build/test command, an investigation result), call remember — one self-contained fact per call, phrased so it still makes sense when recalled later.
+- Prefer recall over re-reading a large file to answer "what did we already establish about X".
+- Never store secrets or credentials.
+- Use list_namespaces and list_memories to orient when unsure what's stored.`
+
 // Config configures a Server.
 type Config struct {
 	Store       rostam.Store      // required: embedded or remote engine
@@ -171,6 +183,9 @@ func (s *Server) dispatch(ctx context.Context, c *conn, req *request) error {
 			// Derived, not written down: a literal here goes stale at the
 			// next release and the client shows a version that never existed.
 			"serverInfo": map[string]any{"name": "rostam", "version": buildinfo.Version()},
+			// Teaches the agent WHEN to use the memory tools; clients inject
+			// this into the model's context.
+			"instructions": instructions,
 		})
 	case "ping":
 		return c.reply(req.ID, map[string]any{})

--- a/mcp/server_test.go
+++ b/mcp/server_test.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"encoding/json"
 	"io"
+	"strings"
 	"testing"
 	"time"
 
@@ -24,12 +25,21 @@ func TestInitializeHandshake(t *testing.T) {
 			Name    string `json:"name"`
 			Version string `json:"version"`
 		} `json:"serverInfo"`
+		Instructions string `json:"instructions"`
 	}
 	if err := json.Unmarshal(res, &init); err != nil {
 		t.Fatalf("decode: %v", err)
 	}
 	if init.ProtocolVersion != "2025-06-18" || init.Capabilities.Tools == nil || init.ServerInfo.Name != "rostam" {
 		t.Fatalf("bad initialize result: %s", res)
+	}
+	// The instructions string is how the server teaches an agent WHEN to use
+	// the memory tools; clients inject it into the model's context. Assert it's
+	// present and carries the load-bearing doctrine, not just non-empty.
+	for _, want := range []string{"recall", "remember", "namespace", "secret"} {
+		if !strings.Contains(strings.ToLower(init.Instructions), want) {
+			t.Errorf("initialize instructions missing %q; got %q", want, init.Instructions)
+		}
 	}
 	// The version used to be a literal "0.1.0" written once and never touched,
 	// so a v0.2.0 binary introduced itself to its client as 0.1.0 and every bug
@@ -43,6 +53,33 @@ func TestInitializeHandshake(t *testing.T) {
 	}
 	if init.ServerInfo.Version == "" {
 		t.Error("serverInfo.version is empty; clients display this")
+	}
+}
+
+func TestMemoryToolDescriptionsCarryUsageNudges(t *testing.T) {
+	c := startServer(t, Config{Store: newHeapStore(t)})
+	c.initialize()
+	res := c.rpc("tools/list", nil, false)
+	var out struct {
+		Tools []struct {
+			Name        string `json:"name"`
+			Description string `json:"description"`
+		} `json:"tools"`
+	}
+	if err := json.Unmarshal(res, &out); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	desc := map[string]string{}
+	for _, tl := range out.Tools {
+		desc[tl.Name] = strings.ToLower(tl.Description)
+	}
+	// recall should nudge "call at task start / before re-reading"; remember
+	// should nudge "one self-contained fact / project namespace / no secrets".
+	if d, ok := desc["recall"]; !ok || !strings.Contains(d, "start") || !strings.Contains(d, "namespace") {
+		t.Errorf("recall description missing usage nudge: %q", desc["recall"])
+	}
+	if d, ok := desc["remember"]; !ok || !strings.Contains(d, "namespace") || !strings.Contains(d, "secret") {
+		t.Errorf("remember description missing usage nudge: %q", desc["remember"])
 	}
 }
 

--- a/mcp/server_test.go
+++ b/mcp/server_test.go
@@ -34,11 +34,23 @@ func TestInitializeHandshake(t *testing.T) {
 		t.Fatalf("bad initialize result: %s", res)
 	}
 	// The instructions string is how the server teaches an agent WHEN to use
-	// the memory tools; clients inject it into the model's context. Assert it's
-	// present and carries the load-bearing doctrine, not just non-empty.
-	for _, want := range []string{"recall", "remember", "namespace", "secret"} {
-		if !strings.Contains(strings.ToLower(init.Instructions), want) {
-			t.Errorf("initialize instructions missing %q; got %q", want, init.Instructions)
+	// the memory tools; clients inject it into the model's context. Assert each
+	// load-bearing doctrine rule is present via a distinctive marker (not just
+	// non-empty, and not the full wording) so a regression that drops any single
+	// rule fails here rather than silently shipping.
+	got := strings.ToLower(init.Instructions)
+	for rule, marker := range map[string]string{
+		"recall-at-task-start":    "recall",
+		"before-re-reading":       "re-reading",
+		"remember-durable-facts":  "remember",
+		"one-self-contained-fact": "self-contained",
+		"namespace-per-project":   "namespace",
+		"never-store-secrets":     "secret",
+		"orient-list-namespaces":  "list_namespaces",
+		"orient-list-memories":    "list_memories",
+	} {
+		if !strings.Contains(got, marker) {
+			t.Errorf("initialize instructions missing the %s rule (marker %q); got %q", rule, marker, init.Instructions)
 		}
 	}
 	// The version used to be a literal "0.1.0" written once and never touched,
@@ -73,13 +85,18 @@ func TestMemoryToolDescriptionsCarryUsageNudges(t *testing.T) {
 	for _, tl := range out.Tools {
 		desc[tl.Name] = strings.ToLower(tl.Description)
 	}
-	// recall should nudge "call at task start / before re-reading"; remember
-	// should nudge "one self-contained fact / project namespace / no secrets".
-	if d, ok := desc["recall"]; !ok || !strings.Contains(d, "start") || !strings.Contains(d, "namespace") {
-		t.Errorf("recall description missing usage nudge: %q", desc["recall"])
+	// Each nudge must survive independently of the exact wording: recall nudges
+	// "at task start / before re-reading / project namespace"; remember nudges
+	// "one self-contained fact / not transient / project namespace / no secrets".
+	for _, marker := range []string{"start", "re-reading", "namespace"} {
+		if d := desc["recall"]; !strings.Contains(d, marker) {
+			t.Errorf("recall description missing %q nudge: %q", marker, d)
+		}
 	}
-	if d, ok := desc["remember"]; !ok || !strings.Contains(d, "namespace") || !strings.Contains(d, "secret") {
-		t.Errorf("remember description missing usage nudge: %q", desc["remember"])
+	for _, marker := range []string{"self-contained", "transient", "namespace", "secret"} {
+		if d := desc["remember"]; !strings.Contains(d, marker) {
+			t.Errorf("remember description missing %q nudge: %q", marker, d)
+		}
 	}
 }
 


### PR DESCRIPTION
## Make the memory feature self-teaching

The MCP server (#12) ships the memory tools (`recall`/`remember`/…) but nothing tells an agent *when* to use them — that usage doctrine currently only exists in individual users' hand-written CLAUDE.md files. This bakes it into the product through two **client-agnostic** channels (works in Cursor, Claude Desktop, Claude Code, any MCP client — not a single-harness skill):

1. **`initialize` `instructions` field** — the MCP spec's top-level server instructions, which clients inject into the model's context. Carries the ~6-rule doctrine: recall-at-task-start, namespace-per-project, one-self-contained-fact-per-remember, prefer-recall-over-re-reading, never-store-secrets, list-to-orient.
2. **`recall` / `remember` tool-description nudges** — a short when-to-call hint on the two load-bearing tools, so the guidance is present even where a client doesn't surface `instructions` prominently.

### Changes
- `mcp/server.go`: add an `instructions` const and return it from `initialize`.
- `mcp/memory.go`: enrich the `recall` and `remember` tool descriptions.
- `mcp/server_test.go`: assert `initialize` returns instructions carrying the load-bearing terms (recall/remember/namespace/secret), and that the `recall`/`remember` descriptions carry their usage nudges.

### Testing
`go build ./...`, `go vet ./mcp/`, `go test ./mcp/`, and `golangci-lint run ./mcp/...` all green.

### Non-goals
No standalone Claude Code skill and no copy-paste CLAUDE.md snippet — deliberately chosen against in favor of the universal channels above, for cross-client adoption reach.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added guidance for using memory tools to retain durable, project-scoped facts.
  * Clarified that memory should be recalled at the start of tasks and organized by namespace.
  * Added reminders not to store secrets or sensitive information.
  * Updated memory-tool descriptions with clearer usage and security guidance.

* **Tests**
  * Expanded validation of server instructions and memory-tool guidance during initialization.
  * Added checks confirming that memory tools provide namespace and safe-usage recommendations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->