### PR TITLE
docs(api): document the native-TCP Go typed client and Python r.vector methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -320,6 +320,20 @@ hits = c.hybrid_text("docs", vector=vec, text="hello", k=5)
 hits = c.search("docs", vector=vec, k=10, filter={"tenant": "acme"})
 ```
 
+`RostamClient` above talks REST on `:8080`. The same package also ships a
+**native client over the binary TCP protocol** (the server's `-tcp` port,
+`7000`) — the full vector surface, recommendation and hybrid search included,
+with no HTTP round trip:
+
+```python
+from rostam import Rostam
+
+r = Rostam("127.0.0.1", 7000)                     # binary TCP, not REST
+r.vector.upsert("docs", 1, vec, content="hello", metadata={"tenant": "acme"})
+hits = r.vector.hybrid_text("docs", dense=vec, text="hello", k=5)   # dense + BM25
+recs = r.vector.recommend("docs", positive=[1], k=10)               # "more like this"
+```
+
 Bulk ingest ships vectors as raw f32 over a binary wire rather than JSON text,
 which is what makes large loads fast — a 1M × 768d load runs in **282 s**.
 → [Python client docs](https://docs.rostamlabs.com/api/python/)
@@ -361,6 +375,11 @@ Beyond kNN: hybrid dense+sparse fusion (RRF/weighted/DBSF), BM25 full-text,
 recommendation (± examples), discovery, group-by, scroll with order-by, IVF and
 Vamana indexes, binary/PQ quantization with mmap-resident codes, per-collection
 quotas and TTL. → [Vector engine docs](https://docs.rostamlabs.com/vector/collections-and-indexes/)
+
+Talking to a *remote* server from Go rather than embedding? The typed
+`client.Collection` handle mirrors this API over the binary TCP protocol:
+`client.NewRouted(...)`, then `c.Collection("docs").HybridText(...)` /
+`.Recommend(...)`. → [Go client docs](https://docs.rostamlabs.com/api/go-client/)
 
 ## Quick start — key-value store (Go library)
 

--- a/docs/api/go-client.md
+++ b/docs/api/go-client.md
@@ -1,5 +1,225 @@
 # Go client (TCP smart client)
 
+Two ways to reach Rostam from Go, both over the compact binary TCP protocol to
+a running server or cluster (`rostam-server -tcp ...`):
+
+- **Typed `Collection` client** (`client.NewRouted` + `c.Collection(name)`) —
+  the recommended API for vector work: request/response structs, typed errors,
+  shard-aware routing on by default.
+- **Low-level client** (`rostam.NewClient`) — the same `rostam.Store`
+  interface as the embedded backends, plus `Call` as an escape hatch for
+  custom ops and WASM procedures.
+
+## Typed Collection client
+
+`client.NewRouted` builds a `*client.Client` with Rostam's builtin routing
+registry wired in, so each request is dispatched to the shard that owns its
+key instead of round-robin:
+
+```go
+import (
+	"os"
+
+	"github.com/rostamlabs/rostam/client"
+)
+
+c, err := client.NewRouted(client.Config{
+	Servers:   []string{"127.0.0.1:7000"}, // binary TCP port, bootstrap list
+	AuthToken: os.Getenv("ROSTAM_TOKEN"),
+})
+if err != nil { ... }
+defer c.Close()
+
+posts := c.Collection("posts")
+```
+
+`client.New(cfg)` builds the same client without the routing registry (nil
+`Ops` — no self-routing). It exists for internal/verbatim-dialing callers that
+need to address a specific, already-resolved node (e.g. a leader-pinned read);
+application code should use `NewRouted`.
+
+### Collection handle
+
+`c.Collection(name)` returns a `*client.Collection` bound to that name. It
+performs no I/O and does not require the collection to exist yet.
+
+```go
+type CreateRequest struct {
+	Dim            int
+	Metric         vector.Metric // zero value = vector.Cosine (also L2, DotProduct)
+	M              int
+	EfConstruction int
+	EfSearch       int
+	Persistent     bool
+	FullText       *vector.FullTextConfig // set to enable BM25 (required for HybridText)
+}
+
+err := posts.Create(ctx, client.CreateRequest{Dim: 768, Metric: vector.Cosine})
+err  = posts.Drop(ctx) // idempotent — a never-created name is a no-op, not an error
+```
+
+### Writing
+
+```go
+type WriteRequest struct {
+	ID       uint64
+	Vector   []float32
+	Content  string              // raw text tokenized into the BM25 lane (Upsert only)
+	Metadata vector.Metadata     // build with vector.NewString/NewInt/NewFloat/NewBool/...
+	Sparse   vector.SparseVector // optional client sparse vector
+	TTL      time.Duration       // 0 = no expiry
+	// CAS: HasExpectedVersion must be true for ExpectedVersion to apply.
+	ExpectedVersion    uint64
+	HasExpectedVersion bool
+	KeyTTLMs           map[string]int64
+}
+
+err := posts.Upsert(ctx, client.WriteRequest{ID: 1, Vector: vec, Content: "..."})
+err  = posts.Insert(ctx, client.WriteRequest{ID: 2, Vector: vec}) // fails if id exists
+err  = posts.Delete(ctx, client.DeleteRequest{ID: 2})
+```
+
+`Insert` rejects a non-empty `Content` (the insert wire op carries no content
+field) — use `Upsert` when you need the BM25 content lane.
+
+`UpsertBatch` issues one `Upsert` per point over the (optionally pipelined)
+connection — there is no single batch op on the wire — and returns the
+per-point failures, if any:
+
+```go
+errs := posts.UpsertBatch(ctx, []client.PointInput{
+	{ID: 1, Vector: v1, Content: "first post"},
+	{ID: 2, Vector: v2, Content: "second post"},
+})
+for _, e := range errs { // nil/empty slice means everything succeeded
+	log.Printf("point %d: %v", e.ID, e.Err)
+}
+```
+
+### Reading
+
+```go
+pt, err := posts.Get(ctx, client.GetRequest{ID: 1, WithVector: true, WithPayload: true})
+// pt: Point{ID, Vector, Metadata, TTLMs, Version}
+// err is client.ErrNotFound if the point is absent, client.ErrCollectionNotFound
+// if the collection itself doesn't exist.
+
+batch, err := posts.GetBatch(ctx, client.GetBatchRequest{IDs: []uint64{1, 2, 3}})
+// batch.Points + batch.Missing (requested ids that weren't found — not an error)
+
+page, err := posts.Scroll(ctx, client.ScrollRequest{Limit: 100})
+for page.NextCursor != "" {
+	page, err = posts.Scroll(ctx, client.ScrollRequest{Limit: 100, Cursor: page.NextCursor})
+}
+```
+
+### Searching
+
+Every search method returns a `SearchResponse` (or a doc/group variant of it)
+carrying explicit degraded-partition info:
+
+```go
+type SearchResponse struct {
+	Results  []vector.Result // {ID, Distance, Score}
+	Degraded bool            // true if a partition was unavailable when this answered
+	Missing  []uint16        // the unavailable partition indices
+}
+```
+
+```go
+res, err := posts.Search(ctx, client.SearchRequest{Query: qvec, K: 10, Filter: f})
+
+docs, err := posts.SearchDocs(ctx, client.SearchDocsRequest{Query: qvec, K: 10})
+// docs.Documents: []client.Document{ID, Distance, Score, Content, Metadata}
+
+groups, err := posts.SearchGroups(ctx, client.GroupSearchRequest{
+	Query: qvec, K: 5, GroupBy: "doc_id", GroupSize: 2,
+})
+// groups.Groups: []client.Group{Key, Hits []Document}
+
+res, err = posts.HybridSearch(ctx, client.HybridSearchRequest{
+	Dense: qvec, Sparse: sparseVec, K: 10, Method: vector.FusionRRF,
+})
+
+res, err = posts.HybridText(ctx, client.HybridTextRequest{
+	Dense: qvec, Text: "how do i rotate api keys", K: 10, Method: vector.FusionRRF,
+})
+// HybridText requires the collection to have been Created with FullText set.
+```
+
+`Search`/`SearchDocs`/`SearchGroups`/`HybridSearch`/`HybridText` all accept a
+`Consistency` field (`client.ConsistencyDefault` is the strong/leader-read
+server default) and return `client.ErrCollectionNotFound` when the collection
+doesn't exist.
+
+### Recommend / raw Query
+
+```go
+res, err := posts.Recommend(ctx, client.RecommendRequest{
+	Positive: []uint64{1, 2},  // point ids the caller liked
+	Negative: []uint64{9},     // optional: steer away from these
+	K:        10,
+})
+```
+
+`Recommend` resolves the example ids to their stored vectors server-side and
+excludes them from the results. It rides `Query` under the hood, sending a
+`ModeFusion` spec with a single `RECOMMEND` prefetch lane; that shape only
+fuses correctly behind a routed/multi-node (coordinator) deployment — against
+a single coordinator-less node the fused result cannot be decoded. `Query` is
+the power-user escape hatch for any `vector.QuerySpec` (multi-leaf fusion,
+rerank, discover), decoded into the same `SearchResponse` shape.
+
+### Typed errors
+
+| Error | Meaning |
+|---|---|
+| `client.ErrNotFound` | point/key absent |
+| `client.ErrVersionConflict` | CAS `ExpectedVersion` mismatch |
+| `client.ErrCollectionExists` | `Create` on a name that already exists |
+| `client.ErrCollectionNotFound` | the collection itself doesn't exist |
+
+```go
+if errors.Is(err, client.ErrCollectionExists) { ... }
+```
+
+### Worked example: recommend the next post
+
+```go
+posts := c.Collection("posts")
+_ = posts.Create(ctx, client.CreateRequest{
+	Dim: 768, Metric: vector.Cosine,
+	FullText: &vector.FullTextConfig{}, // defaults: english analyzer, k1=1.2, b=0.75
+})
+
+for _, p := range []struct {
+	id      uint64
+	vec     []float32
+	content string
+} {
+	{1, embed("rotating api keys safely"), "rotating api keys safely"},
+	{2, embed("kubernetes autoscaling basics"), "kubernetes autoscaling basics"},
+	{3, embed("zero-downtime key rotation at scale"), "zero-downtime key rotation at scale"},
+} {
+	_ = posts.Upsert(ctx, client.WriteRequest{
+		ID: p.id, Vector: p.vec, Content: p.content,
+		Metadata: vector.Metadata{"tenant": vector.NewString("acme")},
+	})
+}
+
+// Fuse a dense query with BM25 full-text.
+hits, err := posts.HybridText(ctx, client.HybridTextRequest{
+	Dense: embed("how do i rotate api keys"),
+	Text:  "how do i rotate api keys",
+	K:     5, Method: vector.FusionRRF,
+})
+
+// Or: the reader just finished post 1 — recommend what's similar.
+next, err := posts.Recommend(ctx, client.RecommendRequest{Positive: []uint64{1}, K: 5})
+```
+
+## Low-level client
+
 `rostam.NewClient` returns the same `rostam.Store` interface as the embedded
 backends, speaking the compact binary TCP protocol to a running server or
 cluster (`rostam-server -tcp ...`).

--- a/docs/api/python.md
+++ b/docs/api/python.md
@@ -21,6 +21,22 @@ All errors raise `RostamError(message, status)` carrying the HTTP status.
 Metadata is plain Python dicts — the client converts to/from the server's
 tagged value encoding automatically.
 
+!!! info "Two clients, two ports"
+    This package ships **two** clients:
+
+    - `RostamClient` (below) speaks **REST over HTTP**, against the server's
+      HTTP port (`8080` above).
+    - `Rostam` (see [Native TCP client](#native-tcp-client-rostam)) speaks the
+      **binary protocol over TCP**, against the server's `-tcp` port (`7000`
+      in the examples). It carries both the KV store (which is TCP-only) and
+      the full vector API as `r.vector.*` — the same collections, the same
+      points, just a different wire.
+
+    Reach for the native client when you want the lower-overhead binary
+    protocol or need the KV store; reach for `RostamClient` for a
+    dependency-free REST surface (and the LangChain/LlamaIndex/Haystack
+    adapters, which are HTTP-only).
+
 ## Connections
 
 The client keeps a small pool of connections and reuses them, so a sequence of
@@ -187,6 +203,113 @@ c.mv_create_collection("docs-colbert", dim=128)
 c.mv_add("docs-colbert", doc_id=1, tokens=token_vectors, metadata={"src": "faq"})
 c.mv_search("docs-colbert", query_tokens, k=10)   # -> [MultiResult(id, score, metadata)]
 c.mv_delete("docs-colbert", 1)
+```
+
+## Native TCP client (Rostam)
+
+`Rostam` (alias `RostamKV`) is a dependency-free, stdlib-only client for the
+binary TCP protocol — the same protocol the [Go smart client](go-client.md)
+speaks. It connects to the server's `-tcp` port (**`7000`** in the examples
+throughout these docs), not the HTTP port:
+
+```python
+from rostam import Rostam
+
+r = Rostam("127.0.0.1", 7000, auth_token=None, timeout=30.0, pool_maxsize=8)
+r.put("user:42", b'{"coins":100}')       # KV ops are TCP-only — see kv/overview.md
+r.vector.create_collection("posts", dim=768, metric="cosine")
+```
+
+Key-value operations (`get`/`put`/`delete`/`incr`/`expire`/`ping`) are methods
+on `r` directly — see [Key-value store](../kv/overview.md). Vector operations
+live under `r.vector`, sharing the same connection pool and auth token.
+
+### Vector operations
+
+`r.vector` covers the full vector surface over TCP, including the batch/scroll/
+RAG-shaped search/hybrid/recommend methods added alongside the Go typed
+[`Collection` client](go-client.md#typed-collection-client):
+
+```python
+r.vector.create_collection("posts", dim=768, metric="cosine", full_text=True)
+
+r.vector.upsert("posts", 1, vec, content="rotating api keys safely",
+                metadata={"tenant": "acme"})
+r.vector.insert("posts", 2, vec)                    # create-only: errors if id exists
+r.vector.upsert_batch("posts", [
+    {"id": 3, "vector": v3, "content": "third post"},
+    {"id": 4, "vector": v4, "content": "fourth post"},
+])                                                    # N sequential upserts, not pipelined
+
+point = r.vector.get("posts", 1, with_vector=True, with_payload=True)
+# -> {vector, metadata, ttl_ms, sparse, content} or None if absent
+
+rows = r.vector.get_batch("posts", [1, 2, 3], with_vector=True, with_payload=True)
+# -> [{id, found, vector, metadata, ttl_ms, sparse, version, content}, ...]
+
+docs, next_cursor = r.vector.scroll("posts", limit=100)
+while next_cursor:
+    docs, next_cursor = r.vector.scroll("posts", limit=100, cursor=next_cursor)
+
+r.vector.delete("posts", 2)                          # -> bool (existed)
+r.vector.exists("posts", 1)                           # -> bool
+```
+
+Search-family methods return `SearchResults` (or `GroupResults` for
+`search_groups`) — a plain `list` subclass that also carries `.degraded` and
+`.missing`, reporting whether the read was partial (e.g. during a cluster
+outage). Iteration, indexing, `len()`, and equality against a bare list all
+work as normal; `.degraded`/`.missing` just ride along, mirroring the Go typed
+client's `SearchResponse{Results, Degraded, Missing}`:
+
+```python
+hits = r.vector.search("posts", query_vec, k=10, filter=None)
+hits.degraded, hits.missing         # False, [] on a healthy single-node server
+
+docs = r.vector.search_docs("posts", query_vec, k=10, filter=None)
+# -> SearchResults of {id, distance, score, content, metadata}
+
+groups = r.vector.search_groups("posts", query_vec, k=5, group_by="doc_id",
+                                group_size=2, fetch_k=0, filter=None)
+# -> GroupResults of {key, hits}
+
+hits = r.vector.hybrid_search("posts", dense=query_vec, k=10,
+                              sparse={"indices": [3, 17], "values": [0.4, 0.9]},
+                              method="rrf", alpha=0.0)
+
+hits = r.vector.hybrid_text("posts", dense=query_vec, text="rotate api keys",
+                            k=10, method="rrf")
+# requires the collection to have been created with full_text=...
+
+hits = r.vector.recommend("posts", positive=[1, 2], negative=[9], k=10,
+                          strategy="average_vector")   # or "best_score"
+```
+
+`r.vector.query(...)` has the same signature as `recommend` — it exists only
+so callers reaching for the "unified Query API" name find the one shape this
+client speaks. This client is **recommend-shaped only**: it does not build the
+general fusion/rerank/prefetch-tree `QuerySpec` the Go SDK's `Query` supports.
+
+### Worked example: recommend the next post (native TCP)
+
+```python
+from rostam import Rostam
+
+r = Rostam("127.0.0.1", 7000)
+r.vector.create_collection("posts", dim=768, metric="cosine", full_text=True)
+
+for id, text in [(1, "rotating api keys safely"),
+                  (2, "kubernetes autoscaling basics"),
+                  (3, "zero-downtime key rotation at scale")]:
+    r.vector.upsert("posts", id, embed(text), content=text,
+                    metadata={"tenant": "acme"})
+
+# Fuse a dense query with BM25 full-text.
+hits = r.vector.hybrid_text("posts", dense=embed("how do i rotate api keys"),
+                            text="how do i rotate api keys", k=5, method="rrf")
+
+# Or: the reader just finished post 1 — recommend what's similar.
+next_up = r.vector.recommend("posts", positive=[1], k=5)
 ```
 
 ## Framework adapters


### PR DESCRIPTION
## Summary

Updates the client reference docs to cover the native-TCP client APIs that shipped in #31 (Go typed client) and #32 (Python native parity). Both pages previously lagged the code.

### `docs/api/go-client.md`
Documents the typed **`Collection`** client alongside the existing low-level client:
- `client.NewRouted(Config{Servers: ["host:7000"]})` over the binary TCP port, with shard-aware routing (and the `New` vs `NewRouted` distinction).
- `c.Collection("posts")` + its methods: Create/Drop, Insert/Upsert/UpsertBatch/Delete, Get/GetBatch/Scroll, Search/SearchDocs/SearchGroups/HybridSearch/HybridText, Recommend/Query — with request structs, `SearchResponse{Results, Degraded, Missing}`, and the typed errors.
- A worked "recommend the next post" snippet.

### `docs/api/python.md`
Documents the native `Rostam(...).vector` advanced methods (`get_batch`, `scroll`, `search_docs`, `search_groups`, `hybrid_search`, `hybrid_text`, `recommend`, `query`, `upsert_batch`) and makes the **transport/port distinction explicit**:
- a **"Two clients, two ports"** callout — native `Rostam("127.0.0.1", 7000)` speaks the binary protocol over the **TCP port (7000)**; the HTTP `RostamClient` uses REST on 8080.
- `SearchResults`/`GroupResults` carry `.degraded`/`.missing` but behave as lists; `recommend`/`query` are recommend-shaped.

## Verification
- Every signature/return type verified against the merged source (`client/*.go`, `clients/python/rostam/kv.py` + `_vecwire.py`), not invented.
- `mkdocs build --strict` builds clean (only a pre-existing, unrelated `pymdownx.tabbed` deprecation warning). No nav changes needed — both pages already listed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Added comprehensive Go client guidance for collection lifecycle operations, writes, reads, batch processing, searches, recommendations, queries, consistency, TTLs, CAS, metadata, and error handling.
  - Clarified Python client options for HTTP and native TCP usage, including supported capabilities and examples for key-value, vector, search, hybrid, batch, scroll, and recommendation workflows.
  - Expanded README quick starts with native TCP examples for Python and typed collection, hybrid search, and recommendation workflows for Go.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->