### PR TITLE
Put the mark on the docs and the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+<img src="docs/assets/logo.svg" alt="" width="64" height="64">
+
 # Rostam
 
 [![CI](https://github.com/rostamlabs/rostam/actions/workflows/test.yml/badge.svg)](https://github.com/rostamlabs/rostam/actions/workflows/test.yml)

--- a/docs/assets/favicon.svg
+++ b/docs/assets/favicon.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <rect width="32" height="32" rx="7" fill="#070A13"/>
+  <g fill="none" stroke="#E5A83D" stroke-width="1.7" stroke-linejoin="round">
+    <rect x="8.4" y="8.4" width="15.2" height="15.2"/>
+    <rect x="8.4" y="8.4" width="15.2" height="15.2" transform="rotate(45 16 16)"/>
+  </g>
+  <circle cx="16" cy="16" r="2.2" fill="#E5A83D"/>
+</svg>

--- a/docs/assets/logo.svg
+++ b/docs/assets/logo.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 32 32"><g fill="none" stroke="#e5a83d" stroke-width="1.7" stroke-linejoin="round"><rect x="8.4" y="8.4" width="15.2" height="15.2"/><rect x="8.4" y="8.4" width="15.2" height="15.2" transform="rotate(45 16 16)"/></g><circle cx="16" cy="16" r="2.2" fill="#e5a83d"/></svg>

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -22,6 +22,11 @@ exclude_docs: |
 
 theme:
   name: material
+  # The mark the landing page and the repo use. Material falls back to its own
+  # generic icon when these are unset, which quietly puts a third identity in
+  # front of anyone reading the docs.
+  logo: assets/logo.svg
+  favicon: assets/favicon.svg
   # The landing page self-hosts its faces; the docs load the same files from
   # docs/assets/fonts via rostam.css. Leaving this unset would pull Roboto from
   # Google Fonts and quietly break the shared identity (and add a third-party


### PR DESCRIPTION
Keeps the existing mark — the khatam star already shipping as the site favicon — and puts it on the surfaces that had nothing.

## What changes

- `docs/assets/logo.svg` + `docs/assets/favicon.svg`, wired into `mkdocs.yml` as `theme.logo` / `theme.favicon`. Previously Material fell back to its own generic icon, so docs.rostamlabs.com showed a third identity after the landing page and the repo.
- The mark at the top of `README.md`.

## One non-obvious detail

The SVG carries explicit `width` and `height`. That is load-bearing, not tidiness: Material sizes the header logo with `height:1.2rem;width:auto`, and an SVG used as `<img src>` with only a `viewBox` has **no intrinsic size**, so `width:auto` computes to zero and the mark renders as nothing at all.

The markup looks identical either way — `<img src="assets/logo.svg">` is emitted correctly in both cases. It took rendering the page and looking at it to catch.

Also worth recording so nobody re-debugs it: **Material hides the header logo below `76.1875em`** (about 1219px). It is invisible in a narrow window by design. I lost a round to that after fixing the real bug.

## Verified

`mkdocs build --strict` passes, the assets land in the built site, and the mark renders in the header above the breakpoint.

The README uses a stacked image rather than `align="left"` — a float would wrap the badges and the intro paragraph around it, and GitHub's rendering is not something I can preview locally.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added the Rostam logo to the project README.
  * Updated documentation branding with a logo and favicon for a more consistent visual experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->