### PR TITLE
feat(docker): serve the binary TCP port by default, for the Go client

### DIFF
--- a/cmd/rostam-server/Dockerfile
+++ b/cmd/rostam-server/Dockerfile
@@ -34,8 +34,10 @@ EXPOSE 8080 7000
 #     docker run -p 8080:8080 -p 7000:7000 -e ROSTAM_API_KEY=<token> ...        # + Go/TCP clients
 #
 # The token guards every transport identically, so publishing 7000 is no less
-# safe than 8080. Publish only the ports you use: the unpublished listener is
-# unreachable from outside the container.
+# safe than 8080. Publish only the ports you use: an unpublished listener is not
+# reachable from the host, though other containers on the same Docker network
+# can still reach it on the container's port (and host networking publishes
+# everything) — which is why the auth gate, not port publication, is the control.
 #
 # ROSTAM_API_KEY is read instead of -api-key so the secret never appears in the
 # process table or in `docker inspect`'s Cmd. For a deliberately open dev

--- a/cmd/rostam-server/Dockerfile
+++ b/cmd/rostam-server/Dockerfile
@@ -18,18 +18,27 @@ USER rostam
 # the data dir (empty data dir → relative to CWD), so CWD must be writable by
 # the rostam user even in the in-memory default.
 WORKDIR /data
-EXPOSE 8080
+# 8080 = REST, 7000 = binary TCP. Both are only DOCUMENTED here; neither is
+# reachable until you publish it with -p. TCP is bound by default because the Go
+# remote client (rostam.NewClient) speaks only the binary protocol — without it,
+# a Go service could not reach the container without overriding the command.
+EXPOSE 8080 7000
 # Single-node, in-memory by default (fast HNSW, no disk). Override the flags to
-# enable persistence / mmap (-persistent-vectors -cluster ... -data /data) or
-# other transports (-grpc :9090 -tcp :7000).
+# enable persistence / mmap (-persistent-vectors -cluster ... -data /data) or to
+# add gRPC (-grpc :9090).
 #
 # AUTHENTICATION IS REQUIRED. The default CMD binds 0.0.0.0, which the server
 # refuses to serve unauthenticated, so pass a key:
 #
-#     docker run -p 8080:8080 -e ROSTAM_API_KEY=<token> rostam-server:latest
+#     docker run -p 8080:8080 -e ROSTAM_API_KEY=<token> rostam-server:latest   # REST only
+#     docker run -p 8080:8080 -p 7000:7000 -e ROSTAM_API_KEY=<token> ...        # + Go/TCP clients
+#
+# The token guards every transport identically, so publishing 7000 is no less
+# safe than 8080. Publish only the ports you use: the unpublished listener is
+# unreachable from outside the container.
 #
 # ROSTAM_API_KEY is read instead of -api-key so the secret never appears in the
 # process table or in `docker inspect`'s Cmd. For a deliberately open dev
 # container, append -insecure to the command instead.
 ENTRYPOINT ["rostam-server"]
-CMD ["-http", "0.0.0.0:8080"]
+CMD ["-http", "0.0.0.0:8080", "-tcp", "0.0.0.0:7000"]

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -54,9 +54,9 @@ The published image bound only REST (`:8080`), but the Go remote client
 service could not reach the container without overriding its command. The
 default now binds REST **and** TCP (`:7000`) and documents both with `EXPOSE`.
 
-Nothing new is reachable by default: a bound port is not a *published* one, so
-`docker run -p 8080:8080` still exposes only REST, and a Go deployment adds
-`-p 7000:7000`. The token guards every transport identically — the startup
+Nothing new is published to the host by default: a bound port is not a
+*published* one, so `docker run -p 8080:8080` still maps only REST to the host,
+and a Go deployment adds `-p 7000:7000`. The token guards every transport identically — the startup
 gate refuses an unauthenticated non-loopback bind on any of them — so
 publishing `7000` is no less safe than `8080`. gRPC stays opt-in
 (`-grpc 0.0.0.0:9090`).

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -47,6 +47,20 @@ the user to know which kind of question they are asking.
 `-no-hybrid` restores pure dense KNN. Note the returned `Score` is the fusion
 score, not the original per-lane score — they are not comparable across modes.
 
+### The container serves the Go client out of the box
+
+The published image bound only REST (`:8080`), but the Go remote client
+(`rostam.NewClient`) speaks the binary TCP protocol and nothing else — so a Go
+service could not reach the container without overriding its command. The
+default now binds REST **and** TCP (`:7000`) and documents both with `EXPOSE`.
+
+Nothing new is reachable by default: a bound port is not a *published* one, so
+`docker run -p 8080:8080` still exposes only REST, and a Go deployment adds
+`-p 7000:7000`. The token guards every transport identically — the startup
+gate refuses an unauthenticated non-loopback bind on any of them — so
+publishing `7000` is no less safe than `8080`. gRPC stays opt-in
+(`-grpc 0.0.0.0:9090`).
+
 ### The Python client reaches the Query API
 
 `rostam-client` gains `query()`, `recommend()` and `discover()`. Recommend and

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -40,14 +40,18 @@ runtime dependencies.
     For anything beyond local use, mount a secret or use your orchestrator's
     secret store.
 
