### PR TITLE
perf(client): zero-alloc KV reads via GetInto + pooled request args

### DIFF
--- a/client.go
+++ b/client.go
@@ -98,16 +98,58 @@ type networkedStore struct {
 	c *client.Client
 }
 
+// kvArgsPool recycles the small request-args buffer shared by the KV ops
+// (get/del key args, and put args for small values), so Get/GetInto/Del/Put
+// allocate nothing on the request side in steady state. neither the inline
+// doCall framing nor the pipelined encodeRequestFrame retains args past the
+// call, so the buffer is safe to return afterward. Buffers grown past
+// maxPooledKVArgs (a large Put value) are dropped rather than pooled, to bound
+// retained memory.
+const maxPooledKVArgs = 4 << 10
+
+var kvArgsPool = sync.Pool{New: func() any { b := make([]byte, 0, 128); return &b }}
+
+func putKVArgs(bp *[]byte) {
+	if cap(*bp) <= maxPooledKVArgs {
+		kvArgsPool.Put(bp)
+	}
+}
+
 func (n *networkedStore) Get(ctx context.Context, key []byte) ([]byte, error) {
-	raw, err := n.c.Call(ctx, "get", ops.EncodeKeyArgs(key))
+	bp := kvArgsPool.Get().(*[]byte)
+	*bp = ops.AppendKeyArgs((*bp)[:0], key)
+	raw, err := n.c.Call(ctx, "get", *bp)
+	putKVArgs(bp)
 	if err != nil {
 		return nil, mapErr(err)
 	}
 	return raw, nil
 }
 
+// GetInto is the allocation-light Get: the value is copied into dst inside the
+// zero-copy CallFunc callback (no defensive payload copy) and the request args
+// are pooled, so a reused dst yields a zero-allocation read. Returns ErrNotFound
+// (via mapErr) when the key is absent; the returned slice may alias dst.
+func (n *networkedStore) GetInto(ctx context.Context, key, dst []byte) ([]byte, error) {
+	bp := kvArgsPool.Get().(*[]byte)
+	*bp = ops.AppendKeyArgs((*bp)[:0], key)
+	var out []byte
+	err := n.c.CallFunc(ctx, "get", *bp, func(payload []byte) error {
+		out = append(dst[:0], payload...)
+		return nil
+	})
+	putKVArgs(bp)
+	if err != nil {
+		return nil, mapErr(err)
+	}
+	return out, nil
+}
+
 func (n *networkedStore) Put(ctx context.Context, key, value []byte, ttl time.Duration) error {
-	_, err := n.c.Call(ctx, "put", ops.EncodePutArgs(key, value, ttl))
+	bp := kvArgsPool.Get().(*[]byte)
+	*bp = ops.AppendPutArgs((*bp)[:0], key, value, ttl)
+	_, err := n.c.Call(ctx, "put", *bp)
+	putKVArgs(bp)
 	return mapErr(err)
 }
 
