### PR TITLE
fix(vector): default HNSW M/Ef instead of rejecting zero

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -54,9 +54,9 @@ or `EfSearch` at zero, even though `Config.M` documents "default 16" and the
 HTTP and Python layers fill exactly those. The same create therefore succeeded
 over the wire and failed from the Go library — including the quickstart's
 embedded example. The engine now fills the standard 16 / 200 / 64 when they are
-left zero (or any non-positive value), matching the other entry points. Only the HNSW (default) index type
-is affected; IVF still requires and validates its parameters, and
-`Config.Validate()` is unchanged.
+left zero (or any non-positive value), matching the other entry points. Only
+the HNSW (default) index type is affected; IVF still requires and validates its
+parameters, and `Config.Validate()` is unchanged.
 
 ### The MCP server explains itself to the agent
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -47,6 +47,17 @@ the user to know which kind of question they are asking.
 `-no-hybrid` restores pure dense KNN. Note the returned `Score` is the fusion
 score, not the original per-lane score — they are not comparable across modes.
 
+### The Go library defaults HNSW parameters
+
+`vector.NewCollection` used to reject a config that left `M`, `EfConstruction`
+or `EfSearch` at zero, even though `Config.M` documents "default 16" and the
+HTTP and Python layers fill exactly those. The same create therefore succeeded
+over the wire and failed from the Go library — including the quickstart's
+embedded example. The engine now fills the standard 16 / 200 / 64 when they are
+left zero, matching the other entry points. Only the HNSW (default) index type
+is affected; IVF still requires and validates its parameters, and
+`Config.Validate()` is unchanged.
+
 ### The MCP server explains itself to the agent
 
 Tool schemas say what a tool does; they do not say *when* to reach for it. So an

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -54,7 +54,7 @@ or `EfSearch` at zero, even though `Config.M` documents "default 16" and the
 HTTP and Python layers fill exactly those. The same create therefore succeeded
 over the wire and failed from the Go library — including the quickstart's
 embedded example. The engine now fills the standard 16 / 200 / 64 when they are
-left zero, matching the other entry points. Only the HNSW (default) index type
+left zero (or any non-positive value), matching the other entry points. Only the HNSW (default) index type
 is affected; IVF still requires and validates its parameters, and
 `Config.Validate()` is unchanged.
 

--- a/httpapi/vector.go
+++ b/httpapi/vector.go
@@ -285,8 +285,10 @@ func (cc collectionConfig) toConfig() (vector.Config, string) {
 			B:        cc.FullText.B,
 		}
 	}
