### PR TITLE
release: stamp changelog v0.4.0 + pin sdk module to v0.1.0

### DIFF
--- a/client/go.mod
+++ b/client/go.mod
@@ -5,7 +5,7 @@ go 1.26.5
 require (
 	github.com/cespare/xxhash/v2 v2.3.0
 	github.com/jackc/puddle/v2 v2.2.2
-	github.com/rostamlabs/rostam/sdk v0.0.0-00010101000000-000000000000
+	github.com/rostamlabs/rostam/sdk v0.1.0
 )
 
 require (

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -5,6 +5,8 @@ Notable user-visible changes. Entries that alter existing behaviour are marked
 
 ## Unreleased
 
+## v0.4.0 — 2026-08-24
+
 - **Security: bump `google.golang.org/grpc` to v1.82.1.** Addresses
   GHSA-hrxh-6v49-42gf (a DoS in the xDS RBAC / HTTP/2 server paths) present in
   v1.81.1. The gRPC API surface is unchanged.

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -3,8 +3,6 @@
 Notable user-visible changes. Entries that alter existing behaviour are marked
 **Breaking** and say what to do about it.
 
-## Unreleased
-
 ## v0.4.0 — 2026-08-24
 
 - **Security: bump `google.golang.org/grpc` to v1.82.1.** Addresses

--- a/go.mod
+++ b/go.mod
@@ -28,7 +28,7 @@ require (
 	github.com/mattn/go-isatty v0.0.14 // indirect
 	github.com/panjf2000/ants/v2 v2.12.1 // indirect
 	github.com/rostamlabs/rostam/client v0.0.0-00010101000000-000000000000
-	github.com/rostamlabs/rostam/sdk v0.0.0-00010101000000-000000000000
+	github.com/rostamlabs/rostam/sdk v0.1.0
 	github.com/valyala/bytebufferpool v1.0.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	go.uber.org/zap v1.28.0 // indirect


### PR DESCRIPTION
Release-prep for **v0.4.0** (server) + the first Go module release (**sdk/v0.1.0**, **client/v0.1.0**) + **py-v0.2.0** (Python). Stamps the current `## Unreleased` changelog set as `## v0.4.0`, and pins the root + client `go.mod` to `sdk v0.1.0` (local replace kept for in-repo builds; external consumers resolve `sdk@v0.1.0`). Verified: workspace build, server binary builds standalone (GOWORK=off via replace), client still engine-free, golden byte-identical. Tags pushed after merge per docs/RELEASING_MODULES.md.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the changelog so version `v0.4.0` is the current release heading.
  * Removed the temporary “Unreleased” heading to keep release information clear and up to date.

* **Chores**
  * Aligned the SDK dependency with the stable `v0.1.0` release across the project, improving consistency for builds and release tracking.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->