### PR TITLE
docs: fix the install, show Python beside Go, and the Go example that never ran

### DIFF
--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -35,8 +35,19 @@ runtime dependencies.
     ```
 
     Multi-arch (amd64/arm64). The image binds `0.0.0.0`, so it **requires** a
-    token — passing it by environment variable keeps the secret out of the
-    process table and out of `docker inspect`.
+    token. An environment variable keeps it off the command line and out of
+    `ps`, but it is *not* hidden: `docker inspect` shows it under `Config.Env`.
+    For anything beyond local use, mount a secret or use your orchestrator's
+    secret store.
+
+    The image serves **HTTP only** — its default command is
+    `-http 0.0.0.0:8080` and only 8080 is exposed. To also speak the binary TCP
+    protocol, override the command and publish the port:
+
+    ```sh
+    docker run -p 8080:8080 -p 8081:8081 -e ROSTAM_API_KEY=secret \
+      ghcr.io/rostamlabs/rostam -http 0.0.0.0:8080 -tcp 0.0.0.0:8081
+    ```
 
 === "Go"
 
@@ -74,8 +85,13 @@ without the token.
 
 ## Your first search
 
-Create a collection, add a point, and search it. Against the container, add
-`-H 'Authorization: Bearer secret'` (curl) or pass the token to the client.
+Create a collection, add a point, and search it. These target the **loopback**
+server from [Run it](#run-it), which needs no token.
+
+Against the container, authenticate every call: add
+`-H 'Authorization: Bearer secret'` to each curl, construct the Python client as
+`RostamClient("http://localhost:8080", api_key="secret")`, and set
+`ClientConfig.AuthToken` in Go.
 
 === "curl"
 
@@ -125,6 +141,7 @@ Create a collection, add a point, and search it. Against the container, add
 === "Go"
 
     ```sh
+    go mod init example.com/myapp    # modern Go needs a module first
     go get github.com/rostamlabs/rostam
     ```
 
@@ -143,7 +160,8 @@ Create a collection, add a point, and search it. Against the container, add
     func main() {
     	ctx := context.Background()
 
-    	// Talks to the -tcp port, not -http.
+    	// The -tcp port from "Run it" above, not -http. The container does not
+    	// serve TCP unless you override its command as shown in Install.
     	store, err := rostam.NewClient(rostam.ClientConfig{
     		Servers: []string{"127.0.0.1:8081"},
     	})

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -7,25 +7,59 @@ mode — the server and Python paths first, the Go embedding paths after.
 
 ## Requirements
 
-- **Go 1.26+** for library use and building the server.
+**Nothing, to run the server.** It ships as a single static binary with no
+runtime dependencies.
+
+- **Go 1.26+** only if you embed the library or build from source.
 - The default full-module build requires **cgo** (the WASM stored-procedure
   backend uses `wasmtime-go`). The vector engine and cache packages are pure Go —
   see [Development](development.md#building) for `CGO_ENABLED=0` builds.
 - mmap persistence and the AVX2 kernels are Linux/amd64; everything has a
   portable fallback.
 
-## Run the server
+## Install the server
+
+=== "Install script"
+
+    ```sh
+    curl -fsSL https://rostamlabs.com/install.sh | sh
+    ```
+
+    Detects your OS and architecture, downloads the matching release binary and
+    puts it in `~/.local/bin`. Set `ROSTAM_INSTALL_DIR` to place it elsewhere.
+
+=== "Docker"
+
+    ```sh
+    docker run -p 8080:8080 -e ROSTAM_API_KEY=secret ghcr.io/rostamlabs/rostam
+    ```
+
+    Multi-arch (amd64/arm64). The image binds `0.0.0.0`, so it **requires** a
+    token — passing it by environment variable keeps the secret out of the
+    process table and out of `docker inspect`.
+
+=== "Go"
+
+    ```sh
+    go install github.com/rostamlabs/rostam/cmd/rostam-server@latest
+    ```
+
+=== "From source"
+
+    ```sh
+    git clone https://github.com/rostamlabs/rostam
+    cd rostam
+    go build -o rostam-server ./cmd/rostam-server
+    ```
+
+## Run it
 
 `rostam-server` exposes the same engine over three transports: REST (`-http`),
-gRPC (`-grpc`), and a compact binary TCP protocol (`-tcp`). From a clone of the
-repo:
+gRPC (`-grpc`), and a compact binary TCP protocol (`-tcp`). Start it with REST
+and TCP on loopback, persisting to `./data`:
 
 ```sh
