### PR TITLE
feat(python): native-protocol KV client (RostamKV)

### DIFF
--- a/clients/python/rostam/__init__.py
+++ b/clients/python/rostam/__init__.py
@@ -8,9 +8,11 @@ extra.
 from . import filters
 from .client import Document, Group, MultiResult, Point, RostamClient, RostamError, ScrollPage, SearchResult
 from .embeddings import Embedder, FunctionEmbedder, OpenAIEmbedder, TextStore
+from .kv import RostamKV
 
 __all__ = [
     "RostamClient",
+    "RostamKV",
     "RostamError",
     "SearchResult",
     "Document",

--- a/clients/python/rostam/kv.py
+++ b/clients/python/rostam/kv.py
@@ -181,23 +181,39 @@ class RostamKV:
             raise RostamError("request frame exceeds the server's frame limit")
         frame = struct.pack(">I", len(body)) + body
 
-        s = self._pool.acquire()
+        # Acquire may connect, and a failed connect raises OSError — convert it to
+        # the client's RostamError contract like every other transport failure.
+        try:
+            s = self._pool.acquire()
+        except OSError as e:
+            raise RostamError(f"connect failed: {e}") from e
+
+        # Send, read, AND fully parse inside the try: a socket is returned to the
+        # pool only after a well-formed response, so a truncated or malformed
+        # frame discards the connection instead of poisoning the next caller.
         try:
             s.sendall(frame)
             body_len = struct.unpack(">I", _recv_exactly(s, 4))[0]
+            # A response body is at least [status u8][payloadLen u32] = 5 bytes and
+            # never larger than a frame. Reject a bogus length before reading it, so
+            # a broken or hostile peer cannot make _recv_exactly buffer unboundedly.
+            if body_len < 5 or body_len > _MAX_FRAME:
+                raise RostamError(f"invalid response frame length {body_len}")
             resp = _recv_exactly(s, body_len)
-        except (OSError, RostamError) as e:
+            status = resp[0]
+            payload_len = struct.unpack(">I", resp[1:5])[0]
+            if 5 + payload_len != body_len:
+                raise RostamError("response payload length does not match frame")
+            payload = resp[5:5 + payload_len]
+        except (OSError, RostamError, struct.error) as e:
             self._pool.discard(s)
             if isinstance(e, RostamError):
                 raise
             raise RostamError(f"transport error: {e}") from e
-        else:
-            self._pool.release(s)
+        # Well-formed response: the connection is healthy even if the op failed
+        # at the application level (StatusError etc.), so keep it pooled.
+        self._pool.release(s)
 
-        # resp = [status u8][payloadLen u32][payload]
-        status = resp[0]
-        payload_len = struct.unpack(">I", resp[1:5])[0]
-        payload = resp[5:5 + payload_len]
         if status == _STATUS_OK:
             return payload
         if status == _STATUS_NOT_FOUND:

--- a/clients/python/rostam/kv.py
+++ b/clients/python/rostam/kv.py
@@ -1,0 +1,261 @@
+"""A native-protocol client for Rostam's key-value store.
+
+The KV store is not on the REST API — it lives only on the binary TCP protocol,
+because it is built for sub-microsecond operations that an HTTP round trip would
+defeat. So this client speaks that protocol directly, over a plain socket, using
+only the standard library.
+
+    from rostam import RostamKV
+
+    kv = RostamKV("127.0.0.1", 7000)          # the server's -tcp port
+    kv.put("user:42", b'{"coins":100}')
+    kv.get("user:42")                          # -> b'{"coins":100}'
+    kv.incr("views:42", 1)                     # -> 1
+    kv.delete("user:42")                       # -> True
+
+Keys and values may be ``str`` (encoded UTF-8) or ``bytes``; every method
+returns ``bytes`` (or ``None`` for a miss), never decoding for you — a value
+store holds opaque bytes.
+
+Wire, for reference (all big-endian):
+
+    frame     [len u32][body]
+    body v1   [opNameLen u8][opName][argsLen u32][args]
+    body v2   [0x02][tokenLen u8][token][opNameLen u8][opName][argsLen u32][args]
+    response  [bodyLen u32][status u8][payloadLen u32][payload]
+
+v2 is used when an auth token is set, v1 otherwise — mirroring the Go client.
+"""
+
+from __future__ import annotations
+
+import socket
+import struct
+import threading
+from typing import List, Optional, Union
+
+from .client import RostamError
+
+Key = Union[str, bytes]
+
+_STATUS_OK = 0
+_STATUS_NOT_FOUND = 1
+_STATUS_NOT_LEADER = 2
+_STATUS_ERROR = 3
+_STATUS_UNAUTHORIZED = 4
+
+_PROTOCOL_V2 = 0x02
+# The server rejects a frame whose length prefix exceeds this; used only to
+# fail fast with a clear message rather than send a doomed frame.
+_MAX_FRAME = 64 * 1024 * 1024
+
+
+def _as_bytes(x: Key) -> bytes:
+    return x.encode("utf-8") if isinstance(x, str) else bytes(x)
+
+
+def _enc_key(key: bytes) -> bytes:
+    if len(key) > 0xFFFF:
+        raise ValueError(f"key length {len(key)} exceeds 65535")
+    return struct.pack(">H", len(key)) + key
+
+
+class _SocketPool:
+    """A tiny pool of connected sockets, safe to share across threads.
+
+    Mirrors the HTTP client's pool: hand a live socket to a caller, take it back
+    when they are done. A socket that errored mid-call is discarded rather than
+    returned, so a broken connection never poisons the next request.
+    """
+
+    def __init__(self, host: str, port: int, timeout: float, maxsize: int):
+        self._host = host
+        self._port = port
+        self._timeout = timeout
+        self._maxsize = maxsize
+        self._free: List[socket.socket] = []
+        self._lock = threading.Lock()
+        self._closed = False
+
+    def _connect(self) -> socket.socket:
+        s = socket.create_connection((self._host, self._port), timeout=self._timeout)
+        # Nagle off: these are small, latency-sensitive request/response frames.
+        s.setsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)
+        return s
+
+    def acquire(self) -> socket.socket:
+        with self._lock:
+            if self._closed:
+                raise RostamError("client is closed")
+            s = self._free.pop() if self._free else None
+        if s is None:
+            s = self._connect()
+        else:
+            s.settimeout(self._timeout)
+        return s
+
+    def release(self, s: socket.socket) -> None:
+        with self._lock:
+            if self._closed or len(self._free) >= self._maxsize:
+                drop = True
+            else:
+                self._free.append(s)
+                drop = False
+        if drop:
+            _silent_close(s)
+
+    def discard(self, s: socket.socket) -> None:
+        _silent_close(s)
+
+    def close(self) -> None:
+        with self._lock:
+            self._closed = True
+            socks, self._free = self._free, []
+        for s in socks:
+            _silent_close(s)
+
+
+def _silent_close(s: socket.socket) -> None:
+    try:
+        s.close()
+    except OSError:
+        pass
+
+
+def _recv_exactly(s: socket.socket, n: int) -> bytes:
+    """Read exactly n bytes or raise — a short read means the peer went away."""
+    chunks = []
+    got = 0
+    while got < n:
+        b = s.recv(n - got)
+        if not b:
+            raise RostamError("connection closed by server mid-response")
+        chunks.append(b)
+        got += len(b)
+    return b"".join(chunks)
+
+
+class RostamKV:
+    """Native-protocol client for Rostam's key-value operations.
+
+    Talks to the server's binary TCP port (``-tcp``), which the container serves
+    by default on ``7000``. Set ``auth_token`` when the server requires one; it
+    is sent on every request via the protocol-v2 frame.
+    """
+
+    def __init__(
+        self,
+        host: str = "127.0.0.1",
+        port: int = 7000,
+        *,
+        auth_token: Optional[str] = None,
+        timeout: float = 30.0,
+        pool_maxsize: int = 8,
+    ):
+        self._token = auth_token or ""
+        if len(self._token.encode("utf-8")) > 255:
+            raise ValueError("auth_token is longer than 255 bytes")
+        self._pool = _SocketPool(host, port, timeout, pool_maxsize)
+
+    # ---- framing -----------------------------------------------------------
+
+    def _encode_body(self, op: str, args: bytes) -> bytes:
+        op_b = op.encode("ascii")
+        if len(op_b) > 0xFF:
+            raise ValueError("op name too long")
+        v1 = bytes([len(op_b)]) + op_b + struct.pack(">I", len(args)) + args
+        if not self._token:
+            return v1
+        tok = self._token.encode("utf-8")
+        return bytes([_PROTOCOL_V2, len(tok)]) + tok + v1
+
+    def _call(self, op: str, args: bytes) -> bytes:
+        """Send one op, return its payload. Raises RostamError on a non-OK status.
+
+        A miss (StatusNotFound) is NOT an error here — it returns ``None`` — so
+        the read ops can distinguish "absent" from "empty value" without an
+        exception. Every other non-OK status raises.
+        """
+        body = self._encode_body(op, args)
+        if 4 + len(body) > _MAX_FRAME:
+            raise RostamError("request frame exceeds the server's frame limit")
+        frame = struct.pack(">I", len(body)) + body
+
+        s = self._pool.acquire()
+        try:
+            s.sendall(frame)
+            body_len = struct.unpack(">I", _recv_exactly(s, 4))[0]
+            resp = _recv_exactly(s, body_len)
+        except (OSError, RostamError) as e:
+            self._pool.discard(s)
+            if isinstance(e, RostamError):
+                raise
+            raise RostamError(f"transport error: {e}") from e
+        else:
+            self._pool.release(s)
+
+        # resp = [status u8][payloadLen u32][payload]
+        status = resp[0]
+        payload_len = struct.unpack(">I", resp[1:5])[0]
+        payload = resp[5:5 + payload_len]
+        if status == _STATUS_OK:
+            return payload
+        if status == _STATUS_NOT_FOUND:
+            return None  # type: ignore[return-value]
+        raise RostamError(_status_message(status, payload), status=status)
+
+    # ---- key-value ops -----------------------------------------------------
+
+    def get(self, key: Key) -> Optional[bytes]:
+        """Return the value bytes, or ``None`` if the key is absent."""
+        return self._call("get", _enc_key(_as_bytes(key)))
+
+    def put(self, key: Key, value: Key, *, ttl_ms: int = 0) -> None:
+        """Store ``value`` under ``key``. ``ttl_ms`` > 0 sets an expiry."""
+        k = _as_bytes(key)
+        v = _as_bytes(value)
+        args = _enc_key(k) + struct.pack(">I", len(v)) + v + struct.pack(">Q", ttl_ms)
+        self._call("put", args)
+
+    def delete(self, key: Key) -> bool:
+        """Delete ``key``. Returns whether it existed."""
+        payload = self._call("del", _enc_key(_as_bytes(key)))
+        return bool(payload and payload[0])
+
+    def incr(self, key: Key, delta: int = 1) -> int:
+        """Atomically add ``delta`` (may be negative) and return the new value.
+
+        A missing key is treated as 0, so the first ``incr`` returns ``delta``.
+        """
+        args = _enc_key(_as_bytes(key)) + struct.pack(">q", delta)
+        payload = self._call("incr", args)
+        return struct.unpack(">q", payload)[0]
+
+    def expire(self, key: Key, ttl_ms: int) -> None:
+        """Set a TTL (in milliseconds) on an existing key."""
+        args = _enc_key(_as_bytes(key)) + struct.pack(">Q", ttl_ms)
+        self._call("expire", args)
+
+    def ping(self) -> bool:
+        """Round-trip a heartbeat; True if the server answered."""
+        self._call("__ping__", b"")
+        return True
+
+    def close(self) -> None:
+        self._pool.close()
+
+    def __enter__(self) -> "RostamKV":
+        return self
+
+    def __exit__(self, *exc) -> None:
+        self.close()
+
+
+def _status_message(status: int, payload: bytes) -> str:
+    detail = payload.decode("utf-8", "replace") if payload else ""
+    name = {
+        _STATUS_NOT_LEADER: "not leader",
+        _STATUS_ERROR: "server error",
+        _STATUS_UNAUTHORIZED: "unauthorized (auth token missing or invalid)",
+    }.get(status, f"status {status}")
+    return f"{name}: {detail}" if detail else name