-    The image serves **HTTP only** — its default command is
-    `-http 0.0.0.0:8080` and only 8080 is exposed. To also speak the binary TCP
-    protocol, override the command and publish the port:
+    The default command serves **both** REST (`8080`) and the binary TCP
+    protocol (`7000`) — publish only the ports you use. The command above maps
+    REST; add TCP for the Go client, which speaks only the binary protocol:
 
     ```sh
-    docker run -p 8080:8080 -p 8081:8081 -e ROSTAM_API_KEY=secret \
-      ghcr.io/rostamlabs/rostam -http 0.0.0.0:8080 -tcp 0.0.0.0:8081
+    docker run -p 8080:8080 -p 7000:7000 -e ROSTAM_API_KEY=secret \
+      ghcr.io/rostamlabs/rostam
     ```
+
+    An unpublished listener is unreachable from outside the container, and the
+    token guards every transport identically — so publishing `7000` is no less
+    safe than `8080`. For gRPC, add `-grpc 0.0.0.0:9090` and `-p 9090:9090`.
 
 === "Go"
 
@@ -70,7 +74,7 @@ gRPC (`-grpc`), and a compact binary TCP protocol (`-tcp`). Start it with REST
 and TCP on loopback, persisting to `./data`:
 
 ```sh
-rostam-server -http 127.0.0.1:8080 -tcp 127.0.0.1:8081 -data ./data
+rostam-server -http 127.0.0.1:8080 -tcp 127.0.0.1:7000 -data ./data
 ```
 
 !!! note "Non-loopback binds require authentication"
@@ -160,10 +164,11 @@ Against the container, authenticate every call: add
     func main() {
     	ctx := context.Background()
 
-    	// The -tcp port from "Run it" above, not -http. The container does not
-    	// serve TCP unless you override its command as shown in Install.
+    	// The -tcp port, not -http: the Go remote client speaks the binary
+    	// protocol only. The Docker image serves this port too — publish it with
+    	// -p 7000:7000 (see the Docker tab in Install).
     	store, err := rostam.NewClient(rostam.ClientConfig{
-    		Servers: []string{"127.0.0.1:8081"},
+    		Servers: []string{"127.0.0.1:7000"},
     	})
     	if err != nil {
     		log.Fatal(err)

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -49,9 +49,11 @@ runtime dependencies.
       ghcr.io/rostamlabs/rostam
     ```
 
-    An unpublished listener is unreachable from outside the container, and the
-    token guards every transport identically — so publishing `7000` is no less
-    safe than `8080`. For gRPC, add `-grpc 0.0.0.0:9090` and `-p 9090:9090`.
+    An unpublished listener is not reachable from the host (though other
+    containers on the same network still can reach it, and host networking
+    publishes everything). Either way the token guards every transport
+    identically — so exposing `7000` is no less safe than `8080`. For gRPC, add
+    `-grpc 0.0.0.0:9090` and `-p 9090:9090`.
 
 === "Go"
 
@@ -165,10 +167,12 @@ Against the container, authenticate every call: add
     	ctx := context.Background()
 
     	// The -tcp port, not -http: the Go remote client speaks the binary
-    	// protocol only. The Docker image serves this port too — publish it with
-    	// -p 7000:7000 (see the Docker tab in Install).
+    	// protocol only. This targets the loopback server from "Run it" (no
+    	// token). Against the container, publish the port (-p 7000:7000) and set
+    	// AuthToken to the same value as ROSTAM_API_KEY.
     	store, err := rostam.NewClient(rostam.ClientConfig{
     		Servers: []string{"127.0.0.1:7000"},
+    		// AuthToken: "secret",   // required when the server has -api-key set
     	})
     	if err != nil {
     		log.Fatal(err)


### PR DESCRIPTION
You were right that TCP is first-class: `rostam.NewClient` — the Go remote client — speaks the binary TCP protocol and **nothing else**, so a Go service talking to a remote server needs that port. The published image bound only REST, so Go users had to override the container's command. For a Go-native engine, that's the wrong default.

## Change

`CMD` now binds **REST (`:8080`) and TCP (`:7000`)**; `EXPOSE` lists both.

## Why this costs HTTP users nothing

A bound port is not a *published* one. `docker run -p 8080:8080` still reaches only REST — the TCP listener sits idle and unpublished inside the container. A Go deployment adds `-p 7000:7000` and needs no command override.

## Why it's safe

The startup gate refuses an unauthenticated non-loopback bind on **all three** transports (it loops over the http/grpc/tcp addresses), and TCP/gRPC enforce the same `Authenticator` as HTTP. So publishing `7000` is exactly as safe as `8080`.

Verified by running the default flags, not by reasoning:

- both listeners come up
- nothing binds publicly (loopback test)
- `0.0.0.0` with **no** token → refused, **no listener left behind** (fail-closed proven for TCP)
- a token starts both

## Also

- Ports aligned to the project convention: **`:7000`** for TCP (used throughout the docs). The quickstart's earlier `:8081` is corrected to match, and its Go tab no longer claims the container doesn't serve TCP.
- **gRPC stays opt-in** — least-used transport; typed-gRPC users customize their run anyway. Add `-grpc 0.0.0.0:9090` + `-p 9090:9090`.

Part of v0.3.0; changelog entry included (the changelog guard requires it — `cmd/` is touched). `mkdocs build --strict` passes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Docker and quickstart guidance to cover REST and binary TCP access.
  * Documented TCP usage on port 7000, including port publishing and authentication.
  * Added transport security guidance and clarified that gRPC remains opt-in.
  * Added release notes for version 0.3.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->