-git clone https://github.com/rostamlabs/rostam
-cd rostam
-
-# Single node: REST on loopback :8080, persisted to ./data
-go run ./cmd/rostam-server -http 127.0.0.1:8080 -data ./data
+rostam-server -http 127.0.0.1:8080 -tcp 127.0.0.1:8081 -data ./data
 ```
 
 !!! note "Non-loopback binds require authentication"
@@ -35,64 +69,130 @@ go run ./cmd/rostam-server -http 127.0.0.1:8080 -data ./data
     `ROSTAM_API_KEY`, or pass `-insecure` to run open deliberately — see
     [Security](server/security.md).
 
-### In a container
-
-The image binds `0.0.0.0`, so it requires a token. Passing it by environment
-variable keeps the secret out of the process table and out of `docker inspect`:
-
-```sh
-docker build -f cmd/rostam-server/Dockerfile -t rostam-server .
-docker run -p 8080:8080 -e ROSTAM_API_KEY=secret rostam-server
-```
-
-`GET /v1/health` and `/v1/ready` remain auth-exempt so orchestrator probes work
+`GET /v1/health` and `/v1/ready` stay auth-exempt so orchestrator probes work
 without the token.
 
-Create a collection, insert a point, and search — with plain curl. These assume
-the loopback server above; against the container, add
-`-H 'Authorization: Bearer secret'` to each call:
+## Your first search
 
-```sh
-# Create a 4-dimensional cosine collection
-curl -s localhost:8080/v1/collections \
-  -d '{"name":"docs","config":{"dim":4,"metric":"cosine"}}'
+Create a collection, add a point, and search it. Against the container, add
+`-H 'Authorization: Bearer secret'` (curl) or pass the token to the client.
 
-# Upsert a point (metadata values use a tagged encoding — see docs/vector/filtering.md)
-curl -s localhost:8080/v1/collections/docs/points \
-  -d '{"id":1,"vector":[0.1,0.2,0.3,0.4],"content":"hello rostam",
-       "metadata":{"tenant":{"kind":"string","str":"acme"}},"upsert":true}'
+=== "curl"
 
-# Search
-curl -s localhost:8080/v1/collections/docs/points/search \
-  -d '{"query":[0.1,0.2,0.3,0.4],"k":3}'
-```
+    ```sh
+    # Create a 4-dimensional cosine collection
+    curl -s localhost:8080/v1/collections \
+      -d '{"name":"docs","config":{"dim":4,"metric":"cosine"}}'
+
+    # Upsert a point. Metadata values use a tagged encoding — see Filtering.
+    curl -s localhost:8080/v1/collections/docs/points \
+      -d '{"id":1,"vector":[0.1,0.2,0.3,0.4],"content":"hello rostam",
+           "metadata":{"tenant":{"kind":"string","str":"acme"}},"upsert":true}'
+
+    # Search
+    curl -s localhost:8080/v1/collections/docs/points/search \
+      -d '{"query":[0.1,0.2,0.3,0.4],"k":3}'
+    ```
+
+=== "Python"
+
+    ```sh
+    pip install rostam-client
+    ```
+
+    ```python
+    from rostam import RostamClient, filters as f
+
+    c = RostamClient("http://localhost:8080")
+
+    c.create_collection("docs", dim=4, metric="cosine")
+    c.upsert("docs", 1, [0.1, 0.2, 0.3, 0.4],
+             content="hello rostam",
+             metadata={"tenant": "acme"})
+
+    # search() returns ids, distances and scores.
+    hits = c.search("docs", [0.1, 0.2, 0.3, 0.4], k=3)
+
+    # search_docs() returns the stored content too, and takes a filter.
+    docs = c.search_docs("docs", [0.1, 0.2, 0.3, 0.4], k=3,
+                         filter=f.eq("tenant", "acme"))
+    print([(d.id, d.content) for d in docs])
+    ```
+
+    The client sends plain Python values — it applies the tagged metadata
+    encoding for you. Full reference: [Python client](api/python.md).
+
+=== "Go"
+
+    ```sh
+    go get github.com/rostamlabs/rostam
+    ```
+
+    ```go
+    package main
+
+    import (
+    	"context"
+    	"fmt"
+    	"log"
+
+    	"github.com/rostamlabs/rostam"
+    	"github.com/rostamlabs/rostam/vector"
+    )
+
+    func main() {
+    	ctx := context.Background()
+
+    	// Talks to the -tcp port, not -http.
+    	store, err := rostam.NewClient(rostam.ClientConfig{
+    		Servers: []string{"127.0.0.1:8081"},
+    	})
+    	if err != nil {
+    		log.Fatal(err)
+    	}
+    	defer store.Close()
+
+    	// M / EfConstruction / EfSearch are required here — unlike the REST and
+    	// Python paths, the Go API does not fill them in.
+    	if err := store.CreateCollection(ctx, "docs", rostam.VectorConfig{
+    		Dim: 4, Metric: vector.Cosine,
+    		M: 16, EfConstruction: 200, EfSearch: 64,
+    	}); err != nil {
+    		log.Fatal(err)
+    	}
+
+    	if err := store.VectorUpsert(ctx, "docs", 1,
+    		[]float32{0.1, 0.2, 0.3, 0.4}, "hello rostam",
+    		rostam.VectorInsertOpts{}); err != nil {
+    		log.Fatal(err)
+    	}
+
+    	hits, err := store.VectorSearch(ctx, "docs", []float32{0.1, 0.2, 0.3, 0.4}, 3)
+    	if err != nil {
+    		log.Fatal(err)
+    	}
+    	fmt.Println(hits)
+    }
+    ```
+
+    Full reference: [Go client](api/go-client.md).
 
 The full endpoint inventory is in the [HTTP API reference](api/http.md). To add
 authentication and TLS, see [Security](server/security.md); for multi-node
 clusters, see [Clustering](server/clustering.md).
 
-## Use it from Python
+## Large initial loads
 
-The Python client is a dependency-free REST wrapper (source lives under
-`clients/python`):
-
-```sh
-pip install rostam-client
-```
+For a first bulk import, `bulk_stage(...)` + `bulk_build(...)` ship vectors over
+a binary wire and build the index on all cores — far faster than upserting point
+by point:
 
 ```python
