### PR TITLE
feat(python): collection handle — r.collection(name)

### DIFF
--- a/README.md
+++ b/README.md
@@ -341,6 +341,15 @@ r.kv.put("user:42", b'{"coins":100}', ttl_ms=300_000)   # TCP-only
 r.kv.incr("views:42", 1)                                  # atomic; missing key counts as 0
 ```
 
+Working against one collection? `r.collection(name)` binds it so you stop
+repeating the name (mirrors the Go client's `client.Collection`):
+
+```python
+docs = r.collection("docs")
+docs.upsert(1, vec, content="hello")
+hits = docs.hybrid_text(dense=vec, text="hello", k=5)
+```
+
 Bulk ingest (`bulk_stage` + `bulk_build`, HTTP-only) ships vectors as raw f32
 over a binary wire rather than JSON text, which is what makes large loads
 fast — a 1M × 768d load runs in **282 s**.

--- a/clients/python/README.md
+++ b/clients/python/README.md
@@ -122,6 +122,11 @@ hits = r.recommend("docs", positive=[1, 2], k=5)
 r.kv.put("user:42", b'{"coins":100}', ttl_ms=300_000)
 r.kv.get("user:42")
 r.kv.incr("views:42", 1)   # atomic; missing key counts as 0
+
+# Bind a collection so its name stops repeating (mirrors Go's client.Collection):
+docs = r.collection("docs")
+docs.upsert(1, embedding, content="the chunk text")
+hits = docs.hybrid_text(embedding, "apple pie", k=5)
 ```
 
 `r.query(...)` (the general composable Query API) and a few HTTP-only extras

--- a/clients/python/rostam/__init__.py
+++ b/clients/python/rostam/__init__.py
@@ -22,11 +22,13 @@ from ._types import (
     SearchResults,
     TransportError,
 )
