### PR TITLE
ci: require a changelog entry for user-visible changes

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -1,0 +1,89 @@
+name: changelog
+
+# A user-visible change that never reaches docs/changelog.md is invisible to
+# everyone who was not in the PR. That has now happened twice: the MCP server
+# and the LLM proxy shipped unlisted and were caught only while cutting v0.2.0,
+# and the RAG CLI, hybrid fusion and the MCP doctrine repeated it before v0.3.0
+# — by which point README.md was telling people to run a subcommand the
+# released binary did not have.
+#
+# Both times the fix was a person noticing. This makes it the pipeline's job.
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, labeled, unlabeled]
+
+permissions:
+  contents: read
+
+jobs:
+  entry:
+    name: user-visible change has a changelog entry
+    runs-on: ubuntu-latest
+    # An escape hatch that is deliberately explicit: a PR that genuinely has no
+    # user-visible surface (a refactor, a test-only change) gets the label and
+    # says so in the open, rather than the check being silently weakened for
+    # everyone.
+    if: ${{ !contains(github.event.pull_request.labels.*.name, 'no-changelog') }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Check
+        env:
+          BASE: ${{ github.event.pull_request.base.sha }}
+          HEAD: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -euo pipefail
+
+          # Paths whose contents a user can observe: the CLI surface, the
+          # documented subcommands, the wire, and the client libraries.
+          #
+          # README.md is deliberately NOT here. It gets touched for typos,
+          # badges and logos, and firing on those trains people to reach for
+          # the label — which would hollow out the check. Nothing is lost:
+          # a feature documented in the README always ships code alongside it,
+          # and the code paths below catch that.
+          WATCHED='^(cmd/|mcp/|rag/|llmproxy/|httpapi/|server/|clients/)'
+
+          changed=$(git diff --name-only "$BASE".."$HEAD")
+
+          # A PR that only touches tests is not a user-visible change, so strip
+          # test files before deciding. Without this the guard fires on
+          # test-only follow-ups and trains people to reach for the label.
+          user_visible=$(printf '%s\n' "$changed" \
+            | grep -E "$WATCHED" \
+            | grep -vE '(_test\.go$|/testdata/|^clients/python/tests/)' \
+            || true)
+
+          if [ -z "$user_visible" ]; then
+            echo "No user-visible paths touched — nothing to require."
+            exit 0
+          fi
+
+          echo "User-visible paths in this PR:"
+          printf %s\\n "$user_visible" | sed "s/^/  /"
+
+          if printf '%s\n' "$changed" | grep -qx 'docs/changelog.md'; then
+            echo
+            echo "docs/changelog.md is updated. OK."
+            exit 0
+          fi
+
+          cat >&2 <<'EOF'
+
+          This PR changes something a user can observe, but does not touch
+          docs/changelog.md.
+
+          Add an entry under the top heading describing the change from the
+          reader's side — what they can now do, and anything that will bite
+          them. If the change genuinely has no user-visible surface, apply the
+          `no-changelog` label to say so explicitly.
+
+          Why this check exists: the MCP server and the LLM proxy both shipped
+          with no changelog entry and were caught only while cutting a release.
+          The RAG CLI then did it again, and README.md spent that whole window
+          telling people to run a subcommand the released binary did not have.
+          EOF
+          exit 1

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -47,7 +47,13 @@ jobs:
           # and the code paths below catch that.
           WATCHED='^(cmd/|mcp/|rag/|llmproxy/|httpapi/|server/|clients/)'
 
-          changed=$(git diff --name-only "$BASE".."$HEAD")
+          # Three-dot: diff from the merge-base, i.e. only what this PR
+          # introduces. Two-dot compares the two tips, so anything that landed
+          # on the base branch after this PR diverged shows up as part of it —
+          # and for THIS check that is self-defeating: an unrelated changelog
+          # edit on main would appear in the range and silently pass a PR that
+          # has no entry of its own. Demonstrated, not theorised.
+          changed=$(git diff --name-only "$BASE"..."$HEAD")
 
           # A PR that only touches tests is not a user-visible change, so strip
           # test files before deciding. Without this the guard fires on


### PR DESCRIPTION
Makes the changelog gap the pipeline's problem instead of someone's memory.

Twice now a user-visible change has shipped unlisted, and both times it was caught while cutting a release rather than at the PR:

- **MCP server + LLM proxy** — caught while cutting v0.2.0.
- **RAG CLI + hybrid fusion + MCP doctrine** — caught while cutting v0.3.0. That window was worse: `README.md` spent it telling people to run `rostam-server rag ask`, a subcommand the released binary did not have.

Twice is a pattern, not an oversight.

## What it does

Fails a PR that touches `cmd/`, `mcp/`, `rag/`, `llmproxy/`, `httpapi/`, `server/` or `clients/` without touching `docs/changelog.md`. A **`no-changelog`** label opts out — deliberately visible, so a genuine refactor says so out loud rather than the check being quietly weakened for everyone.

## The two exclusions matter more than the rule

A guard that fires on innocent PRs teaches people to reach for the label, and then it catches nothing.

- **Test-only changes don't count.** `_test.go`, `testdata/`, `clients/python/tests/`.
- **`README.md` is not watched** — though it was in my first draft. It gets edited for typos, badges and logos, and **the logo PR (#19) failed that draft.** Nothing is lost: a feature documented in the README always ships code alongside it, and the code paths catch that.

## Verified against real history

I extracted the script from the YAML and ran it over four actual commit ranges rather than reasoning about it:

| Range | Expected | Result |
|---|---|---|
| RAG fusion merge (#20) | fail | ✅ fail |
| RAG CLI merge (#17) | fail | ✅ fail |
| Logo PR (#19) | pass | ✅ pass |
| Changelog PR (#21) | pass | ✅ pass |

The first two are the PRs this check exists to have caught. The README exclusion exists *because* the third one failed the first draft — that's the test finding the design flaw, not me anticipating it.

## Security

`base.sha` / `head.sha` reach the shell through `env:` rather than direct `${{ }}` interpolation. They're hex and not attacker-controlled, but the safe pattern costs nothing and the next person editing this file may add something that is. No titles, bodies or refs are interpolated anywhere.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Added automated checks to ensure pull requests with user-visible changes include a changelog entry.
  - Validation covers key application areas while excluding tests and test data.
  - Pull requests marked as exempt can bypass the requirement.
  - Checks pass when the changelog is updated and provide clear guidance when an entry is missing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->