### PR TITLE
feat: persistence on Windows (file mappings for the cache and vector layers)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -283,6 +283,40 @@ jobs:
           echo "working tree unchanged by the test run"
 
 
+  test-windows:
+    name: storage tests (windows/amd64)
+    runs-on: windows-latest
+    env:
+      # Pure Go: wasmtime is the only cgo dependency and none of the packages
+      # below reach it, so there is no C toolchain to arrange on the runner.
+      CGO_ENABLED: "0"
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+
+      - name: Build
+        run: go build ./...
+
+      # Windows is the only platform besides Linux that maps shard and slab files
+      # (cache/mmap_windows.go, vector/mmap_windows.go), and a mapping bug there
+      # is invisible to every other lane: the cross-compile matrix builds
+      # windows/amd64 but never runs it, so the four persistence test files that
+      # used to be linux-only would compile and never execute. These three
+      # packages are the whole path a Windows user's data travels — the shard
+      # files, the collections on top of them, and the MCP memory store that
+      # reopens both.
+      #
+      # `go vet ./...` is deliberately not run here: the one conversion a file
+      # mapping cannot avoid (MapViewOfFile hands back a uintptr, which has to
+      # become a *byte) is exactly what vet's unsafeptr check reports, and it has
+      # no way to express that an OS mapping address is not a Go pointer. The
+      # ubuntu lane still vets everything that is not windows-tagged.
+      - name: Test (storage + memory packages)
+        run: go test -count=1 -timeout 30m ./cache/... ./mcp/...
+
   cgo-disabled-build:
     name: cgo-disabled build
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -317,6 +317,20 @@ jobs:
       - name: Test (storage + memory packages)
         run: go test -count=1 -timeout 30m ./cache/... ./mcp/...
 
