### PR TITLE
docs: fix two broken cross-reference anchors

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -50,7 +50,7 @@ are hand-vectorized (AVX2 with scalar fallback).
 |---|---|
 | Add vector search to a Go program (no server) | [Quickstart → Embedded vector search](quickstart.md#embedded-vector-search-go-library) |
 | Use a fast in-process KV cache / store in Go | [Quickstart → Embedded key-value store](quickstart.md#embedded-key-value-store-go-library) |
-| Run Rostam as a server and talk REST/gRPC | [Quickstart → Run the server](quickstart.md#run-the-server) |
+| Run Rostam as a server and talk REST/gRPC | [Quickstart → Run it](quickstart.md#run-it) |
 | Use Rostam from Python | [Python client](api/python.md) |
 | Run a replicated multi-node cluster | [Clustering](server/clustering.md) |
 | Understand how it all fits together | [Architecture](concepts/architecture.md) |

--- a/docs/server/rag.md
+++ b/docs/server/rag.md
@@ -87,7 +87,7 @@ needed, works immediately after `rag ingest`. Set `-embed-url`,
 `-embed-model`, and `-embed-dim` (or the equivalent `ROSTAM_EMBED_*` env
 vars, plus `ROSTAM_EMBED_KEY` if the endpoint needs one) and retrieval
 switches to **dense+BM25 hybrid fusion** by default (see
-[Hybrid fusion](#hybrid-fusion-dense--bm25) below); `-no-hybrid` selects
+[Hybrid fusion](#hybrid-fusion-dense-bm25) below); `-no-hybrid` selects
 pure dense kNN over the embedded vectors instead.
 
 Note that ingestion and retrieval must agree: chunks embedded at ingest


### PR DESCRIPTION
Two internal links resolve to no anchor (verified broken on the live `docs.rostamlabs.com`):

- `docs/index.md` linked `quickstart.md#run-the-server`, but the heading is **Run it** → `#run-it`.
- `docs/server/rag.md` linked `#hybrid-fusion-dense--bm25` (stray double hyphen); the generated anchor is `#hybrid-fusion-dense-bm25`.

The current `--strict` docs build doesn't validate these (a toolchain gap), but a newer mkdocs does — this surfaced while aggregating the docs into the unified site. Docs-only.