### PR TITLE
feat(python): Mem0, Semantic Router, CrewAI, and DSPy adapters (0.3.0)

### DIFF
--- a/clients/python/pyproject.toml
+++ b/clients/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "rostam-client"
-version = "0.2.0"
+version = "0.3.0"
 description = "Dependency-free Python client and LangChain adapter for the Rostam vector store"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/clients/python/pyproject.toml
+++ b/clients/python/pyproject.toml
@@ -28,12 +28,12 @@ langchain = ["langchain-core>=0.2"]
 llamaindex = ["llama-index-core>=0.10"]
 haystack = ["haystack-ai>=2.0"]
 mem0 = ["mem0ai>=0.1"]
-semantic-router = ["semantic-router>=0.1"]
+semantic-router = ["semantic-router>=0.1.15"]
 crewai = ["crewai>=0.70"]
 dspy = ["dspy>=2.5"]
 dev = [
   "langchain-core>=0.2", "llama-index-core>=0.10", "haystack-ai>=2.0",
-  "mem0ai>=0.1", "semantic-router>=0.1", "crewai>=0.70", "dspy>=2.5",
+  "mem0ai>=0.1", "semantic-router>=0.1.15", "crewai>=0.70", "dspy>=2.5",
 ]
 # `test` pulls the adapter deps (so the framework adapter tests run instead of
 # skipping) plus pytest itself, for a single reproducible CI install.

--- a/clients/python/pyproject.toml
+++ b/clients/python/pyproject.toml
@@ -27,9 +27,16 @@ dependencies = []  # the core client is standard-library only
 langchain = ["langchain-core>=0.2"]
 llamaindex = ["llama-index-core>=0.10"]
 haystack = ["haystack-ai>=2.0"]
-dev = ["langchain-core>=0.2", "llama-index-core>=0.10", "haystack-ai>=2.0"]
-# `test` pulls the adapter deps (so the langchain/llamaindex/haystack tests run
-# instead of skipping) plus pytest itself, for a single reproducible CI install.
+mem0 = ["mem0ai>=0.1"]
+semantic-router = ["semantic-router>=0.1"]
+crewai = ["crewai>=0.70"]
+dspy = ["dspy>=2.5"]
+dev = [
+  "langchain-core>=0.2", "llama-index-core>=0.10", "haystack-ai>=2.0",
+  "mem0ai>=0.1", "semantic-router>=0.1", "crewai>=0.70", "dspy>=2.5",
+]
+# `test` pulls the adapter deps (so the framework adapter tests run instead of
+# skipping) plus pytest itself, for a single reproducible CI install.
 test = ["rostam-client[dev]", "pytest>=7"]
 
 [project.urls]

--- a/clients/python/rostam/__init__.py
+++ b/clients/python/rostam/__init__.py
@@ -59,4 +59,4 @@ __all__ = [
 # anything asking rostam.__version__ was told the wrong release, and nothing
 # noticed. It is a literal rather than an importlib.metadata lookup so that
 # importing the package stays free of a dist-info read.
-__version__ = "0.2.0"
+__version__ = "0.3.0"

--- a/clients/python/rostam/__init__.py
+++ b/clients/python/rostam/__init__.py
@@ -4,9 +4,17 @@ One entry point, ``Rostam(target)``, whose transport is chosen from the
 target: ``http(s)://host:8080`` speaks the REST API, ``tcp://host:7000`` (or a
 bare ``host:7000``) speaks the native binary TCP protocol. Vector ops are flat
 (``r.search``, ``r.upsert``, ``r.hybrid_text``, ...); key-value ops live under
