### PR TITLE
clients: add LangChain & LlamaIndex partner packages

### DIFF
--- a/clients/PARTNER_PACKAGES.md
+++ b/clients/PARTNER_PACKAGES.md
@@ -1,0 +1,52 @@
+# Framework partner packages
+
+Discovery-oriented packages so Rostam appears in the LangChain and LlamaIndex
+integration registries. Each is a thin re-export of the adapter that already
+ships in [`rostam-client`](./python) — the implementation lives there; these
+packages only expose it under the name each framework's ecosystem expects.
+
+| Package | Exposes | Wraps |
+|---|---|---|
+| [`langchain-rostam`](./langchain-rostam) | `langchain_rostam.RostamVectorStore` | `rostam.langchain.RostamVectorStore` |
+| [`llama-index-vector-stores-rostam`](./llama-index-vector-stores-rostam) | `llama_index.vector_stores.rostam.RostamVectorStore` | `rostam.llamaindex.RostamVectorStore` |
+
+Haystack needs no package — it's a catalog entry pointing at `rostam-client`
+(submitted at deepset-ai/haystack-integrations#583).
+
+## Publishing (per package)
+
+```sh
+cd clients/langchain-rostam            # or llama-index-vector-stores-rostam
+python -m build                        # -> dist/*.whl and *.tar.gz
+python -m twine upload dist/*          # needs your PyPI token
+```
+
+Both pin `rostam-client>=0.2` (the 0.2.0 release already contains the adapter
+modules). Bump the partner package's own version on each release; it does not
+have to track `rostam-client`.
+
+## Getting listed in the registries (after publishing)
+
+**LlamaIndex** — the package follows the `llama-index-vector-stores-*`
+convention, so once it's on PyPI, open a PR to
+[`run-llama/llama_index`](https://github.com/run-llama/llama_index) adding it
+under `llama-index-integrations/vector_stores/` (or referencing the published
+package per their current contribution guide). Include a short usage example and
+note that the store implements `BasePydanticVectorStore`.
+
+**LangChain** — publish `langchain-rostam`, then open a docs PR to
+[`langchain-ai/langchain`](https://github.com/langchain-ai/langchain) adding a
+notebook at `docs/docs/integrations/vectorstores/rostam.ipynb` that demonstrates
+`RostamVectorStore` (add texts, similarity search, MMR, filtering). Note:
+LangChain has become selective about new community vector stores — expect
+review, and lead with the working notebook.
+
+## Verifying before you publish
+
+```sh
+pip install ./clients/langchain-rostam ./clients/llama-index-vector-stores-rostam
+pytest clients/langchain-rostam/tests clients/llama-index-vector-stores-rostam/tests --import-mode=importlib
+```
+
+Both re-export tests assert the class is importable under the framework name and
+subclasses the right base type.

--- a/clients/langchain-rostam/.gitignore
+++ b/clients/langchain-rostam/.gitignore
@@ -1,0 +1,5 @@
+dist/
+*.egg-info/
+__pycache__/
+build/
+.pytest_cache/

--- a/clients/langchain-rostam/README.md
+++ b/clients/langchain-rostam/README.md
@@ -1,0 +1,35 @@
+# langchain-rostam
+
+LangChain [`VectorStore`](https://python.langchain.com/docs/integrations/vectorstores/)
+integration for [Rostam](https://rostamlabs.com) — a high-performance vector
+database and sub-microsecond key-value store in a single Go engine.
+
+```bash
+pip install langchain-rostam
+```
+
+```python
+from langchain_rostam import RostamVectorStore
+
+store = RostamVectorStore(
+    url="http://localhost:8080",
+    collection="docs",
+    embedding=my_embeddings,   # any LangChain Embeddings
+)
+store.add_texts(["Rostam is a vector DB and KV store in one Go engine."])
+docs = store.similarity_search("what is rostam?", k=5)
+```
+
+Run a Rostam server:
+
+```bash
+docker run -p 8080:8080 -e ROSTAM_API_KEY=secret ghcr.io/rostamlabs/rostam:latest
+```
+
+`RostamVectorStore` implements the standard LangChain `VectorStore` interface
+(add/search/MMR/delete + metadata filtering). The implementation ships in the
+[`rostam-client`](https://pypi.org/project/rostam-client/) package; this package
+re-exports it under the conventional `langchain_rostam` name.
+
+See the [Rostam docs](https://docs.rostamlabs.com/) for indexes, hybrid search,
+and filtering. Apache-2.0.

--- a/clients/langchain-rostam/langchain_rostam/__init__.py
+++ b/clients/langchain-rostam/langchain_rostam/__init__.py
@@ -1,0 +1,11 @@
+"""LangChain integration for the Rostam vector database.
+
+Re-exports ``RostamVectorStore`` from the ``rostam-client`` package under the
+conventional ``langchain_rostam`` partner-package name, so it is discoverable in
+the LangChain integrations ecosystem. The implementation lives in
+``rostam-client`` (``rostam.langchain``).
+"""
+
+from rostam.langchain import RostamVectorStore
+
+__all__ = ["RostamVectorStore"]

--- a/clients/langchain-rostam/pyproject.toml
+++ b/clients/langchain-rostam/pyproject.toml
@@ -1,0 +1,25 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "langchain-rostam"
+version = "0.1.0"
+description = "LangChain VectorStore integration for the Rostam vector database"
+readme = "README.md"
+requires-python = ">=3.9"
+license = "Apache-2.0"
+authors = [{ name = "RostamLabs" }]
+keywords = ["langchain", "vector", "database", "rostam", "embeddings", "rag"]
+dependencies = [
+  "rostam-client>=0.2",
+  "langchain-core>=0.2",
+]
+
+[project.urls]
+Homepage = "https://rostamlabs.com"
+Documentation = "https://docs.rostamlabs.com/"
+Repository = "https://github.com/rostamlabs/rostam"
+
+[tool.hatch.build.targets.wheel]
+packages = ["langchain_rostam"]

--- a/clients/langchain-rostam/tests/test_import.py
+++ b/clients/langchain-rostam/tests/test_import.py
@@ -1,0 +1,5 @@
+def test_reexport():
+    from langchain_rostam import RostamVectorStore
+    from langchain_core.vectorstores import VectorStore
+
+    assert issubclass(RostamVectorStore, VectorStore)

--- a/clients/llama-index-vector-stores-rostam/.gitignore
+++ b/clients/llama-index-vector-stores-rostam/.gitignore
@@ -1,0 +1,5 @@
+dist/
+*.egg-info/
+__pycache__/
+build/
+.pytest_cache/

--- a/clients/llama-index-vector-stores-rostam/README.md
+++ b/clients/llama-index-vector-stores-rostam/README.md
@@ -1,0 +1,32 @@
+# llama-index-vector-stores-rostam
+
+LlamaIndex vector store integration for [Rostam](https://rostamlabs.com) — a
+high-performance vector database and sub-microsecond key-value store in a single
+Go engine.
+
+```bash
+pip install llama-index-vector-stores-rostam
+```
+
+```python
+from llama_index.core import VectorStoreIndex, StorageContext
+from llama_index.vector_stores.rostam import RostamVectorStore
+
+vector_store = RostamVectorStore(url="http://localhost:8080", collection="docs")
+storage_context = StorageContext.from_defaults(vector_store=vector_store)
+index = VectorStoreIndex.from_documents(documents, storage_context=storage_context)
+```
+
+Run a Rostam server:
+
+```bash
+docker run -p 8080:8080 -e ROSTAM_API_KEY=secret ghcr.io/rostamlabs/rostam:latest
+```
+
+`RostamVectorStore` implements LlamaIndex's `BasePydanticVectorStore`. The
+implementation ships in the [`rostam-client`](https://pypi.org/project/rostam-client/)
+package; this package re-exports it under the conventional
+`llama_index.vector_stores.rostam` namespace.
+
+See the [Rostam docs](https://docs.rostamlabs.com/) for indexes, hybrid search,
+and filtering. Apache-2.0.

--- a/clients/llama-index-vector-stores-rostam/llama_index/vector_stores/rostam/__init__.py
+++ b/clients/llama-index-vector-stores-rostam/llama_index/vector_stores/rostam/__init__.py
@@ -1,0 +1,11 @@
+"""LlamaIndex vector store integration for the Rostam vector database.
+
+Re-exports ``RostamVectorStore`` from the ``rostam-client`` package under the
+conventional ``llama_index.vector_stores.rostam`` namespace, so it is
+discoverable in the LlamaIndex integrations ecosystem. The implementation lives
+in ``rostam-client`` (``rostam.llamaindex``).
+"""
+
+from rostam.llamaindex import RostamVectorStore
+
+__all__ = ["RostamVectorStore"]

--- a/clients/llama-index-vector-stores-rostam/pyproject.toml
+++ b/clients/llama-index-vector-stores-rostam/pyproject.toml
@@ -1,0 +1,25 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "llama-index-vector-stores-rostam"
+version = "0.1.0"
+description = "LlamaIndex vector store integration for the Rostam vector database"
+readme = "README.md"
+requires-python = ">=3.9"
+license = "Apache-2.0"
+authors = [{ name = "RostamLabs" }]
+keywords = ["llama-index", "llamaindex", "vector", "database", "rostam", "rag"]
+dependencies = [
+  "rostam-client>=0.2",
+  "llama-index-core>=0.10",
+]
+
+[project.urls]
+Homepage = "https://rostamlabs.com"
+Documentation = "https://docs.rostamlabs.com/"
+Repository = "https://github.com/rostamlabs/rostam"
+
+[tool.hatch.build.targets.wheel]
+packages = ["llama_index"]

--- a/clients/llama-index-vector-stores-rostam/tests/test_import.py
+++ b/clients/llama-index-vector-stores-rostam/tests/test_import.py
@@ -1,0 +1,5 @@
+def test_reexport():
+    from llama_index.vector_stores.rostam import RostamVectorStore
+    from llama_index.core.vector_stores.types import BasePydanticVectorStore
+
+    assert issubclass(RostamVectorStore, BasePydanticVectorStore)


### PR DESCRIPTION
Adds two thin **partner packages** so Rostam is discoverable in the framework integration registries (where users actually browse for a vector store):

| Package | Import | Wraps |
|---|---|---|
| `langchain-rostam` | `langchain_rostam.RostamVectorStore` | `rostam.langchain` (in `rostam-client`) |
| `llama-index-vector-stores-rostam` | `llama_index.vector_stores.rostam.RostamVectorStore` | `rostam.llamaindex` (in `rostam-client`) |

The adapters already ship in `rostam-client[langchain]` / `[llamaindex]`; these packages just re-export them under the name each ecosystem expects (LangChain's `langchain-*` and LlamaIndex's `llama-index-vector-stores-*` conventions). Both pin `rostam-client>=0.2` (0.2.0 already contains the adapter modules).

**Verified:** both wheels build (hatchling), the namespace package is packaged correctly, and the re-export smoke tests pass against real `langchain-core` / `llama-index-core` (`RostamVectorStore` imports and subclasses `VectorStore` / `BasePydanticVectorStore`).

`clients/PARTNER_PACKAGES.md` documents publishing (`python -m build && twine upload`) and the registry-submission steps for each framework.

Haystack is handled separately as a catalog entry (deepset-ai/haystack-integrations#583) — no package needed there.

_No changelog entry: this adds package source only; the user-facing "pip install" lands when the packages are published to PyPI._