### PR TITLE
build(release): publish opt-in `:localembed` image + document local-embedding install

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,20 @@
+# Keep the Docker build context minimal and secret-free.
+#
+# Both images do `COPY . .` and export build layers to the GHA cache
+# (cache-to: mode=max). actions/checkout persists GITHUB_TOKEN under .git, so
+# .git must never enter the build context or it can leak into cached layers.
+# The rest below are simply not build inputs (the server builds from Go source
+# + go.mod/go.sum); dropping them shrinks the context and speeds the build.
+.git
+.github
+.dockerignore
+
+# Agent/tooling scratch (git-ignored, never a build input)
+.omc
+.superpowers
+.claude
+
+# Editor / OS noise
+.vscode
+.idea
+.DS_Store

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -174,3 +174,52 @@ jobs:
           done
         env:
           VERSION: ${{ steps.meta.outputs.version }}
+
+  # Opt-in local-embedding image (-tags localembed): a SEPARATE image that
+  # bundles ONNX Runtime and is published as :localembed. It is NOT part of the
+  # default multi-arch manifest above — the default image stays lean and
+  # ONNX-free. linux/amd64 only, because the bundled ONNX Runtime is the x64
+  # release (Dockerfile.localembed fails the build on any other arch), so this
+  # image is single-arch and pushed directly rather than through the by-digest
+  # manifest dance.
+  image-localembed:
+    name: image (localembed)
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.tag || github.ref }}
+
+      - uses: docker/setup-buildx-action@v3
+
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ github.repository }}
+          # Pinned tags always; the moving :localembed only on a real tag push,
+          # so re-releasing an OLD tag by hand cannot drag it backwards (the
+          # same rule the default image applies to :latest).
+          tags: |
+            type=semver,pattern=localembed-{{version}},value=${{ inputs.tag || github.ref_name }}
+            type=semver,pattern=localembed-{{major}}.{{minor}},value=${{ inputs.tag || github.ref_name }}
+            type=raw,value=localembed,enable=${{ github.event_name == 'push' }}
+
+      - uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: cmd/rostam-server/Dockerfile.localembed
+          platforms: linux/amd64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha,scope=localembed
+          cache-to: type=gha,mode=max,scope=localembed

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -73,6 +73,10 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: ${{ inputs.tag || github.ref }}
+          # The context is copied into the image (COPY . .) and layers are
+          # exported to the build cache; do not persist GITHUB_TOKEN in .git,
+          # where it could leak into a cached layer.
+          persist-credentials: false
 
       - uses: docker/setup-buildx-action@v3
 
@@ -192,6 +196,10 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: ${{ inputs.tag || github.ref }}
+          # The context is copied into the image (COPY . .) and layers are
+          # exported to the build cache; do not persist GITHUB_TOKEN in .git,
+          # where it could leak into a cached layer.
+          persist-credentials: false
 
       - uses: docker/setup-buildx-action@v3
 

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -93,13 +93,20 @@ release:
 
     # Container (always a cgo build; authentication is required)
     docker run -p 8080:8080 -e ROSTAM_API_KEY=secret ghcr.io/rostamlabs/rostam:{{ .Tag }}
+
+    # Container with local ONNX embeddings (opt-in, linux/amd64; bundles ONNX Runtime)
+    docker run -p 8080:8080 -e ROSTAM_API_KEY=secret \
+      -e ROSTAM_EMBED_LOCAL=minilm-l6-v2 -v rostam-models:/models \
+      ghcr.io/rostamlabs/rostam:localembed-{{ .Version }}
     ```
 
     The binaries attached below are **pure-Go builds**: everything works except
     WASM stored procedures, which return `wasm: stored procedures require a cgo
     build`. The container image always includes them. `go install` includes them
     only when it builds with cgo — a native build (cgo defaults off when
-    cross-compiling) on a machine with a C compiler.
+    cross-compiling) on a machine with a C compiler. Local in-process embeddings
+    (`-tags localembed`) are likewise cgo-only and are shipped as the separate
+    `:localembed` image above, not in these binaries.
 
     Verify a download against `checksums.txt`:
 

--- a/README.md
+++ b/README.md
@@ -238,6 +238,23 @@ container image always includes them. `go install` includes them only when it
 builds with cgo — a native build (cgo defaults off when cross-compiling) on a
 machine with a C compiler.
 
+Local in-process embeddings (`-tags localembed`) are a cgo feature too, and need
+an ONNX Runtime shared library at runtime, so they are **not** in the pure-Go
+binaries either. Two supported ways to get them:
+
+```sh
+# Opt-in container image (linux/amd64) — bundles ONNX Runtime, self-contained
+docker run -p 8080:8080 -e ROSTAM_API_KEY=secret \
+  -e ROSTAM_EMBED_LOCAL=minilm-l6-v2 -v rostam-models:/models \
+  ghcr.io/rostamlabs/rostam:localembed
+
+# Or build from source with the tag (needs ONNX Runtime >= 1.29.0 installed)
+CGO_ENABLED=1 go install -tags localembed \
+  github.com/rostamlabs/rostam/cmd/rostam-server@latest
+```
+
+See [Local embeddings](docs/server/mcp.md) for the model catalog and configuration.
+
 ## Quick start — run the server
 
 ```sh

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -14,6 +14,10 @@ Notable user-visible changes. Entries that alter existing behaviour are marked
 - **768-dim "base" tier for local embeddings.** The `-tags localembed` catalog
   adds three higher-quality 768-dim models: `bge-base-en-v1.5`, `gte-base`, and
   `all-mpnet-base-v2`. Select one with `ROSTAM_EMBED_LOCAL=<name>`.
