### PR TITLE
docs(changelog): cover the RAG CLI, hybrid fusion and the MCP doctrine

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -16,7 +16,10 @@ rostam-server rag query "How does the LLM proxy decide what's cacheable?"
 ```
 
 `ingest` chunks and indexes every recognized file into a local corpus
-(`./.rostam-rag` by default), `query` returns the matching chunks with a
+(`./.rostam-rag` by default) — recognized meaning a known text extension whose
+contents are valid UTF-8; anything else is skipped and reported, and a source
+that *becomes* invalid has its stale chunks purged rather than left to be
+returned by searches. `query` returns the matching chunks with a
 `source#chunk-index` and score, and `ask` sends them to an LLM and prints an
 answer that cites the chunks it used. There is no separate ingestion service
 and no vector store to stand up first.

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -3,6 +3,66 @@
 Notable user-visible changes. Entries that alter existing behaviour are marked
 **Breaking** and say what to do about it.
 
+## v0.3.0 — 2026-08-16
+
+### A RAG CLI with no pipeline to assemble
+
+`rostam-server rag` turns the engine into a retrieval-augmented-generation tool
+you can point at a directory:
+
+```sh
+rostam-server rag ingest ./docs
+rostam-server rag query "How does the LLM proxy decide what's cacheable?"
+```
+
+`ingest` chunks and indexes every recognized file into a local corpus
+(`./.rostam-rag` by default), `query` returns the matching chunks with a
+`source#chunk-index` and score, and `ask` sends them to an LLM and prints an
+answer that cites the chunks it used. There is no separate ingestion service
+and no vector store to stand up first.
+
+As with the MCP server, it does something useful before you configure anything:
+retrieval runs on BM25 with no embedder, no API key and no network. Pointing it
+at an OpenAI-compatible embedding endpoint upgrades retrieval in place, without
+changing the commands. Full flag and file-type reference:
+[RAG CLI](server/rag.md).
+
+### Retrieval fuses dense and BM25 by default
+
+With an embedder configured, `rag query` and `rag ask` now run **both** a dense
+KNN search and a BM25 search and fuse the two ranked lists, rather than
+searching dense alone. Fusion is reciprocal-rank by default, with a weighted
+rank-blend available; chunks are deduplicated on `source#index`, and ties break
+in a fixed first-seen order so the same corpus and query always produce the same
+output.
+
+This matters because the two lanes fail differently: dense retrieval misses
+exact identifiers, error strings and flag names that a user copies verbatim into
+a question, and BM25 misses paraphrase. Fusing them covers both without asking
+the user to know which kind of question they are asking.
+
+`-no-hybrid` restores pure dense KNN. Note the returned `Score` is the fusion
+score, not the original per-lane score — they are not comparable across modes.
+
+### The MCP server explains itself to the agent
+
+Tool schemas say what a tool does; they do not say *when* to reach for it. So an
+agent with memory available would still re-read a file it had already
+summarised. The server now returns MCP's top-level `instructions` from
+`initialize` — clients inject it into the model's context — and the `remember`
+and `recall` descriptions carry the same guidance at the point of use.
+
+The doctrine is short and deliberate: recall at the start of a task before
+re-exploring a codebase, namespace per project rather than `default`, one
+self-contained durable fact per `remember`, and never store secrets.
+
+### Fixed: the MCP server reported the wrong version
+
+`initialize` answered with a hardcoded `0.1.0`, so a v0.2.0 binary introduced
+itself to Claude Code, Cursor and every other client as 0.1.0 — and every bug
+report filed through an MCP client named the wrong release. It now reports the
+binary's real version, derived from the same source `-version` uses.
+
 ## v0.2.0 — 2026-08-15
 
 ### The MCP server: agent memory with nothing to set up


### PR DESCRIPTION
Release-blocking, and the second time this exact gap has appeared.

Four user-visible changes have landed since v0.2.0 — each with a docs page, README updates and tests — and **not one changelog entry between them**.

## The sharp end

`README.md` on `main` tells people to run:

```sh
rostam-server rag ask "How does the LLM proxy decide what's cacheable?"
```

That subcommand **does not exist in v0.2.0**, which is what `curl | sh` installs. Anyone who installs today and follows the README gets an unknown-subcommand error. This is precisely the failure that made v0.2.0 necessary, recurring three weeks later with a different subcommand.

Main is 31 commits ahead of the tag.

## What this adds

- **`rostam-server rag`** (#17) — ingest / query / ask, `./.rostam-rag` corpus, cited answers. Leads with the property that makes it testable in one command: BM25 retrieval works with no embedder, no API key and no network.
- **Dense+BM25 fusion by default** (#20) — including the part a user can actually be bitten by: the returned `Score` is the *fusion* score, not the per-lane score, so it is not comparable across modes. Also records why fusing matters — dense misses verbatim identifiers and error strings, BM25 misses paraphrase.
- **The MCP `instructions` doctrine** (#18) — tool schemas say what a tool does, not when to reach for it, which is why an agent with memory available still re-reads a file it already summarised.
- **The serverInfo version fix** (#16) — why clients currently report `0.1.0`.

## Why v0.3.0

A new subcommand plus a retrieval-behaviour change is a feature release, not a patch.

## Follow-up

A separate PR adds a CI guard so this stops depending on someone remembering. Twice is a pattern.

`mkdocs build --strict` passes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a standalone RAG command-line interface supporting document ingestion, search queries, and LLM-assisted answers.
  * Added hybrid dense and BM25 retrieval with result merging, deduplication, and deterministic ranking.
  * Added an option for dense-only retrieval.

* **Documentation**
  * Added MCP initialization instructions and expanded guidance for memory tools.
  * Documented accurate version reporting from the command-line binary.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->