-from rostam import RostamClient
-
-c = RostamClient("http://localhost:8080")
-c.create_collection("docs", dim=4)
-c.upsert("docs", 1, [0.1, 0.2, 0.3, 0.4], content="hello rostam",
-         metadata={"tenant": "acme"})
-hits = c.search_docs("docs", [0.1, 0.2, 0.3, 0.4], k=3)
+c.bulk_stage("docs", ids, vectors)
+c.bulk_build("docs")          # concurrent build, all cores
 ```
 
-For large initial loads, `c.bulk_stage(...)` + `c.bulk_build(...)` ship vectors
-over a binary wire and build the index on all cores. Full method reference:
-[Python client](api/python.md).
+Full method reference: [Python client](api/python.md).
 
 ## Embedded vector search (Go library)
 
@@ -117,6 +217,11 @@ func main() {
 		Dim:    768,
 		Metric: vector.Cosine,
 		Quant:  vector.QuantSQ8, // int8 codes: 4× smaller, ~98% recall retained
+
+		// Required: the HNSW path validates these and does not fill them in.
+		M:              16,
+		EfConstruction: 200,
+		EfSearch:       64,
 	})
 	if err != nil {
 		panic(err)

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -170,8 +170,8 @@ Against the container, authenticate every call: add
     	}
     	defer store.Close()
 
-    	// M / EfConstruction / EfSearch are required here — unlike the REST and
-    	// Python paths, the Go API does not fill them in.
+    	// M / EfConstruction / EfSearch default to 16 / 200 / 64 when omitted,
+    	// as they do over REST and Python. Set here to keep the tuning visible.
     	if err := store.CreateCollection(ctx, "docs", rostam.VectorConfig{
     		Dim: 4, Metric: vector.Cosine,
     		M: 16, EfConstruction: 200, EfSearch: 64,
@@ -236,7 +236,8 @@ func main() {
 		Metric: vector.Cosine,
 		Quant:  vector.QuantSQ8, // int8 codes: 4× smaller, ~98% recall retained
 
-		// Required: the HNSW path validates these and does not fill them in.
+		// Optional — these default to 16 / 200 / 64. Shown so the recall/latency
+		// dials are visible in the example you copy from.
 		M:              16,
 		EfConstruction: 200,
 		EfSearch:       64,

--- a/docs/vector/collections-and-indexes.md
+++ b/docs/vector/collections-and-indexes.md
@@ -24,10 +24,9 @@ col, err := vector.NewCollection("docs", vector.Config{
 | `MaxEfSearch` | 1024 | cap on the automatic ef widening filtered search uses; unfiltered search ignores it |
 | `Seed` | 0 | RNG seed for deterministic builds |
 
-† **Defaulted over HTTP and from the Python client, but required in the Go
-library.** `vector.NewCollection` validates these and rejects zero with
-`vector: invalid M (must be > 0 and <= 128)`; only the Vamana path fills them
-in. Set them explicitly in Go:
+† **Defaulted to 16 / 200 / 64 when omitted**, on every entry point — the HTTP
+API, the Python client and the Go library alike. Setting them explicitly is
+optional; the examples below do so to keep the recall/latency dials visible:
 
 === "Go"
 
@@ -36,7 +35,7 @@ in. Set them explicitly in Go:
     	Dim:    768,
     	Metric: vector.Cosine,
 
-    	M:              16,   // required here — not defaulted
+    	M:              16,   // optional — shown to make the dial visible
     	EfConstruction: 200,
     	EfSearch:       64,
     })

--- a/docs/vector/collections-and-indexes.md
+++ b/docs/vector/collections-and-indexes.md
@@ -48,8 +48,9 @@ in. Set them explicitly in Go:
     # The server fills in M / ef_construction / ef_search when omitted.
     c.create_collection("docs", dim=768, metric="cosine")
 
-    # ...or set them explicitly.
-    c.create_collection("docs", dim=768, metric="cosine",
+    # The same collection with the knobs set explicitly. These are
+    # alternatives — creating "docs" twice raises "collection already exists".
+    c.create_collection("docs-tuned", dim=768, metric="cosine",
                         m=16, ef_construction=200, ef_search=64)
     ```
 