@@ -119,7 +161,10 @@ func (n *networkedStore) PutBatch(ctx context.Context, entries []ops.PutEntry) e
 }
 
 func (n *networkedStore) Del(ctx context.Context, key []byte) (bool, error) {
-	raw, err := n.c.Call(ctx, "del", ops.EncodeKeyArgs(key))
+	bp := kvArgsPool.Get().(*[]byte)
+	*bp = ops.AppendKeyArgs((*bp)[:0], key)
+	raw, err := n.c.Call(ctx, "del", *bp)
+	putKVArgs(bp)
 	if err != nil {
 		return false, mapErr(err)
 	}

--- a/direct.go
+++ b/direct.go
@@ -126,6 +126,17 @@ func (d *directStore) Get(_ context.Context, key []byte) ([]byte, error) {
 	return raw, nil
 }
 
+func (d *directStore) GetInto(_ context.Context, key, dst []byte) ([]byte, error) {
+	raw, err := d.cache.GetInto(dst[:0], key)
+	if err != nil {
+		if errors.Is(err, cache.ErrNotFound) {
+			return nil, ErrNotFound
+		}
+		return nil, err
+	}
+	return raw, nil
+}
+
 // Put and Del write straight to the cache but MUST take the same per-shard opMu
 // that Call's read-write path uses, so a raw Put/Del serializes against a
 // multi-step RMW op (e.g. incr) on the same key. Without it, a Put could land

--- a/embedded.go
+++ b/embedded.go
@@ -786,6 +786,17 @@ func (e *embedded) Get(_ context.Context, key []byte) ([]byte, error) {
 	return result, nil
 }
 
+// GetInto is the allocation-light Get: the value is copied into dst (reusing its
+// capacity when large enough). Same ErrNotFound semantics as Get; the returned
+// slice may alias dst.
+func (e *embedded) GetInto(_ context.Context, key, dst []byte) ([]byte, error) {
+	result, err := e.node.Call("get", ops.EncodeKeyArgs(key))
+	if err != nil {
+		return nil, mapErr(err)
+	}
+	return append(dst[:0], result...), nil
+}
+
 // Put writes key/value through Raft with the given TTL. Returns
 // ErrNotLeader if the shard leader is unavailable.
 func (e *embedded) Put(_ context.Context, key, value []byte, ttl time.Duration) error {

--- a/kv_zeroalloc_test.go
+++ b/kv_zeroalloc_test.go
@@ -1,0 +1,100 @@
+// SPDX-License-Identifier: Apache-2.0
+package rostam
+
+import (
+	"context"
+	"encoding/binary"
+	"io"
+	"net"
+	"testing"
+)
+
+// cannedValueServer answers every request with the SAME StatusOK response
+// carrying `value` as the payload, reusing its read buffer so the server side
+// allocates nothing per request. This isolates the CLIENT-side allocation count
+// of GetInto over a real TCP round-trip.
+func cannedValueServer(tb testing.TB, value []byte) (addr string, stop func()) {
+	tb.Helper()
+	// body: [status:1=OK][payloadLen:u32][value]; frame: [frameLen:u32][body].
+	body := make([]byte, 1+4+len(value))
+	body[0] = 0
+	binary.BigEndian.PutUint32(body[1:5], uint32(len(value)))
+	copy(body[5:], value)
+	frame := make([]byte, 4+len(body))
+	binary.BigEndian.PutUint32(frame[0:4], uint32(len(body)))
+	copy(frame[4:], body)
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		tb.Fatal(err)
+	}
+	go func() {
+		for {
+			conn, err := ln.Accept()
+			if err != nil {
+				return
+			}
+			go func(c net.Conn) {
+				defer c.Close()
+				hdr := make([]byte, 4)
+				var reqBody []byte
+				for {
+					if _, err := io.ReadFull(c, hdr); err != nil {
+						return
+					}
+					n := binary.BigEndian.Uint32(hdr)
+					if cap(reqBody) < int(n) {
+						reqBody = make([]byte, n)
+					}
+					if _, err := io.ReadFull(c, reqBody[:n]); err != nil {
+						return
+					}
+					if _, err := c.Write(frame); err != nil {
+						return
+					}
+				}
+			}(conn)
+		}
+	}()
+	return ln.Addr().String(), func() { _ = ln.Close() }
+}
+
+// TestGetIntoZeroAllocClientSide guards the KV read promise: with a reused dst,
+// a GetInto round-trip allocates nothing on the client — pooled request args, no
+// defensive payload copy, value copied straight into dst. It broke before
+// AppendKeyArgs + the kv args pool + the GetInto CallFunc path landed.
+func TestGetIntoZeroAllocClientSide(t *testing.T) {
+	value := []byte("a-cached-value-of-modest-size-0123456789")
+	addr, stop := cannedValueServer(t, value)
+	defer stop()
+
+	cli, err := NewClient(ClientConfig{Servers: []string{addr}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = cli.Close() }()
+
+	ctx := context.Background()
+	key := []byte("some-key")
+	dst := make([]byte, 0, len(value))
+
+	// Warm up: first call dials the conn and sizes pool/read/args buffers.
+	dst, err = cli.GetInto(ctx, key, dst[:0])
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(dst) != string(value) {
+		t.Fatalf("got %q, want %q", dst, value)
+	}
+
+	allocs := testing.AllocsPerRun(2000, func() {
+		var e error
+		dst, e = cli.GetInto(ctx, key, dst[:0])
+		if e != nil {
+			t.Fatal(e)
+		}
+	})
+	if allocs != 0 {
+		t.Fatalf("GetInto: got %v allocs/op, want 0", allocs)
+	}
+}

--- a/ops/wire/builtin.go
+++ b/ops/wire/builtin.go
@@ -43,7 +43,20 @@ const ReplMetricsOp = "__repl_metrics__"
 
 // EncodeKeyArgs encodes "{keyLen u16}{key}" used by get and del.
 func EncodeKeyArgs(key []byte) []byte {
-	buf := make([]byte, 2+len(key))
+	return AppendKeyArgs(nil, key)
+}
+
+// AppendKeyArgs is EncodeKeyArgs appending into dst (reusing its capacity when
+// large enough), for a hot-loop caller that pools the buffer. Passing dst=nil
+// reproduces EncodeKeyArgs's bytes exactly. The returned slice may alias dst.
+func AppendKeyArgs(dst, key []byte) []byte {
+	n := 2 + len(key)
+	var buf []byte
+	if cap(dst) >= n {
+		buf = dst[:n]
+	} else {
+		buf = make([]byte, n)
+	}
 	binary.BigEndian.PutUint16(buf[0:2], uint16(len(key))) //nolint:gosec // bounded by upstream key/value length limits
 	copy(buf[2:], key)
 	return buf
@@ -63,7 +76,20 @@ func DecodeKeyArgs(args []byte) ([]byte, error) {
 
 // EncodePutArgs encodes "{keyLen u16}{key}{valLen u32}{val}{ttlMs u64}".
 func EncodePutArgs(key, val []byte, ttl time.Duration) []byte {
-	buf := make([]byte, 2+len(key)+4+len(val)+8)
+	return AppendPutArgs(nil, key, val, ttl)
+}
+
+// AppendPutArgs is EncodePutArgs appending into dst (reusing its capacity when
+// large enough), for a hot-loop caller that pools the buffer. Passing dst=nil
+// reproduces EncodePutArgs's bytes exactly. The returned slice may alias dst.
+func AppendPutArgs(dst, key, val []byte, ttl time.Duration) []byte {
+	n := 2 + len(key) + 4 + len(val) + 8
+	var buf []byte
+	if cap(dst) >= n {
+		buf = dst[:n]
+	} else {
+		buf = make([]byte, n)
+	}
 	binary.BigEndian.PutUint16(buf[0:2], uint16(len(key))) //nolint:gosec // bounded by upstream key/value length limits
 	copy(buf[2:], key)
 	off := 2 + len(key)

--- a/ops/wire/builtin_append_test.go
+++ b/ops/wire/builtin_append_test.go
@@ -1,0 +1,56 @@
+// SPDX-License-Identifier: Apache-2.0
+package wire
+
+import (
+	"bytes"
+	"encoding/binary"
+	"testing"
+	"time"
+)
+
+// TestAppendKeyArgsByteIdentical checks AppendKeyArgs against an INDEPENDENT
+// hand-built encoding (not the delegating EncodeKeyArgs), across nil and a
+// pre-grown (reused-cap) dst.
+func TestAppendKeyArgsByteIdentical(t *testing.T) {
+	key := []byte("some/key-0123456789")
+
+	oracle := make([]byte, 2+len(key))
+	binary.BigEndian.PutUint16(oracle[0:2], uint16(len(key)))
+	copy(oracle[2:], key)
+
+	if got := AppendKeyArgs(nil, key); !bytes.Equal(got, oracle) {
+		t.Fatalf("dst=nil: got %x want %x", got, oracle)
+	}
+	dirty := bytes.Repeat([]byte{0xEE}, len(oracle)+64)
+	got := AppendKeyArgs(dirty[:0], key)
+	if !bytes.Equal(got, oracle) || len(got) != len(oracle) {
+		t.Fatalf("reused-cap: got %x (len %d) want %x (len %d)", got, len(got), oracle, len(oracle))
+	}
+}
+
+// TestAppendPutArgsByteIdentical checks AppendPutArgs against an INDEPENDENT
+// hand-built encoding, across nil and a pre-grown (reused-cap) dst.
+func TestAppendPutArgsByteIdentical(t *testing.T) {
+	key := []byte("k1")
+	val := []byte("value-payload-here")
+	ttl := 5 * time.Second
+
+	n := 2 + len(key) + 4 + len(val) + 8
+	oracle := make([]byte, n)
+	binary.BigEndian.PutUint16(oracle[0:2], uint16(len(key)))
+	copy(oracle[2:], key)
+	off := 2 + len(key)
+	binary.BigEndian.PutUint32(oracle[off:off+4], uint32(len(val)))
+	copy(oracle[off+4:], val)
+	off += 4 + len(val)
+	binary.BigEndian.PutUint64(oracle[off:off+8], uint64(ttl/time.Millisecond))
+
+	if got := AppendPutArgs(nil, key, val, ttl); !bytes.Equal(got, oracle) {
+		t.Fatalf("dst=nil: got %x want %x", got, oracle)
+	}
+	dirty := bytes.Repeat([]byte{0xEE}, n+64)
+	got := AppendPutArgs(dirty[:0], key, val, ttl)
+	if !bytes.Equal(got, oracle) || len(got) != len(oracle) {
+		t.Fatalf("reused-cap: got %x (len %d) want %x (len %d)", got, len(got), oracle, len(oracle))
+	}
+}

--- a/ops/wire_aliases.go
+++ b/ops/wire_aliases.go
@@ -288,6 +288,8 @@ var (
 	EncodeIncrArgs                            = wire.EncodeIncrArgs
 	EncodeIncrResult                          = wire.EncodeIncrResult
 	EncodeKeyArgs                             = wire.EncodeKeyArgs
+	AppendKeyArgs                             = wire.AppendKeyArgs
+	AppendPutArgs                             = wire.AppendPutArgs
 	EncodeKeysAddArgs                         = wire.EncodeKeysAddArgs
 	EncodeKeysListArgs                        = wire.EncodeKeysListArgs
 	EncodeKeysListResult                      = wire.EncodeKeysListResult

--- a/store.go
+++ b/store.go
@@ -22,6 +22,19 @@ type Store interface {
 	// ErrNotFound if absent or expired.
 	Get(ctx context.Context, key []byte) ([]byte, error)
 
+	// GetInto is the allocation-light variant of Get: the value is copied into
+	// dst (reusing its capacity when large enough) and the resulting slice is
+	// returned. With a reused dst the Networked path is a zero-allocation read
+	// (pooled request args, no defensive response copy). Same ErrNotFound
+	// semantics as Get. The returned slice may alias dst; do not retain the
+	// argument after the call.
+	//
+	// Note: on the Networked backend GetInto goes through the request-response
+	// path even when PipelineDepth > 0 (pipelining applies to Get, not the
+	// zero-copy CallFunc path GetInto uses) — trade pipelining throughput for
+	// the per-call allocation win accordingly.
+	GetInto(ctx context.Context, key, dst []byte) ([]byte, error)
+
 	// Put writes through Raft with the given TTL. Returns ErrNotLeader
 	// if the backing node (Embedded) or the client's exhausted retry
 	// budget (Networked) cannot reach the shard leader.


### PR DESCRIPTION
## What & why

Extends the merged zero-alloc client work (#40, `VectorSearchInto`) to the hot **KV** path. No wire-format change (Python golden byte-equality unchanged; now 57 subtests).

## Changes

- **`ops/wire`** — added `AppendKeyArgs` / `AppendPutArgs` (append-into-dst; `EncodeKeyArgs`/`EncodePutArgs` now delegate with `dst=nil`, so the bytes are unchanged).
- **`Store.GetInto(ctx, key, dst)`** — the allocation-light `Get`: the value is copied into a reused `dst` inside the zero-copy `CallFunc` callback (no defensive payload copy). Implemented on `networkedStore`, `directStore` (via `cache.GetInto`), and `embedded`.
- **`networkedStore` `Get`/`GetInto`/`Del`/`Put`** — recycle the small request-args buffer through a `sync.Pool`. Safe: neither the inline `doCall` framing nor the pipelined `encodeRequestFrame` retains `args` past the call; the buffer is returned on all exit paths. Buffers grown past 4 KiB by a large Put value are dropped, not pooled, to bound retained memory.

## Result (client-side, warm, reused dst)

| path | allocs/op |
|---|--:|
| `GetInto` round-trip | **0** |

## Verification

- `go build ./...`, `go vet`, `gofmt -l`, `golangci-lint run ./client/... ./ops/... .` — 0 issues
- `go test ./ops/... ./client/...` + root KV/direct/embedded suite (188s) pass
- Python golden byte-identical (57 subtests); new independent-oracle byte-equality tests for both append encoders (nil + reused-cap)
- `TestGetIntoZeroAllocClientSide` asserts `AllocsPerRun == 0` (fails closed on regression)
- Independent review: **approved**, no blocking issues (pool buffer lifetime across pipelined + non-pipelined + retry-hop paths, GetInto payload-copy safety, interface-break coverage, byte-identity all confirmed)

## Notes

- `GetInto` uses the zero-copy `CallFunc` path, which doesn't pipeline even when `PipelineDepth > 0` (documented on the interface) — trades pipelining throughput for the per-call allocation win.
- The uint16/uint32 length casts in the encoders are pre-existing (unchanged), gated by the upstream cache length limits.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `GetInto` for allocation-light reads using a caller-provided destination buffer.
  * Added reusable argument-encoding helpers for key and value operations.
  * Preserved existing not-found and error behavior across storage implementations.

* **Performance**
  * Reduced allocations for repeated reads and key-value operations.
  * Reused buffers when capacity allows, while avoiding retention of oversized buffers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->