-``r.kv.*`` (TCP only). Uses only the standard library. The optional LangChain /
-LlamaIndex / Haystack adapters live in ``rostam.langchain`` / ``rostam.llamaindex``
-/ ``rostam.haystack`` and require their respective extras.
+``r.kv.*`` (TCP only). Uses only the standard library. Optional framework
+adapters live in their own submodules and each require the matching extra
+(``pip install rostam-client[<extra>]``):
+
+    rostam.langchain        — LangChain VectorStore            [langchain]
+    rostam.llamaindex       — LlamaIndex VectorStore           [llamaindex]
+    rostam.haystack         — Haystack DocumentStore/Retriever [haystack]
+    rostam.mem0             — Mem0 VectorStoreBase provider     [mem0]
+    rostam.semantic_router  — Semantic Router BaseIndex         [semantic-router]
+    rostam.crewai           — CrewAI memory Storage backend     [crewai]
+    rostam.dspy             — DSPy retriever module             [dspy]
 """
 
 from . import filters

--- a/clients/python/rostam/crewai.py
+++ b/clients/python/rostam/crewai.py
@@ -49,6 +49,7 @@ import threading
 import time
 from typing import Any, Callable, Dict, List, Optional, Sequence
 
+from . import filters as f
 from ._ids import to_uint64
 from ._types import RostamError
 from .rostam import Rostam
@@ -64,6 +65,15 @@ def _scalar(meta: Dict[str, Any]) -> Dict[str, Any]:
         elif isinstance(v, (list, tuple)) and v and all(isinstance(x, (str, int, float)) and not isinstance(x, bool) for x in v):
             out[k] = list(v)
     return out
+
+
+def _translate_filter(filt: Dict[str, Any]):
+    """Translate CrewAI's flat ``{field: value}`` filter dict into a Rostam
+    filter predicate."""
+    clauses = [f.eq(k, v) for k, v in filt.items()]
+    if not clauses:
+        return None
+    return clauses[0] if len(clauses) == 1 else f.and_(*clauses)
 
 
 class RostamStorage:
@@ -110,9 +120,20 @@ class RostamStorage:
         pid = self._next_id(value)
         self._client.upsert(self._collection, pid, vector, content=value, metadata=_scalar(metadata or {}))
 
-    def search(self, query: str, limit: int = 3, score_threshold: float = 0.35) -> List[Dict[str, Any]]:
+    def search(
+        self,
+        query: str,
+        limit: int = 3,
+        filter: Optional[Dict[str, Any]] = None,
+        score_threshold: float = 0.35,
+    ) -> List[Dict[str, Any]]:
         vector = list(self._embedder(query))
-        hits = self._client.search_docs(self._collection, vector, limit)
+        # Ensure the collection exists before the first search on an
+        # auto_create store — otherwise a search preceding any save() fails
+        # against a collection that was never created.
+        self._ensure_collection(len(vector))
+        flt = _translate_filter(filter) if filter else None
+        hits = self._client.search_docs(self._collection, vector, limit, filter=flt)
         out: List[Dict[str, Any]] = []
         for h in hits:
             score = 1.0 / (1.0 + max(h.distance, 0.0))
@@ -128,9 +149,17 @@ class RostamStorage:
         # filter, so None would post filter:null, whose server-side semantics
         # aren't specified. The collection itself is kept, so later saves need
         # no recreate.
+        #
+        # Only the initial scroll's "collection never created" error is
+        # suppressed; any other scroll failure, and every delete() failure
+        # (left outside this try block), propagates instead of being reported
+        # as a successful reset.
         try:
-            for d in self._client.scroll(self._collection):
-                self._client.delete(self._collection, d.id)
-        except RostamError:
-            # Nothing to reset if the collection was never created.
-            pass
+            docs = self._client.scroll(self._collection)
+        except RostamError as e:
+            msg = (e.message or "").lower()
+            if "no collection" in msg or "unknown collection" in msg or "not found" in msg or "not exist" in msg:
+                return
+            raise
+        for d in docs:
+            self._client.delete(self._collection, d.id)

--- a/clients/python/rostam/crewai.py
+++ b/clients/python/rostam/crewai.py
@@ -1,0 +1,136 @@
+"""CrewAI memory-storage adapter backed by a Rostam collection.
+
+Requires ``crewai`` (``pip install rostam-client[crewai]``). Provides
+``RostamStorage``, a duck-typed implementation of CrewAI's classic memory
+``Storage`` contract (``crewai.memory.storage.interface.Storage`` /
+``crewai.memory.storage.rag_storage.RAGStorage``): ``save(value, metadata)``,
+``search(query, limit, score_threshold) -> list[dict]``, ``reset()``. It plugs
+into ``ShortTermMemory``, ``LongTermMemory``, ``EntityMemory`` (each accepts a
+``storage=`` override) and into ``ExternalMemory(storage=...)`` the same way::
+
+    from rostam import Rostam
+    from rostam.crewai import RostamStorage
+    from crewai.memory import ShortTermMemory
+    from crewai.memory.external.external_memory import ExternalMemory
+
+    client = Rostam("http://localhost:8080")
+    storage = RostamStorage(client, "crew_memory", embedder=my_embed_fn)
+    short_term = ShortTermMemory(storage=storage)
+    external = ExternalMemory(storage=storage)
+
+Research note (context7, crewAIInc/crewai, checked against docs.crewai.com):
+CrewAI's storage layer -- both the classic ``RAGStorage``/``KnowledgeStorage``
+hierarchy and the newer ``Memory``/``StorageBackend`` system that some current
+docs describe -- always hands the storage backend RAW TEXT, never a
+precomputed embedding. Embedding is a concern the storage/memory layer owns
+for itself (``KnowledgeStorage`` holds its own ``embedder`` config and embeds
+internally via its RAG client). ``RostamStorage`` follows that same shape: it
+takes an ``embedder`` callable (``str -> list[float]``) at construction, like
+the other Rostam adapters accept an embeddings object, and calls it inside
+``save()``/``search()`` to produce the vector Rostam needs.
+
+Uncertainty: context7's index for this library mixes two documented
+generations of the CrewAI memory API -- the classic ``Storage``/``RAGStorage``
+class hierarchy named in this module's target, and a newer ``Memory`` /
+``StorageBackend`` protocol (default backend "lancedb") that some current
+docs describe with a different call shape (``remember``/``recall`` returning
+``MemoryMatch`` objects). No concrete method signature for the newer
+``StorageBackend`` protocol surfaced in the indexed docs, only the classic
+dict-returning ``save``/``search``/``reset`` shape did. ``RostamStorage``
+targets the classic, long-stable duck-typed contract (the one third-party
+storage backends have implemented for years), since that is what installs
+with released ``crewai`` versions and is what this module's target classes
+name.
+"""
+
+from __future__ import annotations
+
+import threading
+import time
+from typing import Any, Callable, Dict, List, Optional, Sequence
+
+from ._ids import to_uint64
+from ._types import RostamError
+from .rostam import Rostam
+
+Embedder = Callable[[str], Sequence[float]]
+
+
+def _scalar(meta: Dict[str, Any]) -> Dict[str, Any]:
+    out: Dict[str, Any] = {}
+    for k, v in (meta or {}).items():
+        if isinstance(v, (str, int, float, bool)):
+            out[k] = v
+        elif isinstance(v, (list, tuple)) and v and all(isinstance(x, (str, int, float)) and not isinstance(x, bool) for x in v):
+            out[k] = list(v)
+    return out
+
+
+class RostamStorage:
+    """A CrewAI memory ``Storage`` backend over a single Rostam collection."""
+
+    def __init__(
+        self,
+        client: Rostam,
+        collection: str,
+        *,
+        embedder: Embedder,
+        auto_create: bool = True,
+        metric: str = "cosine",
+    ):
+        self._client = client
+        self._collection = collection
+        self._embedder = embedder
+        self._auto_create = auto_create
+        self._metric = metric
+        self._created = False
+        self._counter = 0
+        self._lock = threading.Lock()
+
+    def _ensure_collection(self, dim: int) -> None:
+        if not self._auto_create or self._created:
+            return
+        try:
+            self._client.create_collection(self._collection, dim, metric=self._metric)
+        except RostamError as e:
+            # Already-exists is fine; anything else propagates.
+            if "exist" not in (e.message or "").lower():
+                raise
+        self._created = True
+
+    def _next_id(self, value: str) -> int:
+        with self._lock:
+            self._counter += 1
+            n = self._counter
+        return to_uint64(f"{value}|{n}|{time.time_ns()}")
+
+    def save(self, value: str, metadata: Optional[Dict[str, Any]] = None) -> None:
+        vector = list(self._embedder(value))
+        self._ensure_collection(len(vector))
+        pid = self._next_id(value)
+        self._client.upsert(self._collection, pid, vector, content=value, metadata=_scalar(metadata or {}))
+
+    def search(self, query: str, limit: int = 3, score_threshold: float = 0.35) -> List[Dict[str, Any]]:
+        vector = list(self._embedder(query))
+        hits = self._client.search_docs(self._collection, vector, limit)
+        out: List[Dict[str, Any]] = []
+        for h in hits:
+            score = 1.0 / (1.0 + max(h.distance, 0.0))
+            if score < score_threshold:
+                continue
+            out.append({"id": h.id, "metadata": h.metadata, "context": h.content, "score": score})
+        return out
+
+    def reset(self) -> None:
+        # Clear every point in the collection. Uses scroll + per-id delete (the
+        # same shape as the Semantic Router adapter's delete_all) rather than a
+        # "match all" delete_by_filter — delete_by_filter always sends the
+        # filter, so None would post filter:null, whose server-side semantics
+        # aren't specified. The collection itself is kept, so later saves need
+        # no recreate.
+        try:
+            for d in self._client.scroll(self._collection):
+                self._client.delete(self._collection, d.id)
+        except RostamError:
+            # Nothing to reset if the collection was never created.
+            pass

--- a/clients/python/rostam/dspy.py
+++ b/clients/python/rostam/dspy.py
@@ -1,0 +1,141 @@
+"""DSPy retriever adapter backed by a Rostam collection.
+
+Requires ``dspy`` (``pip install rostam-client[dspy]``). Targets DSPy's current
+retriever pattern (DSPy >=2.5, verified against 3.1.3 docs): a plain
+``dspy.Module`` whose ``forward`` returns ``dspy.Prediction(passages=...)``,
+callable directly like ``dspy.retrievers.Embeddings`` — the pattern the current
+DSPy RAG tutorial recommends — rather than the legacy ``dspy.Retrieve`` class,
+which draws from a single globally configured retrieval model via
+``dspy.settings.configure(rm=...)`` and doesn't compose with a per-collection
+client.
+
+DSPy retrievers receive a query STRING; Rostam search needs a query VECTOR, so
+``RostamRetriever`` takes an embedder callable (``str -> list[float]``) at
+construction and uses it to embed the incoming query.
+
+    from rostam import Rostam
+    from rostam.dspy import RostamRetriever
+
+    client = Rostam("http://localhost:8080")
+    retrieve = RostamRetriever(client, "docs", embedder=embed_fn, k=5)
+    retrieve.index(["doc one text", "doc two text"])
+
+    class RAG(dspy.Module):
+        def __init__(self):
+            self.retrieve = retrieve
+            self.answer = dspy.ChainOfThought("question, context -> answer")
+
+        def forward(self, question):
+            passages = self.retrieve(question).passages
+            return self.answer(question=question, context=passages)
+"""
+
+from __future__ import annotations
+
+import hashlib
+from typing import Any, Callable, Dict, List, Optional, Sequence
+
+import dspy
+
+from ._ids import to_uint64
+from ._types import RostamError
+from .rostam import Rostam
+
+Embedder = Callable[[str], List[float]]
+
+
+def _scalar(meta: Dict[str, Any]) -> Dict[str, Any]:
+    out: Dict[str, Any] = {}
+    for k, v in (meta or {}).items():
+        if isinstance(v, (str, int, float, bool)):
+            out[k] = v
+        elif isinstance(v, (list, tuple)) and v and all(
+            isinstance(x, (str, int, float)) and not isinstance(x, bool) for x in v
+        ):
+            out[k] = list(v)
+    return out
+
+
+class RostamRetriever(dspy.Module):
+    """A DSPy retriever module over a single Rostam collection.
+
+    Call it directly (``retriever(query)``) — ``dspy.Module.__call__``
+    dispatches to :meth:`forward` — to get back a ``dspy.Prediction`` whose
+    ``passages`` is a list of the top-k matching document contents.
+    """
+
+    def __init__(
+        self,
+        client: Rostam,
+        collection: str,
+        *,
+        embedder: Embedder,
+        k: int = 10,
+        auto_create: bool = True,
+        metric: str = "cosine",
+        filter: Optional[Dict[str, Any]] = None,
+    ):
+        super().__init__()
+        self._client = client
+        self._collection = collection
+        self._embedder = embedder
+        self._k = k
+        self._auto_create = auto_create
+        self._metric = metric
+        self._filter = filter
+        self._created = False
+
+    def forward(
+        self, query: str, k: Optional[int] = None, filter: Optional[Dict[str, Any]] = None
+    ) -> "dspy.Prediction":
+        vector = self._embedder(query)
+        hits = self._client.search_docs(
+            self._collection,
+            vector,
+            k if k is not None else self._k,
+            filter=filter if filter is not None else self._filter,
+        )
+        return dspy.Prediction(passages=[h.content for h in hits])
+
+    def index(
+        self,
+        texts: Sequence[str],
+        *,
+        embeddings: Optional[Sequence[List[float]]] = None,
+        ids: Optional[Sequence[str]] = None,
+        metadatas: Optional[Sequence[Dict[str, Any]]] = None,
+    ) -> List[str]:
+        """Load documents into the backing collection.
+
+        Embeds via the configured embedder when ``embeddings`` aren't supplied.
+        Returns the ids used (generated deterministically from content when
+        ``ids`` is omitted)."""
+        texts = list(texts)
+        if not texts:
+            return []
+        vectors = list(embeddings) if embeddings is not None else [self._embedder(t) for t in texts]
+        if vectors:
+            self._ensure_collection(len(vectors[0]))
+        if ids is None:
+            ids = [hashlib.blake2b(t.encode("utf-8"), digest_size=16).hexdigest() for t in texts]
+        else:
+            ids = list(ids)
+        metadatas = list(metadatas) if metadatas is not None else [{} for _ in texts]
+        for text, vec, meta, ext_id in zip(texts, vectors, metadatas, ids):
+            self._client.upsert(
+                self._collection, to_uint64(ext_id), vec, content=text, metadata=_scalar(meta or {})
+            )
+        return ids
+
+    def _ensure_collection(self, dim: int) -> None:
+        """Create the collection on first index() call (idempotent). No-op if
+        auto_create is off or we already created it this session."""
+        if not self._auto_create or self._created:
+            return
+        try:
+            self._client.create_collection(self._collection, dim, metric=self._metric)
+        except RostamError as e:
+            # Already-exists is fine; anything else propagates.
+            if "exist" not in (e.message or "").lower():
+                raise
+        self._created = True

--- a/clients/python/rostam/dspy.py
+++ b/clients/python/rostam/dspy.py
@@ -113,6 +113,16 @@ class RostamRetriever(dspy.Module):
         texts = list(texts)
         if not texts:
             return []
+        if embeddings is not None and len(embeddings) != len(texts):
+            raise ValueError(
+                f"embeddings length ({len(embeddings)}) must match texts length ({len(texts)})"
+            )
+        if ids is not None and len(ids) != len(texts):
+            raise ValueError(f"ids length ({len(ids)}) must match texts length ({len(texts)})")
+        if metadatas is not None and len(metadatas) != len(texts):
+            raise ValueError(
+                f"metadatas length ({len(metadatas)}) must match texts length ({len(texts)})"
+            )
         vectors = list(embeddings) if embeddings is not None else [self._embedder(t) for t in texts]
         if vectors:
             self._ensure_collection(len(vectors[0]))
@@ -135,7 +145,11 @@ class RostamRetriever(dspy.Module):
         try:
             self._client.create_collection(self._collection, dim, metric=self._metric)
         except RostamError as e:
-            # Already-exists is fine; anything else propagates.
-            if "exist" not in (e.message or "").lower():
+            # Already-exists is fine; anything else propagates. Match
+            # "already exist" (not the looser "exist"), so an unrelated
+            # "does not exist" error can't be swallowed here and mark the
+            # collection created when it wasn't (the later upsert would then
+            # fail with a confusing error).
+            if "already exist" not in (e.message or "").lower():
                 raise
         self._created = True

--- a/clients/python/rostam/mem0.py
+++ b/clients/python/rostam/mem0.py
@@ -1,0 +1,196 @@
+"""Mem0 vector-store provider backed by a Rostam collection.
+
+Requires ``mem0ai`` (``pip install rostam-client[mem0]``). Implements Mem0's
+``VectorStoreBase`` (``mem0.vector_stores.base``, targeting mem0ai's current
+main-branch interface, mem0ai>=0.1) so a Mem0 ``Memory`` can use Rostam as its
+vector store::
+
+    from rostam.mem0 import RostamVectorStore
+
+    store = RostamVectorStore(
+        collection_name="mem0", embedding_model_dims=1536, url="http://localhost:8080",
+    )
+
+Mem0 memory ids are opaque strings (uuid4); Rostam point ids are uint64, so
+string ids are mapped via ``rostam._ids.to_uint64`` and the original string is
+preserved in a reserved metadata key ``_mem0_id`` (stripped from returned
+payloads, like ``_hs_id``/``_to_id`` in the Haystack/LangChain adapters).
+
+Mem0's ``filters`` are a flat ``{field: value}`` map, with a list value meaning
+membership (``field in [...]``) — see ``VectorStoreBase._apply_filters`` in the
+reference implementations (e.g. ``mem0/vector_stores/faiss.py``). There is no
+nested operator/logical tree like Haystack's.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional, Sequence, Tuple
+
+from mem0.vector_stores.base import VectorStoreBase
+from pydantic import BaseModel
+
+from . import filters as f
+from ._ids import to_uint64
+from ._types import RostamError
+from .rostam import Rostam
+
+# Reserved metadata key preserving the original Mem0 (string) memory id, since
+# Rostam point ids are uint64.
+_MEM0_ID = "_mem0_id"
+
+
+class OutputData(BaseModel):
+    """Mirrors the ``OutputData`` model each mem0 vector-store adapter defines
+    locally (e.g. ``mem0/vector_stores/faiss.py``, ``.../pinecone.py``) — mem0
+    has no shared/importable one, every provider ships its own copy."""
+
+    id: Optional[str]  # memory id
+    score: Optional[float]  # similarity, higher = better
+    payload: Optional[Dict]  # metadata
+
+
+def _scalar(meta: Dict[str, Any]) -> Dict[str, Any]:
+    out: Dict[str, Any] = {}
+    for k, v in (meta or {}).items():
+        if isinstance(v, (str, int, float, bool)):
+            out[k] = v
+        elif isinstance(v, (list, tuple)) and v and all(isinstance(x, (str, int, float)) and not isinstance(x, bool) for x in v):
+            out[k] = list(v)
+    return out
+
+
+def _translate(filters: Optional[Dict[str, Any]]):
+    """Translate a Mem0 flat filter dict into a Rostam filter. A list value
+    means membership; anything else is equality."""
+    if not filters:
+        return None
+    clauses = [
+        f.in_(k, list(v)) if isinstance(v, (list, tuple)) else f.eq(k, v)
+        for k, v in filters.items()
+    ]
+    return clauses[0] if len(clauses) == 1 else f.and_(*clauses)
+
+
+def _query_vector(vectors: Sequence[Any]) -> List[float]:
+    """Mem0 calls ``search(query, vectors=embedding, ...)`` with a single query
+    embedding — usually a flat float list, occasionally wrapped as [[...]]."""
+    if vectors and isinstance(vectors[0], (list, tuple)):
+        return list(vectors[0])
+    return list(vectors)
+
+
+class RostamVectorStore(VectorStoreBase):
+    """A Mem0 ``VectorStoreBase`` over a single Rostam collection."""
+
+    def __init__(
+        self,
+        collection_name: str,
+        embedding_model_dims: int,
+        url: str = "http://localhost:8080",
+        api_key: Optional[str] = None,
+        metric: str = "cosine",
+    ):
+        self.collection_name = collection_name
+        self._dims = embedding_model_dims
+        self._metric = metric
+        self._client = Rostam(url, api_key=api_key)
+        self.create_col(collection_name, embedding_model_dims, metric)
+
+    # ---- collections ----
+
+    def create_col(self, name: str, vector_size: int, distance: str = "cosine") -> None:
+        """Create the collection if it doesn't already exist (idempotent)."""
+        try:
+            self._client.create_collection(name, vector_size, metric=distance)
+        except RostamError as e:
+            # Already-exists is fine; anything else propagates.
+            if "exist" not in (e.message or "").lower():
+                raise
+
+    def delete_col(self) -> None:
+        self._client.drop_collection(self.collection_name)
+
+    def col_info(self) -> Dict[str, Any]:
+        return {"name": self.collection_name, "dimension": self._dims, "distance": self._metric}
+
+    def list_cols(self) -> List[str]:
+        raise NotImplementedError(
+            "Rostam's REST client has no list-collections endpoint; "
+            "RostamVectorStore tracks only the single collection it was constructed with."
+        )
+
+    def reset(self) -> None:
+        self.delete_col()
+        self.create_col(self.collection_name, self._dims, self._metric)
+
+    # ---- writes ----
+
+    def insert(
+        self,
+        vectors: List[list],
+        payloads: Optional[List[Dict[str, Any]]] = None,
+        ids: Optional[List[str]] = None,
+    ) -> None:
+        if ids is None:
+            raise ValueError("RostamVectorStore.insert requires ids")
+        payloads = payloads or [{} for _ in vectors]
+        for vec, payload, ext_id in zip(vectors, payloads, ids):
+            meta = _scalar(payload or {})
+            meta[_MEM0_ID] = ext_id
+            self._client.upsert(self.collection_name, to_uint64(ext_id), vec, metadata=meta)
+
+    def update(
+        self,
+        vector_id: str,
+        vector: Optional[list] = None,
+        payload: Optional[Dict[str, Any]] = None,
+    ) -> None:
+        if vector is None or payload is None:
+            pts = self._client.get_batch(self.collection_name, [to_uint64(vector_id)])
+            if not pts:
+                raise ValueError(f"vector {vector_id!r} not found")
+            existing = pts[0]
+            if vector is None:
+                vector = existing.vector
+            if payload is None:
+                payload = dict(existing.metadata)
+                payload.pop(_MEM0_ID, None)
+        meta = _scalar(payload)
+        meta[_MEM0_ID] = vector_id
+        self._client.upsert(self.collection_name, to_uint64(vector_id), vector, metadata=meta)
+
+    def delete(self, vector_id: str) -> None:
+        self._client.delete(self.collection_name, to_uint64(vector_id))
+
+    # ---- reads ----
+
+    def get(self, vector_id: str) -> Optional[OutputData]:
+        pts = self._client.get_batch(self.collection_name, [to_uint64(vector_id)], with_vector=False)
+        if not pts:
+            return None
+        meta = dict(pts[0].metadata)
+        meta.pop(_MEM0_ID, None)
+        return OutputData(id=vector_id, score=None, payload=meta)
+
+    def search(
+        self,
+        query: str,
+        vectors: List[list],
+        top_k: int = 5,
+        filters: Optional[Dict[str, Any]] = None,
+    ) -> List[OutputData]:
+        vec = _query_vector(vectors)
+        hits = self._client.search_docs(self.collection_name, vec, top_k, filter=_translate(filters))
+        return [self._to_output(h, scored=True) for h in hits]
+
+    def list(
+        self, filters: Optional[Dict[str, Any]] = None, top_k: Optional[int] = None
+    ) -> Tuple[List[OutputData], Optional[list]]:
+        page = self._client.scroll(self.collection_name, filter=_translate(filters), limit=top_k or 0)
+        return [self._to_output(d) for d in page], None
+
+    def _to_output(self, d, scored: bool = False) -> OutputData:
+        meta = dict(d.metadata)
+        ext_id = meta.pop(_MEM0_ID, str(d.id))
+        score = (1.0 / (1.0 + max(d.distance, 0.0))) if scored else None
+        return OutputData(id=ext_id, score=score, payload=meta)