+- **Prebuilt local-embedding image.** Releases now publish an opt-in
+  `ghcr.io/rostamlabs/rostam:localembed` image (linux/amd64) that bundles ONNX
+  Runtime, so local embeddings work without building from source or installing
+  ONNX Runtime yourself. The default image stays lean and ONNX-free.
 
 ## v0.3.0 — 2026-08-16
 

--- a/docs/server/mcp.md
+++ b/docs/server/mcp.md
@@ -161,9 +161,14 @@ the conventional install locations be searched.
 ### Docker
 
 The default image (`cmd/rostam-server/Dockerfile`) is deliberately lean and has
-no ONNX Runtime. A separate, opt-in image bundles it:
+no ONNX Runtime. A separate, opt-in image bundles it. Releases publish a prebuilt
+one (linux/amd64), or build it yourself:
 
 ```sh
+# Prebuilt (published per release; linux/amd64)
+docker run --rm ghcr.io/rostamlabs/rostam:localembed mcp -list-embed-models
+
+# Or build it yourself
 docker build -f cmd/rostam-server/Dockerfile.localembed -t rostam-server:localembed .
 docker run --rm rostam-server:localembed mcp -list-embed-models
 ```

--- a/install.sh
+++ b/install.sh
@@ -19,6 +19,12 @@
 # only when the build has cgo on: a native build (cgo defaults off when
 # cross-compiling) on a machine with a C compiler.
 #
+# Local in-process embeddings (-tags localembed) are likewise a cgo feature and
+# need ONNX Runtime at runtime, so they are NOT in these binaries. Use the
+# ghcr.io/rostamlabs/rostam:localembed image (bundles ONNX Runtime), or build
+# from source: CGO_ENABLED=1 go install -tags localembed \
+#   github.com/rostamlabs/rostam/cmd/rostam-server@latest
+#
 # POSIX sh on purpose: this runs on whatever /bin/sh a machine happens to have.
 set -eu
 


### PR DESCRIPTION
## What

Distributes the local ONNX embedder (`-tags localembed`, merged in #34) through the release pipeline, and documents how to get it.

## Why

The prebuilt release binaries and `install.sh` are pure-Go (`CGO_ENABLED=0`) and deliberately exclude cgo features — the same reason WASM stored procedures aren't in them. Local embeddings need cgo **and** an ONNX Runtime shared library at runtime, so they can't ride a downloadable binary. The clean distribution vehicle is a container image that bundles ONNX Runtime.

## Changes

- **`.github/workflows/release.yml`** — a new `image-localembed` job builds `cmd/rostam-server/Dockerfile.localembed` (linux/amd64) and pushes `ghcr.io/rostamlabs/rostam:localembed` plus pinned `localembed-<version>` / `localembed-<major>.<minor>` tags. Single-arch, so it pushes directly rather than through the by-digest + manifest dance the default multi-arch image uses. The moving `:localembed` tag is gated on a real tag push (same rule the default image applies to `:latest`), and it never emits `:latest` or bare version tags, so it can't collide with the default image.
- **Docs** — README, `install.sh` header, the goreleaser release-notes footer, `docs/server/mcp.md`, and the changelog now point to the `:localembed` image and the `-tags localembed` from-source recipe.

## Notes / scope

- **linux/amd64 only** — `Dockerfile.localembed` bundles the x64 ONNX Runtime and fails the build on any other arch (arm64 is a follow-up).
- **Nothing about the default image or the pure-Go binaries changes.** They stay lean and ONNX-free.

## Validation

- Both YAML files parse; `goreleaser check` passes; `sh -n install.sh` OK.
- `Dockerfile.localembed` itself was built and smoke-tested when #34 landed (image runs, catalog lists, `ROSTAM_EMBED_LOCAL` loads ONNX Runtime and embeds).
- Reviewed against the existing `image`/`image-manifest` jobs: metadata-action tag syntax, `enable=` gating, permissions, and single-arch push all confirmed consistent.
- The release job itself can only be exercised by a real `v*` tag release.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a prebuilt Linux/amd64 container image with local ONNX embeddings.
  * Added versioned and rolling image tags for local embedding releases.
  * Added setup options for running the image or building from source with ONNX Runtime.

* **Documentation**
  * Documented required configuration, model volumes, cgo build settings, and ONNX Runtime installation.
  * Clarified that the default container remains lean and does not include ONNX Runtime.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->