### PR TITLE
docs(clustering): clarify reconfigure vs reshard scope for KV

### DIFF
--- a/docs/server/clustering.md
+++ b/docs/server/clustering.md
@@ -168,7 +168,9 @@ rebalance completes; size the context deadline to your data volume.
 This redistributes the fixed `-shards` groups (key-value **and** vector shards
 alike) across the new membership — a shard gains the new node as a Raft voter,
 waits for it to catch up, then drops departing owners, so a caught-up owner is
-retained at every step and reads and writes never pause. It does **not** change
+retained at every step. Reconfiguration requires no planned downtime, though a
+write can still hit a transient retryable error if a departing owner was the
+shard leader (see [Failure behavior](#failure-behavior)). It does **not** change
 the shard count: `-shards` is fixed for the life of the cluster, so choose it
 with headroom (shards ≫ nodes) if you expect to grow. Changing the *partition
 count* is a per-collection operation (below) and applies to vector collections

--- a/docs/server/clustering.md
+++ b/docs/server/clustering.md
@@ -165,9 +165,19 @@ decommissioned ones. Decommissioned nodes keep running and forwarding until
 their shards re-home, then can be shut down. The call blocks until the
 rebalance completes; size the context deadline to your data volume.
 
+This redistributes the fixed `-shards` groups (key-value **and** vector shards
+alike) across the new membership — a shard gains the new node as a Raft voter,
+waits for it to catch up, then drops departing owners, so a caught-up owner is
+retained at every step and reads and writes never pause. It does **not** change
+the shard count: `-shards` is fixed for the life of the cluster, so choose it
+with headroom (shards ≫ nodes) if you expect to grow. Changing the *partition
+count* is a per-collection operation (below) and applies to vector collections
+only — there is no key-value equivalent.
+
 ## Resharding collections online
 
-Partitioned vector collections can change partition count without downtime:
+Partitioned vector collections (not the key-value store) can change partition
+count without downtime:
 
 ```
 POST /v1/collections/{name}/reshard        {"new_partitions": 8}


### PR DESCRIPTION
The **Changing the cluster: reconfigure** and **Resharding collections online** sections sat next to each other in `docs/server/clustering.md` without stating an important distinction, so a reader could reasonably assume the KV shard count is elastic.

## What this clarifies

- **reconfigure** redistributes the *fixed* `-shards` groups (KV **and** vector shards alike) across the new membership — the online gain-then-release Raft membership change, with a caught-up owner retained at every step so reads/writes never pause. It does **not** change the shard count.
- `-shards` is **fixed for the life of the cluster** — choose it with headroom (shards ≫ nodes) if you expect to grow.
- The partition-count `/reshard` endpoint is a **per-collection, vector-only** operation — there is no KV equivalent. The resharding heading now says so explicitly.

Docs-only; no behavior change. `mkdocs build --strict` passes clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified how fixed shard groups are redistributed when cluster membership changes.
  * Documented that a caught-up owner is preserved while reads and writes remain available.
  * Explained that the cluster’s shard count remains fixed for its lifetime.
  * Distinguished cluster shard redistribution from partition-count changes for partitioned vector collections.
  * Clarified that resharding applies only to partitioned vector collections.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->