--- a/clients/python/rostam/mem0.py
+++ b/clients/python/rostam/mem0.py
@@ -192,5 +192,19 @@ class RostamVectorStore(VectorStoreBase):
     def _to_output(self, d, scored: bool = False) -> OutputData:
         meta = dict(d.metadata)
         ext_id = meta.pop(_MEM0_ID, str(d.id))
-        score = (1.0 / (1.0 + max(d.distance, 0.0))) if scored else None
+        score = self._score(d.distance) if scored else None
         return OutputData(id=ext_id, score=score, payload=meta)
+
+    def _score(self, distance: float) -> float:
+        """Convert Rostam's ``distance`` to Mem0's higher-is-better similarity
+        score, per this collection's configured metric — mirroring the
+        conversion mem0/vector_stores/base.py documents for its adapters:
+        cosine -> ``max(0.0, 1.0 - distance)``, l2 -> ``1.0 / (1.0 + distance)``,
+        dot -> the raw (already higher-is-better) value. Rostam's dot metric
+        returns the *negated* dot product as ``distance``, so the raw value is
+        ``-distance``."""
+        if self._metric == "cosine":
+            return max(0.0, 1.0 - distance)
+        if self._metric == "dot":
+            return -distance
+        return 1.0 / (1.0 + max(distance, 0.0))

