### PR TITLE
fix(docker): copy sdk/client go.mod + go.work before go mod download (completes v0.4.0 → v0.4.1)

### DIFF
--- a/cmd/rostam-server/Dockerfile
+++ b/cmd/rostam-server/Dockerfile
@@ -5,7 +5,9 @@
 # carries a C toolchain and the runtime image is debian-slim (not scratch).
 FROM golang:1.26-bookworm AS build
 WORKDIR /src
-COPY go.mod go.sum ./
+COPY go.mod go.sum go.work go.work.sum ./
+COPY sdk/go.mod sdk/go.sum ./sdk/
+COPY client/go.mod client/go.sum ./client/
 RUN go mod download
 COPY . .
 RUN CGO_ENABLED=1 go build -trimpath -ldflags="-s -w" -o /out/rostam-server ./cmd/rostam-server

--- a/cmd/rostam-server/Dockerfile.localembed
+++ b/cmd/rostam-server/Dockerfile.localembed
@@ -42,7 +42,9 @@ RUN set -eu; \
 # image carries a C toolchain and the runtime image is debian-slim (not scratch).
 FROM golang:1.26-bookworm AS build
 WORKDIR /src
-COPY go.mod go.sum ./
+COPY go.mod go.sum go.work go.work.sum ./
+COPY sdk/go.mod sdk/go.sum ./sdk/
+COPY client/go.mod client/go.sum ./client/
 RUN go mod download
 COPY . .
 RUN CGO_ENABLED=1 go build -trimpath -tags localembed -ldflags="-s -w" \

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -3,6 +3,15 @@
 Notable user-visible changes. Entries that alter existing behaviour are marked
 **Breaking** and say what to do about it.
 
+## v0.4.1 — 2026-08-24
+
+- **Fix the Docker image build after the module split.** The server image's
+  `go mod download` layer copied only the root `go.mod`/`go.sum`, but the root
+  module now has `replace` directives to the in-repo `sdk` and `client` modules,
+  so the download step failed reading `sdk/go.mod`/`client/go.mod`. The
+  Dockerfiles now copy the sub-module manifests and `go.work` before download.
+  (v0.4.0 shipped binaries + PyPI but no Docker images; v0.4.1 completes it.)
+
 ## v0.4.0 — 2026-08-24
 
 - **Security: bump `google.golang.org/grpc` to v1.82.1.** Addresses


### PR DESCRIPTION
**Completes the v0.4.0 release.** v0.4.0 shipped binaries + PyPI (py-v0.2.0) + the Go module tags (sdk/client v0.1.0), but the **Docker image jobs failed**: the module split added `replace => ./sdk` and `=> ./client` to the root `go.mod`, and the image build's `go mod download` layer (which copies only root `go.mod`/`go.sum` before the full source) then failed reading `sdk/go.mod`/`client/go.mod`.

Fix: both Dockerfiles now copy the sub-module manifests + `go.work` before `go mod download`. **Verified by building the image locally end-to-end** (go mod download ✓, go build ✓, image exported). Cut as **v0.4.1** after merge to re-run the server release with working images.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Docker image builds so dependencies from the root, SDK, and client modules are downloaded correctly.

* **Documentation**
  * Added a v0.4.1 changelog entry describing the Docker build fix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->