--- a/clients/python/tests/test_cross_stack_kv.py
+++ b/clients/python/tests/test_cross_stack_kv.py
@@ -1,0 +1,164 @@
+"""Python<->Go cross-stack test for the native KV client.
+
+The KV store is only on the binary TCP protocol, so there is no HTTP path and no
+fake worth trusting: the whole point is that the Python framing, the protocol-v2
+auth prefix, and each op's byte layout agree with the Go server exactly. A slip
+in any of them produces a wrong value or a spurious error, not a clean failure.
+So this launches the real server with `-tcp` and drives every op against it.
+
+Skipped when no server binary is found (same rule as the other cross-stack
+modules): $ROSTAM_SERVER_BIN, or a `rostam-server*` built at the repo root.
+"""
+
+from __future__ import annotations
+
+import socket
+import subprocess
+import tempfile
+import time
+import unittest
+
+from _serverbin import find_server_bin
+from rostam import RostamKV, RostamError
+
+
+def _free_port():
+    s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    s.bind(("127.0.0.1", 0))
+    port = s.getsockname()[1]
+    s.close()
+    return port
+
+
+_BIN, _WHY = find_server_bin()
+
+
+def _wait_tcp(host, port, deadline):
+    while time.time() < deadline:
+        try:
+            socket.create_connection((host, port), timeout=0.5).close()
+            return True
+        except OSError:
+            time.sleep(0.1)
+    return False
+
+
+@unittest.skipUnless(_BIN, _WHY)
+class CrossStackKVTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.http = _free_port()
+        cls.tcp = _free_port()
+        cls.datadir = tempfile.mkdtemp(prefix="rostam-kv-")
+        cls.proc = subprocess.Popen(
+            [_BIN, "-http", f"127.0.0.1:{cls.http}", "-tcp", f"127.0.0.1:{cls.tcp}",
+             "-data", cls.datadir],
+            stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
+        )
+        if not _wait_tcp("127.0.0.1", cls.tcp, time.time() + 20):
+            cls.proc.kill()
+            raise RuntimeError("rostam-server -tcp did not come up in time")
+        cls.kv = RostamKV("127.0.0.1", cls.tcp)
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.kv.close()
+        cls.proc.terminate()
+        try:
+            cls.proc.wait(timeout=5)
+        except Exception:
+            cls.proc.kill()
+
+    def test_ping(self):
+        self.assertTrue(self.kv.ping())
+
+    def test_put_get_bytes_and_str(self):
+        self.kv.put("k:bytes", b'{"coins":100}')
+        self.assertEqual(self.kv.get("k:bytes"), b'{"coins":100}')
+        self.kv.put("k:str", "hello")            # str encodes UTF-8
+        self.assertEqual(self.kv.get("k:str"), b"hello")
+
+    def test_miss_returns_none_not_empty(self):
+        # Absent must be None, and distinct from a stored empty value.
+        self.assertIsNone(self.kv.get("k:absent"))
+        self.kv.put("k:empty", b"")
+        self.assertEqual(self.kv.get("k:empty"), b"")
+
+    def test_incr_from_missing_and_negative(self):
+        self.assertEqual(self.kv.incr("k:ctr", 1), 1)   # missing = 0, so +1
+        self.assertEqual(self.kv.incr("k:ctr", 5), 6)
+        self.assertEqual(self.kv.incr("k:ctr", -2), 4)  # signed delta
+
+    def test_delete_reports_existence(self):
+        self.kv.put("k:del", "x")
+        self.assertTrue(self.kv.delete("k:del"))        # existed
+        self.assertFalse(self.kv.delete("k:del"))       # already gone
+        self.assertIsNone(self.kv.get("k:del"))
+
+    def test_expire_on_a_live_key(self):
+        self.kv.put("k:ttl", "x")
+        self.kv.expire("k:ttl", 60_000)                 # 60s — still present now
+        self.assertEqual(self.kv.get("k:ttl"), b"x")
+
+    def test_binary_safe_keys_and_values(self):
+        key = bytes(range(256))
+        val = bytes([0, 1, 2, 255, 254])
+        self.kv.put(key, val)
+        self.assertEqual(self.kv.get(key), val)
+
+
+@unittest.skipUnless(_BIN, _WHY)
+class CrossStackKVAuthTest(unittest.TestCase):
+    """The protocol-v2 auth prefix, end to end: a token guards every op."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.http = _free_port()
+        cls.tcp = _free_port()
+        cls.datadir = tempfile.mkdtemp(prefix="rostam-kvauth-")
+        # A token makes the authenticator active even on loopback.
+        cls.proc = subprocess.Popen(
+            [_BIN, "-http", f"127.0.0.1:{cls.http}", "-tcp", f"127.0.0.1:{cls.tcp}",
+             "-api-key", "s3cret", "-data", cls.datadir],
+            stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
+        )
+        if not _wait_tcp("127.0.0.1", cls.tcp, time.time() + 20):
+            cls.proc.kill()
+            raise RuntimeError("authed rostam-server did not come up in time")
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.proc.terminate()
+        try:
+            cls.proc.wait(timeout=5)
+        except Exception:
+            cls.proc.kill()
+
+    def test_correct_token_works(self):
+        kv = RostamKV("127.0.0.1", self.tcp, auth_token="s3cret")
+        try:
+            kv.put("k", "v")
+            self.assertEqual(kv.get("k"), b"v")
+        finally:
+            kv.close()
+
+    def test_missing_token_is_unauthorized(self):
+        kv = RostamKV("127.0.0.1", self.tcp)
+        try:
+            with self.assertRaises(RostamError) as cm:
+                kv.get("k")
+            self.assertEqual(cm.exception.status, 4)  # StatusUnauthorized
+        finally:
+            kv.close()
+
+    def test_wrong_token_is_unauthorized(self):
+        kv = RostamKV("127.0.0.1", self.tcp, auth_token="nope")
+        try:
+            with self.assertRaises(RostamError):
+                kv.get("k")
+        finally:
+            kv.close()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/clients/python/tests/test_kv_framing.py
+++ b/clients/python/tests/test_kv_framing.py
@@ -1,0 +1,112 @@
+"""Unit tests for RostamKV's response-frame handling, against a fake socket.
+
+These do not need the server binary: they assert the client is robust to a peer
+that sends a hostile or truncated frame — an oversized length must not make the
+client buffer unboundedly, and a malformed body must surface as RostamError
+(not IndexError/struct.error) with the socket discarded, not returned to the
+pool. A real server never does this; a broken proxy or a bug might.
+"""
+
+from __future__ import annotations
+
+import socket
+import struct
+import threading
+import unittest
+
+from rostam import RostamKV, RostamError
+from rostam.kv import _MAX_FRAME
+
+
+class _FakeServer:
+    """Accepts one connection and replies to each request with `responder()`."""
+
+    def __init__(self, responder):
+        self._responder = responder
+        self._sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        self._sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        self._sock.bind(("127.0.0.1", 0))
+        self._sock.listen(1)
+        self.port = self._sock.getsockname()[1]
+        self._t = threading.Thread(target=self._serve, daemon=True)
+        self._t.start()
+
+    def _serve(self):
+        try:
+            conn, _ = self._sock.accept()
+        except OSError:
+            return
+        # A client that got a deliberately bad frame hangs up abruptly, so recv
+        # or sendall can hit ECONNRESET — expected here, not a test failure.
+        try:
+            with conn:
+                while True:
+                    hdr = conn.recv(4)
+                    if len(hdr) < 4:
+                        return
+                    n = struct.unpack(">I", hdr)[0]
+                    remaining = n
+                    while remaining > 0:
+                        chunk = conn.recv(remaining)
+                        if not chunk:
+                            return
+                        remaining -= len(chunk)
+                    reply = self._responder()
+                    if reply is None:
+                        return
+                    conn.sendall(reply)
+        except OSError:
+            return
+
+    def close(self):
+        try:
+            self._sock.close()
+        except OSError:
+            pass
+
+
+class KVFramingTest(unittest.TestCase):
+    def _kv(self, responder):
+        srv = _FakeServer(responder)
+        self.addCleanup(srv.close)
+        kv = RostamKV("127.0.0.1", srv.port, timeout=2.0)
+        self.addCleanup(kv.close)
+        return kv
+
+    def test_oversized_body_length_is_rejected_not_buffered(self):
+        # Advertise a body far larger than a frame but send nothing more. The
+        # client must reject the length outright rather than block reading it.
+        kv = self._kv(lambda: struct.pack(">I", _MAX_FRAME + 1))
+        with self.assertRaises(RostamError) as cm:
+            kv.get("k")
+        self.assertIn("invalid response frame length", str(cm.exception))
+
+    def test_body_shorter_than_header_is_rostam_error(self):
+        # body_len = 3 (< the 5-byte minimum): must be RostamError, not IndexError.
+        kv = self._kv(lambda: struct.pack(">I", 3) + b"\x00\x00\x00")
+        with self.assertRaises(RostamError):
+            kv.get("k")
+
+    def test_payload_length_mismatch_is_rostam_error(self):
+        # Frame says body is 5 bytes (status + payloadLen=100) but no payload.
+        def reply():
+            return struct.pack(">I", 5) + bytes([0]) + struct.pack(">I", 100)
+        kv = self._kv(reply)
+        with self.assertRaises(RostamError):
+            kv.get("k")
+
+    def test_connect_failure_is_rostam_error(self):
+        # Nothing is listening on this port: acquire()'s connect must convert
+        # OSError into the client's RostamError contract.
+        s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        s.bind(("127.0.0.1", 0))
+        port = s.getsockname()[1]
+        s.close()  # port now free → connection refused
+        kv = RostamKV("127.0.0.1", port, timeout=1.0)
+        self.addCleanup(kv.close)
+        with self.assertRaises(RostamError):
+            kv.get("k")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/clients/python/tests/test_kv_framing.py
+++ b/clients/python/tests/test_kv_framing.py
@@ -18,6 +18,17 @@ from rostam import RostamKV, RostamError
 from rostam.kv import _MAX_FRAME
 
 
+def _recv_all(conn, n):
+    """Read exactly n bytes, or None if the peer closes first."""
+    buf = b""
+    while len(buf) < n:
+        chunk = conn.recv(n - len(buf))
+        if not chunk:
+            return None
+        buf += chunk
+    return buf
+
+
 class _FakeServer:
     """Accepts one connection and replies to each request with `responder()`."""
 
@@ -41,16 +52,12 @@ class _FakeServer:
         try:
             with conn:
                 while True:
-                    hdr = conn.recv(4)
-                    if len(hdr) < 4:
+                    hdr = _recv_all(conn, 4)   # TCP may split even a 4-byte header
+                    if hdr is None:
                         return
                     n = struct.unpack(">I", hdr)[0]
-                    remaining = n
-                    while remaining > 0:
-                        chunk = conn.recv(remaining)
-                        if not chunk:
-                            return
-                        remaining -= len(chunk)
+                    if _recv_all(conn, n) is None:
+                        return
                     reply = self._responder()
                     if reply is None:
                         return

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -47,6 +47,27 @@ the user to know which kind of question they are asking.
 `-no-hybrid` restores pure dense KNN. Note the returned `Score` is the fusion
 score, not the original per-lane score — they are not comparable across modes.
 
+### KV from Python, over the native protocol
+
+The key-value store is not on the REST API — it lives only on the binary TCP
+protocol — so it had been unreachable from Python entirely. The new `RostamKV`
+client speaks that protocol directly (standard library only) and covers the five
+built-in ops:
+
+```python
+from rostam import RostamKV
+
+kv = RostamKV("127.0.0.1", 7000)   # the server's -tcp port
+kv.put("user:42", payload, ttl_ms=300_000)
+kv.get("user:42")                  # bytes, or None on miss
+kv.incr("views:42", 1)             # atomic; missing key counts as 0
+```
+
+Keys and values are `str` or `bytes`; `auth_token=` rides the protocol-v2 frame
+on every request when the server requires one. Custom ops and WASM procedures
+stay Go-only (they need per-op argument encoders). This pairs with the container
+now serving the TCP port by default.
+
 ### The Python client reaches the Query API
 
 `rostam-client` gains `query()`, `recommend()` and `discover()`. Recommend and

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -52,13 +52,13 @@ score, not the original per-lane score — they are not comparable across modes.
 The key-value store is not on the REST API — it lives only on the binary TCP
 protocol — so it had been unreachable from Python entirely. The new `RostamKV`
 client speaks that protocol directly (standard library only) and covers the five
-built-in ops:
+built-in ops (`get`, `put`, `delete`, `incr`, `expire`), plus a `ping` heartbeat:
 
 ```python
 from rostam import RostamKV
 
 kv = RostamKV("127.0.0.1", 7000)   # the server's -tcp port
-kv.put("user:42", payload, ttl_ms=300_000)
+kv.put("user:42", b'{"coins":100}', ttl_ms=300_000)
 kv.get("user:42")                  # bytes, or None on miss
 kv.incr("views:42", 1)             # atomic; missing key counts as 0
 ```

--- a/docs/kv/overview.md
+++ b/docs/kv/overview.md
@@ -15,6 +15,7 @@ is the native `RostamKV` client, which speaks the same protocol over a socket.
 === "Go"
 
     ```go
+    payload := []byte(`{"coins":100}`)
     _ = store.Put(ctx, []byte("user:42"), payload, 5*time.Minute) // ttl 0 = no expiry
     v, err := store.Get(ctx, []byte("user:42"))                   // rostam.ErrNotFound on miss/expiry
     existed, err := store.Del(ctx, []byte("user:42"))
@@ -26,7 +27,7 @@ is the native `RostamKV` client, which speaks the same protocol over a socket.
     from rostam import RostamKV
 
     kv = RostamKV("127.0.0.1", 7000)             # the server's -tcp port
-    kv.put("user:42", payload, ttl_ms=300_000)   # ttl_ms 0 = no expiry
+    kv.put("user:42", b'{"coins":100}', ttl_ms=300_000)   # ttl_ms 0 = no expiry
     kv.get("user:42")                            # bytes, or None on miss/expiry
     kv.delete("user:42")                         # -> bool (existed)
     ```

--- a/docs/kv/overview.md
+++ b/docs/kv/overview.md
@@ -5,25 +5,61 @@ TTL, optional mmap persistence, and optional per-shard Raft replication. You use
 it through the `rostam.Store` facade (any backend) or, for a standalone
 in-process cache, through `cache.Cache` directly.
 
+Unlike the vector API, KV is **not on the REST endpoint** — it lives only on the
+binary TCP protocol, because it is built for sub-microsecond operations an HTTP
+round trip would defeat. In Go that is the `Store` facade below; from Python it
+is the native `RostamKV` client, which speaks the same protocol over a socket.
+
 ## Core operations
 
-```go
-_ = store.Put(ctx, []byte("user:42"), payload, 5*time.Minute) // ttl 0 = no expiry
-v, err := store.Get(ctx, []byte("user:42"))                   // rostam.ErrNotFound on miss/expiry
-existed, err := store.Del(ctx, []byte("user:42"))
-```
+=== "Go"
 
-Beyond get/put/del, two built-in atomic ops run server-side through
-`Call` — no read-modify-write race, no extra round trips:
+    ```go
+    _ = store.Put(ctx, []byte("user:42"), payload, 5*time.Minute) // ttl 0 = no expiry
+    v, err := store.Get(ctx, []byte("user:42"))                   // rostam.ErrNotFound on miss/expiry
+    existed, err := store.Del(ctx, []byte("user:42"))
+    ```
 
-```go
-// counter += 1, returns the new value as big-endian int64
-res, err := store.Call(ctx, "incr", ops.EncodeIncrArgs([]byte("views:42"), 1))
-n, _ := ops.DecodeIncrResult(res)
+=== "Python"
 
-// refresh a TTL without rewriting the value
-_, err = store.Call(ctx, "expire", ops.EncodeExpireArgs([]byte("user:42"), time.Hour))
-```
+    ```python
+    from rostam import RostamKV
+
+    kv = RostamKV("127.0.0.1", 7000)             # the server's -tcp port
+    kv.put("user:42", payload, ttl_ms=300_000)   # ttl_ms 0 = no expiry
+    kv.get("user:42")                            # bytes, or None on miss/expiry
+    kv.delete("user:42")                         # -> bool (existed)
+    ```
+
+    Keys and values may be `str` (encoded UTF-8) or `bytes`; reads always return
+    `bytes` (or `None`). Pass `auth_token=` when the server requires one — it
+    rides the protocol-v2 frame on every request.
+
+Beyond get/put/del, two built-in atomic ops run server-side — no
+read-modify-write race, no extra round trips:
+
+=== "Go"
+
+    ```go
+    // counter += 1, returns the new value as big-endian int64
+    res, err := store.Call(ctx, "incr", ops.EncodeIncrArgs([]byte("views:42"), 1))
+    n, _ := ops.DecodeIncrResult(res)
+
+    // refresh a TTL without rewriting the value
+    _, err = store.Call(ctx, "expire", ops.EncodeExpireArgs([]byte("user:42"), time.Hour))
+    ```
+
+=== "Python"
+
+    ```python
+    kv.incr("views:42", 1)          # atomic add, returns the new int (missing = 0)
+    kv.expire("user:42", 3_600_000) # refresh the TTL without rewriting the value
+    ```
+
+The Python client covers the five built-in ops (`get`, `put`, `delete`, `incr`,
+`expire`). [Custom ops](custom-ops.md) and [WASM procedures](wasm.md) are
+dispatched through Go's `Call(ctx, name, args)` with op-specific argument
+encoders, and are Go-only for now.
 
 `Call(ctx, name, args)` dispatches any registered op by name. Read-only ops
 execute locally on the routed shard; read-write ops serialize through the


### PR DESCRIPTION
The KV store is **not on REST** — it lives only on the binary TCP protocol (sub-microsecond ops that HTTP would defeat), so it had been unreachable from Python. `RostamKV` speaks that protocol directly, standard library only.

```python
from rostam import RostamKV

kv = RostamKV("127.0.0.1", 7000)             # the server's -tcp port
kv.put("user:42", payload, ttl_ms=300_000)
kv.get("user:42")                            # bytes, or None on miss
kv.incr("views:42", 1)                       # atomic; missing key = 0
kv.delete("user:42")                         # -> bool (existed)
```

Covers the five built-in ops (`get`/`put`/`delete`/`incr`/`expire`) plus `ping`.

## Wire (all big-endian, matching the Go server)

```
frame     [len u32][body]
body v1   [opNameLen u8][opName][argsLen u32][args]
body v2   [0x02][tokenLen u8][token][ ...v1 body... ]   (auth)
response  [bodyLen u32][status u8][payloadLen u32][payload]
```

v2 framing carries the auth token on every request when one is set (mirroring the Go client); v1 otherwise. A small lock-guarded socket pool with `TCP_NODELAY` mirrors the HTTP client's reuse; a socket that errors mid-call is discarded, not returned, so a broken connection can't poison the next request. Keys/values are `str` (UTF-8) or `bytes`; reads return `bytes` or `None`, so a miss is distinct from a stored empty value.

## Verification

Cross-stack against a **real server** on its `-tcp` port — there's no fake worth trusting for a byte-level protocol. `test_cross_stack_kv.py` (10 tests) covers every op, the miss-vs-empty distinction, binary-safe keys and values, and the **protocol-v2 auth path**: correct token works, missing/wrong token refused with `StatusUnauthorized`. Full Python suite: **81 passed, 26 skipped**.

## Scope

Custom ops and WASM stay Go-only (they need per-op argument encoders). Part of the "everything the server exposes, from Python" goal: **vector over HTTP + KV over native TCP**. Pairs with #26 (container serves the TCP port by default). Changelog entry included (guard requires it).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Python `RostamKV` client for TCP-based key-value operations.
  * Supports getting, storing, deleting, incrementing, expiring, and pinging data, including binary keys and values.
  * Added optional request authentication, connection pooling, context-manager support, and robust error handling.
  * Made `RostamKV` available through the public Python package API.

* **Documentation**
  * Added Python usage examples, authentication guidance, TTL details, and protocol availability notes.

* **Tests**
  * Added coverage for cross-stack operations, authentication, binary data, expiration, connection failures, and malformed responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->