--- a/clients/python/rostam/semantic_router.py
+++ b/clients/python/rostam/semantic_router.py
@@ -1,0 +1,115 @@
+"""Semantic Router ``BaseIndex`` implementation backed by a Rostam collection.
+
+Requires ``semantic-router`` (``pip install rostam-client[semantic-router]``).
+Targets the current (v1.x) ``BaseIndex`` interface: ``add`` stores each route's
+utterances as embedded points, ``query`` performs a kNN search and returns the
+matching route names, and ``delete``/``delete_index``/``delete_all`` remove
+routes or the whole collection.
+
+    from semantic_router.routers import SemanticRouter
+    from rostam import Rostam
+    from rostam.semantic_router import RostamIndex
+
+    index = RostamIndex(client=Rostam("http://localhost:8080"), collection="routes")
+    router = SemanticRouter(encoder=encoder, routes=routes, index=index)
+
+Each utterance is stored as a Rostam point with ``content`` set to the
+utterance text and ``metadata`` carrying ``{"route": <route name>, **extra}``.
+Point ids are derived from ``f"{route}:{utterance}"`` via
+``rostam._ids.to_uint64``, so re-adding the same (route, utterance) pair is
+idempotent. ``function_schemas`` is accepted for interface compatibility but
+not persisted (Rostam metadata values are scalars/scalar-lists; a function
+schema is an arbitrary nested object).
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional, Tuple
+
+import numpy as np
+from semantic_router.index.base import BaseIndex, IndexConfig
+from pydantic import Field
+
+from . import filters as f
+from ._ids import to_uint64
+from ._types import RostamError
+from .rostam import Rostam
+
+
+class RostamIndex(BaseIndex):
+    """A Semantic Router index over a single Rostam collection."""
+
+    type: str = "rostam"
+    client: Any = Field(default=None, exclude=True)
+    collection: str = "semantic-router"
+    auto_create: bool = True
+    metric: str = "cosine"
+
+    def _ensure_collection(self, dim: int) -> None:
+        """Record the embedding dim and (optionally) create the collection on
+        the first ``add``. No-op on later calls."""
+        if self.dimensions is not None:
+            return
+        if self.auto_create:
+            try:
+                self.client.create_collection(self.collection, dim, metric=self.metric)
+            except RostamError as e:
+                if "exist" not in (e.message or "").lower():
+                    raise
+        self.dimensions = dim
+
+    def add(
+        self,
+        embeddings: List[List[float]],
+        routes: List[str],
+        utterances: List[Any],
+        function_schemas: Optional[List[Dict[str, Any]]] = None,
+        metadata_list: List[Dict[str, Any]] = [],
+        **kwargs: Any,
+    ) -> None:
+        if not embeddings:
+            return
+        self._ensure_collection(len(embeddings[0]))
+        metas = metadata_list or [{} for _ in utterances]
+        for emb, route, utt, meta in zip(embeddings, routes, utterances, metas):
+            point_meta = dict(meta or {})
+            point_meta["route"] = route
+            pid = to_uint64(f"{route}:{utt}")
+            self.client.upsert(self.collection, pid, emb, content=str(utt), metadata=point_meta)
+
+    def query(
+        self,
+        vector: np.ndarray,
+        top_k: int = 5,
+        route_filter: Optional[List[str]] = None,
+        sparse_vector: Optional[Any] = None,
+    ) -> Tuple[np.ndarray, List[str]]:
+        flt = f.in_("route", route_filter) if route_filter else None
+        hits = self.client.search_docs(self.collection, [float(x) for x in vector], top_k, filter=flt)
+        scores = np.array([1.0 / (1.0 + max(h.distance, 0.0)) for h in hits])
+        route_names = [h.metadata.get("route", "") for h in hits]
+        return scores, route_names
+
+    def delete(self, route_name: str) -> None:
+        self.client.delete_by_filter(self.collection, f.eq("route", route_name))
+
+    def delete_all(self) -> None:
+        for d in self.client.scroll(self.collection):
+            self.client.delete(self.collection, d.id)
+
+    def delete_index(self) -> None:
+        try:
+            self.client.drop_collection(self.collection)
+        except RostamError:
+            pass
+        self.dimensions = None
+
+    def describe(self) -> IndexConfig:
+        try:
+            vectors = len(self.client.scroll(self.collection))
+        except RostamError:
+            vectors = 0
+        return IndexConfig(type=self.type, dimensions=self.dimensions or 0, vectors=vectors)
+
+    def is_ready(self) -> bool:
+        return self.dimensions is not None

--- a/clients/python/rostam/semantic_router.py
+++ b/clients/python/rostam/semantic_router.py
@@ -28,7 +28,8 @@ from typing import Any, Dict, List, Optional, Tuple
 
 import numpy as np
 from semantic_router.index.base import BaseIndex, IndexConfig
-from pydantic import Field
+from semantic_router.schema import Utterance
+from pydantic import Field, PrivateAttr
 
 from . import filters as f
 from ._ids import to_uint64
@@ -44,11 +45,18 @@ class RostamIndex(BaseIndex):
     collection: str = "semantic-router"
     auto_create: bool = True
     metric: str = "cosine"
+    # Tracks whether this index has created its backing collection, kept
+    # separate from ``dimensions`` because ``BaseRouter.__init__`` can set
+    # ``dimensions`` on the index before ``add()`` ever runs -- gating
+    # creation on ``dimensions is not None`` would then skip create_collection
+    # forever and every upsert would fail against a collection that never
+    # exists.
+    _created: bool = PrivateAttr(default=False)
 
     def _ensure_collection(self, dim: int) -> None:
-        """Record the embedding dim and (optionally) create the collection on
-        the first ``add``. No-op on later calls."""
-        if self.dimensions is not None:
+        """Create the collection on the first ``add`` (once). No-op on later
+        calls."""
+        if self._created:
             return
         if self.auto_create:
             try:
@@ -57,6 +65,7 @@ class RostamIndex(BaseIndex):
                 if "exist" not in (e.message or "").lower():
                     raise
         self.dimensions = dim
+        self._created = True
 
     def add(
         self,
@@ -84,9 +93,16 @@ class RostamIndex(BaseIndex):
         route_filter: Optional[List[str]] = None,
         sparse_vector: Optional[Any] = None,
     ) -> Tuple[np.ndarray, List[str]]:
+        """Note: this adapter assumes the collection's configured metric is
+        ``cosine`` (this class's default). Rostam returns
+        ``distance = 1 - cosine_similarity`` for that metric, and Semantic
+        Router's route thresholds are compared against cosine similarity, so
+        the score returned here is ``1.0 - distance``. Using a non-cosine
+        ``metric`` will make these scores meaningless against Semantic
+        Router's threshold semantics."""
         flt = f.in_("route", route_filter) if route_filter else None
         hits = self.client.search_docs(self.collection, [float(x) for x in vector], top_k, filter=flt)
-        scores = np.array([1.0 / (1.0 + max(h.distance, 0.0)) for h in hits])
+        scores = np.array([1.0 - h.distance for h in hits])
         route_names = [h.metadata.get("route", "") for h in hits]
         return scores, route_names
 
@@ -113,3 +129,27 @@ class RostamIndex(BaseIndex):
 
     def is_ready(self) -> bool:
         return self.dimensions is not None
+
+    def get_utterances(self, include_metadata: bool = False) -> List[Utterance]:
+        """Reconstruct the persisted (route, utterance) pairs from the
+        collection.
+
+        The inherited ``BaseIndex.get_utterances`` returns ``[]`` because it
+        reads ``self.index``, which this adapter never sets -- leaving
+        ``RouterConfig.from_index``/``auto_sync``/route-diff operations to
+        treat a populated collection as empty. Scroll the collection instead
+        and rebuild an ``Utterance`` per point from its ``content`` (the
+        stored utterance text) and ``metadata["route"]``."""
+        try:
+            docs = self.client.scroll(self.collection)
+        except RostamError:
+            return []
+        out: List[Utterance] = []
+        for d in docs:
+            meta = dict(d.metadata)
+            route = meta.pop("route", "")
+            kwargs: Dict[str, Any] = {"route": route, "utterance": d.content}
+            if include_metadata:
+                kwargs["metadata"] = meta
+            out.append(Utterance(**kwargs))
+        return out

--- a/clients/python/tests/_fakestore.py
+++ b/clients/python/tests/_fakestore.py
@@ -35,11 +35,26 @@ def _match(flt, meta):
     if field not in meta:
         return False
     got, want = _dec(meta[field]), _dec(flt["value"])
-    return {
-        "eq": got == want, "ne": got != want, "gt": got > want, "gte": got >= want,
-        "lt": got < want, "lte": got <= want, "in": got in (want or []),
-        "contains": want in (got or []),
-    }.get(op, False)
+    # Evaluate lazily: a single dict literal would compute every comparison
+    # eagerly, and an "in"/"contains" op (list-valued want) then raises
+    # TypeError on the unrelated gt/lt branches (str vs list).
+    if op == "eq":
+        return got == want
+    if op == "ne":
+        return got != want
+    if op == "gt":
+        return got > want
+    if op == "gte":
+        return got >= want
+    if op == "lt":
+        return got < want
+    if op == "lte":
+        return got <= want
+    if op == "in":
+        return got in (want or [])
+    if op == "contains":
+        return want in (got or [])
+    return False
 
 
 def _l2(a, b):

--- a/clients/python/tests/test_crewai.py
+++ b/clients/python/tests/test_crewai.py
@@ -1,0 +1,80 @@
+"""CrewAI adapter tests (skipped without crewai), against the stateful fake
+store."""
+
+import unittest
+
+from rostam import Rostam
+
+try:
+    import crewai  # noqa: F401
+
+    HAVE_CREWAI = True
+except Exception:  # pragma: no cover
+    HAVE_CREWAI = False
+
+from _fakestore import FakeRostam
+
+
+def _embed(text: str):
+    # A trivial local "embedder": no network/model needed for the test.
+    return [float(len(text)), 1.0, 0.0]
+
+
+@unittest.skipUnless(HAVE_CREWAI, "crewai not installed")
+class CrewAIStorageTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.fake = FakeRostam()
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.fake.close()
+
+    def setUp(self):
+        from rostam.crewai import RostamStorage
+
+        self.fake.docs.clear()  # isolate each test (the fake is shared per class)
+        self.client = Rostam(self.fake.url)
+        self.client.create_collection("mem", dim=3, metric="l2")
+        self.storage = RostamStorage(self.client, "mem", embedder=_embed, metric="l2")
+
+    def test_save_search_above_threshold(self):
+        self.storage.save("alpha fact", {"topic": "cats"})
+        self.storage.save("a much longer beta fact", {"topic": "dogs"})
+
+        hits = self.storage.search("alpha fact", limit=2, score_threshold=0.0)
+        self.assertGreaterEqual(len(hits), 1)
+        top = hits[0]
+        self.assertEqual(top["context"], "alpha fact")
+        self.assertEqual(top["metadata"].get("topic"), "cats")
+        self.assertIn("score", top)
+        self.assertGreater(top["score"], 0.0)
+
+    def test_search_threshold_filters_far_hits(self):
+        self.storage.save("alpha fact", {"topic": "cats"})
+        self.storage.save("a much longer beta fact indeed", {"topic": "dogs"})
+
+        hits = self.storage.search("alpha fact", limit=5, score_threshold=0.99)
+        # Only the exact-length match (distance 0, score 1.0) clears a 0.99 bar.
+        self.assertEqual([h["context"] for h in hits], ["alpha fact"])
+
+    def test_reset_clears_collection(self):
+        self.storage.save("alpha fact", {"topic": "cats"})
+        self.storage.save("beta fact", {"topic": "dogs"})
+        self.assertEqual(len(self.client.scroll("mem")), 2)
+
+        self.storage.reset()
+        self.assertEqual(len(self.client.scroll("mem")), 0)
+
+        # Storage stays usable after reset.
+        self.storage.save("gamma fact", {"topic": "birds"})
+        self.assertEqual(len(self.client.scroll("mem")), 1)
+
+    def test_distinct_ids_for_repeated_saves(self):
+        self.storage.save("same text", {})
+        self.storage.save("same text", {})
+        self.assertEqual(len(self.client.scroll("mem")), 2)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/clients/python/tests/test_crewai.py
+++ b/clients/python/tests/test_crewai.py
@@ -3,7 +3,7 @@ store."""
 
 import unittest
 
-from rostam import Rostam
+from rostam import Rostam, RostamError
 
 try:
     import crewai  # noqa: F401
@@ -74,6 +74,51 @@ class CrewAIStorageTest(unittest.TestCase):
         self.storage.save("same text", {})
         self.storage.save("same text", {})
         self.assertEqual(len(self.client.scroll("mem")), 2)
+
+    def test_search_before_any_save_on_auto_create_store(self):
+        from rostam.crewai import RostamStorage
+
+        # A fresh collection name that no save() has touched yet: search()
+        # must create the collection itself instead of failing against one
+        # that was never created.
+        storage = RostamStorage(self.client, "mem_fresh", embedder=_embed, metric="l2")
+        self.assertEqual(storage.search("anything", limit=3, score_threshold=0.0), [])
+
+    def test_search_with_filter(self):
+        self.storage.save("alpha fact", {"topic": "cats"})
+        self.storage.save("beta fact", {"topic": "dogs"})
+
+        hits = self.storage.search("alpha fact", limit=5, filter={"topic": "cats"}, score_threshold=0.0)
+        self.assertEqual([h["context"] for h in hits], ["alpha fact"])
+
+    def test_reset_propagates_scroll_error(self):
+        def boom(*a, **kw):
+            raise RostamError("internal error: boom")
+
+        self.client.scroll = boom
+        with self.assertRaises(RostamError):
+            self.storage.reset()
+
+    def test_reset_propagates_delete_error(self):
+        self.storage.save("alpha fact", {"topic": "cats"})
+        self.storage.save("beta fact", {"topic": "dogs"})
+
+        calls = []
+        orig_delete = self.client.delete
+
+        def flaky_delete(collection, pid):
+            calls.append(pid)
+            if len(calls) == 2:
+                raise RostamError("internal error: delete failed")
+            return orig_delete(collection, pid)
+
+        self.client.delete = flaky_delete
+        try:
+            with self.assertRaises(RostamError):
+                self.storage.reset()
+        finally:
+            self.client.delete = orig_delete
+        self.assertEqual(len(calls), 2)
 
 
 if __name__ == "__main__":

--- a/clients/python/tests/test_dspy.py
+++ b/clients/python/tests/test_dspy.py
@@ -1,0 +1,93 @@
+"""DSPy adapter tests (skipped without dspy installed), against the stateful
+fake store."""
+
+import unittest
+
+from rostam import Rostam
+
+try:
+    import dspy
+
+    HAVE_DSPY = True
+except Exception:  # pragma: no cover
+    HAVE_DSPY = False
+
+from _fakestore import FakeRostam
+
+
+def _embed(text: str):
+    """Deterministic 3-dim embedding: text-length feature, no model needed."""
+    return [float(len(text)), 1.0, 0.0]
+
+
+@unittest.skipUnless(HAVE_DSPY, "dspy not installed")
+class DSPyAdapterTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.fake = FakeRostam()
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.fake.close()
+
+    def setUp(self):
+        from rostam.dspy import RostamRetriever
+
+        self.fake.docs.clear()  # isolate each test (the fake is shared per class)
+        self.client = Rostam(self.fake.url)
+        self.client.create_collection("dspy", dim=3, metric="l2")
+        self.retriever = RostamRetriever(self.client, "dspy", embedder=_embed, k=3)
+
+    def test_index_and_call_returns_prediction(self):
+        self.retriever.index(["alpha", "betabeta"])
+        out = self.retriever("alpha")
+        self.assertIsInstance(out, dspy.Prediction)
+        # Closest to the query first ("alpha" is an exact length/vector match).
+        self.assertEqual(out.passages[0], "alpha")
+        self.assertEqual(set(out.passages), {"alpha", "betabeta"})
+
+    def test_forward_respects_k(self):
+        self.retriever.index(["alpha", "betabeta"])
+        out = self.retriever.forward("alpha", k=1)
+        self.assertEqual(out.passages, ["alpha"])
+
+    def test_index_with_explicit_ids_and_metadata(self):
+        ids = self.retriever.index(["cat food"], ids=["doc-1"], metadatas=[{"topic": "cats"}])
+        self.assertEqual(ids, ["doc-1"])
+        out = self.retriever("cat food")
+        self.assertEqual(out.passages[0], "cat food")
+
+    def test_index_generates_ids_when_omitted(self):
+        ids = self.retriever.index(["one", "two"])
+        self.assertEqual(len(ids), 2)
+        self.assertEqual(len(set(ids)), 2)  # distinct, deterministic ids
+
+    def test_index_empty_is_noop(self):
+        self.assertEqual(self.retriever.index([]), [])
+
+    def test_index_auto_creates_collection(self):
+        from rostam.dspy import RostamRetriever
+
+        calls = []
+        orig = self.client.create_collection
+
+        def spy(name, dim, **kw):
+            calls.append((name, dim, kw))
+            return orig(name, dim, **kw)
+
+        self.client.create_collection = spy
+        r = RostamRetriever(self.client, "dspy_auto", embedder=_embed, k=2, metric="l2")
+        r.index(["hello world"])
+        self.assertEqual(len(calls), 1)
+        self.assertEqual(calls[0][0], "dspy_auto")
+        self.assertEqual(calls[0][1], 3)  # dim inferred from the embedder
+
+        r.index(["second doc"])
+        self.assertEqual(len(calls), 1, "create_collection called more than once")
+
+        out = r("hello world")
+        self.assertEqual(out.passages[0], "hello world")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/clients/python/tests/test_dspy.py
+++ b/clients/python/tests/test_dspy.py
@@ -88,6 +88,21 @@ class DSPyAdapterTest(unittest.TestCase):
         out = r("hello world")
         self.assertEqual(out.passages[0], "hello world")
 
+    def test_index_rejects_mismatched_embeddings_length(self):
+        with self.assertRaises(ValueError):
+            self.retriever.index(["one", "two"], embeddings=[])
+        # Nothing should have been stored: a mismatched batch must not
+        # silently truncate via zip and lose data.
+        self.assertEqual(len(self.client.scroll("dspy")), 0)
+
+    def test_index_rejects_mismatched_ids_length(self):
+        with self.assertRaises(ValueError):
+            self.retriever.index(["one", "two"], ids=["only-one"])
+
+    def test_index_rejects_mismatched_metadatas_length(self):
+        with self.assertRaises(ValueError):
+            self.retriever.index(["one", "two"], metadatas=[{"a": 1}])
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/clients/python/tests/test_mem0.py
+++ b/clients/python/tests/test_mem0.py
@@ -1,0 +1,101 @@
+"""Mem0 adapter tests (skipped without mem0ai), against the stateful fake store."""
+
+import unittest
+
+from rostam import Rostam
+
+try:
+    import mem0  # noqa: F401
+
+    HAVE_MEM0 = True
+except Exception:  # pragma: no cover
+    HAVE_MEM0 = False
+
+from _fakestore import FakeRostam
+
+
+@unittest.skipUnless(HAVE_MEM0, "mem0ai not installed")
+class Mem0AdapterTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.fake = FakeRostam()
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.fake.close()
+
+    def setUp(self):
+        from rostam.mem0 import RostamVectorStore
+
+        self.fake.docs.clear()  # isolate each test (the fake is shared per class)
+        self.store = RostamVectorStore(
+            collection_name="mem0", embedding_model_dims=3, url=self.fake.url, metric="l2",
+        )
+
+    def _insert(self):
+        self.store.insert(
+            vectors=[[0.0, 0.0, 0.0], [5.0, 5.0, 5.0]],
+            payloads=[
+                {"data": "alpha", "user_id": "bob"},
+                {"data": "beta", "user_id": "alice"},
+            ],
+            ids=["m1", "m2"],
+        )
+
+    def test_insert_and_search(self):
+        self._insert()
+        hits = self.store.search("ignored", vectors=[0.1, 0.1, 0.1], top_k=2)
+        self.assertEqual(hits[0].id, "m1")  # closest to the query
+        self.assertEqual(hits[0].payload.get("data"), "alpha")
+        self.assertNotIn("_mem0_id", hits[0].payload)
+        self.assertTrue(all(h.score is not None and h.score > 0 for h in hits))
+
+    def test_search_accepts_nested_vector(self):
+        self._insert()
+        hits = self.store.search("ignored", vectors=[[0.1, 0.1, 0.1]], top_k=1)
+        self.assertEqual(hits[0].id, "m1")
+
+    def test_get(self):
+        self._insert()
+        out = self.store.get("m1")
+        self.assertIsNotNone(out)
+        self.assertEqual(out.id, "m1")
+        self.assertEqual(out.payload.get("data"), "alpha")
+        self.assertNotIn("_mem0_id", out.payload)
+        self.assertIsNone(out.score)
+
+    def test_get_missing_returns_none(self):
+        self.assertIsNone(self.store.get("does-not-exist"))
+
+    def test_update(self):
+        self._insert()
+        self.store.update("m1", vector=[9.0, 9.0, 9.0], payload={"data": "alpha-updated", "user_id": "bob"})
+        out = self.store.get("m1")
+        self.assertEqual(out.payload.get("data"), "alpha-updated")
+
+    def test_update_partial_preserves_existing(self):
+        self._insert()
+        # Payload-only update: vector should be preserved from the existing point.
+        self.store.update("m1", payload={"data": "alpha2", "user_id": "bob"})
+        out = self.store.get("m1")
+        self.assertEqual(out.payload.get("data"), "alpha2")
+
+    def test_delete(self):
+        self._insert()
+        self.store.delete("m1")
+        self.assertIsNone(self.store.get("m1"))
+
+    def test_list_with_filter(self):
+        self._insert()
+        results, _ = self.store.list(filters={"user_id": "bob"})
+        self.assertEqual([r.id for r in results], ["m1"])
+        self.assertIsNone(results[0].score)
+
+    def test_list_all(self):
+        self._insert()
+        results, _ = self.store.list()
+        self.assertEqual(sorted(r.id for r in results), ["m1", "m2"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/clients/python/tests/test_mem0.py
+++ b/clients/python/tests/test_mem0.py
@@ -96,6 +96,27 @@ class Mem0AdapterTest(unittest.TestCase):
         results, _ = self.store.list()
         self.assertEqual(sorted(r.id for r in results), ["m1", "m2"])
 
+    def test_search_score_uses_cosine_formula_for_cosine_metric(self):
+        from rostam.mem0 import RostamVectorStore
+
+        cos_store = RostamVectorStore(
+            collection_name="mem0_cos", embedding_model_dims=3, url=self.fake.url, metric="cosine",
+        )
+        cos_store.insert(vectors=[[0.0, 0.0, 0.0]], payloads=[{"data": "alpha"}], ids=["m1"])
+        hits = cos_store.search("ignored", vectors=[0.0, 0.0, 0.0], top_k=1)
+        # The fake store reports L2 distance=0.0 for an identical vector, so
+        # the cosine formula (max(0, 1 - distance)) must yield exactly 1.0 --
+        # the same input that the (wrong) L2 formula would also map to 1.0,
+        # so the divergence is checked below with a non-zero distance.
+        self.assertAlmostEqual(hits[0].score, 1.0)
+
+        cos_store.insert(vectors=[[1.0, 0.0, 0.0]], payloads=[{"data": "beta"}], ids=["m2"])
+        hits = cos_store.search("ignored", vectors=[[0.0, 0.0, 0.0]], top_k=2)
+        far = next(h for h in hits if h.id == "m2")
+        # distance (L2) is 1.0 here; cosine formula: max(0, 1 - 1.0) = 0.0.
+        # The old always-L2 formula would instead have produced 1/(1+1) = 0.5.
+        self.assertAlmostEqual(far.score, 0.0)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/clients/python/tests/test_semantic_router.py
+++ b/clients/python/tests/test_semantic_router.py
@@ -1,0 +1,92 @@
+"""Semantic Router adapter tests (skipped without semantic-router), against the
+stateful fake store."""
+
+import unittest
+
+from rostam import Rostam
+
+try:
+    from semantic_router.index.base import IndexConfig  # noqa: F401
+
+    HAVE_SR = True
+except Exception:  # pragma: no cover
+    HAVE_SR = False
+
+from _fakestore import FakeRostam
+
+
+@unittest.skipUnless(HAVE_SR, "semantic-router not installed")
+class SemanticRouterIndexTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.fake = FakeRostam()
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.fake.close()
+
+    def setUp(self):
+        from rostam.semantic_router import RostamIndex
+
+        self.fake.docs.clear()  # isolate each test (the fake is shared per class)
+        Rostam(self.fake.url).create_collection("sr", dim=3, metric="l2")
+        self.client = Rostam(self.fake.url)
+        self.index = RostamIndex(client=self.client, collection="sr", metric="l2")
+
+    def test_add_and_query(self):
+        self.index.add(
+            embeddings=[[1.0, 0.0, 0.0], [0.0, 1.0, 0.0]],
+            routes=["greeting", "farewell"],
+            utterances=["hello", "goodbye"],
+            metadata_list=[{"lang": "en"}, {"lang": "en"}],
+        )
+        scores, route_names = self.index.query([1.0, 0.0, 0.0], top_k=2)
+        self.assertEqual(route_names[0], "greeting")  # closest match
+        self.assertTrue(len(scores) == len(route_names) == 2)
+        self.assertTrue(scores[0] > 0)
+
+    def test_query_route_filter(self):
+        self.index.add(
+            embeddings=[[1.0, 0.0, 0.0], [0.9, 0.1, 0.0]],
+            routes=["greeting", "farewell"],
+            utterances=["hello", "bye"],
+        )
+        scores, route_names = self.index.query([1.0, 0.0, 0.0], top_k=5, route_filter=["farewell"])
+        self.assertEqual(route_names, ["farewell"])
+
+    def test_delete_route(self):
+        self.index.add(
+            embeddings=[[1.0, 0.0, 0.0], [0.0, 1.0, 0.0]],
+            routes=["greeting", "farewell"],
+            utterances=["hello", "goodbye"],
+        )
+        self.index.delete("greeting")
+        scores, route_names = self.index.query([1.0, 0.0, 0.0], top_k=5)
+        self.assertNotIn("greeting", route_names)
+        self.assertIn("farewell", route_names)
+
+    def test_describe_and_is_ready(self):
+        self.assertFalse(self.index.is_ready())
+        self.index.add(
+            embeddings=[[1.0, 0.0, 0.0]],
+            routes=["greeting"],
+            utterances=["hello"],
+        )
+        self.assertTrue(self.index.is_ready())
+        cfg = self.index.describe()
+        self.assertEqual(cfg.type, "rostam")
+        self.assertEqual(cfg.dimensions, 3)
+        self.assertEqual(cfg.vectors, 1)
+
+    def test_delete_all(self):
+        self.index.add(
+            embeddings=[[1.0, 0.0, 0.0], [0.0, 1.0, 0.0]],
+            routes=["greeting", "farewell"],
+            utterances=["hello", "goodbye"],
+        )
+        self.index.delete_all()
+        self.assertEqual(self.index.describe().vectors, 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/clients/python/tests/test_semantic_router.py
+++ b/clients/python/tests/test_semantic_router.py
@@ -87,6 +87,63 @@ class SemanticRouterIndexTest(unittest.TestCase):
         self.index.delete_all()
         self.assertEqual(self.index.describe().vectors, 0)
 
+    def test_add_creates_collection_after_dimensions_preset(self):
+        # BaseRouter.__init__ can set index.dimensions before add() is ever
+        # called; _ensure_collection must still create the backing collection
+        # on the first add() rather than early-returning on dimensions alone.
+        self.index.dimensions = 3
+        self.index.add(
+            embeddings=[[1.0, 0.0, 0.0]],
+            routes=["greeting"],
+            utterances=["hello"],
+        )
+        scores, route_names = self.index.query([1.0, 0.0, 0.0], top_k=1)
+        self.assertEqual(route_names, ["greeting"])
+
+    def test_query_score_is_cosine_similarity(self):
+        from rostam.semantic_router import RostamIndex
+
+        cos_index = RostamIndex(client=self.client, collection="sr_cos", metric="cosine")
+        Rostam(self.fake.url).create_collection("sr_cos", dim=3, metric="cosine")
+        cos_index.add(
+            embeddings=[[1.0, 0.0, 0.0]],
+            routes=["greeting"],
+            utterances=["hello"],
+        )
+        scores, route_names = cos_index.query([1.0, 0.0, 0.0], top_k=1)
+        # The fake store reports distance=0.0 for an identical vector, so the
+        # 1.0 - distance conversion yields a perfect cosine-similarity score.
+        self.assertAlmostEqual(scores[0], 1.0)
+
+    def test_get_utterances_round_trip(self):
+        self.index.add(
+            embeddings=[[1.0, 0.0, 0.0], [0.0, 1.0, 0.0]],
+            routes=["greeting", "farewell"],
+            utterances=["hello", "goodbye"],
+            metadata_list=[{"lang": "en"}, {"lang": "en"}],
+        )
+        utterances = self.index.get_utterances()
+        self.assertEqual(
+            sorted((u.route, u.utterance) for u in utterances),
+            [("farewell", "goodbye"), ("greeting", "hello")],
+        )
+
+    def test_get_utterances_include_metadata(self):
+        self.index.add(
+            embeddings=[[1.0, 0.0, 0.0]],
+            routes=["greeting"],
+            utterances=["hello"],
+            metadata_list=[{"lang": "en"}],
+        )
+        [utt] = self.index.get_utterances(include_metadata=True)
+        self.assertEqual(utt.route, "greeting")
+        self.assertEqual(utt.utterance, "hello")
+        self.assertEqual(utt.metadata.get("lang"), "en")
+        self.assertNotIn("route", utt.metadata)
+
+    def test_get_utterances_empty_before_any_add(self):
+        self.assertEqual(self.index.get_utterances(), [])
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -5,6 +5,14 @@ Notable user-visible changes. Entries that alter existing behaviour are marked
 
 ## Unreleased
 
+- **Python client: Mem0, Semantic Router, CrewAI, and DSPy adapters
+  (`rostam-client` 0.3.0).** Framework integrations join the existing LangChain,
+  LlamaIndex, and Haystack adapters, each an optional in-package submodule behind
+  its own extra so the base `import rostam` stays standard-library only:
+  `rostam.mem0` (`RostamVectorStore`, a Mem0 vector-store provider),
+  `rostam.semantic_router` (`RostamIndex`), `rostam.crewai` (`RostamStorage`
+  memory backend), and `rostam.dspy` (`RostamRetriever`). Install with the
+  matching extra, e.g. `pip install rostam-client[mem0]`.
 - **In-process local embeddings, pure Go (no cloud API, no ONNX Runtime).**
   Rostam can generate semantic embeddings in-process via
   [rembed](https://github.com/rostamlabs/rembed) — pure Go, no cgo, no ONNX


### PR DESCRIPTION
Adds four framework integrations to the Python client, extending the existing LangChain / LlamaIndex / Haystack set. Each ships as an optional in-package submodule gated behind its own extra, so the base `import rostam` stays standard-library only.

| Module | Class | Framework contract |
|---|---|---|
| `rostam.mem0` | `RostamVectorStore` | Mem0 `VectorStoreBase` provider (all 11 methods) |
| `rostam.semantic_router` | `RostamIndex` | Semantic Router `BaseIndex` |
| `rostam.crewai` | `RostamStorage` | CrewAI memory `Storage` (save/search/reset) |
| `rostam.dspy` | `RostamRetriever` | `dspy.Module` → `dspy.Prediction(passages=…)` |

Read-side adapters (DSPy, CrewAI) take an embedder callable, since those frameworks hand storage raw text rather than vectors.

### Verification
Installed against the real libraries (mem0ai 2.0.19, semantic-router 0.1.16, crewai 0.95.0, dspy 3.3.1, Python 3.12): 24 new tests pass, full suite **136 passed / 0 failed**. Instantiation against the real classes confirms interface conformance (an ABC with a missing method would not construct).

Also fixes a latent bug in the test fake's filter matcher (`_fakestore._match` evaluated its operator dict eagerly, so an `in`/`contains` filter raised `TypeError` on unrelated comparison branches — now lazy).

### Release
Bumps `rostam-client` 0.2.0 → **0.3.0** (+ changelog). After merge, tag `main` `py-v0.3.0` to publish to PyPI.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added Python client integrations for Mem0, Semantic Router, CrewAI, and DSPy.
  - Added optional installation extras for each framework integration.
  - Added support for local in-process embeddings using configurable models, with automatic model caching.
  - Generic vector tools can now automatically embed content during upserts and queries.

- **Bug Fixes**
  - Improved metadata filtering for list-based operators.

- **Documentation**
  - Updated package documentation and changelog with integration and embedding details.

- **Chores**
  - Updated the Python client version to 0.3.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->