### PR TITLE
feat(python): reach the Query API — query / recommend / discover

### DIFF
--- a/clients/python/rostam/client.py
+++ b/clients/python/rostam/client.py
@@ -24,7 +24,7 @@ import sys
 import threading
 import urllib.parse
 from dataclasses import dataclass, field
-from typing import Any, Dict, List, Optional, Sequence, Union
+from typing import Any, Dict, List, Optional, Sequence, Tuple, Union
 
 from ._values import decode_metadata, decode_value, encode_metadata
 
@@ -850,6 +850,117 @@ class RostamClient:
             key = decode_value(g["key"]) if isinstance(g.get("key"), dict) else g.get("key")
             groups.append(Group(key=key, hits=[_to_document(d) for d in (g.get("hits") or [])]))
         return groups
+
+    def query(
+        self,
+        collection: str,
+        prefetch: Sequence[Dict[str, Any]],
+        *,
+        root: Optional[Dict[str, Any]] = None,
+        mode: str = "fusion",
+        method: str = "",
+        alpha: float = 0.0,
+        rrf_k: int = 0,
+        k: int = 10,
+        group_by: str = "",
+        group_size: int = 0,
+    ) -> Any:
+        """The composable Query API: run one or more ``prefetch`` lanes and fuse or
+        rerank them in a single request. This is the only entry point that carries
+        recommend and discover over the wire (there are no standalone routes), and
+        the ``recommend()`` / ``discover()`` helpers below are thin wrappers over it.
+
+        Each ``prefetch`` entry is a leaf dict — a dense vector, a sparse lane, a
+        recommend spec, or a discover spec — optionally with its own ``k`` and a
+        ``filter``::
+
+            [{"dense": [0.1, 0.2, ...], "k": 50}]
+            [{"sparse": {"indices": [...], "values": [...]}}]
+            [{"recommend": {"positive": [12, 96], "negative": [40]}, "k": 50}]
+            [{"discover": {"target": 7, "context": [{"positive": 1, "negative": 2}]}}]
+
+        ``mode`` is "fusion" (combine the lanes, default) or "rerank" (``root``
+        re-scores the union of the prefetch candidates — pass a ``root`` leaf for
+        that). ``method`` picks the fusion: "rrf" | "weighted" | "dbsf".
+
+        Returns ``List[SearchResult]``; when ``group_by`` is set the response is
+        grouped and this returns ``List[Group]`` instead, with ``k`` counting groups.
+        """
+        if not prefetch:
+            raise ValueError("query requires at least one prefetch leaf")
+        body: Dict[str, Any] = {
+            "prefetch": list(prefetch),
+            "mode": mode, "method": method, "alpha": alpha, "rrf_k": rrf_k, "k": k,
+        }
+        if root is not None:
+            body["root"] = root
+        if group_by:
+            body["group_by"] = group_by
+            body["group_size"] = group_size or 1
+        res = self._request("POST", f"/v1/collections/{_seg(collection)}/query", body)
+        if group_by:
+            out = []
+            for g in (res.get("groups") or []):
+                key = decode_value(g["key"]) if isinstance(g.get("key"), dict) else g.get("key")
+                out.append(Group(key=key, hits=[_to_document(d) for d in (g.get("hits") or [])]))
+            return out
+        return [SearchResult(id=r["id"], distance=r.get("distance", 0.0), score=r.get("score", 0.0))
+                for r in (res.get("results") or [])]
+
+    def recommend(
+        self,
+        collection: str,
+        positive: Sequence[int],
+        k: int,
+        *,
+        negative: Optional[Sequence[int]] = None,
+        strategy: str = "",
+        filter: Optional[Dict[str, Any]] = None,
+    ) -> List[SearchResult]:
+        """Recommend by example: score toward the ``positive`` ids and away from the
+        ``negative`` ids, instead of from a raw query vector. ``strategy`` is
+        "average" (default, mean(pos) - mean(neg) → one dense query) or "best_score".
+
+        Carried over the wire by the Query API — there is no ``points/recommend``
+        route — so this works identically on HTTP, gRPC and the binary TCP protocol.
+        """
+        rec: Dict[str, Any] = {"positive": [int(i) for i in positive]}
+        if negative:
+            rec["negative"] = [int(i) for i in negative]
+        if strategy:
+            rec["strategy"] = strategy
+        leaf: Dict[str, Any] = {"recommend": rec, "k": k}
+        if filter:
+            leaf["filter"] = filter
+        return self.query(collection, [leaf], k=k)
+
+    def discover(
+        self,
+        collection: str,
+        context: Sequence[Tuple[int, int]],
+        k: int,
+        *,
+        target: Optional[int] = None,
+        target_vec: Optional[Vector] = None,
+        filter: Optional[Dict[str, Any]] = None,
+    ) -> List[SearchResult]:
+        """Guided "more like this, away from that" search. ``context`` is a list of
+        ``(positive_id, negative_id)`` pairs; ``target`` (a point id) or
+        ``target_vec`` (a raw vector) is an optional anchor to explore around.
+
+        Like ``recommend()``, this rides the Query API and so is available on every
+        transport.
+        """
+        pairs = [{"positive": int(p), "negative": int(n)} for (p, n) in context]
+        disc: Dict[str, Any] = {"context": pairs}
+        if target is not None:
+            disc["target"] = int(target)
+        if target_vec is not None:
+            disc["target_vec"] = list(target_vec)
+        leaf: Dict[str, Any] = {"discover": disc, "k": k}
+        if filter:
+            leaf["filter"] = filter
+        return self.query(collection, [leaf], k=k)
 
     def hybrid_search(
         self,

--- a/clients/python/tests/test_cross_stack_query.py
+++ b/clients/python/tests/test_cross_stack_query.py
@@ -1,0 +1,130 @@
+"""Python<->Go cross-stack smoke for the Query API (query/recommend/discover).
+
+recommend and discover have no standalone HTTP route and no engine-fake stand-in
+worth trusting: they are leaves of the unified Query API, and their whole value
+is the RANKING the real engine produces. A fake that returns a canned order
+would prove the client talks to itself, not that these methods retrieve the
+right neighbours. So this launches the real rostam-server and asserts on the
+structure of the results — same-cluster ids come back, the negative example is
+pushed away, the metadata filter is honoured — rather than on a fixed order the
+engine is free to change.
+
+The corpus is two well-separated clusters so "did it retrieve the right region"
+is unambiguous. The server binary is found via $ROSTAM_SERVER_BIN or a
+`rostam-server*` built at the repo root; the module is skipped when none exists.
+"""
+
+from __future__ import annotations
+
+import socket
+import subprocess
+import tempfile
+import time
+import unittest
+
+from _serverbin import find_server_bin
+from rostam import RostamClient, filters as f
+
+DIM = 4
+# Cluster A ids 1-3 near [1,0,0,0]; cluster B ids 4-6 near [0,0,1,0].
+CORPUS = {
+    1: [0.98, 0.02, 0.0, 0.0], 2: [0.95, 0.05, 0.0, 0.0], 3: [0.92, 0.08, 0.0, 0.0],
+    4: [0.0, 0.0, 0.98, 0.02], 5: [0.0, 0.0, 0.95, 0.05], 6: [0.0, 0.0, 0.92, 0.08],
+}
+CLUSTER_A = {1, 2, 3}
+CLUSTER_B = {4, 5, 6}
+
+
+def _free_port():
+    s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    s.bind(("127.0.0.1", 0))
+    port = s.getsockname()[1]
+    s.close()
+    return port
+
+
+_BIN, _WHY = find_server_bin()
+
+
+@unittest.skipUnless(_BIN, _WHY)
+class CrossStackQueryTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.port = _free_port()
+        cls.datadir = tempfile.mkdtemp(prefix="rostam-query-")
+        cls.proc = subprocess.Popen(
+            [_BIN, "-http", f"127.0.0.1:{cls.port}", "-data", cls.datadir],
+            stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
+        )
+        cls.base = f"http://127.0.0.1:{cls.port}"
+        cls.c = RostamClient(cls.base, timeout=120)
+        deadline = time.time() + 20
+        while time.time() < deadline:
+            if cls.proc.poll() is not None:
+                raise RuntimeError("rostam-server exited during startup")
+            try:
+                if cls.c.health():
+                    break
+            except Exception:
+                time.sleep(0.1)
+        else:
+            cls.proc.kill()
+            raise RuntimeError("rostam-server did not become healthy in time")
+
+        cls.c.create_collection("q", dim=DIM, metric="cosine")
+        for i, v in CORPUS.items():
+            cls.c.upsert("q", i, v, content=f"pt{i}",
+                         metadata={"grp": ("a" if i in CLUSTER_A else "b")})
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.c.close()
+        cls.proc.terminate()
+        try:
+            cls.proc.wait(timeout=5)
+        except Exception:
+            cls.proc.kill()
+
+    def test_query_single_dense_lane(self):
+        hits = self.c.query("q", [{"dense": CORPUS[1]}], k=3)
+        self.assertTrue(hits, "query returned no hits")
+        # Nearest to cluster A's centre must be cluster A.
+        self.assertIn(hits[0].id, CLUSTER_A)
+
+    def test_query_requires_a_prefetch_leaf(self):
+        with self.assertRaises(ValueError):
+            self.c.query("q", [], k=3)
+
+    def test_recommend_pulls_toward_positive_cluster(self):
+        hits = self.c.recommend("q", positive=[1, 2], k=3)
+        ids = [h.id for h in hits]
+        self.assertTrue(ids, "recommend returned no hits")
+        # The example ids are excluded from their own results, so of cluster A
+        # only id 3 remains — and it must rank first, ahead of any cluster-B
+        # point. (Asserting "majority A" would be wrong: A has three members and
+        # two are the query, so the ranking cannot contain more than one A hit.)
+        self.assertEqual(hits[0].id, 3)
+        self.assertNotIn(1, ids)
+        self.assertNotIn(2, ids)
+
+    def test_recommend_negative_pushes_away(self):
+        # Toward 1 (cluster A), away from 4 (cluster B): the top hit stays in A.
+        hits = self.c.recommend("q", positive=[1], negative=[4], k=3)
+        self.assertTrue(hits)
+        self.assertIn(hits[0].id, CLUSTER_A)
+
+    def test_recommend_honours_filter(self):
+        # Score toward cluster A but restrict to grp=b — every hit must be in B.
+        hits = self.c.recommend("q", positive=[1], k=3, filter=f.eq("grp", "b"))
+        self.assertTrue(hits, "filtered recommend returned no hits")
+        self.assertTrue(all(h.id in CLUSTER_B for h in hits))
+
+    def test_discover_explores_positive_region(self):
+        # Context (positive=5 in B, negative=1 in A) → cluster B.
+        hits = self.c.discover("q", context=[(5, 1)], k=3, target=5)
+        self.assertTrue(hits, "discover returned no hits")
+        self.assertIn(hits[0].id, CLUSTER_B)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -47,6 +47,17 @@ the user to know which kind of question they are asking.
 `-no-hybrid` restores pure dense KNN. Note the returned `Score` is the fusion
 score, not the original per-lane score — they are not comparable across modes.
 
+### The Python client reaches the Query API
+
+`rostam-client` gains `query()`, `recommend()` and `discover()`. Recommend and
+discover have no standalone route on any transport — they are leaves of the
+composable Query API — so they were previously unreachable from Python without
+hand-building the request. `recommend(collection, positive=[...], k=...)` scores
+toward example ids (and away from `negative` ones); `discover(...)` guides a
+search with `(positive, negative)` context pairs and an optional anchor; both
+take an optional metadata `filter`. `query()` is the general form for
+multi-lane fusion or rerank.
+
 ### The MCP server explains itself to the agent
 
 Tool schemas say what a tool does; they do not say *when* to reach for it. So an


### PR DESCRIPTION
Closes the last "—" in the search availability matrix #23 just published: the composable Query API was unreachable from the Python client.

## Why

Recommend and discover have **no standalone route on any transport** — they are leaves of `/query`. So a Python user who wanted either had to hand-assemble the request body. Everything else in the search matrix had a Python method; these two did not.

## What

Three methods, mirroring the `filters` module's split (typed helpers for common cases, general form underneath):

- `recommend(collection, positive, k, *, negative=None, strategy="", filter=None)`
- `discover(collection, context, k, *, target=None, target_vec=None, filter=None)`
- `query(collection, prefetch, *, root=None, mode, method, alpha, rrf_k, k, group_by, group_size)` — multi-lane fusion or rerank; returns `Group`s when `group_by` is set.

## The wire detail a fake wouldn't have caught

recommend/discover must be **prefetch** leaves, each with its own `k` — not a bare `root`. Fusion mode rejects a spec with no prefetch: `query spec has no prefetch leaves`. My first cut put them in `root` and got a 500. The helpers set both the leaf `k` and the top-level `k`. **Found by running it against a live server, not by reading the handler.**

## Testing

Cross-stack against a real `rostam-server` (`test_cross_stack_query.py`), because ranking is the whole value and no fake is worth trusting for it. Two well-separated clusters make "did it retrieve the right region" unambiguous:

- recommend pulls toward the positive cluster and honours a metadata filter
- the negative example pushes the top hit away
- discover explores the positive region
- `query([])` raises client-side

One assertion the test writes down explicitly: recommend's result is "the one remaining same-cluster point ranks first", **not** "a majority is same-cluster" — the example ids are excluded from their own results, so with a 3-member cluster and 2 examples a majority is impossible. (My first assertion got this wrong; the run corrected it.)

Full Python suite: **71 passed, 26 skipped**, including under the exact CI invocation (`pytest tests` from `clients/python` with `ROSTAM_SERVER_BIN` set).

## Note

This is part of v0.3.0; its changelog entry slots under the existing v0.3.0 section. Independent of #24 (the HNSW-default fix) — they touch different layers.