--- a/docs/vector/collections-and-indexes.md
+++ b/docs/vector/collections-and-indexes.md
@@ -18,11 +18,40 @@ col, err := vector.NewCollection("docs", vector.Config{
 |---|---|---|
 | `Dim` | — (required) | vector dimensionality |
 | `Metric` | — | `Cosine`, `L2`, or `DotProduct` |
-| `M` | 16 | HNSW graph degree |
-| `EfConstruction` | 200 | build-time beam width |
-| `EfSearch` | 64 | query-time beam width (recall/latency dial) |
+| `M` | 16 † | HNSW graph degree |
+| `EfConstruction` | 200 † | build-time beam width |
+| `EfSearch` | 64 † | query-time beam width (recall/latency dial) |
 | `MaxEfSearch` | 1024 | cap on the automatic ef widening filtered search uses; unfiltered search ignores it |
 | `Seed` | 0 | RNG seed for deterministic builds |
+
+† **Defaulted over HTTP and from the Python client, but required in the Go
+library.** `vector.NewCollection` validates these and rejects zero with
+`vector: invalid M (must be > 0 and <= 128)`; only the Vamana path fills them
+in. Set them explicitly in Go:
+
+=== "Go"
+
+    ```go
+    col, err := vector.NewCollection("docs", vector.Config{
+    	Dim:    768,
+    	Metric: vector.Cosine,
+
+    	M:              16,   // required here — not defaulted
+    	EfConstruction: 200,
+    	EfSearch:       64,
+    })
+    ```
+
+=== "Python"
+
+    ```python
+    # The server fills in M / ef_construction / ef_search when omitted.
+    c.create_collection("docs", dim=768, metric="cosine")
+
+    # ...or set them explicitly.
+    c.create_collection("docs", dim=768, metric="cosine",
+                        m=16, ef_construction=200, ef_search=64)
+    ```
 
 Higher `M`/`EfConstruction` buys recall at build cost; `EfSearch` is the runtime
 knob you tune first.

--- a/docs/vector/filtering.md
+++ b/docs/vector/filtering.md
@@ -108,6 +108,7 @@ an ordering, and inventing one leaves `x >= 3 AND x <= 2` matching a NaN row.
 from rostam import RostamClient, filters as f
 
 c = RostamClient("http://localhost:8080")
+query = [0.1, 0.2, 0.3, 0.4]   # your embedding model's output
 
 c.search_docs("docs", query, k=5, filter=f.eq("tenant", "acme"))
 c.search_docs("docs", query, k=5, filter=f.in_("tenant", ["acme", "beta"]))
@@ -125,6 +126,7 @@ out of reach: a filter is just a dict, so spell out the JSON form and pass it
 directly.
 
 ```python
+# Continues from the client and `query` above.
 # Full-text match — no helper, so write the wire form.
 c.search_docs("docs", query, k=5, filter={
     "op": "match", "field": "$content",

--- a/docs/vector/filtering.md
+++ b/docs/vector/filtering.md
@@ -100,6 +100,41 @@ an ordering, and inventing one leaves `x >= 3 AND x <= 2` matching a NaN row.
     both paths answer the same question. To keep such points matchable, write a
     real sentinel value instead of NaN.
 
+## Building filters from Python
+
+`rostam.filters` has helpers for the operators you reach for most:
+
+```python
+from rostam import RostamClient, filters as f
+
+c = RostamClient("http://localhost:8080")
+
+c.search_docs("docs", query, k=5, filter=f.eq("tenant", "acme"))
+c.search_docs("docs", query, k=5, filter=f.in_("tenant", ["acme", "beta"]))
+c.search_docs("docs", query, k=5,
+              filter=f.and_(f.gte("year", 2021), f.eq("tenant", "beta")))
+```
+
+Helpers exist for `eq`, `ne`, `gt`, `gte`, `lt`, `lte`, `in_`, `contains`,
+`and_`, `or_` and `not_` — note the trailing underscore on the three that would
+otherwise collide with Python keywords.
+
+**The rest of the operator table has no helper**, including `match`, `regex`,
+`is_empty`, `is_null`, the datetime bounds and the geo predicates. They are not
+out of reach: a filter is just a dict, so spell out the JSON form and pass it
+directly.
+
+```python
+# Full-text match — no helper, so write the wire form.
+c.search_docs("docs", query, k=5, filter={
+    "op": "match", "field": "$content",
+    "value": {"kind": "string", "str": "gamma"},
+})
+```
+
+Note that raw dicts take the **tagged** value encoding shown above; only the
+helpers accept plain Python values.
+
 ## The filter-first planner (why filtered recall doesn't collapse)
 
 Filtered ANN has a classic failure mode: **post-filtering** (search the graph,

--- a/docs/vector/hybrid-search.md
+++ b/docs/vector/hybrid-search.md
@@ -9,12 +9,27 @@ A sparse vector is `{Indices []uint32, Values []float32}` with strictly
 ascending indices — typically SPLADE/BM25-style term weights. Attach one to a
 point at write time (the `sparse` parameter on insert/upsert), then:
 
-```go
-hits, err := col.HybridSearch(denseQuery, sparseQuery, 10, vector.HybridOpts{
-	Method: vector.FusionRRF, // RRF | Weighted | DBSF
-	Filter: filter,
-})
-```
+=== "Go"
+
+    ```go
+    hits, err := col.HybridSearch(denseQuery, sparseQuery, 10, vector.HybridOpts{
+    	Method: vector.FusionRRF, // RRF | Weighted | DBSF
+    	Filter: filter,
+    })
+    ```
+
+=== "Python"
+
+    ```python
+    # Attach the sparse lane at write time...
+    c.upsert("docs", 1, dense_vec, content="how do i rotate api keys",
+             sparse={"indices": [3, 17], "values": [0.8, 0.4]})
+
+    # ...then query both lanes and fuse.
+    hits = c.hybrid_search("docs", dense_query, k=10,
+                           sparse={"indices": [3, 17], "values": [0.8, 0.4]},
+                           method="rrf")   # "rrf" | "weighted" | "dbsf"
+    ```
 
 Malformed sparse data fails fast: `ErrSparseMismatch` (length mismatch),
 `ErrSparseUnsorted` (indices not strictly ascending).
@@ -47,9 +62,25 @@ the Python client for defaults.)
 The server tokenizes stored content and queries — no sparse encoder needed on
 the client:
 
-```go
-docs, err := col.SearchText("how do i rotate api keys", 10, filter) // BM25 top-k
-```
+=== "Go"
+
+    ```go
+    docs, err := col.SearchText("how do i rotate api keys", 10, filter) // BM25 top-k
+    ```
+
+=== "Python"
+
+    ```python
+    # Pure BM25 — no embedding needed on the client at all.
+    docs = c.search_text("docs", "how do i rotate api keys", k=10)
+
+    # BM25 fused with a dense lane.
+    docs = c.hybrid_text("docs", dense_query, "how do i rotate api keys",
+                         k=10, method="rrf")
+    ```
+
+    Enable the index at creation with `full_text=True`; calling text search
+    without it raises the client's error for `ErrFullTextDisabled`.
 
 Through the store facade / HTTP, `search/text` runs pure BM25 and
 `search/hybrid-text` (Go: `VectorHybridText`) fuses BM25 with a dense lane

--- a/docs/vector/persistence.md
+++ b/docs/vector/persistence.md
@@ -6,6 +6,15 @@ Multi-vector collections take a WAL **or** mmap `Persistent` (mutually
 exclusive; `Persistent` requires a quantization mode); named-vector collections
 take a WAL. Both snapshot like dense collections.
 
+!!! info "Go library and server configuration only"
+
+    Nothing on this page is reachable from the Python client: it has no
+    snapshot, flush, or cold-tier methods. Persistence is chosen when the
+    collection or server is created — `-data` on `rostam-server`, `DataDir` on
+    the store, or the persistence fields on `vector.Config` — and then happens
+    without further calls.
+
+
 ## Snapshots
 
 Point-in-time serialization of a collection to any `io.Writer`:

--- a/docs/vector/persistence.md
+++ b/docs/vector/persistence.md
@@ -9,10 +9,14 @@ take a WAL. Both snapshot like dense collections.
 !!! info "Go library and server configuration only"
 
     Nothing on this page is reachable from the Python client: it has no
-    snapshot, flush, or cold-tier methods. Persistence is chosen when the
-    collection or server is created — `-data` on `rostam-server`, `DataDir` on
-    the store, or the persistence fields on `vector.Config` — and then happens
-    without further calls.
+    snapshot, flush, or cold-tier methods.
+
+    Two different things are described below. **Durable storage** is chosen at
+    creation — `-data` on `rostam-server`, `DataDir` on the store, or the
+    persistence fields on `vector.Config` — and then keeps itself up to date
+    with no further calls. **Snapshots, flush and the cold tier are explicit
+    operations**: `Snapshot`, `Restore`, `Flush`, `EvictCollection` and
+    `SweepCold` are calls you make from Go or drive from the server.
 
 
 ## Snapshots

--- a/docs/vector/search.md
+++ b/docs/vector/search.md
@@ -33,6 +33,7 @@ designing around one:
     from rostam import RostamClient, filters as f
 
     c = RostamClient("http://localhost:8080")
+    query = [0.1, 0.2, 0.3, 0.4]   # your embedding model's output
 
     hits = c.search("docs", query, k=10)                       # ids, distances, scores
     hits = c.search("docs", query, k=10, filter=f.eq("tenant", "acme"))
@@ -121,6 +122,8 @@ Collapse hits by a payload field (e.g. one best chunk per source document):
 === "Python"
 
     ```python
+    query = [0.1, 0.2, 0.3, 0.4]
+
     groups = c.search_groups("docs", query, k=5,
                              group_by="doc_id", group_size=2)
     for g in groups:

--- a/docs/vector/search.md
+++ b/docs/vector/search.md
@@ -4,14 +4,50 @@ All search entry points live on the collection (library) and under
 `/v1/collections/{name}/points/...` (HTTP). Results are `(id, distance)` pairs;
 fusion-based searches also carry a `score`.
 
+**Not every mode is reachable from every entry point.** Check here before
+designing around one:
+
+| Mode | Go library | HTTP | Python client |
+|---|---|---|---|
+| [kNN](#k-nearest-neighbors) | ✅ | ✅ | ✅ |
+| [MMR](#mmr-diversified-retrieval) | ✅ | — | — |
+| [Recommend](#recommendation-positivenegative-examples) | ✅ | via [Query API](#unified-query-api-multi-stage-fusion-rerank) | — |
+| [Discover](#discovery-context-pairs) | ✅ | via [Query API](#unified-query-api-multi-stage-fusion-rerank) | — |
+| [Grouping](#grouping-top-k-per-group) | ✅ | ✅ | ✅ |
+| [Scroll](#scroll-filtered-listing-with-pagination) | ✅ | ✅ | ✅ |
+
 ## k-nearest neighbors
 
-```go
-hits, err := col.Search(query, 10)                       // plain kNN
-hits, err = col.SearchFiltered(query, 10, filter)        // kNN + metadata filter
-hits, err = col.SearchInto(dst, query, 10, filter)       // allocation-light: reuses dst
-docs, err := col.SearchDocs(query, 10, filter)           // hits + stored content + metadata
-```
+=== "Go"
+
+    ```go
+    hits, err := col.Search(query, 10)                       // plain kNN
+    hits, err = col.SearchFiltered(query, 10, filter)        // kNN + metadata filter
+    hits, err = col.SearchInto(dst, query, 10, filter)       // allocation-light: reuses dst
+    docs, err := col.SearchDocs(query, 10, filter)           // hits + stored content + metadata
+    ```
+
+=== "Python"
+
+    ```python
+    from rostam import RostamClient, filters as f
+
+    c = RostamClient("http://localhost:8080")
+
+    hits = c.search("docs", query, k=10)                       # ids, distances, scores
+    hits = c.search("docs", query, k=10, filter=f.eq("tenant", "acme"))
+    docs = c.search_docs("docs", query, k=10)                  # + content and metadata
+    ```
+
+=== "curl"
+
+    ```sh
+    curl -s localhost:8080/v1/collections/docs/points/search \
+      -d '{"query":[0.1,0.2,0.3,0.4],"k":10}'
+
+    curl -s localhost:8080/v1/collections/docs/points/search/docs \
+      -d '{"query":[0.1,0.2,0.3,0.4],"k":10}'
+    ```
 
 `SearchDocs` returns `Document{ID, Distance, Score, Content, Metadata}` — the
 RAG-friendly shape. Filtering semantics and the filter-first planner are covered
@@ -25,7 +61,12 @@ effect, so exploring low-ef behaviour means lowering `k` too.
 ## MMR — diversified retrieval
 
 Maximal Marginal Relevance re-ranks a candidate pool to balance relevance
-against diversity — useful when the top-k would otherwise be near-duplicates:
+against diversity — useful when the top-k would otherwise be near-duplicates.
+
+!!! info "Go library only"
+
+    MMR has no HTTP route and no Python method. Over the wire, fetch a wider
+    `k` and re-rank client-side.
 
 ```go
 hits, err := col.SearchMMR(query, 10, vector.MMROpts{
@@ -67,22 +108,43 @@ hits, err := col.Discover(10, vector.DiscoverOpts{
 
 Collapse hits by a payload field (e.g. one best chunk per source document):
 
-```go
-groups, err := col.SearchGroups(query, 5, vector.GroupOpts{
-	GroupBy:   "doc_id", // required
-	GroupSize: 2,        // hits kept per group (default 1)
-})
-// Group{Key, Hits []Document}
-```
+=== "Go"
+
+    ```go
+    groups, err := col.SearchGroups(query, 5, vector.GroupOpts{
+    	GroupBy:   "doc_id", // required
+    	GroupSize: 2,        // hits kept per group (default 1)
+    })
+    // Group{Key, Hits []Document}
+    ```
+
+=== "Python"
+
+    ```python
+    groups = c.search_groups("docs", query, k=5,
+                             group_by="doc_id", group_size=2)
+    for g in groups:
+        print(g.key, [d.id for d in g.hits])
+    ```
 
 ## Scroll — filtered listing with pagination
 
 Deterministic id-ascending listing of live points, with cursor pagination:
 
-```go
-docs, err := col.ScrollDocs(filter, 100)                                  // first page
-docs, next, more, err := col.ScrollDocsPage(filter, afterID, true, 100)   // continue after id
-```
+=== "Go"
+
+    ```go
+    docs, err := col.ScrollDocs(filter, 100)                                  // first page
+    docs, next, more, err := col.ScrollDocsPage(filter, afterID, true, 100)   // continue after id
+    ```
+
+=== "Python"
+
+    ```python
+    page = c.scroll("docs", limit=100)                     # first page
+    while page.next_cursor:                                # pass the cursor back verbatim
+        page = c.scroll("docs", limit=100, cursor=page.next_cursor)
+    ```
 
 `ScrollDocsPageOrder` adds order-by on a payload key (numeric, datetime, or
 string; multi-key via `Tail`), ascending or descending, with resumable cursors.

--- a/docs/vector/search.md
+++ b/docs/vector/search.md
@@ -7,14 +7,32 @@ fusion-based searches also carry a `score`.
 **Not every mode is reachable from every entry point.** Check here before
 designing around one:
 
-| Mode | Go library | HTTP | Python client |
-|---|---|---|---|
-| [kNN](#k-nearest-neighbors) | ✅ | ✅ | ✅ |
-| [MMR](#mmr-diversified-retrieval) | ✅ | — | — |
-| [Recommend](#recommendation-positivenegative-examples) | ✅ | via [Query API](#unified-query-api-multi-stage-fusion-rerank) | — |
-| [Discover](#discovery-context-pairs) | ✅ | via [Query API](#unified-query-api-multi-stage-fusion-rerank) | — |
-| [Grouping](#grouping-top-k-per-group) | ✅ | ✅ | ✅ |
-| [Scroll](#scroll-filtered-listing-with-pagination) | ✅ | ✅ | ✅ |
+| Mode | Go library | HTTP | gRPC | Binary TCP | Python |
+|---|---|---|---|---|---|
+| [kNN](#k-nearest-neighbors) | `Search` | `points/search` | `Search` | `vector_search` | `search()` |
+| kNN + content | `SearchDocs` | `points/search/docs` | `SearchDocs` | `vector_search_docs` | `search_docs()` |
+| [Grouping](#grouping-top-k-per-group) | `SearchGroups` | `points/search/groups` | `SearchGroups` | `vector_search_groups` | `search_groups()` |
+| [Scroll](#scroll-filtered-listing-with-pagination) | `ScrollDocs` | `points/scroll` | `Scroll` | `vector_scroll` | `scroll()` |
+| [Recommend](#recommendation-positivenegative-examples) | `Recommend` | via Query API | via `VectorQuery` | via `vector_query` | — |
+| [Discover](#discovery-context-pairs) | `Discover` | via Query API | via `VectorQuery` | via `vector_query` | — |
+| [MMR](#mmr-diversified-retrieval) | `SearchMMR` | — | — | — | client-side † |
+
+Two different situations hide behind the gaps, and they are worth telling apart.
+
+**Recommend and Discover are not missing remotely** — they are leaves of the
+[unified Query API](#unified-query-api-multi-stage-fusion-rerank) rather than
+routes of their own. One composable endpoint carries them on all three
+transports, which is why there is no `points/recommend`.
+
+**MMR really is Go-only.** It appears in no transport layer at all, because it
+needs the candidate *vectors* to score pairwise diversity and the search wire
+returns ids and distances, not vectors. Nothing makes that impossible to add —
+it would need an op that returns vectors, or the diversity computed server-side
+— so treat it as a gap rather than a rule.
+
+† Over the wire, MMR is done by fetching candidates with their vectors and
+re-ranking locally. The Python LangChain integration already implements exactly
+that (`max_marginal_relevance_search`), so reach for it before writing your own.
 
 ## k-nearest neighbors
 


### PR DESCRIPTION
Fixes the install error you spotted, and adds Python beside Go across the vector docs. Every example was **executed**, not reviewed — which is how the two real bugs below turned up.

## The install was wrong

The quickstart told people to `git clone` and `go run ./cmd/rostam-server`, and to `docker build` the image locally. All of it predates the release pipeline: there is a one-line install script, a published multi-arch image, and `go install`. It also implied a Go toolchain is needed to try the server, which it is not — Requirements now leads with "nothing, to run the server".

Install methods and the first search are now tabbed.

## The flagship Go example never ran

```
vector: invalid M (must be > 0 and <= 128)
```

`vector.Config` documents `M int // graph degree (default 16)` and the Core parameters table repeats it — but that default is only applied on the **Vamana** path. HNSW validates `M` and rejects zero. So the embedded example demonstrating the project's main differentiator failed on first copy-paste, in the page most likely to be someone's first contact.

Examples now set `M`/`EfConstruction`/`EfSearch` explicitly, and the asymmetry is documented where it bites: defaulted over HTTP and Python, required in Go.

**This leaves a code decision I did not make:** the comment promises a default that does not exist. Either the comment is wrong, or HNSW should honour it like Vamana. The second is better DX but a behaviour change — happy to do it as its own PR.

## Where Python cannot follow

The valuable part was not translating Go. It was establishing what the Python client actually reaches, which the docs never said:

| Mode | Go | HTTP | Python |
|---|---|---|---|
| kNN, Grouping, Scroll | ✅ | ✅ | ✅ |
| Recommend, Discover | ✅ | only via Query API | — |
| MMR | ✅ | — | — |

`search.md` now opens with that matrix. **MMR has no HTTP route at all**, so the honest advice is to fetch a wider `k` and re-rank client-side rather than leave a silent gap.

Same treatment elsewhere:

- **filtering** — helpers cover 11 of ~20 operators; the rest are reachable by passing the wire form as a dict (verified with `match` on `$content`). Raw dicts need the tagged encoding; helpers take plain values.
- **persistence** — no tabs, because the client has no snapshot/flush/cold-tier method at all. Says so, and points at where persistence is actually chosen.

## Tabs were already paid for

`pymdownx.tabbed` and the theme's `content.tabs.link` were configured — with a comment explaining that picking Python once keeps every tab on Python — but only `index.md` used them.

## Verification

- Three curl calls, run.
- Every Python snippet, run against a server built from this tree.
- All three quickstart Go programs extracted from the markdown, compiled and run.
- `ScrollPage` exposes `documents`/`next_cursor` — checked, because a plausible `.points` would have been wrong.
- `mkdocs build --strict` clean; tabs confirmed rendering as `tabbed-set` in the built HTML.

One structural fix caught by re-reading the heading tree rather than by the build: my first placement of the filtering section reparented `### NaN and range comparisons` out of `## Payload values`. `--strict` is happy either way.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded the quickstart with server installation, startup, client usage, authentication, metadata, filtering, bulk loading, and embedded vector setup.
  * Added Go and Python guidance for index parameters, defaults, and validation.
  * Documented Python filter helpers, tagged values, and raw filter dictionaries.
  * Added Go and Python examples for sparse vectors, BM25, and hybrid search.
  * Clarified persistence scope, configuration, and storage operations.
  * Expanded search documentation with availability matrices and examples for kNN, grouping, scrolling, and MMR, including client-side reranking and full-text requirements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->