+      # The step above maps the CACHE slab on Windows, but the VECTOR mmap code
+      # (vector/mmap_windows.go: openVecMmap/growVecMmap/syncVecMmap/... and the
+      # level-0 graph slab) is only compile-checked here — the mcp test falls back
+      # to heap-backed vectors (QuantInRAM, no MmapPath/GraphMmapPath), so a
+      # Windows-specific mapping/grow/flush bug in the vector or graph slab would
+      # ship undetected. Run a TARGETED slice of ./vector/ that hits the
+      # open→grow→sync→close→reopen round-trip (mmap/persist/reopen/grow/reserve/
+      # slab tests) — deliberately NOT the full vector suite. The -skip drops the
+      # concurrent/latency grow tests: on a shared runner CPU oversubscription
+      # makes those the flakiest, and they add no Windows-mapping coverage the
+      # serial round-trip doesn't already give (they still run on the Linux lanes).
+      - name: Test (vector mmap/persist round-trip, targeted)
+        run: go test -count=1 -timeout 15m -run 'Mmap|Persist|Reopen|Grow|Reserve|Slab' -skip 'Concurrent|Latency|SIFT' ./vector/
+
   cgo-disabled-build:
     name: cgo-disabled build
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -504,8 +504,9 @@ module stays dependency-light. → [Performance](https://docs.rostamlabs.com/per
 
 ## Development
 
-Requires Go 1.26+. mmap persistence and the AVX2 kernels are Linux/amd64;
-everything has a portable fallback. The full build needs cgo (wasmtime); the
+Requires Go 1.26+. mmap persistence is Linux and Windows (a Windows shard file
+is fully allocated at creation, where a Linux one starts sparse); the AVX2
+kernels are Linux/amd64. Everything else has a portable fallback. The full build needs cgo (wasmtime); the
 vector/cache/ops packages build with `CGO_ENABLED=0`.
 
 Two optional build tags add cgo-only functionality, compiled out by default:

--- a/README.md
+++ b/README.md
@@ -504,8 +504,9 @@ module stays dependency-light. → [Performance](https://docs.rostamlabs.com/per
 
 ## Development
 
-Requires Go 1.26+. mmap persistence is Linux and Windows (a Windows shard file
-is fully allocated at creation, where a Linux one starts sparse); the AVX2
+Requires Go 1.26+. mmap persistence is Linux and 64-bit Windows (windows/amd64;
+a Windows shard file is fully allocated at creation, where a Linux one starts
+sparse); the AVX2
 kernels are Linux/amd64. Everything else has a portable fallback. The full build needs cgo (wasmtime); the
 vector/cache/ops packages build with `CGO_ENABLED=0`.
 

--- a/cache/blocks_linux_test.go
+++ b/cache/blocks_linux_test.go
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: Apache-2.0
+//go:build linux
+
+package cache
+
+import (
+	"syscall"
+	"testing"
+)
+
+// allocatedBlocks reports the 512-byte blocks actually allocated to path. The
+// pages file is always truncated to its full logical size, so "the file shrank"
+// means fewer allocated blocks (the tail of a compacted file is a hole), not a
+// smaller st_size.
+func allocatedBlocks(t *testing.T, path string) int64 {
+	t.Helper()
+	var st syscall.Stat_t
+	if err := syscall.Stat(path, &st); err != nil {
+		t.Fatalf("stat %s: %v", path, err)
+	}
+	return st.Blocks
+}

--- a/cache/blocks_windows_test.go
+++ b/cache/blocks_windows_test.go
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: Apache-2.0
+//go:build windows
+
+package cache
+
+import (
+	"os"
+	"testing"
+	"unsafe"
+
+	"golang.org/x/sys/windows"
+)
+
+// fileStandardInfo is FILE_STANDARD_INFO. AllocationSize is the space the
+// filesystem has actually committed to the file, which is what st_blocks
+// reports on Linux.
+type fileStandardInfo struct {
+	AllocationSize int64
+	EndOfFile      int64
+	NumberOfLinks  uint32
+	DeletePending  bool
+	Directory      bool
+}
+
+// allocatedBlocks reports the 512-byte blocks actually allocated to path, so
+// the compaction tests can assert the same thing they assert on Linux: that the
+// published pages file is fully allocated and carries no hole a later write
+// could fault into.
+//
+// NTFS does not hand out sparse files unless asked (FSCTL_SET_SPARSE), so this
+// is expected to equal the logical size rounded up to the cluster — that the
+// assertion is easy to satisfy here is the point, not a reason to skip it.
+func allocatedBlocks(t *testing.T, path string) int64 {
+	t.Helper()
+	f, err := os.Open(path) //nolint:gosec // G304: test-supplied path
+	if err != nil {
+		t.Fatalf("open %s: %v", path, err)
+	}
+	defer func() { _ = f.Close() }()
+	var info fileStandardInfo
+	if err := windows.GetFileInformationByHandleEx(
+		windows.Handle(f.Fd()),
+		windows.FileStandardInfo,
+		(*byte)(unsafe.Pointer(&info)),
+		uint32(unsafe.Sizeof(info)),
+	); err != nil {
+		t.Fatalf("GetFileInformationByHandleEx %s: %v", path, err)
+	}
+	return info.AllocationSize / 512
+}

--- a/cache/blocks_windows_test.go
+++ b/cache/blocks_windows_test.go
@@ -11,17 +11,6 @@ import (
 	"golang.org/x/sys/windows"
 )
 
-// fileStandardInfo is FILE_STANDARD_INFO. AllocationSize is the space the
-// filesystem has actually committed to the file, which is what st_blocks
-// reports on Linux.
-type fileStandardInfo struct {
-	AllocationSize int64
-	EndOfFile      int64
-	NumberOfLinks  uint32
-	DeletePending  bool
-	Directory      bool
-}
-
 // allocatedBlocks reports the 512-byte blocks actually allocated to path, so
 // the compaction tests can assert the same thing they assert on Linux: that the
 // published pages file is fully allocated and carries no hole a later write

--- a/cache/cache.go
+++ b/cache/cache.go
@@ -71,7 +71,7 @@ func (c *Cache) msyncLoop() {
 			failed, lastErr := 0, error(nil)
 			for _, s := range c.shards {
 				if s.isMmap {
-					if err := msync(s.region); err != nil {
+					if err := msync(s.file, s.region); err != nil {
 						failed++
 						lastErr = err
 					}
@@ -368,14 +368,14 @@ func (c *Cache) SetPBFrontier(seq, epoch uint64) {
 			continue
 		}
 		// Data first, unlocked — see above.
-		if err := msync(s.region); err != nil {
+		if err := msync(s.file, s.region); err != nil {
 			slog.Warn("DURABILITY WARNING: page msync failed before pb frontier", "component", "cache", "pb_seq", seq, "pb_epoch", epoch, "err", err)
 		}
 		s.mu.Lock()
 		setPBFrontier(s.region, seq, epoch)
 		s.pbFrontierSeq.Store(seq)
 		s.pbFrontierEpoch.Store(epoch)
-		err := msync(s.region[:headerSize])
+		err := msync(s.file, s.region[:headerSize])
 		s.mu.Unlock()
 		if err != nil {
 			slog.Warn("DURABILITY WARNING: header msync failed for pb frontier", "component", "cache", "pb_seq", seq, "pb_epoch", epoch, "err", err)
@@ -419,12 +419,12 @@ func (c *Cache) SetAppliedIndex(idx uint64, force bool) {
 			// Durability watermark path: a swallowed msync here means the applied
 			// index (and the data it certifies) may not be durable, yet we would
 			// report it committed. Log both flushes' failures loudly.
-			if err := msync(s.region); err != nil {
+			if err := msync(s.file, s.region); err != nil {
 				slog.Warn("DURABILITY WARNING: page msync failed before applied-index", "component", "cache", "applied_index", idx, "err", err)
 			}
 			setAppliedIndex(s.region, idx)
 			s.appliedIndex.Store(idx)
-			if err := msync(s.region[:headerSize]); err != nil {
+			if err := msync(s.file, s.region[:headerSize]); err != nil {
 				slog.Warn("DURABILITY WARNING: header msync failed for applied-index", "component", "cache", "applied_index", idx, "err", err)
 			}
 		} else {

--- a/cache/compact.go
+++ b/cache/compact.go
@@ -424,7 +424,7 @@ func (s *shard) compactAtOpen(dataDir, pagesPath string, size int64) (int, error
 		stageErr = fmt.Errorf("live set does not fit in %d pages", s.cfg.MaxPagesPerShard())
 	}
 	if stageErr == nil {
-		stageErr = msync(tmpRegion)
+		stageErr = msync(tmpFile, tmpRegion)
 	}
 	if stageErr == nil {
 		stageErr = tmpFile.Sync() // data + metadata durable before anything points here
@@ -522,6 +522,13 @@ func (s *shard) remapPagesFile(pagesPath string, size int64) error {
 
 // syncDir fsyncs a directory so a rename within it is durable.
 func syncDir(dir string) error {
+	// Nothing to force where the platform has no directory fsync (Windows): the
+	// rename's metadata is the filesystem's own to commit there. Returning early
+	// keeps every compaction from logging a durability warning about a step that
+	// is not failing, only absent.
+	if !dirSyncSupported {
+		return nil
+	}
 	d, err := os.Open(dir) //nolint:gosec // G304: dir is the caller-configured DataDir
 	if err != nil {
 		return err

--- a/cache/compact_test.go
+++ b/cache/compact_test.go
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-//go:build linux
+//go:build linux || windows
 
 package cache
 
@@ -11,7 +11,6 @@ import (
 	"hash/crc32"
 	"os"
 	"path/filepath"
-	"syscall"
 	"testing"
 	"time"
 )
@@ -78,19 +77,6 @@ func shardEntry(s *shard, key []byte) (value []byte, exp uint64, ok bool) {
 		return nil, 0, false
 	}
 	return append([]byte(nil), v...), e, true
-}
-
-// allocatedBlocks reports the 512-byte blocks actually allocated to path. The
-// pages file is always truncated to its full logical size, so "the file shrank"
-// means fewer allocated blocks (the tail of a compacted file is a hole), not a
-// smaller st_size.
-func allocatedBlocks(t *testing.T, path string) int64 {
-	t.Helper()
-	var st syscall.Stat_t
-	if err := syscall.Stat(path, &st); err != nil {
-		t.Fatalf("stat %s: %v", path, err)
-	}
-	return st.Blocks
 }
 
 // fillWithOverwrites writes distinct 100 KiB values round-robin over nKeys keys

--- a/cache/config.go
+++ b/cache/config.go
@@ -208,7 +208,7 @@ func (c Config) Validate() error {
 	if c.TTLSweepIntervalMs < 0 {
 		return errors.New("config: TTLSweepIntervalMs must be >= 0")
 	}
-	if c.DataDir != "" && runtime.GOOS != "linux" {
+	if c.DataDir != "" && !mmapSupported {
 		return fmt.Errorf("cache.Config: DataDir set but mmap not supported on %s; use DataDir=\"\"", runtime.GOOS)
 	}
 	if c.Durable && c.DataDir == "" {

--- a/cache/config.go
+++ b/cache/config.go
@@ -43,7 +43,8 @@ type Config struct {
 
 	// DataDir is the directory holding per-shard pages.dat files. When
 	// empty, the cache runs in heap-only mode (heap-only behavior; no
-	// persistence). Linux only — non-Linux platforms reject DataDir != "".
+	// persistence). Requires a platform that can map files (Linux, Windows);
+	// anywhere else Validate rejects DataDir != "".
 	DataDir string
 
 	// Mlock locks the mmap'd region into memory. Requires

--- a/cache/config_test.go
+++ b/cache/config_test.go
@@ -64,13 +64,16 @@ func TestConfigDataDirCrossPlatform(t *testing.T) {
 	cfg := DefaultConfig()
 	cfg.DataDir = t.TempDir()
 	err := cfg.Validate()
-	if runtime.GOOS == "linux" {
+	// Asserted against the same constant Validate consults, so a platform
+	// gaining (or losing) a file-mapping implementation cannot leave the guard
+	// and this test disagreeing about what the platform can do.
+	if mmapSupported {
 		if err != nil {
-			t.Errorf("Linux should accept DataDir: %v", err)
+			t.Errorf("%s maps files and should accept DataDir: %v", runtime.GOOS, err)
 		}
 	} else {
 		if err == nil {
-			t.Error("non-Linux should reject DataDir")
+			t.Errorf("%s cannot map files and should reject DataDir", runtime.GOOS)
 		}
 	}
 }

--- a/cache/dirsync_other.go
+++ b/cache/dirsync_other.go
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: Apache-2.0
+//go:build !windows
+
+package cache
+
+// dirSyncSupported reports whether the platform can be asked to make a
+// directory entry durable. See syncDir in compact.go.
+const dirSyncSupported = true

--- a/cache/dirsync_windows.go
+++ b/cache/dirsync_windows.go
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: Apache-2.0
+//go:build windows
+
+package cache
+
+// dirSyncSupported is false because Windows exposes no directory fsync: a
+// directory handle opened through os.Open cannot be flushed (FlushFileBuffers
+// answers ERROR_ACCESS_DENIED), and NTFS carries the rename through its own
+// metadata log rather than leaving it for the caller to force. See syncDir in
+// compact.go.
+const dirSyncSupported = false

--- a/cache/mmap_linux.go
+++ b/cache/mmap_linux.go
@@ -12,6 +12,11 @@ import (
 	"golang.org/x/sys/unix"
 )
 
+// mmapSupported reports that a shard on this platform can be backed by a file
+// mapping, so Config.Validate accepts a non-empty DataDir. See mmap_windows.go
+// and mmap_other.go for the other two answers.
+const mmapSupported = true
+
 // mmapFile opens path (creating if missing), truncates to size bytes,
 // and returns the mmap'd region. If mlockRequested is true, attempts
 // mlock; failure logs and continues without lock.
@@ -67,7 +72,12 @@ func mmapFileAlloc(path string, size, allocBytes int64, mlockRequested bool) (*o
 }
 
 // msync flushes the region to disk synchronously.
-func msync(region []byte) error {
+//
+// The file is accepted but unused here: MS_SYNC already returns only once the
+// pages are on the disk. Windows needs the handle for the second half of that
+// same guarantee (see mmap_windows.go), and one signature across the platforms
+// keeps the difference inside these files instead of at every call site.
+func msync(_ *os.File, region []byte) error {
 	if len(region) == 0 {
 		return nil
 	}

--- a/cache/mmap_other.go
+++ b/cache/mmap_other.go
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-//go:build !linux
+//go:build !linux && !windows
 
 package cache
 
@@ -7,6 +7,10 @@ import (
 	"errors"
 	"os"
 )
+
+// mmapSupported reports that no shard on this platform can be backed by a file
+// mapping, so Config.Validate rejects a non-empty DataDir.
+const mmapSupported = false
 
 func mmapFile(_ string, _ int64, _ bool) (*os.File, []byte, error) {
 	return nil, nil, errors.New("cache: mmap not supported on this platform; set Config.DataDir=\"\"")
@@ -16,6 +20,6 @@ func mmapFileAlloc(_ string, _, _ int64, _ bool) (*os.File, []byte, error) {
 	return nil, nil, errors.New("cache: mmap not supported on this platform; set Config.DataDir=\"\"")
 }
 
-func msync(_ []byte) error { return nil }
+func msync(_ *os.File, _ []byte) error { return nil }
 
 func munmapAndClose(_ *os.File, _ []byte) error { return nil }

--- a/cache/mmap_test.go
+++ b/cache/mmap_test.go
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-//go:build linux
+//go:build linux || windows
 
 package cache
 
@@ -19,7 +19,7 @@ func TestMmapFileRoundtrip(t *testing.T) {
 		t.Fatalf("region size = %d, want 4096", len(region))
 	}
 	copy(region, []byte("HELLO"))
-	if err := msync(region); err != nil {
+	if err := msync(f, region); err != nil {
 		t.Fatalf("msync: %v", err)
 	}
 	if err := munmapAndClose(f, region); err != nil {

--- a/cache/mmap_windows.go
+++ b/cache/mmap_windows.go
@@ -26,21 +26,32 @@ func mmapFile(path string, size int64, mlockRequested bool) (*os.File, []byte, e
 }
 
 // mmapFileAlloc is mmapFile plus a RESERVATION of the first allocBytes of the
-// file — which on Windows costs nothing to honour, because it has already
-// happened by the time this function looks at allocBytes.
+// file (allocBytes <= 0 reserves nothing, i.e. plain mmapFile), mirroring the
+// Linux fallocate contract.
 //
-// WHY THE PARAMETER IS IGNORED HERE. On Linux the file is sized with a sparse
-// truncate, so blocks are allocated lazily inside a page fault and a full disk
-// turns into SIGBUS, which Go cannot recover from; fallocate exists to pull
-// that failure forward into an ordinary ENOSPC. NTFS does not create the file
-// sparse: os.File.Truncate lands on SetEndOfFile, which commits the clusters
-// there and then, so a full disk fails the Truncate above with an ordinary
-// error and the mapped writes that follow cannot run out of space. The caller's
-// invariant ("the bytes I am about to store are already reserved") therefore
-// holds for the WHOLE file, not just the first allocBytes, without a separate
-// call. The cost of the stronger guarantee is that the file occupies its full
-// length on disk immediately instead of growing as it fills.
-func mmapFileAlloc(path string, size, _ int64, mlockRequested bool) (*os.File, []byte, error) {
+// WHY A SEPARATE RESERVATION IS STILL NEEDED HERE. On Linux the file is sized
+// with a sparse truncate, so blocks are allocated lazily inside a page fault and
+// a full disk turns into SIGBUS, which Go cannot recover from; fallocate exists
+// to pull that failure forward into an ordinary ENOSPC. For an ORDINARY NTFS
+// file this platform does not have that problem — os.File.Truncate lands on
+// SetEndOfFile, which commits the clusters there and then, so a full disk fails
+// the Truncate above with an ordinary error. But a SPARSE or COMPRESSED file
+// (including any file created inside a compressed directory) is the exception:
+// SetEndOfFile can leave AllocationSize < EndOfFile, i.e. the tail unbacked, so
+// a later mapped write into that tail can still hit the delayed out-of-space
+// failure this API exists to prevent. reserveAlloc forces the physical
+// allocation and then VERIFIES it, and ABORTS (returns an error) if the
+// filesystem refused to back the requested bytes, so cold compaction never
+// publishes a shard whose tail is only virtually there.
+//
+// The reservation target is at least allocBytes AND never below size: Windows'
+// FILE_ALLOCATION_INFO controls the whole file's allocation and would shrink a
+// correctly-sized file if set below its length, whereas Linux fallocate only
+// ever adds blocks. Clamping up to size keeps the "never deallocate what
+// Truncate just sized" invariant while still honouring "reserve >= allocBytes".
+// For an ordinary file the clusters are already committed, so the call is a
+// no-op cost.
+func mmapFileAlloc(path string, size, allocBytes int64, mlockRequested bool) (*os.File, []byte, error) {
 	if size <= 0 {
 		return nil, nil, fmt.Errorf("cache: mmap %s: size must be > 0, got %d", path, size)
 	}
@@ -51,6 +62,16 @@ func mmapFileAlloc(path string, size, _ int64, mlockRequested bool) (*os.File, [
 	if err := f.Truncate(size); err != nil {
 		_ = f.Close()
 		return nil, nil, fmt.Errorf("cache: truncate %s to %d: %w", path, size, err)
+	}
+	if allocBytes > 0 {
+		needed := size
+		if allocBytes > needed {
+			needed = allocBytes
+		}
+		if aerr := reserveAlloc(f, needed); aerr != nil {
+			_ = f.Close()
+			return nil, nil, fmt.Errorf("cache: preallocate %d bytes of %s: %w", needed, path, aerr)
+		}
 	}
 	region, err := mapWholeFile(f, size)
 	if err != nil {
@@ -97,6 +118,62 @@ func mapWholeFile(f *os.File, size int64) ([]byte, error) {
 	// this is the one conversion every Windows file mapping has to make.
 	//nolint:govet,gosec // unsafeptr: see above; the view is exactly size bytes long
 	return unsafe.Slice((*byte)(unsafe.Pointer(addr)), size), nil
+}
+
+// fileAllocationInfo is the input for SetFileInformationByHandle's
+// FileAllocationInfo class (Win32 FILE_ALLOCATION_INFO). Setting it forces the
+// filesystem to reserve AllocationSize bytes of physical clusters for the file.
+// x/sys/windows exports the call and the class constant but not this struct, so
+// it is declared locally, matching how the standard library issues the sibling
+// FileEndOfFileInfo call.
+type fileAllocationInfo struct {
+	AllocationSize int64
+}
+
+// fileStandardInfo is the output of GetFileInformationByHandleEx's
+// FileStandardInfo class (Win32 FILE_STANDARD_INFO). AllocationSize is the
+// number of bytes of physical clusters actually reserved for the file, which is
+// what the reservation must be verified against.
+type fileStandardInfo struct {
+	AllocationSize int64
+	EndOfFile      int64
+	NumberOfLinks  uint32
+	DeletePending  byte
+	Directory      byte
+}
+
+// reserveAlloc forces at least needed bytes of physical allocation for f and
+// verifies it, returning an error when the filesystem could not (or would not)
+// back the request — the sparse/compressed case where SetEndOfFile alone leaves
+// the tail unallocated. It is the Windows analogue of Linux fallocate: pull a
+// would-be out-of-space failure forward into an ordinary error at staging time.
+func reserveAlloc(f *os.File, needed int64) error {
+	h := windows.Handle(f.Fd())
+	alloc := fileAllocationInfo{AllocationSize: needed}
+	if err := windows.SetFileInformationByHandle(
+		h,
+		windows.FileAllocationInfo,
+		(*byte)(unsafe.Pointer(&alloc)),
+		uint32(unsafe.Sizeof(alloc)),
+	); err != nil {
+		return fmt.Errorf("SetFileInformationByHandle(FileAllocationInfo, %d): %w", needed, err)
+	}
+	// Verify: a sparse/compressed file can accept the call yet still report a
+	// short AllocationSize, which is exactly the delayed-ENOSPC hazard. Confirm
+	// the clusters are really there before letting the caller map and write.
+	var std fileStandardInfo
+	if err := windows.GetFileInformationByHandleEx(
+		h,
+		windows.FileStandardInfo,
+		(*byte)(unsafe.Pointer(&std)),
+		uint32(unsafe.Sizeof(std)),
+	); err != nil {
+		return fmt.Errorf("GetFileInformationByHandleEx(FileStandardInfo): %w", err)
+	}
+	if std.AllocationSize < needed {
+		return fmt.Errorf("reservation short: allocated %d of %d bytes (sparse or compressed backing refused the reservation)", std.AllocationSize, needed)
+	}
+	return nil
 }
 
 // regionAddr returns the base address of a mapped region. Callers pass either

--- a/cache/mmap_windows.go
+++ b/cache/mmap_windows.go
@@ -1,0 +1,149 @@
+// SPDX-License-Identifier: Apache-2.0
+//go:build windows
+
+package cache
+
+import (
+	"errors"
+	"fmt"
+	"log/slog"
+	"os"
+	"unsafe"
+
+	"golang.org/x/sys/windows"
+)
+
+// mmapSupported reports that a shard on this platform can be backed by a file
+// mapping, so Config.Validate accepts a non-empty DataDir. See mmap_linux.go
+// and mmap_other.go for the other two answers.
+const mmapSupported = true
+
+// mmapFile opens path (creating if missing), sizes it to size bytes, and
+// returns the mapped region. If mlockRequested is true, attempts to lock the
+// region into the working set; failure logs and continues without the lock.
+func mmapFile(path string, size int64, mlockRequested bool) (*os.File, []byte, error) {
+	return mmapFileAlloc(path, size, 0, mlockRequested)
+}
+
+// mmapFileAlloc is mmapFile plus a RESERVATION of the first allocBytes of the
+// file — which on Windows costs nothing to honour, because it has already
+// happened by the time this function looks at allocBytes.
+//
+// WHY THE PARAMETER IS IGNORED HERE. On Linux the file is sized with a sparse
+// truncate, so blocks are allocated lazily inside a page fault and a full disk
+// turns into SIGBUS, which Go cannot recover from; fallocate exists to pull
+// that failure forward into an ordinary ENOSPC. NTFS does not create the file
+// sparse: os.File.Truncate lands on SetEndOfFile, which commits the clusters
+// there and then, so a full disk fails the Truncate above with an ordinary
+// error and the mapped writes that follow cannot run out of space. The caller's
+// invariant ("the bytes I am about to store are already reserved") therefore
+// holds for the WHOLE file, not just the first allocBytes, without a separate
+// call. The cost of the stronger guarantee is that the file occupies its full
+// length on disk immediately instead of growing as it fills.
+func mmapFileAlloc(path string, size, _ int64, mlockRequested bool) (*os.File, []byte, error) {
+	if size <= 0 {
+		return nil, nil, fmt.Errorf("cache: mmap %s: size must be > 0, got %d", path, size)
+	}
+	f, err := os.OpenFile(path, os.O_RDWR|os.O_CREATE, 0o600) //nolint:gosec // G304: path is caller-supplied and intentional
+	if err != nil {
+		return nil, nil, fmt.Errorf("cache: open %s: %w", path, err)
+	}
+	if err := f.Truncate(size); err != nil {
+		_ = f.Close()
+		return nil, nil, fmt.Errorf("cache: truncate %s to %d: %w", path, size, err)
+	}
+	region, err := mapWholeFile(f, size)
+	if err != nil {
+		_ = f.Close()
+		return nil, nil, fmt.Errorf("cache: mmap %s: %w", path, err)
+	}
+	if mlockRequested {
+		if lkErr := windows.VirtualLock(regionAddr(region), uintptr(size)); lkErr != nil {
+			slog.Warn("VirtualLock failed (continuing without lock; consider raising the process working-set limit)", "component", "cache", "path", path, "err", lkErr)
+		}
+	}
+	return f, region, nil
+}
+
+// mapWholeFile maps [0, size) of f read/write and shared, and returns it as a
+// byte slice aliasing the view.
+//
+// The section handle is closed before returning ON PURPOSE: a mapped view keeps
+// its own reference to the section object, so the view stays valid after the
+// handle goes away. That is what lets this platform carry the same (file,
+// region) pair as Linux — release needs no third value to be threaded through
+// every caller and stored on every shard.
+func mapWholeFile(f *os.File, size int64) ([]byte, error) {
+	h, err := windows.CreateFileMapping(
+		windows.Handle(f.Fd()),
+		nil,
+		windows.PAGE_READWRITE,
+		uint32(uint64(size)>>32),        //nolint:gosec // deliberate 64->2x32 split of the section size
+		uint32(uint64(size)&0xFFFFFFFF), //nolint:gosec // deliberate 64->2x32 split of the section size
+		nil,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("CreateFileMapping: %w", err)
+	}
+	defer func() { _ = windows.CloseHandle(h) }()
+	addr, err := windows.MapViewOfFile(h, windows.FILE_MAP_READ|windows.FILE_MAP_WRITE, 0, 0, uintptr(size))
+	if err != nil {
+		return nil, fmt.Errorf("MapViewOfFile: %w", err)
+	}
+	// unsafeptr: addr is an OS mapping address, not a Go pointer — there is no
+	// object for the collector to move out from under it, and the view outlives
+	// this conversion by construction (it is released only by the Unmap in
+	// munmapAndClose). go vet's unsafeptr check has no way to express that, and
+	// this is the one conversion every Windows file mapping has to make.
+	//nolint:govet,gosec // unsafeptr: see above; the view is exactly size bytes long
+	return unsafe.Slice((*byte)(unsafe.Pointer(addr)), size), nil
+}
+
+// regionAddr returns the base address of a mapped region. Callers pass either
+// the whole region or a prefix of it (the header slice); both share a base, so
+// this is the address the Win32 view calls want in either case.
+func regionAddr(region []byte) uintptr {
+	return uintptr(unsafe.Pointer(&region[0]))
+}
+
+// msync flushes the region to disk synchronously.
+//
+// It takes the file because ONE Win32 call is not enough. FlushViewOfFile only
+// hands the dirty pages to the filesystem; it returns before they reach the
+// disk, so on its own it is closer to Linux's MS_ASYNC than to the MS_SYNC this
+// function's callers assume. FlushFileBuffers supplies the second half. Both
+// are needed for -durable to mean on this platform what it means on Linux: the
+// msyncLoop and the applied-index watermark log a DURABILITY WARNING when this
+// fails precisely because a silent partial flush is the failure they exist to
+// catch.
+func msync(f *os.File, region []byte) error {
+	if len(region) == 0 {
+		return nil
+	}
+	if err := windows.FlushViewOfFile(regionAddr(region), uintptr(len(region))); err != nil {
+		return fmt.Errorf("cache: FlushViewOfFile: %w", err)
+	}
+	if f == nil {
+		return nil
+	}
+	if err := windows.FlushFileBuffers(windows.Handle(f.Fd())); err != nil {
+		return fmt.Errorf("cache: FlushFileBuffers: %w", err)
+	}
+	return nil
+}
+
+// munmapAndClose releases the mapped view and closes the file.
+func munmapAndClose(f *os.File, region []byte) error {
+	var errs []error
+	if len(region) > 0 {
+		if err := windows.UnmapViewOfFile(regionAddr(region)); err != nil {
+			errs = append(errs, fmt.Errorf("cache: UnmapViewOfFile: %w", err))
+		}
+	}
+	if f != nil {
+		if err := f.Close(); err != nil {
+			errs = append(errs, fmt.Errorf("cache: close: %w", err))
+		}
+	}
+	return errors.Join(errs...)
+}

--- a/cache/recovery_test.go
+++ b/cache/recovery_test.go
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-//go:build linux
+//go:build linux || windows
 
 package cache
 

--- a/cache/shard.go
+++ b/cache/shard.go
@@ -889,7 +889,7 @@ func (s *shard) Close() error {
 	close(s.stopSweeper)
 	s.sweepWG.Wait()
 	if s.region != nil {
-		_ = msync(s.region) // best-effort final sync
+		_ = msync(s.file, s.region) // best-effort final sync
 	}
 	return munmapAndClose(s.file, s.region)
 }

--- a/cache/warm_restart_test.go
+++ b/cache/warm_restart_test.go
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-//go:build linux
+//go:build linux || windows
 
 package cache
 

--- a/cluster/multinode_test.go
+++ b/cluster/multinode_test.go
@@ -871,10 +871,12 @@ func TestThreeNodeRestart(t *testing.T) {
 // FSM.Apply's applied-index guard correctly skips log entries that are
 // already reflected in the persisted mmap pages.
 //
-// Linux-only because cache.DataDir (mmap) is Linux-only.
+// Gated to Linux. cache.DataDir also maps files on Windows now, but this
+// suite's 3-node clusters have never been exercised there and no CI lane runs
+// them, so widening the gate belongs to whoever validates it, not here.
 func TestSmartClientWarmRestart(t *testing.T) {
 	if runtime.GOOS != "linux" {
-		t.Skip("mmap is Linux-only")
+		t.Skip("the cluster suite is only exercised on Linux")
 	}
 
 	const n = 3

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -6,7 +6,7 @@ Notable user-visible changes. Entries that alter existing behaviour are marked
 ## Unreleased
 
 - **Persistence works on Windows.** `cache.Config.DataDir` and mmap-backed
-  (`Persistent`) vector collections are now supported on `windows/amd64`, so an
+  (`Persistent`) vector collections are now supported on Windows, so an
   embedded store — and the MCP memory server on its default `-data auto` — keeps
   its data across restarts there instead of refusing to open with `cache.Config:
   DataDir set but mmap not supported on windows`. Windows previously had no file

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -5,6 +5,20 @@ Notable user-visible changes. Entries that alter existing behaviour are marked
 
 ## Unreleased
 
+- **Persistence works on Windows.** `cache.Config.DataDir` and mmap-backed
+  (`Persistent`) vector collections are now supported on `windows/amd64`, so an
+  embedded store — and the MCP memory server on its default `-data auto` — keeps
+  its data across restarts there instead of refusing to open with `cache.Config:
+  DataDir set but mmap not supported on windows`. Windows previously had no file
+  mapping wired up at all, only stubs that returned that error, which made
+  `-data ""` (heap, no persistence) the one working mode. Durability means the
+  same thing on both platforms: the flush pairs `FlushViewOfFile` with
+  `FlushFileBuffers`, so `-durable` is not claiming a guarantee Windows was never
+  asked for. One difference to plan for: NTFS does not hand out sparse files, so
+  a shard file occupies its full configured size on disk the moment it is
+  created. A fresh embedded store therefore reserves its whole cache budget up
+  front (1 GiB by default off Linux, where system memory is not probed), while on
+  Linux the same file starts as a hole and consumes space only as it fills.
 - **Python client: Mem0, Semantic Router, CrewAI, and DSPy adapters
   (`rostam-client` 0.3.0).** Framework integrations join the existing LangChain,
   LlamaIndex, and Haystack adapters, each an optional in-package submodule behind

--- a/docs/development.md
+++ b/docs/development.md
@@ -3,7 +3,8 @@
 ## Requirements
 
 - **Go 1.26+** (from `go.mod`)
-- mmap persistence works on Linux and Windows; the AVX2 kernels are Linux/amd64.
+- mmap persistence works on Linux and 64-bit Windows (windows/amd64); the AVX2
+  kernels are Linux/amd64.
   Other platforms use portable fallbacks (and run heap-only, with no `DataDir`)
 - **cgo** for the full module (the WASM backend links `wasmtime-go`); the
   storage and vector packages are pure Go

--- a/docs/development.md
+++ b/docs/development.md
@@ -3,8 +3,8 @@
 ## Requirements
 
 - **Go 1.26+** (from `go.mod`)
-- Linux/amd64 gets mmap persistence and the AVX2 kernels; other platforms use
-  portable fallbacks
+- mmap persistence works on Linux and Windows; the AVX2 kernels are Linux/amd64.
+  Other platforms use portable fallbacks (and run heap-only, with no `DataDir`)
 - **cgo** for the full module (the WASM backend links `wasmtime-go`); the
   storage and vector packages are pure Go
 
@@ -62,6 +62,7 @@ GitHub Actions runs these lanes on every push/PR:
 | `test-root` / `test-inttest` / `test-cluster` / `test-shard` | the heavy integration suites, each isolated in its own job so they never oversubscribe one runner |
 | `cgo-disabled-build` | the whole module keeps building with `CGO_ENABLED=0` (the wasmtime backend swaps to its `!cgo` stub) |
 | `cross-compile` | build-only matrix across linux/386, linux/arm, linux/arm64, darwin, windows, freebsd — catches 32-bit and cross-platform breakage the linux/amd64 lanes can't |
+| `test-windows` | the cache and MCP-memory packages **run** on windows/amd64 — the only other platform that maps shard and slab files. The cross-compile lane builds windows but never executes it, so a file-mapping bug there would reach users unseen |
 | `test-386` | the wire-decoding packages **run** as a linux/386 binary, so `int(uint32)` length conversions execute with a 32-bit `int` — where an over-MaxInt32 length widens negative and slips past `len(args) < off+n` checks. The cross-compile lane only builds; this one executes |
 | `race` | race detector over the concurrency-critical packages, with `-short`: the heavy differential suites in `vector/` size their corpora off it by design (see `filter_bitset_test.go`), and without it the package alone exceeds the lane's timeout |
 | `python-client` | the Python client's pytest suite |

--- a/docs/kv/cache.md
+++ b/docs/kv/cache.md
@@ -15,7 +15,7 @@ to `cache.New`).
 | `InitialPagesPerShard` | 0 (lazy) | pre-allocate pages up front instead of on demand |
 | `AtCapPolicy` | `PolicyRingbufEvict` | at capacity: overwrite oldest entries (`PolicyRingbufEvict`) or reject writes with `cache.ErrFull` (`PolicyRejectWrites`) |
 | `TTLSweepIntervalMs` | 1000 | background expiry sweep; 0 disables (lazy expiry on read still applies) |
-| `DataDir` | "" (heap) | directory for per-shard mmap files; enables persistence + warm restart. Linux only. |
+| `DataDir` | "" (heap) | directory for per-shard mmap files; enables persistence + warm restart. Linux and Windows only. |
 | `Durable` | false | `msync` on commit boundaries (bounded by `MsyncIntervalMs`, default 100 ms); false = opportunistic OS flushing |
 | `Mlock` | false | pin the mmap into RAM (needs `ulimit -l` headroom; failure logs and continues) |
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -14,7 +14,8 @@ runtime dependencies.
 - The default full-module build requires **cgo** (the WASM stored-procedure
   backend uses `wasmtime-go`). The vector engine and cache packages are pure Go —
   see [Development](development.md#building) for `CGO_ENABLED=0` builds.
-- mmap persistence works on Linux and Windows; the AVX2 kernels are Linux/amd64.
+- mmap persistence works on Linux and 64-bit Windows (windows/amd64); the AVX2
+  kernels are Linux/amd64.
   Everything else has a portable fallback. On Windows a shard file is fully
   allocated when it is created rather than growing from a hole, so a data
   directory takes its configured size on disk up front.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -14,8 +14,10 @@ runtime dependencies.
 - The default full-module build requires **cgo** (the WASM stored-procedure
   backend uses `wasmtime-go`). The vector engine and cache packages are pure Go —
   see [Development](development.md#building) for `CGO_ENABLED=0` builds.
-- mmap persistence and the AVX2 kernels are Linux/amd64; everything has a
-  portable fallback.
+- mmap persistence works on Linux and Windows; the AVX2 kernels are Linux/amd64.
+  Everything else has a portable fallback. On Windows a shard file is fully
+  allocated when it is created rather than growing from a hole, so a data
+  directory takes its configured size on disk up front.
 
 ## Install the server
 

--- a/sdk/vtypes/config.go
+++ b/sdk/vtypes/config.go
@@ -240,7 +240,7 @@ type Config struct {
 	// combine with QuantMmap to push both the vectors and the graph's largest
 	// array off-heap. The file is a native-endian runtime backing store (like
 	// MmapPath), not a portable artifact, and must differ from MmapPath.
-	// Linux-only; other platforms return an mmap-unsupported error.
+	// Linux and Windows only; other platforms return an mmap-unsupported error.
 	GraphMmapPath string
 
 	// FilterFirstThreshold caps the candidate-set size for which an

--- a/vector/arena.go
+++ b/vector/arena.go
@@ -80,6 +80,30 @@ type arena struct {
 	mmapF      *os.File
 	mmapRegion []byte
 
+	// poisoned marks a TERMINAL failure of an mmap slab growth (growVecs or the
+	// graph's growLevel0). growVecMmap unmaps the old view BEFORE it truncates and
+	// remaps, so a failure partway through leaves the old region freed and the
+	// aliasing slice header (vecs / level0) nil'd — there is no valid mapping to
+	// fall back to. The guard is LAYERED so no op dereferences the freed region:
+	//   - write / persist / snapshot chokepoints (insertBody, SavePersist,
+	//     Snapshot) check the flag at the top and return ErrIndexPoisoned;
+	//   - read chokepoints check UNDER h.mu, which also closes the TOCTOU against a
+	//     concurrent grow: the error-returning read ops (SearchMMR, group, discover,
+	//     the hybrid lane builders) reject with ErrIndexPoisoned, and the two shared
+	//     under-lock helpers — searchDenseLockedWith (all dense search) and vecFor
+	//     (the Get / materialization path) — return an empty/nil result so the
+	//     no-error ops (SearchText, Get*) stay panic-safe;
+	//   - the nil-out of the freed headers at the failure site is a BACKSTOP, so a
+	//     path that ever slips past the flag faults cleanly instead of reading
+	//     unmapped memory.
+	// Set once (never cleared) under the owning index's write lock; read lock-free
+	// via atomic so read-path ops can gate cheaply. A fresh arena installed by
+	// snapshot restore starts un-poisoned, which is the intended recovery. A
+	// poisoned arena OR a poisoned graph poisons the index; the graph failure sets
+	// this same flag through h.arena (the arena is always present), keeping the
+	// terminal state in one place.
+	poisoned atomic.Bool
+
 	// vecsRes, when non-nil, is the address-space reservation vecs is carved
 	// out of — the mechanism that makes growth O(1) with a STABLE base address
 	// instead of an O(n) copy/remap under the write lock (see reserve.go). It
@@ -432,8 +456,11 @@ func (a *arena) growVecs(needFloats int) error {
 		if err != nil {
 			// growVecMmap unmaps the old view BEFORE truncate+remap; on error the old
 			// backing is already gone, so a.mmapRegion/a.vecs (which aliases it) point
-			// at an unmapped region. Nil them so a later access faults cleanly instead
-			// of reading unmapped memory. (a.codes has no file backing — leave it.)
+			// at an unmapped region. Poison the index so every public op rejects with
+			// ErrIndexPoisoned, and nil the headers (belt-and-suspenders) so a bug that
+			// bypasses the guard faults cleanly instead of reading unmapped memory.
+			// (a.codes has no file backing — leave it.)
+			a.poisoned.Store(true)
 			a.mmapRegion = nil
 			a.vecs = nil
 			return err

--- a/vector/arena.go
+++ b/vector/arena.go
@@ -430,6 +430,12 @@ func (a *arena) growVecs(needFloats int) error {
 	if a.mmapF != nil {
 		region, err := growVecMmap(a.mmapF, a.mmapRegion, newBytes)
 		if err != nil {
+			// growVecMmap unmaps the old view BEFORE truncate+remap; on error the old
+			// backing is already gone, so a.mmapRegion/a.vecs (which aliases it) point
+			// at an unmapped region. Nil them so a later access faults cleanly instead
+			// of reading unmapped memory. (a.codes has no file backing — leave it.)
+			a.mmapRegion = nil
+			a.vecs = nil
 			return err
 		}
 		a.mmapRegion = region

--- a/vector/bm25_hnsw.go
+++ b/vector/bm25_hnsw.go
@@ -213,6 +213,12 @@ func (h *hnsw) buildTextLanes(dense []float32, query string, k int, opts HybridO
 
 	h.mu.RLock()
 	defer h.mu.RUnlock()
+	// Reject on a poisoned index (failed mmap grow) under the lock so the hybrid
+	// text entry points surface the sentinel instead of a silent empty dense lane
+	// — see arena.poisoned.
+	if h.arena.poisoned.Load() {
+		return nil, nil, nil, ErrIndexPoisoned
+	}
 	h.searchOps.Add(1)
 
 	if q != nil {
@@ -288,6 +294,12 @@ func (h *hnsw) buildTextLanesGlobal(dense []float32, query string, k int, opts H
 
 	h.mu.RLock()
 	defer h.mu.RUnlock()
+	// Reject on a poisoned index (failed mmap grow) under the lock so the hybrid
+	// text entry points surface the sentinel instead of a silent empty dense lane
+	// — see arena.poisoned.
+	if h.arena.poisoned.Load() {
+		return nil, nil, nil, ErrIndexPoisoned
+	}
 	h.searchOps.Add(1)
 
 	if q != nil {

--- a/vector/discover.go
+++ b/vector/discover.go
@@ -136,6 +136,11 @@ func (h *hnsw) Discover(k int, opts DiscoverOpts) ([]Result, error) {
 
 	h.mu.RLock()
 	defer h.mu.RUnlock()
+	// Reject on a poisoned index (failed mmap grow) under the lock so the sentinel
+	// surfaces instead of a silent empty result — see arena.poisoned.
+	if h.arena.poisoned.Load() {
+		return nil, ErrIndexPoisoned
+	}
 	h.searchOps.Add(1)
 
 	// Resolve context pair vectors (skip pairs referencing missing ids).
@@ -186,6 +191,11 @@ func (h *hnsw) DiscoverVecs(k int, opts DiscoverVecsOpts) ([]Result, error) {
 
 	h.mu.RLock()
 	defer h.mu.RUnlock()
+	// Reject on a poisoned index (failed mmap grow) under the lock so the sentinel
+	// surfaces instead of a silent empty result — see arena.poisoned.
+	if h.arena.poisoned.Load() {
+		return nil, ErrIndexPoisoned
+	}
 	h.searchOps.Add(1)
 
 	return h.discoverScoredLocked(s, k, fetchK, opts.Target, opts.Context, pred)
@@ -222,6 +232,11 @@ func (h *hnsw) RecommendVecs(k int, opts RecommendVecsOpts) ([]Result, error) {
 
 	h.mu.RLock()
 	defer h.mu.RUnlock()
+	// Reject on a poisoned index (failed mmap grow) under the lock so the sentinel
+	// surfaces instead of a silent empty result — see arena.poisoned.
+	if h.arena.poisoned.Load() {
+		return nil, ErrIndexPoisoned
+	}
 	h.searchOps.Add(1)
 
 	return h.recommendBestLocked(s, k, fetchK, opts.Positive, opts.Negative, pred)

--- a/vector/gpu_cuda.go
+++ b/vector/gpu_cuda.go
@@ -444,6 +444,13 @@ func (g *gpuIndex) searchIntoGPU(dst []Result, query []float32, k int, filter Fi
 
 	h.mu.Lock()
 	defer h.mu.Unlock()
+	// Reject on a poisoned index (failed mmap grow): the GPU search reads
+	// h.arena.vecs, which is nil'd after the failure. The embedded *hnsw's other
+	// ops are already guarded; only these GPU-overridden dense entries bypass them.
+	// See arena.poisoned.
+	if h.arena.poisoned.Load() {
+		return dst, ErrIndexPoisoned
+	}
 	h.searchOps.Add(1)
 
 	return g.gpuSearchLocked(dst, q, k, pred, admit)
@@ -470,6 +477,11 @@ func (g *gpuIndex) gpuSearchBatch(queries [][]float32, k int) ([][]Result, error
 	}
 	h.mu.Lock()
 	defer h.mu.Unlock()
+	// Reject on a poisoned index (failed mmap grow) before uploading/scanning the
+	// nil'd h.arena.vecs — see arena.poisoned.
+	if h.arena.poisoned.Load() {
+		return nil, ErrIndexPoisoned
+	}
 	if err := g.ensureResidentLocked(); err != nil {
 		return nil, err
 	}

--- a/vector/graph.go
+++ b/vector/graph.go
@@ -173,6 +173,13 @@ func (h *hnsw) growLevel0(needU32 int) error {
 	if h.graphMmapF != nil {
 		region, err := growVecMmap(h.graphMmapF, h.graphRegion, newBytes)
 		if err != nil {
+			// growVecMmap unmaps the old view BEFORE truncate+remap; on error the old
+			// backing is already gone, so h.graphRegion/h.level0 (which aliases it)
+			// point at an unmapped region. Nil them so a later access faults cleanly
+			// instead of reading unmapped memory. (h.nodes/h.level0Len are heap-backed
+			// — leave them.)
+			h.graphRegion = nil
+			h.level0 = nil
 			return err
 		}
 		h.graphRegion = region

--- a/vector/graph.go
+++ b/vector/graph.go
@@ -175,9 +175,12 @@ func (h *hnsw) growLevel0(needU32 int) error {
 		if err != nil {
 			// growVecMmap unmaps the old view BEFORE truncate+remap; on error the old
 			// backing is already gone, so h.graphRegion/h.level0 (which aliases it)
-			// point at an unmapped region. Nil them so a later access faults cleanly
-			// instead of reading unmapped memory. (h.nodes/h.level0Len are heap-backed
-			// — leave them.)
+			// point at an unmapped region. Poison the index (via the arena, which is
+			// always present and holds the single terminal flag) so every public op
+			// rejects with ErrIndexPoisoned, and nil the headers (belt-and-suspenders)
+			// so a bug that bypasses the guard faults cleanly instead of reading
+			// unmapped memory. (h.nodes/h.level0Len are heap-backed — leave them.)
+			h.arena.poisoned.Store(true)
 			h.graphRegion = nil
 			h.level0 = nil
 			return err

--- a/vector/group.go
+++ b/vector/group.go
@@ -52,6 +52,11 @@ func (h *hnsw) GroupCandidates(query []float32, opts GroupOpts) ([]Document, err
 
 	h.mu.RLock()
 	defer h.mu.RUnlock()
+	// Reject on a poisoned index (failed mmap grow) under the lock so the sentinel
+	// surfaces instead of a silent empty result — see arena.poisoned.
+	if h.arena.poisoned.Load() {
+		return nil, ErrIndexPoisoned
+	}
 
 	raw := h.searchDenseLocked(s, q, fetchK, pred, nil)
 	docs := make([]Document, 0, len(raw))
@@ -154,6 +159,11 @@ func (h *hnsw) SearchGroups(query []float32, k int, opts GroupOpts) ([]Group, er
 
 	h.mu.RLock()
 	defer h.mu.RUnlock()
+	// Reject on a poisoned index (failed mmap grow) under the lock so the sentinel
+	// surfaces instead of a silent empty result — see arena.poisoned.
+	if h.arena.poisoned.Load() {
+		return nil, ErrIndexPoisoned
+	}
 
 	raw := h.searchDenseLocked(s, q, fetchK, pred, nil)
 	h.searchOps.Add(1)

--- a/vector/hnsw.go
+++ b/vector/hnsw.go
@@ -985,6 +985,16 @@ func (h *hnsw) vecsDropped() bool { return h.arena.vecsDropped }
 // reconstructed and aliases arena storage otherwise; callers that retain it must
 // clone. Must hold h.mu (read). Mirrors ivf.vecFor.
 func (h *hnsw) vecFor(slot uint32) []float32 {
+	// Under-lock backstop for the materialization paths (Get/GetProjected/GetInto,
+	// discover context pairs, MMR diversity vecs): a failed mmap grow nils the
+	// arena floats, so arena.Vec would slice a nil region and panic. Return nil
+	// instead. The dense search scorer does NOT route through here (it reads the
+	// arena base pointer directly), so this adds no atomic load to the hot loop;
+	// that path is guarded once at the top of searchDenseLockedWith. See
+	// arena.poisoned.
+	if h.arena.poisoned.Load() {
+		return nil
+	}
 	if !h.arena.vecsDropped {
 		return h.arena.Vec(slot)
 	}
@@ -1892,6 +1902,11 @@ func (h *hnsw) InsertAt(id uint64, vec []float32, ttl time.Duration, meta Metada
 // one-snapshot rule and byte-identical to the historical multi-read path under a
 // stable clock.
 func (h *hnsw) insertBody(id uint64, vec []float32, ttl time.Duration, meta Metadata, sparse *SparseVector, keyTTLMs map[string]int64, cas CASCond, stamped bool, nowMs uint64) (uint64, map[string]uint64, error) {
+	// A failed mmap slab growth freed the backing region; reject rather than
+	// write into it (see arena.poisoned / ErrIndexPoisoned).
+	if h.arena.poisoned.Load() {
+		return 0, nil, ErrIndexPoisoned
+	}
 	start := time.Now()
 	defer func() { h.insertLat.observe(time.Since(start)) }()
 
@@ -3251,6 +3266,11 @@ func (h *hnsw) SearchInto(dst []Result, query []float32, k int, filter Filter) (
 // always traverses the graph (predicate-eval only), gating membership against
 // the external payload via searchDenseLockedWith.
 func (h *hnsw) searchIntoWith(dst []Result, query []float32, k int, filter Filter, metaOf func(id uint64) Metadata) ([]Result, error) {
+	// A failed mmap slab growth freed the backing region; reject rather than
+	// read from it (see arena.poisoned / ErrIndexPoisoned).
+	if h.arena.poisoned.Load() {
+		return dst, ErrIndexPoisoned
+	}
 	start := time.Now()
 	defer func() { h.searchLat.observe(time.Since(start)) }()
 
@@ -3278,6 +3298,13 @@ func (h *hnsw) searchIntoWith(dst []Result, query []float32, k int, filter Filte
 	h.mu.RLock()
 	defer h.mu.RUnlock()
 	h.searchOps.Add(1)
+
+	// Re-check under h.mu (poison is published under the write lock): closes the
+	// window between the pre-lock check and here, and covers the filter-first
+	// branch below, whose exact rescore reads vecFor into a distance kernel.
+	if h.arena.poisoned.Load() {
+		return dst, ErrIndexPoisoned
+	}
 
 	// Query planner: when an indexed filter narrows to a materializable candidate
 	// set, choose between exact brute force over those candidates (filter-first)
@@ -3610,6 +3637,17 @@ func (h *hnsw) searchDenseLocked(s *layerScratch, q []float32, k int, pred Predi
 // caller (SearchFilteredWith) never routes the payload index on the provider
 // path, so a metadata-less sub-arena is correctly searched by full traversal.
 func (h *hnsw) searchDenseLockedWith(s *layerScratch, q []float32, k int, pred Predicate, dst []Result, metaOf func(id uint64) Metadata) []Result {
+	// Under-lock backstop: a failed mmap slab growth nils the graph/vector regions,
+	// so every dense read op (Search, MMR, group, discover, hybrid) funnels through
+	// here before touching h.level0 / the arena floats. Return the caller's dst
+	// unchanged rather than dereference the freed region. This runs under the
+	// caller's h.mu RLock, so it also closes the TOCTOU against a concurrent grow
+	// that poisons after a top-of-op check. Ops with an error return additionally
+	// reject with ErrIndexPoisoned at their own top; the no-error ops (SearchText)
+	// rely on this backstop for panic-safety. See arena.poisoned.
+	if h.arena.poisoned.Load() {
+		return dst
+	}
 	// The entry point and the top level are read as ONE pair (see entryState): a
 	// linker running concurrently under the read lock can promote a taller node,
 	// and descending from the old entry through the new top level would walk
@@ -3816,6 +3854,12 @@ func (h *hnsw) buildLanes(dense []float32, sparse SparseVector, k int, opts Hybr
 
 	h.mu.RLock()
 	defer h.mu.RUnlock()
+	// Reject on a poisoned index (failed mmap grow) under the lock so both
+	// HybridSearch and HybridLanes surface the sentinel instead of a silent empty
+	// result — see arena.poisoned.
+	if h.arena.poisoned.Load() {
+		return nil, nil, ErrIndexPoisoned
+	}
 	h.searchOps.Add(1)
 
 	// Dense lane.

--- a/vector/index.go
+++ b/vector/index.go
@@ -730,4 +730,12 @@ var (
 	// ErrCollectionRateLimited is returned when MaxInsertsPerSecond is configured
 	// and the token bucket is empty. Callers can retry after the bucket refills.
 	ErrCollectionRateLimited = errors.New("vector: collection insert rate limited")
+
+	// ErrIndexPoisoned is returned by every public op once a memory-mapped slab
+	// growth (vecs or the level-0 graph) has failed. That failure unmaps the old
+	// view before it can remap, so the backing region is gone and cannot be
+	// recovered in place; the index is in a TERMINAL state and each op rejects
+	// rather than dereference the freed mapping. It is not retryable — the
+	// collection must be reopened/restored.
+	ErrIndexPoisoned = errors.New("vector: index poisoned by a failed mmap growth")
 )

--- a/vector/ivf.go
+++ b/vector/ivf.go
@@ -345,6 +345,15 @@ func (ix *ivf) pq4Active() bool {
 // IVFRerank). The returned slice is freshly allocated when reconstructed and
 // aliases arena storage otherwise; callers that retain it must clone.
 func (ix *ivf) vecFor(slot uint32) []float32 {
+	// Under-lock backstop for the materialization paths (Get/GetProjected/GetInto,
+	// discover context pairs): a failed mmap grow nils the arena floats, so
+	// arena.Vec would slice a nil region and panic. Return nil instead. Callers
+	// that dereference the result element-wise (meanOf, discover pairs) reject at
+	// their own top under the lock; this keeps the Get* path panic-safe. See
+	// arena.poisoned.
+	if ix.arena.poisoned.Load() {
+		return nil
+	}
 	if !ix.pqDropped {
 		return ix.arena.Vec(slot)
 	}
@@ -1707,6 +1716,11 @@ func (ix *ivf) SearchInto(dst []Result, query []float32, k int, filter Filter) (
 
 	ix.mu.RLock()
 	defer ix.mu.RUnlock()
+	// Reject on a poisoned index (failed mmap grow) under the lock so the sentinel
+	// surfaces instead of a silent empty result — see arena.poisoned.
+	if ix.arena.poisoned.Load() {
+		return dst, ErrIndexPoisoned
+	}
 	ix.searchOps.Add(1)
 	return ix.searchLocked(q, k, pred, dst), nil
 }
@@ -1743,6 +1757,11 @@ func (ix *ivf) SearchFilteredWith(dst []Result, query []float32, k int, filter F
 
 	ix.mu.RLock()
 	defer ix.mu.RUnlock()
+	// Reject on a poisoned index (failed mmap grow) under the lock so the sentinel
+	// surfaces instead of a silent empty result — see arena.poisoned.
+	if ix.arena.poisoned.Load() {
+		return dst, ErrIndexPoisoned
+	}
 	ix.searchOps.Add(1)
 
 	matched := ix.gatherLockedWith(q, k, pred, metaOf)
@@ -1761,6 +1780,14 @@ func (ix *ivf) SearchFilteredWith(dst []Result, query []float32, k int, filter F
 // re-checked against the live shared payload (the sub-arena carries no metadata).
 // Must hold ix.mu (read).
 func (ix *ivf) gatherLockedWith(q []float32, k int, pred Predicate, metaOf metaProvider) []slotDist {
+	// Under-lock backstop: a failed mmap grow nils the arena floats, so every dense
+	// scan (this and gatherLocked below) would slice the freed region. Return an
+	// empty candidate set instead. Runs under the caller's ix.mu RLock, closing the
+	// TOCTOU against a concurrent grow that poisons after a top-of-op check. See
+	// arena.poisoned.
+	if ix.arena.poisoned.Load() {
+		return nil
+	}
 	if metaOf == nil {
 		return ix.gatherLocked(q, k, pred)
 	}
@@ -2186,6 +2213,13 @@ func (ix *ivf) gatherFlatBatched(batch *batchKernel, cells []int, total int, adm
 // returned set is every admitted candidate in the probed cells (the caller
 // top-k's it). Must hold ix.mu (read).
 func (ix *ivf) gatherLocked(q []float32, k int, pred Predicate) []slotDist {
+	// Under-lock backstop: a failed mmap grow nils the arena floats, so the cell
+	// scan / brute force below (both read arena.Vec) would slice the freed region.
+	// Return an empty candidate set instead; the error-returning ops reject with
+	// ErrIndexPoisoned at their own top. See arena.poisoned.
+	if ix.arena.poisoned.Load() {
+		return nil
+	}
 	dist := ix.metricDist()
 	if !ix.trained || len(ix.centroids) == 0 {
 		return ix.bruteForceLocked(q, dist, pred)
@@ -2531,6 +2565,12 @@ func (ix *ivf) buildLanes(dense []float32, sparse SparseVector, k int, opts Hybr
 
 	ix.mu.RLock()
 	defer ix.mu.RUnlock()
+	// Reject on a poisoned index (failed mmap grow) under the lock so both
+	// HybridSearch and HybridLanes surface the sentinel instead of a silent empty
+	// dense lane — see arena.poisoned.
+	if ix.arena.poisoned.Load() {
+		return nil, nil, ErrIndexPoisoned
+	}
 	ix.searchOps.Add(1)
 
 	if q != nil {
@@ -2587,6 +2627,11 @@ func (ix *ivf) SearchMMR(query []float32, k int, opts MMROpts) ([]Result, error)
 
 	ix.mu.RLock()
 	defer ix.mu.RUnlock()
+	// Reject on a poisoned index (failed mmap grow) under the lock so the sentinel
+	// surfaces instead of a silent empty result — see arena.poisoned.
+	if ix.arena.poisoned.Load() {
+		return nil, ErrIndexPoisoned
+	}
 	ix.searchOps.Add(1)
 
 	cands := ix.searchLocked(q, fetchK, pred, nil)
@@ -2656,6 +2701,13 @@ func (ix *ivf) Recommend(k int, opts RecommendOpts) ([]Result, error) {
 	}
 	target := make([]float32, ix.cfg.Dim)
 	ix.mu.RLock()
+	// Reject on a poisoned index (failed mmap grow) before meanOf dereferences the
+	// freed arena floats element-wise (vecFor's nil return would panic there) —
+	// see arena.poisoned.
+	if ix.arena.poisoned.Load() {
+		ix.mu.RUnlock()
+		return nil, ErrIndexPoisoned
+	}
 	nPos := ix.meanOf(target, opts.Positive)
 	if nPos == 0 {
 		ix.mu.RUnlock()
@@ -2744,6 +2796,12 @@ func (ix *ivf) Discover(k int, opts DiscoverOpts) ([]Result, error) {
 
 	ix.mu.RLock()
 	defer ix.mu.RUnlock()
+	// Reject on a poisoned index (failed mmap grow) before the context-pair vectors
+	// are materialized (vecFor returns nil, which discoverScoredLocked would
+	// dereference) — see arena.poisoned.
+	if ix.arena.poisoned.Load() {
+		return nil, ErrIndexPoisoned
+	}
 	ix.searchOps.Add(1)
 
 	pairs := make([]DiscoverPair, 0, len(opts.Context))
@@ -2788,6 +2846,11 @@ func (ix *ivf) DiscoverVecs(k int, opts DiscoverVecsOpts) ([]Result, error) {
 
 	ix.mu.RLock()
 	defer ix.mu.RUnlock()
+	// Reject on a poisoned index (failed mmap grow) under the lock so the sentinel
+	// surfaces instead of a silent empty result — see arena.poisoned.
+	if ix.arena.poisoned.Load() {
+		return nil, ErrIndexPoisoned
+	}
 	ix.searchOps.Add(1)
 
 	return ix.discoverScoredLocked(k, fetchK, opts.Target, opts.Context, pred)
@@ -2816,6 +2879,11 @@ func (ix *ivf) RecommendVecs(k int, opts RecommendVecsOpts) ([]Result, error) {
 
 	ix.mu.RLock()
 	defer ix.mu.RUnlock()
+	// Reject on a poisoned index (failed mmap grow) under the lock so the sentinel
+	// surfaces instead of a silent empty result — see arena.poisoned.
+	if ix.arena.poisoned.Load() {
+		return nil, ErrIndexPoisoned
+	}
 	ix.searchOps.Add(1)
 
 	return ix.recommendBestLocked(k, fetchK, opts.Positive, opts.Negative, pred)
@@ -2911,6 +2979,11 @@ func (ix *ivf) GroupCandidates(query []float32, opts GroupOpts) ([]Document, err
 
 	ix.mu.RLock()
 	defer ix.mu.RUnlock()
+	// Reject on a poisoned index (failed mmap grow) under the lock so the sentinel
+	// surfaces instead of a silent empty result — see arena.poisoned.
+	if ix.arena.poisoned.Load() {
+		return nil, ErrIndexPoisoned
+	}
 
 	raw := ix.searchLocked(q, fetchK, pred, nil)
 	docs := make([]Document, 0, len(raw))
@@ -3839,6 +3912,13 @@ func (ix *ivf) ivfSOARActive() bool { return ix.soarTrained }
 func (ix *ivf) Snapshot(w io.Writer) error {
 	ix.mu.RLock()
 	defer ix.mu.RUnlock()
+	// A failed mmap slab growth freed the arena floats; refuse to serialize rather
+	// than emit a silently truncated snapshot. Called from the raft FSM snapshot
+	// and backup paths (goroutines with no panic recovery), so checked under ix.mu
+	// (closes the TOCTOU with a concurrent grow) — see arena.poisoned.
+	if ix.arena.poisoned.Load() {
+		return ErrIndexPoisoned
+	}
 	bw := bufio.NewWriter(w)
 
 	// Choose snapshot version: v5 (SOAR block) when SOAR built a secondary

--- a/vector/ivf_persist.go
+++ b/vector/ivf_persist.go
@@ -298,7 +298,7 @@ func (ix *ivf) savePersist(metaPath string) error {
 		if a.mmapF == nil {
 			return ErrPersistUnsupported
 		}
-		if err := syncVecMmap(a.mmapRegion); err != nil {
+		if err := syncVecMmap(a.mmapF, a.mmapRegion); err != nil {
 			return err
 		}
 	}

--- a/vector/ivf_persist.go
+++ b/vector/ivf_persist.go
@@ -288,6 +288,13 @@ func (ix *ivf) savePersist(metaPath string) error {
 	ix.mu.RLock()
 	defer ix.mu.RUnlock()
 
+	// A failed mmap slab growth freed the arena floats; refuse to persist rather
+	// than externalize a truncated/unbacked sidecar (same hazard as Snapshot; runs
+	// in the same durable-artifact paths). See arena.poisoned.
+	if ix.arena.poisoned.Load() {
+		return ErrIndexPoisoned
+	}
+
 	a := ix.arena
 	vecsPresent := !a.vecsDropped
 	if vecsPresent {

--- a/vector/mmap_linux.go
+++ b/vector/mmap_linux.go
@@ -53,7 +53,12 @@ func growVecMmap(f *os.File, old []byte, newSize int64) ([]byte, error) {
 
 // syncVecMmap flushes dirty pages of region to its backing file, so a
 // subsequently-written sidecar can safely reference the mmap'd contents.
-func syncVecMmap(region []byte) error {
+//
+// The file is accepted but unused here: MS_SYNC already returns only once the
+// pages are on the disk. Windows needs the handle for the second half of that
+// same guarantee (see mmap_windows.go), and one signature across the platforms
+// keeps the difference inside these files instead of at every call site.
+func syncVecMmap(_ *os.File, region []byte) error {
 	if len(region) == 0 {
 		return nil
 	}
@@ -75,6 +80,20 @@ func closeVecMmap(f *os.File, region []byte) error {
 		if err := f.Close(); err != nil {
 			return fmt.Errorf("vector: close: %w", err)
 		}
+	}
+	return nil
+}
+
+// unmapVecMmap releases a mapping made by openVecMmap/growVecMmap WITHOUT
+// closing the file — used when a slab migrates from the legacy whole-file
+// mapping onto a reservation, where the file stays but its old mapping must go.
+func unmapVecMmap(region []byte) error {
+	if len(region) == 0 {
+		return nil
+	}
+	_ = unix.Msync(region, unix.MS_SYNC)
+	if err := unix.Munmap(region); err != nil {
+		return fmt.Errorf("vector: munmap (migrate): %w", err)
 	}
 	return nil
 }

--- a/vector/mmap_other.go
+++ b/vector/mmap_other.go
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-//go:build !linux
+//go:build !linux && !windows
 
 package vector
 
@@ -20,6 +20,8 @@ func growVecMmap(_ *os.File, _ []byte, _ int64) ([]byte, error) {
 	return nil, errMmapUnsupported
 }
 
-func syncVecMmap(_ []byte) error { return errMmapUnsupported }
+func syncVecMmap(_ *os.File, _ []byte) error { return errMmapUnsupported }
 
 func closeVecMmap(_ *os.File, _ []byte) error { return nil }
+
+func unmapVecMmap(_ []byte) error { return nil }

--- a/vector/mmap_windows.go
+++ b/vector/mmap_windows.go
@@ -1,0 +1,150 @@
+// SPDX-License-Identifier: Apache-2.0
+//go:build windows
+
+package vector
+
+import (
+	"fmt"
+	"os"
+	"unsafe"
+
+	"golang.org/x/sys/windows"
+)
+
+// openVecMmap opens path (creating if missing), sizes it to size bytes, and
+// maps it read/write and shared. Used as the float32 vector backing store when
+// QuantStorage is QuantMmap.
+func openVecMmap(path string, size int64) (*os.File, []byte, error) {
+	if size <= 0 {
+		return nil, nil, fmt.Errorf("vector: mmap %s: size must be > 0, got %d", path, size)
+	}
+	f, err := os.OpenFile(path, os.O_RDWR|os.O_CREATE, 0o600) //nolint:gosec // G304: path is caller-supplied and intentional
+	if err != nil {
+		return nil, nil, fmt.Errorf("vector: open %s: %w", path, err)
+	}
+	if err := f.Truncate(size); err != nil {
+		_ = f.Close()
+		return nil, nil, fmt.Errorf("vector: truncate %s to %d: %w", path, size, err)
+	}
+	region, err := mapVecView(f, size)
+	if err != nil {
+		_ = f.Close()
+		return nil, nil, fmt.Errorf("vector: mmap %s: %w", path, err)
+	}
+	return f, region, nil
+}
+
+// growVecMmap unmaps old, grows the file to newSize bytes, and remaps it.
+// Returns the new region. The caller must rebuild any slice headers that
+// aliased the old region (the mapping address changes).
+//
+// The unmap has to come first for a second reason here that it does not have on
+// Linux: Windows refuses to change the length of a file that still has a view
+// mapped (ERROR_USER_MAPPED_FILE), so the Truncate below would fail outright
+// rather than merely racing readers.
+func growVecMmap(f *os.File, old []byte, newSize int64) ([]byte, error) {
+	if len(old) > 0 {
+		if err := windows.UnmapViewOfFile(vecRegionAddr(old)); err != nil {
+			return nil, fmt.Errorf("vector: UnmapViewOfFile (grow): %w", err)
+		}
+	}
+	if err := f.Truncate(newSize); err != nil {
+		return nil, fmt.Errorf("vector: truncate (grow) to %d: %w", newSize, err)
+	}
+	region, err := mapVecView(f, newSize)
+	if err != nil {
+		return nil, fmt.Errorf("vector: mmap (grow) to %d: %w", newSize, err)
+	}
+	return region, nil
+}
+
+// syncVecMmap flushes dirty pages of region to its backing file, so a
+// subsequently-written sidecar can safely reference the mmap'd contents.
+//
+// FlushViewOfFile alone only pushes the pages into the filesystem; the sidecar
+// is a durability record, so the flush has to reach the disk, which on this
+// platform is the FlushFileBuffers that follows.
+func syncVecMmap(f *os.File, region []byte) error {
+	if len(region) == 0 {
+		return nil
+	}
+	if err := windows.FlushViewOfFile(vecRegionAddr(region), uintptr(len(region))); err != nil {
+		return fmt.Errorf("vector: FlushViewOfFile: %w", err)
+	}
+	if f == nil {
+		return nil
+	}
+	if err := windows.FlushFileBuffers(windows.Handle(f.Fd())); err != nil {
+		return fmt.Errorf("vector: FlushFileBuffers: %w", err)
+	}
+	return nil
+}
+
+// closeVecMmap syncs, unmaps, and closes the backing file.
+func closeVecMmap(f *os.File, region []byte) error {
+	if len(region) > 0 {
+		_ = syncVecMmap(f, region)
+		if err := windows.UnmapViewOfFile(vecRegionAddr(region)); err != nil {
+			return fmt.Errorf("vector: UnmapViewOfFile: %w", err)
+		}
+	}
+	if f != nil {
+		if err := f.Close(); err != nil {
+			return fmt.Errorf("vector: close: %w", err)
+		}
+	}
+	return nil
+}
+
+// unmapVecMmap releases a mapped region whose backing file stays open — the
+// migrate path, where a slab moves off the mapping and the file outlives it.
+//
+// The flush is best-effort and view-only: without the file handle it cannot
+// reach FlushFileBuffers, which mirrors the best-effort MS_SYNC the Linux side
+// does at the same point.
+func unmapVecMmap(region []byte) error {
+	if len(region) == 0 {
+		return nil
+	}
+	_ = windows.FlushViewOfFile(vecRegionAddr(region), uintptr(len(region)))
+	if err := windows.UnmapViewOfFile(vecRegionAddr(region)); err != nil {
+		return fmt.Errorf("vector: UnmapViewOfFile (migrate): %w", err)
+	}
+	return nil
+}
+
+// mapVecView maps [0, size) of f read/write and shared.
+//
+// The section handle is closed before returning: the view holds its own
+// reference and stays valid without it, which is what keeps the (file, region)
+// pair this package passes around sufficient to release everything later.
+func mapVecView(f *os.File, size int64) ([]byte, error) {
+	h, err := windows.CreateFileMapping(
+		windows.Handle(f.Fd()),
+		nil,
+		windows.PAGE_READWRITE,
+		uint32(uint64(size)>>32),        //nolint:gosec // deliberate 64->2x32 split of the section size
+		uint32(uint64(size)&0xFFFFFFFF), //nolint:gosec // deliberate 64->2x32 split of the section size
+		nil,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("CreateFileMapping: %w", err)
+	}
+	defer func() { _ = windows.CloseHandle(h) }()
+	addr, err := windows.MapViewOfFile(h, windows.FILE_MAP_READ|windows.FILE_MAP_WRITE, 0, 0, uintptr(size))
+	if err != nil {
+		return nil, fmt.Errorf("MapViewOfFile: %w", err)
+	}
+	// unsafeptr: addr is an OS mapping address, not a Go pointer — there is no
+	// object for the collector to move out from under it, and the view outlives
+	// this conversion by construction (it is released only by the Unmap in
+	// closeVecMmap/unmapVecMmap). go vet's unsafeptr check has no way to express that, and
+	// this is the one conversion every Windows file mapping has to make.
+	//nolint:govet,gosec // unsafeptr: see above; the view is exactly size bytes long
+	return unsafe.Slice((*byte)(unsafe.Pointer(addr)), size), nil
+}
+
+// vecRegionAddr returns the base address of a mapped region.
+func vecRegionAddr(region []byte) uintptr {
+	return uintptr(unsafe.Pointer(&region[0]))
+}

--- a/vector/mmr.go
+++ b/vector/mmr.go
@@ -64,6 +64,11 @@ func (h *hnsw) SearchMMR(query []float32, k int, opts MMROpts) ([]Result, error)
 
 	h.mu.RLock()
 	defer h.mu.RUnlock()
+	// Reject on a poisoned index (failed mmap grow) under the lock so the sentinel
+	// surfaces instead of a silent empty result — see arena.poisoned.
+	if h.arena.poisoned.Load() {
+		return nil, ErrIndexPoisoned
+	}
 	h.searchOps.Add(1)
 
 	cands := h.searchDenseLocked(s, q, fetchK, pred, nil)

--- a/vector/persist.go
+++ b/vector/persist.go
@@ -131,10 +131,10 @@ func (h *hnsw) SavePersist(metaPath string) error {
 
 	// Flush the mmap'd vectors and graph so the sidecar we write references
 	// durable bytes.
-	if err := syncVecMmap(h.arena.mmapRegion); err != nil {
+	if err := syncVecMmap(h.arena.mmapF, h.arena.mmapRegion); err != nil {
 		return err
 	}
-	if err := syncVecMmap(h.graphRegion); err != nil {
+	if err := syncVecMmap(h.graphMmapF, h.graphRegion); err != nil {
 		return err
 	}
 

--- a/vector/persist.go
+++ b/vector/persist.go
@@ -113,6 +113,11 @@ var (
 // Persistent collection can be flushed after Delete/DeleteByFilter. Metadata,
 // TTL, and sparse vectors are persisted. Safe to call while live (read lock).
 func (h *hnsw) SavePersist(metaPath string) error {
+	// A failed mmap slab growth freed the backing region; reject rather than
+	// flush/serialize from it (see arena.poisoned / ErrIndexPoisoned).
+	if h.arena.poisoned.Load() {
+		return ErrIndexPoisoned
+	}
 	// Exclusive side of the link barrier, for the same reason Snapshot takes it,
 	// and in the same order — BEFORE h.mu, never after. writeMeta walks every
 	// node's level0Len and upper-level edges; an insert holds the barrier's read
@@ -123,6 +128,14 @@ func (h *hnsw) SavePersist(metaPath string) error {
 	defer h.linkMu.Unlock()
 	h.mu.RLock()
 	defer h.mu.RUnlock()
+
+	// Re-check under h.mu: poison + the nil-out are published under the write
+	// lock, so a grow that failed in the window between the pre-lock check and
+	// here would otherwise let this serialize (in a no-recover FSM/backup
+	// goroutine) over the freed regions — a truncated sidecar or a crash.
+	if h.arena.poisoned.Load() {
+		return ErrIndexPoisoned
+	}
 
 	if h.graphMmapF == nil || h.arena.mmapF == nil {
 		return ErrPersistUnsupported

--- a/vector/persist_test.go
+++ b/vector/persist_test.go
@@ -381,6 +381,108 @@ func TestPersistMetadataRoundtrip(t *testing.T) {
 	}
 }
 
+// TestPersistMmapGrowReopen exercises the full Windows-critical round-trip on the
+// VECTOR and GRAPH mmap slabs together: build an mmap-backed collection with
+// serial inserts that cross the initial 1024-slot reserve on BOTH slabs (forcing
+// at least one growVecMmap each — the unmap+truncate+remap grow path that only the
+// windows CI lane now actually runs), sync+close via SavePersist, then reopen from
+// the same paths and assert the vectors and graph survived (ids present, count
+// matches, search results identical). Small dim + fixed seed keep it deterministic
+// and fast; the two file-size asserts prove a grow really happened (else the test
+// would be a no-op for the grow path it exists to cover).
+func TestPersistMmapGrowReopen(t *testing.T) {
+	const dim, k = 16, 10
+	// > mmapInitVectors (1024) so BOTH the vector slab (initial 1024*dim floats) and
+	// the level-0 graph slab (initial 1024*m0 u32) grow at least once via growVecMmap.
+	// At these sizes newBytes stays well under slabReserveThreshold, so growth takes
+	// the mmap truncate+remap path (not a reservation) — exactly the Windows code.
+	const n = 1500
+	dir := t.TempDir()
+	cfg := Config{
+		Dim: dim, Metric: Cosine, M: 16, EfConstruction: 100, EfSearch: 64, Seed: 1,
+		Quant: QuantSQ8, QuantStorage: QuantMmap, MmapPath: filepath.Join(dir, "vecs.dat"),
+		RescoreFactor: 3, GraphMmapPath: filepath.Join(dir, "graph.dat"),
+	}
+	h, err := newHNSW(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ids, vecs := siftLikeCorpus(n, dim, 4)
+	for _, v := range vecs { // SQ8 is cosine-scope
+		normalize(v)
+	}
+	// Serial Insert exercises the incremental remap-on-grow path (each insert can
+	// extend both mmap regions), unlike BuildConcurrent's single pre-sizing grow.
+	for i := range vecs {
+		if _, _, err := h.Insert(ids[i], vecs[i], 0, nil, nil, nil, CASCond{}); err != nil {
+			t.Fatalf("insert %d: %v", i, err)
+		}
+	}
+
+	// Both slabs must have grown past their initial reserve — otherwise this test
+	// never engaged growVecMmap and would silently stop covering it.
+	initVec := int64(mmapInitVectors * dim * 4)
+	initGraph := int64(mmapInitVectors * h.m0 * 4)
+	if fi, err := os.Stat(cfg.MmapPath); err != nil {
+		t.Fatalf("stat vec file: %v", err)
+	} else if fi.Size() <= initVec {
+		t.Fatalf("vec file = %d bytes, want > initial reserve %d (no growVecMmap happened)", fi.Size(), initVec)
+	}
+	if fi, err := os.Stat(cfg.GraphMmapPath); err != nil {
+		t.Fatalf("stat graph file: %v", err)
+	} else if fi.Size() <= initGraph {
+		t.Fatalf("graph file = %d bytes, want > initial reserve %d (no growVecMmap happened)", fi.Size(), initGraph)
+	}
+
+	_, queries := siftLikeCorpus(40, dim, 9)
+	for _, q := range queries {
+		normalize(q)
+	}
+	before := make([][]uint64, len(queries))
+	for i, q := range queries {
+		res, err := h.Search(q, k)
+		if err != nil {
+			t.Fatal(err)
+		}
+		before[i] = resultIDs(res)
+	}
+
+	metaPath := filepath.Join(dir, "meta.bin")
+	if err := h.SavePersist(metaPath); err != nil { // sync mmaps + write sidecar
+		t.Fatalf("SavePersist: %v", err)
+	}
+	if err := h.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+
+	// Reopen by MAPPING the same files (no rebuild / no Insert loop).
+	h2, err := openPersist(cfg, metaPath)
+	if err != nil {
+		t.Fatalf("openPersist: %v", err)
+	}
+	defer func() { _ = h2.Close() }()
+
+	if got := h2.arena.Size(); got != n {
+		t.Errorf("reopened size = %d, want %d", got, n)
+	}
+	for _, id := range ids {
+		if _, ok := h2.arena.idMap[id]; !ok {
+			t.Errorf("id %d missing after reopen", id)
+			break
+		}
+	}
+	for i, q := range queries {
+		res, err := h2.Search(q, k)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !eqUint64(resultIDs(res), before[i]) {
+			t.Errorf("query %d: reopened results %v != original %v", i, resultIDs(res), before[i])
+			break
+		}
+	}
+}
+
 // TestPersistConfigMismatch checks OpenPersist rejects a Config whose
 // dim/metric/M/quant differ from the saved index.
 func TestPersistConfigMismatch(t *testing.T) {

--- a/vector/poisoned_test.go
+++ b/vector/poisoned_test.go
@@ -1,0 +1,210 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package vector
+
+import (
+	"bytes"
+	"errors"
+	"testing"
+	"time"
+)
+
+// TestPoisonedIndexRejectsOps proves the terminal-state guard: once a slab
+// growth has failed (which nils the freed mmap region), every public op must
+// reject with ErrIndexPoisoned instead of dereferencing the freed backing.
+//
+// Test seam: the poisoned flag is an unexported atomic.Bool on the arena, so a
+// white-box test in package vector sets it directly (h.arena.poisoned.Store) —
+// the same state the real growVecs/growLevel0 failure branches reach. This
+// proves the GUARD (no op touches the freed region) without having to simulate
+// an ENOSPC on the mmap grow, which is not portably injectable here. The Windows
+// mmap path that produces the real failure is exercised by the windows/amd64 CI
+// lane; this test locks down the platform-agnostic rejection contract on Linux.
+func TestPoisonedIndexRejectsOps(t *testing.T) {
+	cfg := Config{Dim: 4, Metric: L2, M: 16, EfConstruction: 100, EfSearch: 32, Seed: 1}
+	h, err := newHNSW(cfg)
+	if err != nil {
+		t.Fatalf("newHNSW: %v", err)
+	}
+
+	// Seed one live point so the ops have real work they would otherwise do.
+	if _, _, err := h.Insert(1, []float32{1, 0, 0, 0}, 0, nil, nil, nil, CASCond{}); err != nil {
+		t.Fatalf("seed Insert: %v", err)
+	}
+
+	// Drive the index into the terminal state, exactly as a failed mmap grow does.
+	h.arena.poisoned.Store(true)
+
+	t.Run("Search", func(t *testing.T) {
+		defer mustNotPanic(t)
+		if _, err := h.Search([]float32{1, 0, 0, 0}, 5); !errors.Is(err, ErrIndexPoisoned) {
+			t.Fatalf("Search: got %v, want ErrIndexPoisoned", err)
+		}
+	})
+
+	t.Run("Insert", func(t *testing.T) {
+		defer mustNotPanic(t)
+		if _, _, err := h.Insert(2, []float32{0, 1, 0, 0}, 0, nil, nil, nil, CASCond{}); !errors.Is(err, ErrIndexPoisoned) {
+			t.Fatalf("Insert: got %v, want ErrIndexPoisoned", err)
+		}
+	})
+
+	t.Run("InsertAt", func(t *testing.T) {
+		defer mustNotPanic(t)
+		if _, _, err := h.InsertAt(3, []float32{0, 0, 1, 0}, 0, nil, nil, nil, CASCond{}, time.Now().UnixMilli()); !errors.Is(err, ErrIndexPoisoned) {
+			t.Fatalf("InsertAt: got %v, want ErrIndexPoisoned", err)
+		}
+	})
+
+	t.Run("SavePersist", func(t *testing.T) {
+		defer mustNotPanic(t)
+		if err := h.SavePersist(t.TempDir() + "/meta"); !errors.Is(err, ErrIndexPoisoned) {
+			t.Fatalf("SavePersist: got %v, want ErrIndexPoisoned", err)
+		}
+	})
+
+	t.Run("Snapshot", func(t *testing.T) {
+		defer mustNotPanic(t)
+		var buf bytes.Buffer
+		err := h.Snapshot(&buf)
+		if !errors.Is(err, ErrIndexPoisoned) {
+			t.Fatalf("Snapshot: got %v, want ErrIndexPoisoned", err)
+		}
+		// The refusal must happen BEFORE any bytes are written — no silently
+		// truncated checkpoint (Capacity()/vecs are 0 after the poison).
+		if buf.Len() != 0 {
+			t.Fatalf("Snapshot wrote %d bytes on a poisoned index; want a clean refusal with no output", buf.Len())
+		}
+	})
+
+	t.Run("Get", func(t *testing.T) {
+		// Get has no error return; the contract here is panic-safety (vecFor returns
+		// nil rather than slicing the freed arena region).
+		defer mustNotPanic(t)
+		_, _, _, _, _, _ = h.Get(1)
+	})
+
+	t.Run("SearchMMR", func(t *testing.T) {
+		defer mustNotPanic(t)
+		if _, err := h.SearchMMR([]float32{1, 0, 0, 0}, 5, MMROpts{}); !errors.Is(err, ErrIndexPoisoned) {
+			t.Fatalf("SearchMMR: got %v, want ErrIndexPoisoned", err)
+		}
+	})
+
+	t.Run("GroupCandidates", func(t *testing.T) {
+		defer mustNotPanic(t)
+		// GroupBy must be non-empty to reach the under-lock guard (an empty GroupBy
+		// short-circuits to ErrEmptyGroupBy before the lock).
+		if _, err := h.GroupCandidates([]float32{1, 0, 0, 0}, GroupOpts{GroupBy: "doc"}); !errors.Is(err, ErrIndexPoisoned) {
+			t.Fatalf("GroupCandidates: got %v, want ErrIndexPoisoned", err)
+		}
+	})
+
+	t.Run("HybridSearch", func(t *testing.T) {
+		defer mustNotPanic(t)
+		if _, err := h.HybridSearch([]float32{1, 0, 0, 0}, SparseVector{}, 5, HybridOpts{}); !errors.Is(err, ErrIndexPoisoned) {
+			t.Fatalf("HybridSearch: got %v, want ErrIndexPoisoned", err)
+		}
+	})
+}
+
+// TestPoisonedIVFRejectsOps is the IVF counterpart of TestPoisonedIndexRejectsOps.
+// The *ivf index type shares the same arena (and thus the same poisoned flag) as
+// *hnsw and is poisoned via the same arena.growVecs mmap-grow failure, so every
+// IVF op must reject or stay panic-safe too. Same white-box seam
+// (ix.arena.poisoned.Store). The index is left untrained (a handful of inserts):
+// the guards sit above the trained/untrained branch, so training is irrelevant to
+// what is under test.
+func TestPoisonedIVFRejectsOps(t *testing.T) {
+	ix, err := newIVF(ivfTestConfig(4))
+	if err != nil {
+		t.Fatalf("newIVF: %v", err)
+	}
+	seed := [][]float32{{1, 0, 0, 0}, {0, 1, 0, 0}, {0, 0, 1, 0}}
+	for i, v := range seed {
+		if _, _, err := ix.Insert(uint64(i+1), v, 0, nil, nil, nil, CASCond{}); err != nil {
+			t.Fatalf("seed Insert %d: %v", i, err)
+		}
+	}
+
+	ix.arena.poisoned.Store(true)
+
+	q := []float32{1, 0, 0, 0}
+
+	t.Run("Snapshot", func(t *testing.T) {
+		defer mustNotPanic(t)
+		var buf bytes.Buffer
+		if err := ix.Snapshot(&buf); !errors.Is(err, ErrIndexPoisoned) {
+			t.Fatalf("Snapshot: got %v, want ErrIndexPoisoned", err)
+		}
+		if buf.Len() != 0 {
+			t.Fatalf("Snapshot wrote %d bytes on a poisoned index; want a clean refusal with no output", buf.Len())
+		}
+	})
+
+	t.Run("SavePersist", func(t *testing.T) {
+		defer mustNotPanic(t)
+		if err := ix.SavePersist(t.TempDir() + "/meta"); !errors.Is(err, ErrIndexPoisoned) {
+			t.Fatalf("SavePersist: got %v, want ErrIndexPoisoned", err)
+		}
+	})
+
+	t.Run("Search", func(t *testing.T) {
+		defer mustNotPanic(t)
+		if _, err := ix.Search(q, 5); !errors.Is(err, ErrIndexPoisoned) {
+			t.Fatalf("Search: got %v, want ErrIndexPoisoned", err)
+		}
+	})
+
+	t.Run("SearchMMR", func(t *testing.T) {
+		defer mustNotPanic(t)
+		if _, err := ix.SearchMMR(q, 5, MMROpts{}); !errors.Is(err, ErrIndexPoisoned) {
+			t.Fatalf("SearchMMR: got %v, want ErrIndexPoisoned", err)
+		}
+	})
+
+	t.Run("GroupCandidates", func(t *testing.T) {
+		defer mustNotPanic(t)
+		if _, err := ix.GroupCandidates(q, GroupOpts{GroupBy: "doc"}); !errors.Is(err, ErrIndexPoisoned) {
+			t.Fatalf("GroupCandidates: got %v, want ErrIndexPoisoned", err)
+		}
+	})
+
+	t.Run("HybridSearch", func(t *testing.T) {
+		defer mustNotPanic(t)
+		if _, err := ix.HybridSearch(q, SparseVector{}, 5, HybridOpts{}); !errors.Is(err, ErrIndexPoisoned) {
+			t.Fatalf("HybridSearch: got %v, want ErrIndexPoisoned", err)
+		}
+	})
+
+	t.Run("Recommend", func(t *testing.T) {
+		// Reaches the guard right after RLock, before meanOf dereferences the freed
+		// arena floats element-wise.
+		defer mustNotPanic(t)
+		if _, err := ix.Recommend(5, RecommendOpts{Positive: []uint64{1}}); !errors.Is(err, ErrIndexPoisoned) {
+			t.Fatalf("Recommend: got %v, want ErrIndexPoisoned", err)
+		}
+	})
+
+	t.Run("DiscoverVecs", func(t *testing.T) {
+		defer mustNotPanic(t)
+		opts := DiscoverVecsOpts{Context: []DiscoverPair{{Pos: q, Neg: []float32{0, 1, 0, 0}}}}
+		if _, err := ix.DiscoverVecs(5, opts); !errors.Is(err, ErrIndexPoisoned) {
+			t.Fatalf("DiscoverVecs: got %v, want ErrIndexPoisoned", err)
+		}
+	})
+
+	t.Run("Get", func(t *testing.T) {
+		// No error return; the contract is panic-safety (vecFor returns nil rather
+		// than slicing the freed arena region).
+		defer mustNotPanic(t)
+		_, _, _, _, _, _ = ix.Get(1)
+	})
+}
+
+func mustNotPanic(t *testing.T) {
+	t.Helper()
+	if r := recover(); r != nil {
+		t.Fatalf("op panicked on poisoned index instead of returning ErrIndexPoisoned: %v", r)
+	}
+}

--- a/vector/reserve.go
+++ b/vector/reserve.go
@@ -92,8 +92,10 @@ import (
 // heap-backed configuration too.
 //
 // FALLBACK, EVERYWHERE. A reservation is an optimization, never a requirement.
-// Non-Linux builds have no newSlabReservation (mmap-backed storage is already
-// Linux-only — see mmap_other.go), a reservation that cannot be made is simply
+// Only 64-bit Linux has newSlabReservation — Windows maps files too but keeps
+// the copy/remap growth path (see mmap_windows.go), and the platforms in
+// mmap_other.go have no mmap storage at all — a reservation that cannot be made
+// is simply
 // not made, and a reservation that runs out of reserved range relocates once to
 // a bigger one — paying the old copy/remap exactly there. Every one of those
 // paths lands back on the pre-existing grow code, so behavior is identical and

--- a/vector/reserve_linux.go
+++ b/vector/reserve_linux.go
@@ -188,17 +188,3 @@ func (r *slabReservation) release() error {
 	}
 	return nil
 }
-
-// unmapVecMmap releases a mapping made by openVecMmap/growVecMmap WITHOUT
-// closing the file — used when a slab migrates from the legacy whole-file
-// mapping onto a reservation, where the file stays but its old mapping must go.
-func unmapVecMmap(region []byte) error {
-	if len(region) == 0 {
-		return nil
-	}
-	_ = unix.Msync(region, unix.MS_SYNC)
-	if err := unix.Munmap(region); err != nil {
-		return fmt.Errorf("vector: munmap (migrate): %w", err)
-	}
-	return nil
-}

--- a/vector/reserve_other.go
+++ b/vector/reserve_other.go
@@ -9,9 +9,10 @@ import "os"
 // not available: every non-Linux target, plus 32-bit Linux, where the scheme's
 // free-address-space premise does not hold (see reserve_linux.go's build tag).
 // Every slab keeps the copy/remap growth path it had before — reserve.go's point
-// is that a reservation is an optimization, never a requirement. On non-Linux
-// this only affects heap-backed slabs (mmap storage is Linux-only, per
-// mmap_other.go); on 32-bit Linux it affects both, and both stay correct.
+// is that a reservation is an optimization, never a requirement. Where mmap
+// storage is unavailable (mmap_other.go) this only affects heap-backed slabs;
+// on Windows and 32-bit Linux, which do have mmap storage, it affects both, and
+// both stay correct.
 type slabReservation struct{}
 
 // slabReservationsSupported is false here, so tests that only mean something with
@@ -31,5 +32,3 @@ func (r *slabReservation) region() []byte { return nil }
 func (r *slabReservation) sync() error { return nil }
 
 func (r *slabReservation) release() error { return nil }
-
-func unmapVecMmap(_ []byte) error { return nil }

--- a/vector/snapshot.go
+++ b/vector/snapshot.go
@@ -443,6 +443,15 @@ func (h *hnsw) Snapshot(w io.Writer) error {
 	defer h.linkMu.Unlock()
 	h.mu.RLock()
 	defer h.mu.RUnlock()
+	// A failed mmap slab growth freed the backing region; refuse to serialize
+	// rather than emit a silently truncated snapshot (Capacity()/vecs are 0 after
+	// the poison). This is called from the raft FSM snapshot and backup paths,
+	// both in goroutines with no panic recovery, so a broken checkpoint here would
+	// otherwise be produced silently. Checked under h.mu (closes the TOCTOU with a
+	// concurrent grow) — see arena.poisoned / ErrIndexPoisoned.
+	if h.arena.poisoned.Load() {
+		return ErrIndexPoisoned
+	}
 	return h.writeSnapshot(w)
 }
 


### PR DESCRIPTION
## What this fixes

On Windows, nothing that touches disk starts:

```
$ rostam-server mcp
ERROR mcp: setup failed err="rostam: cache.New: cache: cache.Config: DataDir set
but mmap not supported on windows; use DataDir=\"\""
```

`-data ""` (heap, no persistence) is the only mode that runs today, which for the
MCP memory server means the memory is gone at the end of every session — the one
thing it exists to prevent.

The cause is that Windows has no file-mapping implementation at all. `cache/mmap_other.go`
and `vector/mmap_other.go` are stubs that return an error, and `cache/config.go` guards
on `runtime.GOOS != "linux"` to fail early rather than let them be called. Windows has
the same primitive under a different name, so this wires it up.

## What changed

**`cache/mmap_windows.go`** — `CreateFileMapping` + `MapViewOfFile`, released with
`UnmapViewOfFile`. The section handle is closed as soon as the view exists (a view
holds its own reference), so the `(*os.File, []byte)` pair the package already passes
around stays sufficient to release everything and no third value has to reach every
caller.

**`vector/mmap_windows.go`** — the same for the vector slabs and the graph.
`growVecMmap` keeps Linux's unmap → truncate → remap order, which Windows additionally
*requires*: it refuses to resize a file that still has a view mapped
(`ERROR_USER_MAPPED_FILE`).

**`msync` / `syncVecMmap` now take the file.** `FlushViewOfFile` alone only hands the
dirty pages to the filesystem — that is `MS_ASYNC`, not the `MS_SYNC` these call sites
assume — and `FlushFileBuffers` is the other half. Without it `-durable` would claim a
guarantee Windows was never asked for, which is exactly what the `DURABILITY WARNING`
lines around those calls exist to catch. Linux ignores the added parameter. This is the
only change to shared code: 7 call sites in `cache`, 3 in `vector`.

**`runtime.GOOS != "linux"` becomes a per-build `mmapSupported` const**, so the guard
and the platform files cannot drift apart, and `TestConfigDataDirCrossPlatform` asserts
against that same const instead of naming Linux.

**`syncDir` returns early where there is no directory fsync.** Windows answers
`ERROR_ACCESS_DENIED` for a directory handle, so every cold compaction was logging a
durability warning about a step that is absent, not failing.

**`unmapVecMmap` moves from `reserve_*.go` to the `mmap_*.go` files.** It releases a
mapping, not a reservation, and its old home is tagged `linux && (amd64 || arm64)` — so
every *other* target that can map files silently got the no-op stub and leaked the
mapping on the migrate path. That is already true for linux/386 today (whose own comment
notes that mmap storage still works there); Windows would have inherited it.

## The one behavioural difference

NTFS does not hand out sparse files. `os.File.Truncate` lands on `SetEndOfFile`, which
commits the clusters immediately, so **a shard file occupies its full configured size on
disk the moment it is created** — a fresh embedded store reserves its whole cache budget
up front (1 GiB by default off Linux, where `systemMemoryBytes` returns 0), where on
Linux the same file starts as a hole and fills in.

This also makes `mmapFileAlloc`'s `allocBytes` a documented no-op rather than a gap: the
`fallocate` it performs on Linux exists because a sparse truncate defers allocation into
a page fault, where a full disk becomes an unrecoverable SIGBUS. On NTFS `ENOSPC` comes
back from the `Truncate` as an ordinary error, before any mapped write, and for the whole
file rather than the staged prefix. The compaction test's own comment argues for exactly
this property ("the published file must be FULLY ALLOCATED — no hole above the pack
frontier"), so Windows gets it for free — and the same test now runs there to check it.

Documented in `README.md`, `docs/quickstart.md` and the changelog.

## Testing

`go1.26.5 windows/amd64`, `CGO_ENABLED=0`, measured against `main` at `51dfcc1` in a
clean worktree on the same machine and toolchain:

| Package | Before | After |
|---|---|---|
| `./cache/...` | **test binary does not compile** — `pb_frontier_test.go` uses `compactTestCfg`, defined in the `linux`-tagged `compact_test.go`, so nothing in this package has ever run on Windows | **ok** — compaction, recovery, warm restart and the mapping round trip all run |
| `./mcp/...` | **46 failures** | **ok** — including `TestMemorySurvivesReopen` and `TestCreateCollectionPersistsAcrossReopen` |
| `./vector/...` | **61 failures** | **15 failures** — the WAL and group-commit ones, a subset of the 61, unrelated to mapping (see below) |

Cross-compile of the whole module still passes for linux/{amd64,386,arm,arm64},
darwin/{amd64,arm64}, windows/{386,amd64} and freebsd/amd64, and `go vet ./...` is clean
for linux/amd64 including test files.

A `test-windows` lane is added because none of the above would be caught otherwise: the
cross-compile matrix builds windows/amd64 but never executes it, so the four cache test
files this branch un-gates would compile in CI and never map a single page. Drop that
commit if you would rather not spend the runner minutes.

**Not run:** the race detector. `-race` on Windows needs cgo and a C toolchain I do not
have here. The change adds no goroutines and no new shared state — `msync` gains a read
of `s.file`, which is written only by `remapPagesFile` during `newShard`, i.e. before
`msyncLoop` exists, and beside the `s.region` read that was already there.

## What this does NOT fix

**`./vector/...` still has 15 failures on Windows** 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added persistent memory-mapped storage support for Windows.
  * Windows-based cache and vector data now persists across restarts.
  * Added durable flushing for Windows storage files.
  * Windows storage files are fully allocated on disk when created.

* **Bug Fixes**
  * Improved cross-platform validation and handling of unsupported persistence configurations.

* **Documentation**
  * Updated setup, development, and changelog documentation with Windows support details.

* **Tests**
  * Added Windows build, persistence, compaction, recovery, and restart coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->