+from ._collection import Collection
 from .embeddings import Embedder, FunctionEmbedder, OpenAIEmbedder, TextStore
 from .rostam import Rostam
 
 __all__ = [
     "Rostam",
+    "Collection",
     "RostamError",
     "TransportError",
     "SearchResult",

--- a/clients/python/rostam/_collection.py
+++ b/clients/python/rostam/_collection.py
@@ -1,0 +1,102 @@
+"""A collection-scoped handle over a Rostam client.
+
+``r.collection("posts")`` returns a :class:`Collection` bound to that name, so
+the collection argument stops being repeated on every call::
+
+    posts = r.collection("posts")
+    posts.upsert(1, vec, content="hello")
+    hits = posts.search(query_vec, k=10)
+
+Each method forwards to the identically-named flat method on the client with the
+collection name supplied as the first argument — so transport rules still apply
+(e.g. ``query`` / ``delete_by_filter`` raise ``TransportError`` on a TCP client,
+exactly as the flat ``r.query`` / ``r.delete_by_filter`` do). Mirrors the Go
+client's ``client.Collection`` handle.
+
+Scope: the handle carries the collection-scoped operations — Go's ``Collection``
+surface plus the extra collection-scoped ops the Python flat API has (``exists``,
+``delete_by_filter``). Non-collection-scoped or HTTP-only extras (``health``,
+``bulk_stage`` / ``bulk_build``, ``search_text``, ``discover``, ``mv_*``) stay on
+the flat client by design; reach for them via ``r.<method>`` when you need them.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:  # avoid an import cycle; only needed for type checkers
+    from .rostam import Rostam
+
+
+class Collection:
+    """A handle bound to one collection name. See the module docstring."""
+
+    __slots__ = ("_r", "name")
+
+    def __init__(self, client: "Rostam", name: str):
+        self._r = client
+        #: The collection name this handle is bound to.
+        self.name = name
+
+    def __repr__(self) -> str:
+        return f"Collection({self.name!r})"
+
+    # ---- lifecycle ----------------------------------------------------
+    def create(self, *args, **kwargs):
+        """Create this collection. Forwards to ``client.create_collection(name, ...)``."""
+        return self._r.create_collection(self.name, *args, **kwargs)
+
+    def drop(self, *args, **kwargs):
+        """Drop this collection. Forwards to ``client.drop_collection(name)``."""
+        return self._r.drop_collection(self.name, *args, **kwargs)
+
+    # ---- writes -------------------------------------------------------
+    def upsert(self, *args, **kwargs):
+        return self._r.upsert(self.name, *args, **kwargs)
+
+    def insert(self, *args, **kwargs):
+        return self._r.insert(self.name, *args, **kwargs)
+
+    def upsert_batch(self, *args, **kwargs):
+        return self._r.upsert_batch(self.name, *args, **kwargs)
+
+    def delete(self, *args, **kwargs):
+        return self._r.delete(self.name, *args, **kwargs)
+
+    def delete_by_filter(self, *args, **kwargs):
+        return self._r.delete_by_filter(self.name, *args, **kwargs)
+
+    # ---- reads --------------------------------------------------------
+    def get(self, *args, **kwargs):
+        return self._r.get(self.name, *args, **kwargs)
+
+    def get_batch(self, *args, **kwargs):
+        return self._r.get_batch(self.name, *args, **kwargs)
+
+    def scroll(self, *args, **kwargs):
+        return self._r.scroll(self.name, *args, **kwargs)
+
+    def exists(self, *args, **kwargs):
+        return self._r.exists(self.name, *args, **kwargs)
+
+    # ---- search -------------------------------------------------------
+    def search(self, *args, **kwargs):
+        return self._r.search(self.name, *args, **kwargs)
+
+    def search_docs(self, *args, **kwargs):
+        return self._r.search_docs(self.name, *args, **kwargs)
+
+    def search_groups(self, *args, **kwargs):
+        return self._r.search_groups(self.name, *args, **kwargs)
+
+    def hybrid_search(self, *args, **kwargs):
+        return self._r.hybrid_search(self.name, *args, **kwargs)
+
+    def hybrid_text(self, *args, **kwargs):
+        return self._r.hybrid_text(self.name, *args, **kwargs)
+
+    def recommend(self, *args, **kwargs):
+        return self._r.recommend(self.name, *args, **kwargs)
+
+    def query(self, *args, **kwargs):
+        return self._r.query(self.name, *args, **kwargs)

--- a/clients/python/rostam/rostam.py
+++ b/clients/python/rostam/rostam.py
@@ -3,6 +3,7 @@ from typing import Optional, Tuple
 from urllib.parse import urlsplit
 
 from . import _http, _tcp
+from ._collection import Collection
 from ._kv import _KV, _KVUnavailable
 from ._types import TransportError
 
@@ -107,6 +108,13 @@ class Rostam:
     def _require_http(self, op: str) -> None:
         if self._kind != "http":
             raise TransportError(f"{op} requires the HTTP transport; connect with http://host:8080")
+
+    def collection(self, name: str) -> Collection:
+        """Return a handle bound to `name` so the collection argument stops being
+        repeated: `r.collection("posts").search(vec, k=10)` is
+        `r.search("posts", vec, k=10)`. Construction does no I/O. Mirrors the Go
+        client's `client.Collection`."""
+        return Collection(self, name)
 
     def create_collection(self, *args, **kwargs):
         """See TcpTransport.create_collection / HttpTransport.create_collection."""

--- a/clients/python/tests/test_collection.py
+++ b/clients/python/tests/test_collection.py
@@ -1,0 +1,76 @@
+"""The collection-scoped handle: r.collection(name) binds the collection so it
+stops being repeated, forwarding each call to the identically-named flat method
+with the name as the first positional argument."""
+
+import pytest
+
+from rostam import Collection, Rostam, TransportError
+
+
+class _Spy:
+    """Records every attribute call; any method name is accepted."""
+
+    def __init__(self):
+        self.calls = []
+
+    def __getattr__(self, name):
+        def rec(*args, **kwargs):
+            self.calls.append((name, args, kwargs))
+            return ("result", name)
+        return rec
+
+
+# method on the handle -> flat method it must forward to
+FORWARDS = {
+    "create": "create_collection",
+    "drop": "drop_collection",
+    "upsert": "upsert",
+    "insert": "insert",
+    "upsert_batch": "upsert_batch",
+    "delete": "delete",
+    "delete_by_filter": "delete_by_filter",
+    "get": "get",
+    "get_batch": "get_batch",
+    "scroll": "scroll",
+    "exists": "exists",
+    "search": "search",
+    "search_docs": "search_docs",
+    "search_groups": "search_groups",
+    "hybrid_search": "hybrid_search",
+    "hybrid_text": "hybrid_text",
+    "recommend": "recommend",
+    "query": "query",
+}
+
+
+def test_binds_name_and_forwards_positionally():
+    spy = _Spy()
+    col = Collection(spy, "posts")
+    assert col.name == "posts"
+    for handle_method, flat_method in FORWARDS.items():
+        spy.calls.clear()
+        getattr(col, handle_method)("ARG", kw=1)
+        assert len(spy.calls) == 1, f"{handle_method} did not forward exactly once"
+        called, args, kwargs = spy.calls[0]
+        assert called == flat_method, f"{handle_method} forwarded to {called}, want {flat_method}"
+        assert args == ("posts", "ARG"), f"{handle_method} must pass name first, got {args}"
+        assert kwargs == {"kw": 1}
+
+
+def test_factory_returns_bound_handle_without_io():
+    r = Rostam("tcp://127.0.0.1:7000")  # construction does no I/O
+    col = r.collection("c")
+    assert isinstance(col, Collection)
+    assert col.name == "c"
+
+
+def test_repr():
+    assert repr(Collection(_Spy(), "x")) == "Collection('x')"
+
+
+def test_forwarding_preserves_transport_guard():
+    # query is HTTP-only; forwarding through the handle must still raise the
+    # facade's TransportError on a TCP client (before any I/O).
+    r = Rostam("tcp://127.0.0.1:7000")
+    with pytest.raises(TransportError):
+        r.collection("c").query([])

--- a/docs/api/python.md
+++ b/docs/api/python.md
@@ -76,6 +76,29 @@ c.drop_collection("docs")
 `insert` has no `content` parameter (it's create-only, and the wire op it
 sends carries no content field) — use `upsert` when a point needs stored text.
 
+## Collection handle
+
+When most of your calls target one collection, `r.collection(name)` returns a
+handle that binds the name so it stops being the first argument every time
+(mirrors the Go client's `client.Collection`). Construction does no I/O, and
+each method forwards to the identically-named flat method — so transport rules
+still apply (`query`, `delete_by_filter` raise `TransportError` on TCP just as
+`r.query` / `r.delete_by_filter` do).
+
+```python
+docs = c.collection("docs")   # a handle; does no I/O
+docs.create(dim=384, metric="cosine")
+docs.upsert(1, embedding, content="the chunk text")
+hits = docs.search_docs(embedding, k=5, filter=f.eq("doc_id", 7))
+docs.delete(1)
+docs.drop()          # -> c.drop_collection("docs")
+```
+
+Handle methods: `create`, `drop`, `upsert`, `insert`, `upsert_batch`, `delete`,
+`delete_by_filter`, `get`, `get_batch`, `scroll`, `exists`, `search`,
+`search_docs`, `search_groups`, `hybrid_search`, `hybrid_text`, `recommend`,
+`query`.
+
 ## Connections
 
 The client keeps a small pool of connections and reuses them, so a sequence

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -5,6 +5,14 @@ Notable user-visible changes. Entries that alter existing behaviour are marked
 
 ## Unreleased
 
+- **Python client: collection handle.** `r.collection(name)` returns a handle
+  bound to one collection so its name stops being repeated on every call —
+  `r.collection("posts").search(vec, k=10)` instead of
+  `r.search("posts", vec, k=10)`. Mirrors the Go client's `client.Collection`;
+  construction does no I/O, and transport rules are preserved (e.g. `query` /
+  `delete_by_filter` still raise `TransportError` on a TCP client). Exported as
+  `rostam.Collection`. Additive — the flat API is unchanged.
+
 - **The Python client (`rostam-client` on PyPI) unifies on a single `Rostam`
   class — v0.2.0 (Breaking).** The Python client is versioned and released
   independently of the server/project (this changelog's `v0.3.0` entry


### PR DESCRIPTION
## What & why

Adds a collection-scoped handle to the Python client, mirroring the Go client's `client.Collection`. When most calls target one collection, `r.collection(name)` binds it so the name stops being the first argument on every call.

```python
docs = r.collection("docs")
docs.upsert(1, vec, content="hello")
hits = docs.hybrid_text(vec, "apple pie", k=5)
```

## How

`Collection` wraps `(client, name)` and each method forwards to the identically-named flat method with `name` as the first positional arg (`create`/`drop` map to `create_collection`/`drop_collection`). Construction does no I/O. Transport rules are preserved through forwarding — `query` / `delete_by_filter` still raise `TransportError` on a TCP client, exactly as the flat `r.query` / `r.delete_by_filter` do.

Surface (collection-scoped): `create`, `drop`, `upsert`, `insert`, `upsert_batch`, `delete`, `delete_by_filter`, `get`, `get_batch`, `scroll`, `exists`, `search`, `search_docs`, `search_groups`, `hybrid_search`, `hybrid_text`, `recommend`, `query`. Non-collection-scoped / HTTP-only extras (`health`, `bulk_*`, `search_text`, `discover`, `mv_*`) stay on the flat client by design. Exported as `rostam.Collection`.

## Verification

- `ruff check` clean; `pytest` — 112 passed / 78 skipped (cross-stack need a server bin) / 65 subtests
- `test_collection.py` proves each method forwards to the right flat method with the name passed first, plus a no-I/O factory check, `__repr__`, and that the `TransportError` guard survives forwarding
- Docs updated: README, package README, `docs/api/python.md`
- Independent review: **approved**, no blocking issues (all 18 forwards verified against both `_tcp.py` and `_http.py` signatures; no import cycle)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added collection-bound Python client handles through `Rostam.collection(name)`.
  * Collection operations can now omit the collection name from each call.
  * Supports common create, read, update, delete, search, hybrid search, and query operations.
  * Exported the collection handle for convenient access.

* **Documentation**
  * Added usage examples and API guidance, including supported operations and transport limitations.

* **Tests**
  * Added coverage for collection binding, method forwarding, representations, and error behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->