### PR TITLE
perf(client): zero-alloc vector-search round-trip (routing + request args)

### DIFF
--- a/client.go
+++ b/client.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/cespare/xxhash/v2"
@@ -202,16 +203,27 @@ func (n *networkedStore) VectorSearch(ctx context.Context, collection string, qu
 	return ops.DecodeVectorSearchResults(body)
 }
 
+// vectorSearchArgsPool recycles the request-args buffer for VectorSearchInto so
+// the hot search path allocates nothing on the client: the buffer is filled by
+// AppendVectorSearchArgs, consumed by CallFunc (doCall writes+flushes it before
+// returning), then returned. Initial cap fits a ~128-dim query without growing.
+var vectorSearchArgsPool = sync.Pool{New: func() any { b := make([]byte, 0, 576); return &b }}
+
 // VectorSearchInto sends the search over the zero-copy CallFunc path: the wire
 // response is decoded straight into dst inside the callback (no defensive copy
-// of the payload, and no result-slice allocation when dst is reused).
+// of the payload, and no result-slice allocation when dst is reused). The
+// request-args buffer is pooled, so a reused dst yields a zero-allocation
+// client round-trip.
 func (n *networkedStore) VectorSearchInto(ctx context.Context, collection string, query []float32, k int, dst []VectorResult) ([]VectorResult, error) {
+	bp := vectorSearchArgsPool.Get().(*[]byte)
+	*bp = ops.AppendVectorSearchArgs((*bp)[:0], collection, k, query)
 	var out []VectorResult
-	err := n.c.CallFunc(ctx, "vector_search", ops.EncodeVectorSearchArgs(collection, k, query), func(payload []byte) error {
+	err := n.c.CallFunc(ctx, "vector_search", *bp, func(payload []byte) error {
 		var derr error
 		out, derr = ops.DecodeVectorSearchResultsInto(payload, dst)
 		return derr
 	})
+	vectorSearchArgsPool.Put(bp)
 	if err != nil {
 		return nil, mapErr(err)
 	}

--- a/client/client.go
+++ b/client/client.go
@@ -332,8 +332,27 @@ func (c *Client) nextServer() string {
 // server forwards to an owner — the correctness floor for dumb routing).
 func (c *Client) pickInitialTarget(op string, args []byte) string {
 	if c.cfg.Ops != nil {
-		if _, ke, ok := c.cfg.Ops.Lookup(op); ok && ke != nil {
-			if key, hasKey := ke(args); hasKey {
+		if _, ke, layout, ok := c.cfg.Ops.LookupRouting(op); ok {
+			// maxRouteKeyLen bounds "default/" (8) + a u8-length collection name
+			// (255). Keeping scratch on the stack lets RouteKeyInto extract the
+			// routing key with no heap allocation on the hot path; a DIRECT call
+			// to RouteKeyInto (not through the ke func value) is what lets escape
+			// analysis keep scratch stack-bound — see ops/wire.RouteKeyInto.
+			const maxRouteKeyLen = 8 + 255
+			var scratch [maxRouteKeyLen]byte
+			var key []byte
+			var hasKey bool
+			switch {
+			case layout != wire.RouteLayoutNone:
+				key = wire.RouteKeyInto(layout, args, scratch[:0])
+				hasKey = key != nil
+			case ke != nil:
+				// RouteLayoutNone ops route through ke: KV builtins (the
+				// subslicing stdKeyExtractor, already alloc-free) and
+				// dynamic/WASM ops (no allocation-free layout).
+				key, hasKey = ke(args)
+			}
+			if hasKey {
 				if t := c.topology.get(); t != nil && t.NumShards > 0 {
 					shardID := int(xxhash.Sum64(key) % uint64(t.NumShards)) //nolint:gosec // NumShards bounded by Config validation
 					if len(t.Leaders) == t.NumShards && t.Leaders[shardID] != "" {

--- a/client/routing_zeroalloc_test.go
+++ b/client/routing_zeroalloc_test.go
@@ -1,0 +1,118 @@
+// SPDX-License-Identifier: Apache-2.0
+package client
+
+import (
+	"context"
+	"encoding/binary"
+	"io"
+	"net"
+	"testing"
+
+	"github.com/rostamlabs/rostam/ops/wire"
+)
+
+// echoOKServer accepts connections and, for every request frame it reads,
+// writes one canned StatusOK response with an empty payload. It speaks just
+// enough of the wire protocol to exercise the CLIENT send/recv path in
+// isolation — no engine, so allocs/op are purely client-side.
+func echoOKServer(tb testing.TB) (addr string, stop func()) {
+	tb.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		tb.Fatal(err)
+	}
+	// response body: [status:1=OK][payloadLen:4=0]; outer frame len = 5.
+	resp := []byte{0, 0, 0, 5, 0, 0, 0, 0, 0}
+	go func() {
+		for {
+			conn, err := ln.Accept()
+			if err != nil {
+				return
+			}
+			go func(c net.Conn) {
+				defer c.Close()
+				hdr := make([]byte, 4)
+				var body []byte // reused across requests so the server goroutine's
+				for {           // own allocs don't pollute the client alloc count
+					if _, err := io.ReadFull(c, hdr); err != nil {
+						return
+					}
+					n := binary.BigEndian.Uint32(hdr)
+					if cap(body) < int(n) {
+						body = make([]byte, n)
+					}
+					if _, err := io.ReadFull(c, body[:n]); err != nil {
+						return
+					}
+					if _, err := c.Write(resp); err != nil {
+						return
+					}
+				}
+			}(conn)
+		}
+	}()
+	return ln.Addr().String(), func() { _ = ln.Close() }
+}
+
+// newRoutedEchoClient builds a routed client whose single-shard topology points
+// at a canned-OK echo server, so a keyed CallFunc exercises the full client-side
+// path (pickInitialTarget routing-key extraction → doCall framing → response
+// decode → fn) against a server that itself allocates nothing per request. A
+// vector op is used because vector routing (RouteLayoutColAt1/At2) is the path
+// that used to allocate the routing key; KV ops already subslice.
+func newRoutedEchoClient(tb testing.TB) (*Client, []byte, func()) {
+	tb.Helper()
+	addr, stop := echoOKServer(tb)
+	reg := wire.NewRegistry()
+	if err := wire.RegisterRoutableBuiltins(reg); err != nil {
+		stop()
+		tb.Fatal(err)
+	}
+	c, err := NewRouted(Config{Servers: []string{addr}, Ops: reg})
+	if err != nil {
+		stop()
+		tb.Fatal(err)
+	}
+	c.topology.set(wire.Topology{NumShards: 1, Leaders: []string{addr}})
+	// "posts" (no slash) forces the "default/" prepend — the case that used to
+	// allocate a fresh routing-key slice per call.
+	args := wire.EncodeVectorSearchArgs("posts", 10, []float32{1, 2, 3, 4})
+	return c, args, func() { _ = c.Close(); stop() }
+}
+
+// TestCallFuncRoutedZeroAlloc is the regression guard: a routed CallFunc
+// round-trip must allocate nothing on the client. It broke before routing was
+// switched from the allocating ke(args) to RouteKeyInto with a stack scratch.
+func TestCallFuncRoutedZeroAlloc(t *testing.T) {
+	c, args, cleanup := newRoutedEchoClient(t)
+	defer cleanup()
+	ctx := context.Background()
+	fn := func(payload []byte) error { return nil }
+	// Warm up: first call dials the conn and sizes the pool/read buffers.
+	if err := c.CallFunc(ctx, "vector_search", args, fn); err != nil {
+		t.Fatal(err)
+	}
+	allocs := testing.AllocsPerRun(2000, func() {
+		if err := c.CallFunc(ctx, "vector_search", args, fn); err != nil {
+			t.Fatal(err)
+		}
+	})
+	if allocs != 0 {
+		t.Fatalf("routed CallFunc: got %v allocs/op, want 0", allocs)
+	}
+}
+
+// BenchmarkCallFuncRoutedAllocs reports ns/op + allocs/op for the same path.
+func BenchmarkCallFuncRoutedAllocs(b *testing.B) {
+	c, args, cleanup := newRoutedEchoClient(b)
+	defer cleanup()
+	ctx := context.Background()
+	fn := func(payload []byte) error { return nil }
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if err := c.CallFunc(ctx, "vector_search", args, fn); err != nil {
+			b.Fatal(err)
+		}
+	}
+}

--- a/ops/wire/vector.go
+++ b/ops/wire/vector.go
@@ -630,7 +630,14 @@ func DecodeVectorInsertArgsKeyExpiresInto(dst []float32, args []byte) (collectio
 
 // EncodeVectorSearchArgs serializes vector_search args with no filter (flags=0).
 func EncodeVectorSearchArgs(collection string, k int, query []float32) []byte {
-	return EncodeVectorSearchArgsExt(collection, k, query, vector.Filter{})
+	return AppendVectorSearchArgsExt(nil, collection, k, query, vector.Filter{})
+}
+
+// AppendVectorSearchArgs is EncodeVectorSearchArgs appending into dst (reusing
+// its capacity when large enough), for a hot-loop caller that pools the buffer.
+// The returned slice may alias dst; the caller must store it back.
+func AppendVectorSearchArgs(dst []byte, collection string, k int, query []float32) []byte {
+	return AppendVectorSearchArgsExt(dst, collection, k, query, vector.Filter{})
 }
 
 // EncodeVectorSearchArgsExt serializes vector_search args, optionally carrying a
@@ -638,6 +645,15 @@ func EncodeVectorSearchArgs(collection string, k int, query []float32) []byte {
 //
 //	[flags:u8][colLen:u8][col][k:u32][dim:u32][query][?filterLen:u32][?filterJSON]
 func EncodeVectorSearchArgsExt(collection string, k int, query []float32, filter vector.Filter) []byte {
+	return AppendVectorSearchArgsExt(nil, collection, k, query, filter)
+}
+
+// AppendVectorSearchArgsExt is EncodeVectorSearchArgsExt appending into dst,
+// reusing dst's capacity when it is large enough and allocating only when it
+// must grow. Passing dst=nil yields the exact bytes EncodeVectorSearchArgsExt
+// returned before, so the wire format is unchanged. The returned slice may
+// alias dst; a caller that pools dst must store the result back.
+func AppendVectorSearchArgsExt(dst []byte, collection string, k int, query []float32, filter vector.Filter) []byte {
 	var flags uint8
 	var filterJSON []byte
 	if !filter.IsZero() {
@@ -649,7 +665,12 @@ func EncodeVectorSearchArgsExt(collection string, k int, query []float32, filter
 	if flags&VecFlagFilter != 0 {
 		n += 4 + len(filterJSON)
 	}
-	buf := make([]byte, n)
+	var buf []byte
+	if cap(dst) >= n {
+		buf = dst[:n]
+	} else {
+		buf = make([]byte, n)
+	}
 	buf[0] = flags
 	buf[1] = byte(len(collection))
 	off := 2 + copy(buf[2:], collection)

--- a/ops/wire/vector_append_test.go
+++ b/ops/wire/vector_append_test.go
@@ -1,0 +1,79 @@
+// SPDX-License-Identifier: Apache-2.0
+package wire
+
+import (
+	"bytes"
+	"encoding/binary"
+	"math"
+	"testing"
+
+	"github.com/rostamlabs/rostam/vector"
+)
+
+// oracleVectorSearchArgsNoFilter hand-builds the no-filter vector_search wire
+// bytes INDEPENDENTLY of the production encoder, so a layout error in
+// AppendVectorSearchArgsExt is caught (a self-comparison against Encode*, which
+// now delegates to Append*, would move both sides together and hide it).
+//
+//	[flags:u8=0][colLen:u8][col][k:u32][dim:u32][query f32 BE...]
+func oracleVectorSearchArgsNoFilter(collection string, k int, query []float32) []byte {
+	buf := make([]byte, 0, 2+len(collection)+8+4*len(query))
+	buf = append(buf, 0)                     // flags = 0 (no filter)
+	buf = append(buf, byte(len(collection))) // colLen u8
+	buf = append(buf, collection...)         // col
+	buf = binary.BigEndian.AppendUint32(buf, uint32(k))
+	buf = binary.BigEndian.AppendUint32(buf, uint32(len(query)))
+	for _, f := range query {
+		buf = binary.BigEndian.AppendUint32(buf, math.Float32bits(f))
+	}
+	return buf
+}
+
+// TestAppendVectorSearchArgsByteIdentical guards the append-into-dst encoder
+// against (a) an INDEPENDENT hand-built oracle for the no-filter layout and
+// (b) the allocating Encode* form for the filtered path, across a nil dst and a
+// pre-grown (reused-cap) dst. The golden oracle only covers dst=nil no-filter;
+// this additionally pins the reused-cap branch VectorSearchInto's pool exercises.
+func TestAppendVectorSearchArgsByteIdentical(t *testing.T) {
+	query := []float32{1.5, -2.25, 3, 4, 5, 6, 7, 8}
+
+	// Independent oracle check: the no-filter layout must match a hand-built
+	// encoding, not just the (delegating) Encode* form.
+	oracle := oracleVectorSearchArgsNoFilter("posts", 10, query)
+	if got := AppendVectorSearchArgsExt(nil, "posts", 10, query, vector.Filter{}); !bytes.Equal(got, oracle) {
+		t.Fatalf("no-filter layout diverged from independent oracle:\n got %x\nwant %x", got, oracle)
+	}
+
+	cases := []struct {
+		name   string
+		filter vector.Filter
+	}{
+		{"no_filter", vector.Filter{}},
+		{"filtered", vector.Filter{Op: vector.FilterEq, Field: "genre", Value: vector.NewString("scifi")}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			want := EncodeVectorSearchArgsExt("posts", 10, query, tc.filter)
+
+			// dst=nil must reproduce the legacy bytes exactly.
+			if got := AppendVectorSearchArgsExt(nil, "posts", 10, query, tc.filter); !bytes.Equal(got, want) {
+				t.Fatalf("dst=nil mismatch:\n got %x\nwant %x", got, want)
+			}
+
+			// A pre-grown, dirty dst (reused-cap branch) must yield identical
+			// bytes and length — no stale data beyond the written region.
+			dirty := make([]byte, 0, len(want)+64)
+			dirty = dirty[:cap(dirty)]
+			for i := range dirty {
+				dirty[i] = 0xEE
+			}
+			got := AppendVectorSearchArgsExt(dirty[:0], "posts", 10, query, tc.filter)
+			if !bytes.Equal(got, want) {
+				t.Fatalf("reused-cap mismatch:\n got %x\nwant %x", got, want)
+			}
+			if len(got) != len(want) {
+				t.Fatalf("reused-cap length = %d, want %d", len(got), len(want))
+			}
+		})
+	}
+}

--- a/ops/wire_aliases.go
+++ b/ops/wire_aliases.go
@@ -400,6 +400,8 @@ var (
 	EncodeVectorInsertArgsVersioned           = wire.EncodeVectorInsertArgsVersioned
 	EncodeVectorInsertArgsVersionedKeyExpires = wire.EncodeVectorInsertArgsVersionedKeyExpires
 	EncodeVectorSearchArgs                    = wire.EncodeVectorSearchArgs
+	AppendVectorSearchArgs                    = wire.AppendVectorSearchArgs
+	AppendVectorSearchArgsExt                 = wire.AppendVectorSearchArgsExt
 	EncodeVectorSearchArgsExt                 = wire.EncodeVectorSearchArgsExt
 	EncodeVectorSearchArgsOpts                = wire.EncodeVectorSearchArgsOpts
 	EncodeVectorSearchResults                 = wire.EncodeVectorSearchResults

--- a/vector_search_zeroalloc_test.go
+++ b/vector_search_zeroalloc_test.go
@@ -1,0 +1,113 @@
+// SPDX-License-Identifier: Apache-2.0
+package rostam
+
+import (
+	"context"
+	"encoding/binary"
+	"io"
+	"math"
+	"net"
+	"testing"
+)
+
+// cannedSearchServer answers every request with the SAME pre-built
+// vector_search result frame (3 hits), reusing its read buffer, so the server
+// side allocates nothing per request. This isolates the CLIENT-side allocation
+// count of VectorSearchInto over a real TCP round-trip.
+func cannedSearchServer(tb testing.TB, hits int) (addr string, stop func()) {
+	tb.Helper()
+	// payload: [count:u32][ (id:u64)(dist:f32) ]*count — matches
+	// wire.EncodeVectorSearchResults / DecodeVectorSearchResultsInto.
+	payload := make([]byte, 4+hits*(8+4))
+	binary.BigEndian.PutUint32(payload[0:4], uint32(hits))
+	off := 4
+	for i := 0; i < hits; i++ {
+		binary.BigEndian.PutUint64(payload[off:], uint64(i+1))
+		off += 8
+		binary.BigEndian.PutUint32(payload[off:], math.Float32bits(float32(i)*0.5))
+		off += 4
+	}
+	// body: [status:1=OK][payloadLen:u32][payload]; frame: [frameLen:u32][body].
+	body := make([]byte, 1+4+len(payload))
+	body[0] = 0
+	binary.BigEndian.PutUint32(body[1:5], uint32(len(payload)))
+	copy(body[5:], payload)
+	frame := make([]byte, 4+len(body))
+	binary.BigEndian.PutUint32(frame[0:4], uint32(len(body)))
+	copy(frame[4:], body)
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		tb.Fatal(err)
+	}
+	go func() {
+		for {
+			conn, err := ln.Accept()
+			if err != nil {
+				return
+			}
+			go func(c net.Conn) {
+				defer c.Close()
+				hdr := make([]byte, 4)
+				var reqBody []byte
+				for {
+					if _, err := io.ReadFull(c, hdr); err != nil {
+						return
+					}
+					n := binary.BigEndian.Uint32(hdr)
+					if cap(reqBody) < int(n) {
+						reqBody = make([]byte, n)
+					}
+					if _, err := io.ReadFull(c, reqBody[:n]); err != nil {
+						return
+					}
+					if _, err := c.Write(frame); err != nil {
+						return
+					}
+				}
+			}(conn)
+		}
+	}()
+	return ln.Addr().String(), func() { _ = ln.Close() }
+}
+
+// TestVectorSearchIntoZeroAllocClientSide guards the end-to-end promise: with a
+// reused dst, a VectorSearchInto round-trip allocates nothing on the client —
+// pooled request args, no defensive payload copy, decode straight into dst. It
+// broke before AppendVectorSearchArgs + the args pool eliminated the request
+// buffer allocation.
+func TestVectorSearchIntoZeroAllocClientSide(t *testing.T) {
+	const hits = 3
+	addr, stop := cannedSearchServer(t, hits)
+	defer stop()
+
+	cli, err := NewClient(ClientConfig{Servers: []string{addr}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = cli.Close() }()
+
+	ctx := context.Background()
+	q := []float32{1, 2, 3, 4, 5, 6, 7, 8}
+	dst := make([]VectorResult, 0, hits)
+
+	// Warm up: first call dials the conn and sizes pool/read/args buffers.
+	dst, err = cli.VectorSearchInto(ctx, "posts", q, hits, dst[:0])
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(dst) != hits {
+		t.Fatalf("got %d hits, want %d", len(dst), hits)
+	}
+
+	allocs := testing.AllocsPerRun(2000, func() {
+		var e error
+		dst, e = cli.VectorSearchInto(ctx, "posts", q, hits, dst[:0])
+		if e != nil {
+			t.Fatal(e)
+		}
+	})
+	if allocs != 0 {
+		t.Fatalf("VectorSearchInto: got %v allocs/op, want 0", allocs)
+	}
+}


### PR DESCRIPTION
## What & why

Makes the client vector-search round-trip allocate **nothing on the client** in steady state. No wire-format change (the Python golden byte-equality test is unchanged and green).

> Stacked on #38 (`perf/pb-split-grpc`) — review/merge that first; this PR's diff is only the two commits below.

## The two allocations removed

1. **`perf(client): zero-alloc routing via RouteKeyInto in pickInitialTarget`**
   Routed clients extracted the shard key with `ke(args)`, which for vector ops (`RouteLayoutColAt1/At2`) built a fresh `"default/"+name` slice every call — one heap alloc per routed request. Now routes via `LookupRouting` + `wire.RouteKeyInto` into a **stack** scratch buffer (`[8+255]byte`), falling back to `ke` only for `RouteLayoutNone` ops (the subslicing KV extractor, dynamic/WASM). The direct `RouteKeyInto` call keeps the scratch stack-bound (verified `-gcflags=-m`).

2. **`perf(client): pool vector_search request args`**
   `VectorSearchInto` built its request with `EncodeVectorSearchArgs`, allocating a fresh buffer (~query bytes) per call. Added `AppendVectorSearchArgs(Ext)` (append-into-dst; `Encode*` now delegate with `dst=nil`, so the bytes are unchanged) and recycled that buffer through a `sync.Pool`. `doCall` writes+flushes args before returning, so the buffer is safe to return afterward. The response closure was already stack-allocated (escape analysis), so no closure change was needed.

## Measured (client-side only, via loopback servers that themselves allocate 0/op)

| path | before | after |
|---|--:|--:|
| routed `CallFunc` round-trip | 1 alloc | **0** |
| end-to-end `VectorSearchInto`, reused `dst` | (args + …) | **0** |
| in-process bench (incl. server allocs) | 9 / 1240 B | 8 / 648 B |

## Verification

- `go build ./...`, `go vet`, `gofmt -l`, `golangci-lint run ./client/... ./ops/...` — 0 issues
- `go test ./ops/... ./client/...` + real-server vector net tests pass
- Python golden byte-identical; new direct byte-equality test for the append encoder (nil + reused-cap, no-filter + filtered)
- **Two regression guards** assert `testing.AllocsPerRun == 0` and fail closed if either optimization regresses
- Independent review: **approved**, no blocking issues (pool buffer lifetime, routing equivalence, and byte-identity all confirmed sound)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Reduced memory allocations for vector searches by reusing request buffers.
  * Improved efficiency for routed requests and repeated searches.
* **Compatibility**
  * Added append-style vector search argument encoding while preserving existing output.
* **Bug Fixes**
  * Improved routing support for operations with direct route layouts and fallback routing.
* **Tests**
  * Added coverage validating zero-allocation routed requests and vector searches.
  * Added verification for reusable buffers and filtered vector search encoding.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->