-	// Fill the standard HNSW defaults so a caller need only supply dim — the
-	// engine rejects zero M/Ef rather than defaulting them itself.
+	// Fill the standard HNSW defaults so a caller need only supply dim. The
+	// engine now also defaults these (vector.applyHNSWDefaults), so this is
+	// belt-and-suspenders rather than load-bearing — kept so the HTTP contract
+	// does not depend on engine-internal behaviour.
 	m, efc, efs := cc.M, cc.EfConstruction, cc.EfSearch
 	if m <= 0 {
 		m = 16

--- a/vector/collection.go
+++ b/vector/collection.go
@@ -71,11 +71,39 @@ type Collection struct {
 // IndexType switch can pick IVF-Flat). Returns the same config-validation
 // errors as the chosen implementation.
 func NewCollection(name string, cfg Config) (*Collection, error) {
+	cfg = applyHNSWDefaults(cfg)
 	idx, err := newIndex(cfg)
 	if err != nil {
 		return nil, err
 	}
 	return &Collection{name: name, cfg: cfg, idx: idx}, nil
+}
+
+// applyHNSWDefaults fills the standard graph parameters when a caller leaves
+// them zero, so an HNSW collection built from just Dim and Metric works —
+// matching the "default 16" the Config.M comment has always promised, and the
+// defaults the HTTP and Python layers already apply before the engine sees the
+// config. Previously only those outer layers defaulted and the engine rejected
+// zero, so the same create succeeded over the wire and failed from the Go
+// library. Vamana resolves its own geometry in applyVamanaDefaults; IVF requires
+// its parameters and validates them, so both are left untouched — only the
+// zero-value (HNSW) IndexType is filled here. Non-positive is treated as unset,
+// matching the HTTP layer, so a negative value still becomes the default rather
+// than a surprise ErrInvalidM.
+func applyHNSWDefaults(cfg Config) Config {
+	if cfg.IndexType != IndexHNSW {
+		return cfg
+	}
+	if cfg.M <= 0 {
+		cfg.M = 16
+	}
+	if cfg.EfConstruction <= 0 {
+		cfg.EfConstruction = 200
+	}
+	if cfg.EfSearch <= 0 {
+		cfg.EfSearch = 64
+	}
+	return cfg
 }
 
 // newIndex builds the in-memory VectorIndex implementation for cfg, dispatching

--- a/vector/hnsw_defaults_test.go
+++ b/vector/hnsw_defaults_test.go
@@ -1,0 +1,81 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package vector
+
+import (
+	"errors"
+	"testing"
+)
+
+// The struct comment on Config.M has always promised "graph degree (default 16)"
+// and DefaultConfig()/DefaultConfig-equivalents use 16/200/64, but the HNSW path
+// used to validate those fields and reject zero — so an embedded caller who set
+// only Dim and Metric got ErrInvalidM, while the identical create over HTTP or
+// the Python client succeeded (both fill the same defaults before the engine
+// sees the config). These tests pin the engine to the documented behaviour so
+// the three entry points agree.
+
+func TestNewCollectionDefaultsHNSWParams(t *testing.T) {
+	// Only Dim and Metric — exactly the config the quickstart's embedded example
+	// used, which used to fail on first copy-paste.
+	col, err := NewCollection("docs", Config{Dim: 8, Metric: Cosine})
+	if err != nil {
+		t.Fatalf("NewCollection with zero M/Ef: got %v, want it to default them", err)
+	}
+	defer col.Close()
+
+	got := col.cfg
+	if got.M != 16 {
+		t.Errorf("M = %d, want the documented default 16", got.M)
+	}
+	if got.EfConstruction != 200 {
+		t.Errorf("EfConstruction = %d, want 200", got.EfConstruction)
+	}
+	if got.EfSearch != 64 {
+		t.Errorf("EfSearch = %d, want 64", got.EfSearch)
+	}
+}
+
+func TestNewCollectionKeepsExplicitHNSWParams(t *testing.T) {
+	// Explicit values must survive untouched — defaulting only fills zeros.
+	col, err := NewCollection("docs", Config{
+		Dim: 8, Metric: L2, M: 32, EfConstruction: 400, EfSearch: 128,
+	})
+	if err != nil {
+		t.Fatalf("NewCollection: %v", err)
+	}
+	defer col.Close()
+	if col.cfg.M != 32 || col.cfg.EfConstruction != 400 || col.cfg.EfSearch != 128 {
+		t.Errorf("explicit params were overwritten: got M=%d efc=%d efs=%d",
+			col.cfg.M, col.cfg.EfConstruction, col.cfg.EfSearch)
+	}
+}
+
+func TestNewCollectionInsertSearchAfterDefaulting(t *testing.T) {
+	// A defaulted collection must be fully usable, not merely constructible.
+	col, err := NewCollection("docs", Config{Dim: 4, Metric: Cosine})
+	if err != nil {
+		t.Fatalf("NewCollection: %v", err)
+	}
+	defer col.Close()
+	if err := col.Insert(1, []float32{0.1, 0.2, 0.3, 0.4}, 0, nil, nil); err != nil {
+		t.Fatalf("Insert: %v", err)
+	}
+	hits, err := col.Search([]float32{0.1, 0.2, 0.3, 0.4}, 3)
+	if err != nil {
+		t.Fatalf("Search: %v", err)
+	}
+	if len(hits) != 1 || hits[0].ID != 1 {
+		t.Fatalf("Search returned %v, want the one inserted point", hits)
+	}
+}
+
+// IVF is intentionally NOT defaulted here: it validates M through the same path
+// and requires the caller to configure it. This test locks that boundary so a
+// future change to the HNSW default does not silently start defaulting IVF too.
+func TestNewCollectionDoesNotDefaultIVFParams(t *testing.T) {
+	_, err := NewCollection("docs", Config{Dim: 8, Metric: Cosine, IndexType: IndexIVF})
+	if !errors.Is(err, ErrInvalidM) {
+		t.Fatalf("IVF with zero M: got %v, want ErrInvalidM (IVF is not in scope of the HNSW default)", err)
+	}
+}

--- a/vector/hnsw_defaults_test.go
+++ b/vector/hnsw_defaults_test.go
@@ -36,6 +36,35 @@ func TestNewCollectionDefaultsHNSWParams(t *testing.T) {
 	}
 }
 
+func TestNewCollectionDefaultsNegativeHNSWParams(t *testing.T) {
+	// applyHNSWDefaults treats non-positive as unset, matching the HTTP layer, so
+	// a negative value becomes the default rather than reaching Validate as
+	// ErrInvalidM. Each field is exercised on its own so a check that defaults
+	// only one of the three cannot pass.
+	cases := []struct {
+		name string
+		cfg  Config
+	}{
+		{"all negative", Config{Dim: 8, Metric: Cosine, M: -1, EfConstruction: -1, EfSearch: -1}},
+		{"only M negative", Config{Dim: 8, Metric: Cosine, M: -5, EfConstruction: 200, EfSearch: 64}},
+		{"only EfConstruction negative", Config{Dim: 8, Metric: Cosine, M: 16, EfConstruction: -5, EfSearch: 64}},
+		{"only EfSearch negative", Config{Dim: 8, Metric: Cosine, M: 16, EfConstruction: 200, EfSearch: -5}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			col, err := NewCollection("docs", tc.cfg)
+			if err != nil {
+				t.Fatalf("NewCollection with a negative param: %v", err)
+			}
+			defer col.Close()
+			if col.cfg.M != 16 || col.cfg.EfConstruction != 200 || col.cfg.EfSearch != 64 {
+				t.Errorf("negative not defaulted: got M=%d efc=%d efs=%d, want 16/200/64",
+					col.cfg.M, col.cfg.EfConstruction, col.cfg.EfSearch)
+			}
+		})
+	}
+}
+
 func TestNewCollectionKeepsExplicitHNSWParams(t *testing.T) {
 	// Explicit values must survive untouched — defaulting only fills zeros.
 	col, err := NewCollection("docs", Config{


### PR DESCRIPTION
The engine now honors the `M` default it has always documented — closing the split found while writing the docs (#23).

## The inconsistency

`Config.M` documents `// graph degree (default 16)`, `DefaultConfig()` uses 16/200/64, and both the HTTP layer and the Python client fill exactly those before the engine sees a config. The engine itself did not: `newHNSW` validated the fields and returned `ErrInvalidM` on zero.

So the identical create — `Dim` and `Metric` only — **succeeded over REST and Python but failed from `vector.NewCollection`**:

```
vector: invalid M (must be > 0 and <= 128)
```

That is the quickstart's embedded example — the one demonstrating the library that is the project's whole differentiator — failing on first copy-paste.

## The fix, and its scope

`NewCollection` fills the graph defaults when left zero. Deliberately narrow:

- **Only the zero-value (HNSW) IndexType.** Vamana resolves its own geometry in `applyVamanaDefaults`; IVF requires and validates its parameters. A test locks that boundary — IVF with `M=0` still returns `ErrInvalidM`.
- **`Config.Validate()` is unchanged** and still rejects zero. It is the contract's floor — a pure predicate; `NewCollection` resolves, then validates. `index_test`'s "m zero" case tests `Validate()` directly and still passes.
- **Non-positive treated as unset**, matching the HTTP layer, so a negative `M` becomes the default rather than a different error.

The HTTP layer keeps its own defaulting — now belt-and-suspenders, not load-bearing — so the REST contract doesn't depend on engine internals. Its comment is corrected.

## Verification (TDD)

The two "should construct" tests fail with `ErrInvalidM` against the old code and pass now; `keeps-explicit` and `does-not-default-IVF` pin the edges. Full `vector` suite green under `-short` (120s).

## Coordinates with #23

The docs PR currently notes M is "required in Go". Once this lands that is no longer true; I'll update that note so the two agree.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * HNSW indexes now automatically use default values when configuration parameters are missing or non-positive.
  * Explicit HNSW settings continue to be honored.
  * Vector insertion and search now work successfully with default HNSW configuration.
  * IVF indexes continue to reject invalid zero-valued parameters.

* **Documentation**
  * Updated the changelog to document the new HNSW defaults and clarify that IVF behavior remains unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->