### PR TITLE
fix(wire): reject hostile lengths in 46 decoders that panicked on 32-bit

### DIFF
--- a/ops/hostile_decode_test.go
+++ b/ops/hostile_decode_test.go
@@ -212,6 +212,20 @@ func hostileBodies() [][]byte {
 		}
 		out = append(out, make([]byte, size)) // all zeroes
 	}
+	// Zero-based frames with ONE hostile window swept byte-by-byte. These reach a
+	// length field that sits BEHIND a small/zero preamble (e.g. a second or third
+	// length field). The all-0xFF frames above cannot: a 0xFF preamble makes the
+	// FIRST length huge and the decoder bails before the later field. Stepping by
+	// 1 (not 4) lands on unaligned fields too.
+	for _, size := range []int{12, 16, 24, 32, 48} {
+		for _, p := range patterns {
+			for off := 0; off+4 <= size; off++ {
+				b := make([]byte, size)
+				binary.BigEndian.PutUint32(b[off:], p)
+				out = append(out, b)
+			}
+		}
+	}
 	return out
 }
 

--- a/ops/hostile_decode_test.go
+++ b/ops/hostile_decode_test.go
@@ -3,9 +3,13 @@
 package ops
 
 import (
+	"bytes"
 	"encoding/binary"
+	"errors"
 	"reflect"
 	"testing"
+
+	"github.com/rostamlabs/rostam/sdk/vtypes"
 )
 
 // NO DECODER MAY PANIC ON HOSTILE BYTES.
@@ -280,4 +284,199 @@ func TestHostileBodiesAreActuallyHostile(t *testing.T) {
 		t.Fatal("no hostile body carries a length above MaxInt32 — the sweep is vacuous")
 	}
 	t.Logf("%d length fields above MaxInt32 across %d bodies", overMaxInt32, len(hostileBodies()))
+}
+
+// --- Gated-branch coverage (Finding B) ---------------------------------------
+//
+// hostileBodies above emits zero-padded single-window frames. Those cannot enter
+// decoder branches gated behind nonzero presence/kind/flag bytes: the order
+// block's string-resume tail needs order-present + string-kind + resume-present
+// markers set, and its multi-key tail needs the multi-key flag and a nonzero
+// numTail. A length field living INSIDE such a tail is therefore invisible to
+// the zero-padded sweep — which is exactly how the additive off+sl / off+kl2+1
+// checks in readScrollOrderBlock slipped past it.
+//
+// The seeds below are VALID order frames built with the package's own encoders
+// with the gating bytes set, so the shared readScrollOrderBlock reaches each
+// tail. hostileSeedMutants then drives every embedded length field
+// negative/overflowing while leaving the gating bytes intact, so the branch that
+// reads it stays reachable. Under GOARCH=386 these mutants panic on the
+// pre-fix additive checks and are rejected (ErrVectorArgsTruncated) on the fix.
+
+const (
+	resumeStrMark = "__RESUME_STR_MARK__"
+	tailKeyMark   = "__TAIL_KEY_MARK__"
+	cursorStrMark = "__CURSOR_STR_MARK__"
+)
+
+type scrollOrderSeed struct {
+	name  string
+	frame []byte
+	fn    any
+}
+
+// scrollOrderSeeds returns valid order frames whose order block reaches each
+// control-byte-gated length tail (string-resume, multi-key key, multi-key resume
+// tuple string), paired with the family decoder that must survive every hostile
+// mutant of them. All three families share readScrollOrderBlock, so each is
+// exercised through its own base layout.
+func scrollOrderSeeds() []scrollOrderSeed {
+	filter := vtypes.Filter{}
+	strOrder := &ScrollOrder{Key: "k", Kind: vtypes.OrderString, HasResumeStr: true, ResumeStr: resumeStrMark}
+	mkOrder := &ScrollOrder{Key: "k", Tail: []ScrollOrderKey{{Key: tailKeyMark}}}
+	tupOrder := &ScrollOrder{
+		Key:           "k",
+		Tail:          []ScrollOrderKey{{Key: "t", Kind: vtypes.OrderString}},
+		HasResumeKeys: true,
+		ResumeKeys: []ScrollOrderVal{
+			{Str: "p", Kind: vtypes.OrderString},
+			{Str: cursorStrMark, Kind: vtypes.OrderString},
+		},
+	}
+	var out []scrollOrderSeed
+	for _, o := range []struct {
+		tag   string
+		order *ScrollOrder
+	}{{"strResume", strOrder}, {"multiKey", mkOrder}, {"tupleStr", tupOrder}} {
+		out = append(out,
+			scrollOrderSeed{"Dense/" + o.tag, EncodeScrollArgsOrder("c", filter, 10, 0, 0, 0, false, o.order), DecodeScrollArgsOrder},
+			scrollOrderSeed{"Named/" + o.tag, EncodeNamedScrollArgsOrder("c", filter, 10, 0, false, 0, 0, o.order), DecodeNamedScrollArgsOrder},
+			scrollOrderSeed{"MV/" + o.tag, EncodeMVScrollArgsOrder("c", filter, 10, 0, 0, 0, false, o.order), DecodeMVScrollArgsOrder},
+		)
+	}
+	return out
+}
+
+// hostileSeedMutants overwrites every 4-byte window of seed (stepping by 1 to
+// catch unaligned fields too) with each hostile pattern, leaving the rest of the
+// frame — crucially the gating control bytes — untouched. Every embedded length
+// field is therefore hit while the branch that reads it stays reachable.
+func hostileSeedMutants(seed []byte) [][]byte {
+	patterns := []uint32{0xFFFFFFFF, 0x80000000, 0x7FFFFFFF, 0xFFFFFFFE}
+	var out [][]byte
+	for _, p := range patterns {
+		for off := 0; off+4 <= len(seed); off++ {
+			b := make([]byte, len(seed))
+			copy(b, seed)
+			binary.BigEndian.PutUint32(b[off:], p)
+			out = append(out, b)
+		}
+	}
+	return out
+}
+
+func TestNoScrollOrderDecoderPanicsOnGatedHostileBytes(t *testing.T) {
+	seeds := scrollOrderSeeds()
+	if len(seeds) == 0 {
+		t.Fatal("no scroll-order seeds built")
+	}
+	for _, s := range seeds {
+		fn := reflect.ValueOf(s.fn)
+		if fn.Kind() != reflect.Func || fn.Type().NumIn() != 1 {
+			t.Fatalf("%s: not a single-argument decoder", s.name)
+		}
+		mutants := hostileSeedMutants(s.frame)
+		for i, body := range mutants {
+			func() {
+				defer func() {
+					if r := recover(); r != nil {
+						t.Errorf("%s panicked on gated hostile mutant #%d (len %d): %v\n"+
+							"a control-byte-gated order tail (string-resume / multi-key) length "+
+							"widened negative on 32-bit and slipped past an additive off+n check",
+							s.name, i, len(body), r)
+					}
+				}()
+				arg := make([]byte, len(body))
+				copy(arg, body)
+				fn.Call([]reflect.Value{reflect.ValueOf(arg)})
+			}()
+		}
+	}
+}
+
+// TestScrollOrderSeedMutantsAreHostile guards the gated sweep the way
+// TestHostileBodiesAreActuallyHostile guards the main one: if the mutant
+// generator ever stops emitting length fields above MaxInt32 it would pass
+// vacuously.
+func TestScrollOrderSeedMutantsAreHostile(t *testing.T) {
+	var over int
+	for _, s := range scrollOrderSeeds() {
+		for _, b := range hostileSeedMutants(s.frame) {
+			for off := 0; off+4 <= len(b); off += 4 {
+				if binary.BigEndian.Uint32(b[off:]) > 1<<31-1 {
+					over++
+				}
+			}
+		}
+	}
+	if over == 0 {
+		t.Fatal("no scroll-order seed mutant carries a length field above MaxInt32 — the gated sweep is vacuous")
+	}
+	t.Logf("%d length fields above MaxInt32 across scroll-order seed mutants", over)
+}
+
+// TestScrollOrderStringResumeHostileLenRejected targets the string-resume tail's
+// strLen check (readScrollOrderBlock ~sl). A valid OrderString frame with the
+// resume string present has its strLen driven to 0x7fffffff — the value that
+// stays positive past the sl<0 guard and overflows off+sl on 32-bit. The decode
+// must REJECT it, never panic, on 386 and native alike.
+func TestScrollOrderStringResumeHostileLenRejected(t *testing.T) {
+	order := &ScrollOrder{Key: "k", Kind: vtypes.OrderString, HasResumeStr: true, ResumeStr: resumeStrMark}
+	frame := EncodeScrollArgsOrder("c", vtypes.Filter{}, 10, 0, 0, 0, false, order)
+	mi := bytes.Index(frame, []byte(resumeStrMark))
+	if mi < 4 {
+		t.Fatalf("resume-str marker not found at a decodable offset (%d)", mi)
+	}
+	binary.BigEndian.PutUint32(frame[mi-4:], 0x7fffffff) // strLen field precedes the marker bytes
+	_, _, _, _, _, _, _, _, err := DecodeScrollArgsOrder(frame)
+	if !errors.Is(err, ErrVectorArgsTruncated) {
+		t.Fatalf("string-resume sl=0x7fffffff: got err=%v, want ErrVectorArgsTruncated", err)
+	}
+}
+
+// TestScrollOrderMultiKeyHostileLenRejected targets the multi-key tail's per-key
+// keyLen check (readScrollOrderBlock ~kl2, the off+kl2+1 additive form). A valid
+// multi-key frame with one tail key has that key's keyLen driven to 0x7fffffff.
+// The decode must REJECT it, never panic, on 386 and native alike.
+func TestScrollOrderMultiKeyHostileLenRejected(t *testing.T) {
+	order := &ScrollOrder{Key: "k", Tail: []ScrollOrderKey{{Key: tailKeyMark}}}
+	frame := EncodeScrollArgsOrder("c", vtypes.Filter{}, 10, 0, 0, 0, false, order)
+	mi := bytes.Index(frame, []byte(tailKeyMark))
+	if mi < 4 {
+		t.Fatalf("tail-key marker not found at a decodable offset (%d)", mi)
+	}
+	binary.BigEndian.PutUint32(frame[mi-4:], 0x7fffffff) // keyLen field precedes the marker bytes
+	_, _, _, _, _, _, _, _, err := DecodeScrollArgsOrder(frame)
+	if !errors.Is(err, ErrVectorArgsTruncated) {
+		t.Fatalf("multi-key kl2=0x7fffffff: got err=%v, want ErrVectorArgsTruncated", err)
+	}
+}
+
+// TestResultDecoderDimOverflowRejected covers the inner per-element `dim` length
+// in three result decoders (DecodeMatrix / DecodeScanVectorsResult /
+// DecodeNamedGetResultAt), whose `len < off+4*dim` checks were multiplicative,
+// not the additive `off+n` form the main sweep and the scroll-order seeds target.
+// On 386 a hostile dim = 0x40000000 makes 4*dim widen to 0, slip the old check,
+// and panic make([]float32, dim). These frames set a VALID outer count so decode
+// reaches the inner dim — the zero-padded sweep rejects at the outer count and
+// never gets here. Post-fix (CountFitsIn divide-form) each must reject, not panic.
+func TestResultDecoderDimOverflowRejected(t *testing.T) {
+	// DecodeMatrix: [rows=1][dim=0x40000000]
+	if _, _, err := DecodeMatrix([]byte{0, 0, 0, 1, 0x40, 0, 0, 0}); err == nil {
+		t.Error("DecodeMatrix: hostile dim accepted, want error (must not panic on 386)")
+	}
+	// DecodeScanVectorsResult: [count=1][id:8][dim=0x40000000][pad:12]. len 28 so
+	// the OLD `< off+4*dim+8+4` (== `< 28` when 4*dim overflows to 0) passes and
+	// reaches make(); the fix rejects via CountFitsIn.
+	scan := make([]byte, 28)
+	scan[3] = 1     // count = 1 (body[0:4] big-endian)
+	scan[12] = 0x40 // dim = 0x40000000 (body[12:16] big-endian, MSB)
+	if _, err := DecodeScanVectorsResult(scan); err == nil {
+		t.Error("DecodeScanVectorsResult: hostile dim accepted, want error (must not panic on 386)")
+	}
+	// DecodeNamedGetResultAt: [found=1][numSpaces=1][nameLen=0][dim=0x40000000]
+	named := []byte{1, 0, 0, 0, 1, 0, 0, 0x40, 0, 0, 0}
+	if _, _, _, _, _, _, err := DecodeNamedGetResultAt(named, 0); err == nil {
+		t.Error("DecodeNamedGetResultAt: hostile dim accepted, want error (must not panic on 386)")
+	}
 }

--- a/ops/write_consistency.go
+++ b/ops/write_consistency.go
@@ -88,8 +88,10 @@ func DecodeWCEnvelope(args []byte) (wcf, wait uint8, innerName string, innerArgs
 	argsLen := int(binary.BigEndian.Uint32(args[off : off+4]))
 	off += 4
 	// [args...] — argsLen is safe on 64-bit (uint32 fits in int); the < 0 check
-	// guards hypothetical 32-bit builds where int(0xffffffff) wraps negative.
-	if argsLen < 0 || off+argsLen > len(args) {
+	// guards 32-bit builds where int(0xffffffff) wraps negative. The comparison is
+	// written as argsLen > len(args)-off (never off+argsLen) so a positive argsLen
+	// near MaxInt32 cannot overflow off+argsLen back into range on 32-bit.
+	if argsLen < 0 || argsLen > len(args)-off {
 		return 0, 0, "", nil, errWCEnvelopeTruncated
 	}
 	innerArgs = args[off : off+argsLen]

--- a/sdk/wire/multivector.go
+++ b/sdk/wire/multivector.go
@@ -47,7 +47,9 @@ func DecodeMatrix(b []byte) ([][]float32, int, error) {
 		}
 		dim := int(binary.BigEndian.Uint32(b[off:]))
 		off += 4
-		if len(b) < off+4*dim {
+		// Divide-form: a hostile dim near MaxInt32 overflows 4*dim on 386 and
+		// slips len(b) < off+4*dim, then make([]float32, dim) panics.
+		if !CountFitsIn(dim, len(b)-off, 4) {
 			return nil, 0, ErrVectorArgsTruncated
 		}
 		row := make([]float32, dim)
@@ -893,7 +895,7 @@ func DecodeMVSearchArgsOptsFilter(args []byte) (name string, query [][]float32, 
 		}
 		flen := int(binary.BigEndian.Uint32(args[off:]))
 		off += 4
-		if len(args) < off+flen {
+		if flen < 0 || len(args)-off < flen {
 			return "", nil, 0, 0, 0, 0, vtypes.Filter{}, 0, ErrVectorArgsTruncated
 		}
 		if uerr := json.Unmarshal(args[off:off+flen], &filter); uerr != nil {
@@ -1367,7 +1369,7 @@ func decodeMVResultsN(body []byte) ([]vtypes.MultiResult, int, error) {
 		off += 4
 		mlen := int(binary.BigEndian.Uint32(body[off:]))
 		off += 4
-		if len(body) < off+mlen {
+		if mlen < 0 || len(body)-off < mlen {
 			return nil, 0, ErrVectorArgsTruncated
 		}
 		if mlen > 0 {
@@ -1698,7 +1700,7 @@ func DecodeMVScanResult(body []byte) ([]vtypes.MultiScanRecord, error) {
 		}
 		mlen := int(binary.BigEndian.Uint32(body[off:]))
 		off += 4
-		if len(body) < off+mlen {
+		if mlen < 0 || len(body)-off < mlen {
 			return nil, ErrVectorArgsTruncated
 		}
 		if mlen > 0 {
@@ -1748,7 +1750,7 @@ func DecodeMVScanResult(body []byte) ([]vtypes.MultiScanRecord, error) {
 					}
 					klen := int(binary.BigEndian.Uint32(body[off:]))
 					off += 4
-					if len(body) < off+klen+8 {
+					if klen < 0 || klen > len(body)-off-8 {
 						return nil, ErrVectorArgsTruncated
 					}
 					key := string(body[off : off+klen])
@@ -1962,7 +1964,7 @@ func DecodeMVGetResultAt(body []byte, off int) (found bool, tokens [][]float32, 
 		}
 		mlen := int(binary.BigEndian.Uint32(body[off:]))
 		off += 4
-		if len(body) < off+mlen {
+		if mlen < 0 || len(body)-off < mlen {
 			return false, nil, nil, 0, off, ErrVectorArgsTruncated
 		}
 		m := make(vtypes.Metadata)

--- a/sdk/wire/multivector.go
+++ b/sdk/wire/multivector.go
@@ -381,7 +381,7 @@ func decodeMVAddArgsN(args []byte) (name string, docID uint64, tokens [][]float3
 	}
 	mlen := int(binary.BigEndian.Uint32(args[off:]))
 	off += 4
-	if len(args) < off+mlen {
+	if mlen < 0 || len(args)-off < mlen {
 		return "", 0, nil, nil, 0, ErrVectorArgsTruncated
 	}
 	if mlen > 0 {
@@ -680,7 +680,7 @@ func DecodeMVAddArgsVersionedKeyExpiresSparse(args []byte) (name string, docID u
 			}
 			kl := int(binary.BigEndian.Uint32(args[off:]))
 			off += 4
-			if len(args) < off+kl+8 {
+			if kl < 0 || kl > len(args)-off-8 {
 				return "", 0, nil, nil, 0, nil, nil, ErrVectorArgsTruncated
 			}
 			key := string(args[off : off+kl])
@@ -1023,7 +1023,7 @@ func DecodeMVHybridArgs(args []byte) (name string, query [][]float32, sparseQ vt
 		}
 		flen := int(binary.BigEndian.Uint32(args[off:]))
 		off += 4
-		if len(args) < off+flen {
+		if flen < 0 || len(args)-off < flen {
 			return "", nil, vtypes.SparseVector{}, 0, opts, 0, 0, 0, ErrVectorArgsTruncated
 		}
 		if uerr := json.Unmarshal(args[off:off+flen], &opts.Filter); uerr != nil {
@@ -1299,7 +1299,7 @@ func decodeMVScrollArgsN(args []byte) (col string, filter vtypes.Filter, limit i
 	off += 4
 	flen := int(binary.BigEndian.Uint32(args[off:]))
 	off += 4
-	if len(args) < off+flen {
+	if flen < 0 || len(args)-off < flen {
 		return "", vtypes.Filter{}, 0, 0, ErrVectorArgsTruncated
 	}
 	if flen > 0 {

--- a/sdk/wire/named.go
+++ b/sdk/wire/named.go
@@ -50,7 +50,7 @@ func DecodeNamedCreateArgs(args []byte) (string, map[string]vtypes.NamedVectorPa
 	off := 1 + colLen
 	cfgLen := int(binary.BigEndian.Uint32(args[off:]))
 	off += 4
-	if len(args) < off+cfgLen {
+	if cfgLen < 0 || len(args)-off < cfgLen {
 		return "", nil, 0, ErrVectorArgsTruncated
 	}
 	var cfg map[string]vtypes.NamedVectorParams
@@ -226,6 +226,12 @@ func decodeNamedInsertArgsN(args []byte) (col string, id uint64, vectors map[str
 	off += 8
 	numVecs := int(binary.BigEndian.Uint32(args[off:]))
 	off += 4
+	// An entry costs >= 6 bytes ([nameLen:u16] with an empty name + [dim:u32]); the
+	// divide-form bound rejects a widened-negative or absurd numVecs before the make
+	// hint (4*dim below cannot overflow because dim is bounded the same way).
+	if !CountFitsIn(numVecs, len(args)-off, 6) {
+		return "", 0, nil, nil, 0, 0, ErrVectorArgsTruncated
+	}
 	if numVecs > 0 {
 		vectors = make(map[string][]float32, numVecs)
 	}
@@ -242,7 +248,7 @@ func decodeNamedInsertArgsN(args []byte) (col string, id uint64, vectors map[str
 		off += nameLen
 		dim := int(binary.BigEndian.Uint32(args[off:]))
 		off += 4
-		if len(args) < off+4*dim {
+		if !CountFitsIn(dim, len(args)-off, 4) {
 			return "", 0, nil, nil, 0, 0, ErrVectorArgsTruncated
 		}
 		vec := make([]float32, dim)
@@ -260,7 +266,7 @@ func decodeNamedInsertArgsN(args []byte) (col string, id uint64, vectors map[str
 	ttl = time.Duration(ttlMs) * time.Millisecond //nolint:gosec
 	mlen := int(binary.BigEndian.Uint32(args[off:]))
 	off += 4
-	if len(args) < off+mlen {
+	if mlen < 0 || len(args)-off < mlen {
 		return "", 0, nil, nil, 0, 0, ErrVectorArgsTruncated
 	}
 	if mlen > 0 {
@@ -447,7 +453,7 @@ func decodeNamedSearchArgsN(args []byte) (col, vecName string, query []float32, 
 	off += 4
 	dim := int(binary.BigEndian.Uint32(args[off:]))
 	off += 4
-	if len(args) < off+4*dim+4 {
+	if !CountFitsIn(dim, len(args)-off, 4) {
 		return "", "", nil, 0, 0, vtypes.Filter{}, ErrVectorArgsTruncated
 	}
 	query = make([]float32, dim)
@@ -455,9 +461,12 @@ func decodeNamedSearchArgsN(args []byte) (col, vecName string, query []float32, 
 		query[j] = math.Float32frombits(binary.BigEndian.Uint32(args[off:]))
 		off += 4
 	}
+	if len(args) < off+4 {
+		return "", "", nil, 0, 0, vtypes.Filter{}, ErrVectorArgsTruncated
+	}
 	flen := int(binary.BigEndian.Uint32(args[off:]))
 	off += 4
-	if len(args) < off+flen {
+	if flen < 0 || len(args)-off < flen {
 		return "", "", nil, 0, 0, vtypes.Filter{}, ErrVectorArgsTruncated
 	}
 	if flen > 0 {
@@ -624,7 +633,7 @@ func decodeNamedSparseSearchArgsN(args []byte) (col, space string, query vtypes.
 	}
 	flen := int(binary.BigEndian.Uint32(args[off:]))
 	off += 4
-	if len(args) < off+flen {
+	if flen < 0 || len(args)-off < flen {
 		return "", "", vtypes.SparseVector{}, 0, 0, vtypes.Filter{}, ErrVectorArgsTruncated
 	}
 	if flen > 0 {
@@ -827,7 +836,7 @@ func DecodeNamedHybridArgs(args []byte) (col, denseSpace string, denseQ []float3
 	off += 4
 	dim := int(binary.BigEndian.Uint32(args[off:]))
 	off += 4
-	if len(args) < off+4*dim {
+	if !CountFitsIn(dim, len(args)-off, 4) {
 		return "", "", nil, "", sparseQ, 0, opts, 0, 0, 0, ErrVectorArgsTruncated
 	}
 	if dim > 0 {
@@ -847,7 +856,7 @@ func DecodeNamedHybridArgs(args []byte) (col, denseSpace string, denseQ []float3
 		}
 		flen := int(binary.BigEndian.Uint32(args[off:]))
 		off += 4
-		if len(args) < off+flen {
+		if flen < 0 || len(args)-off < flen {
 			return "", "", nil, "", vtypes.SparseVector{}, 0, opts, 0, 0, 0, ErrVectorArgsTruncated
 		}
 		if uerr := json.Unmarshal(args[off:off+flen], &opts.Filter); uerr != nil {
@@ -972,7 +981,7 @@ func decodeNamedScrollArgsN(args []byte) (col string, filter vtypes.Filter, limi
 	off += 4
 	flen := int(binary.BigEndian.Uint32(args[off:]))
 	off += 4
-	if len(args) < off+flen {
+	if flen < 0 || len(args)-off < flen {
 		return "", vtypes.Filter{}, 0, 0, ErrVectorArgsTruncated
 	}
 	if flen > 0 {

--- a/sdk/wire/named.go
+++ b/sdk/wire/named.go
@@ -185,7 +185,7 @@ func readNamedSparseBlock(args []byte, off int) (sparseVectors map[string]*vtype
 		}
 		nameLen := int(binary.BigEndian.Uint16(args[off:]))
 		off += 2
-		if len(args) < off+nameLen {
+		if nameLen < 0 || len(args)-off < nameLen {
 			return nil, off, false, ErrVectorArgsTruncated
 		}
 		name := string(args[off : off+nameLen])
@@ -241,7 +241,7 @@ func decodeNamedInsertArgsN(args []byte) (col string, id uint64, vectors map[str
 		}
 		nameLen := int(binary.BigEndian.Uint16(args[off:]))
 		off += 2
-		if len(args) < off+nameLen+4 {
+		if nameLen < 0 || nameLen > len(args)-off-4 {
 			return "", 0, nil, nil, 0, 0, ErrVectorArgsTruncated
 		}
 		name := string(args[off : off+nameLen])
@@ -444,7 +444,7 @@ func decodeNamedSearchArgsN(args []byte) (col, vecName string, query []float32, 
 	off := 1 + colLen
 	nameLen := int(binary.BigEndian.Uint16(args[off:]))
 	off += 2
-	if len(args) < off+nameLen+4+4 {
+	if nameLen < 0 || nameLen > len(args)-off-4-4 {
 		return "", "", nil, 0, 0, vtypes.Filter{}, ErrVectorArgsTruncated
 	}
 	vecName = string(args[off : off+nameLen])
@@ -617,7 +617,7 @@ func decodeNamedSparseSearchArgsN(args []byte) (col, space string, query vtypes.
 	off := 1 + colLen
 	nameLen := int(binary.BigEndian.Uint16(args[off:]))
 	off += 2
-	if len(args) < off+nameLen+4 {
+	if nameLen < 0 || nameLen > len(args)-off-4 {
 		return "", "", vtypes.SparseVector{}, 0, 0, vtypes.Filter{}, ErrVectorArgsTruncated
 	}
 	space = string(args[off : off+nameLen])
@@ -810,14 +810,14 @@ func DecodeNamedHybridArgs(args []byte) (col, denseSpace string, denseQ []float3
 	off += colLen
 	dsLen := int(binary.BigEndian.Uint16(args[off:]))
 	off += 2
-	if len(args) < off+dsLen+2 {
+	if dsLen < 0 || dsLen > len(args)-off-2 {
 		return "", "", nil, "", sparseQ, 0, opts, 0, 0, 0, ErrVectorArgsTruncated
 	}
 	denseSpace = string(args[off : off+dsLen])
 	off += dsLen
 	ssLen := int(binary.BigEndian.Uint16(args[off:]))
 	off += 2
-	if len(args) < off+ssLen+4+(1+8+4+4+4)+4 {
+	if ssLen < 0 || ssLen > len(args)-off-4-(1+8+4+4+4)-4 {
 		return "", "", nil, "", sparseQ, 0, opts, 0, 0, 0, ErrVectorArgsTruncated
 	}
 	sparseSpace = string(args[off : off+ssLen])
@@ -1454,14 +1454,16 @@ func DecodeNamedGetResultAt(body []byte, off int) (found bool, vectors map[strin
 		}
 		nameLen := int(binary.BigEndian.Uint16(body[off:]))
 		off += 2
-		if len(body) < off+nameLen+4 {
+		if nameLen < 0 || nameLen > len(body)-off-4 {
 			return false, nil, nil, 0, 0, off, ErrVectorArgsTruncated
 		}
 		name := string(body[off : off+nameLen])
 		off += nameLen
 		dim := int(binary.BigEndian.Uint32(body[off:]))
 		off += 4
-		if len(body) < off+4*dim {
+		// Divide-form: a hostile dim near MaxInt32 overflows 4*dim on 386 and
+		// slips len(body) < off+4*dim, then make([]float32, dim) panics.
+		if !CountFitsIn(dim, len(body)-off, 4) {
 			return false, nil, nil, 0, 0, off, ErrVectorArgsTruncated
 		}
 		vec := make([]float32, dim)
@@ -1484,7 +1486,7 @@ func DecodeNamedGetResultAt(body []byte, off int) (found bool, vectors map[strin
 		}
 		mlen := int(binary.BigEndian.Uint32(body[off:]))
 		off += 4
-		if len(body) < off+mlen {
+		if mlen < 0 || len(body)-off < mlen {
 			return false, nil, nil, 0, 0, off, ErrVectorArgsTruncated
 		}
 		m := make(vtypes.Metadata)

--- a/sdk/wire/query.go
+++ b/sdk/wire/query.go
@@ -1007,7 +1007,7 @@ func DecodeQueryResultGroupedFanOut(body []byte) (vtypes.QueryResult, map[uint64
 		off += 8
 		kl := int(binary.BigEndian.Uint32(body[off:]))
 		off += 4
-		if len(body) < off+kl {
+		if kl < 0 || len(body)-off < kl {
 			return vtypes.QueryResult{}, nil, ErrVectorArgsTruncated
 		}
 		var v vtypes.Value

--- a/sdk/wire/query.go
+++ b/sdk/wire/query.go
@@ -75,7 +75,7 @@ func DecodeQueryArgs(args []byte) (collection string, specBytes []byte, readCons
 	off := 1 + colLen
 	specLen := int(binary.BigEndian.Uint32(args[off:]))
 	off += 4
-	if len(args) < off+specLen {
+	if specLen < 0 || len(args)-off < specLen {
 		return "", nil, 0, 0, 0, ErrVectorArgsTruncated
 	}
 	specBytes = args[off : off+specLen]

--- a/sdk/wire/text.go
+++ b/sdk/wire/text.go
@@ -429,7 +429,7 @@ func decodeHybridTextArgsN(args []byte) (collection string, dense []float32, que
 	}
 	qLen := int(binary.BigEndian.Uint32(args[off:]))
 	off += 4
-	if len(args) < off+qLen {
+	if qLen < 0 || len(args)-off < qLen {
 		return "", nil, "", 0, opts, 0, ErrVectorArgsTruncated
 	}
 	query = string(args[off : off+qLen])
@@ -440,7 +440,7 @@ func decodeHybridTextArgsN(args []byte) (collection string, dense []float32, que
 		}
 		flen := int(binary.BigEndian.Uint32(args[off:]))
 		off += 4
-		if len(args) < off+flen {
+		if flen < 0 || len(args)-off < flen {
 			return "", nil, "", 0, opts, 0, ErrVectorArgsTruncated
 		}
 		if uerr := json.Unmarshal(args[off:off+flen], &opts.Filter); uerr != nil {
@@ -537,7 +537,7 @@ func decodeBM25StatsArgsN(args []byte) (collection string, query string, n int, 
 	off := 1 + colLen
 	qLen := int(binary.BigEndian.Uint32(args[off:]))
 	off += 4
-	if len(args) < off+qLen {
+	if qLen < 0 || len(args)-off < qLen {
 		return "", "", 0, ErrVectorArgsTruncated
 	}
 	query = string(args[off : off+qLen])

--- a/sdk/wire/text.go
+++ b/sdk/wire/text.go
@@ -249,7 +249,7 @@ func decodeSearchTextArgsN(args []byte) (collection string, query string, k int,
 		}
 		flen := int(binary.BigEndian.Uint32(args[off:]))
 		off += 4
-		if len(args) < off+flen {
+		if flen < 0 || len(args)-off < flen {
 			return "", "", 0, filter, 0, ErrVectorArgsTruncated
 		}
 		if uerr := json.Unmarshal(args[off:off+flen], &filter); uerr != nil {

--- a/sdk/wire/vector.go
+++ b/sdk/wire/vector.go
@@ -157,7 +157,9 @@ func readSparse(args []byte, off int) (vtypes.SparseVector, int, error) {
 	}
 	nnz := int(binary.BigEndian.Uint32(args[off:]))
 	off += 4
-	if len(args) < off+8*nnz {
+	// Each term costs 8 bytes ([dim:u32][value:f32]); the divide-form bound rejects a
+	// widened-negative or absurd nnz before the makes (8*nnz cannot overflow here).
+	if !CountFitsIn(nnz, len(args)-off, 8) {
 		return vtypes.SparseVector{}, off, ErrVectorArgsTruncated
 	}
 	sv := vtypes.SparseVector{
@@ -2548,9 +2550,10 @@ func readScrollTail(body []byte, off int) (degraded bool, missing []uint16, next
 	if clen == 0 {
 		return degraded, missing, "", nil
 	}
-	if len(body) < off+clen {
+	if clen < 0 || len(body)-off < clen {
 		// Truncated cursor — tolerate as empty (defensive; a well-formed new body
-		// never hits this).
+		// never hits this). The check is written as len(body)-off (never off+clen)
+		// so a widened-negative or near-MaxInt32 clen cannot overflow past it.
 		return degraded, missing, "", nil
 	}
 	return degraded, missing, string(body[off : off+clen]), nil
@@ -2886,7 +2889,7 @@ func decodeScrollArgsN(args []byte) (collection string, filter vtypes.Filter, li
 	off += 4
 	flen := int(binary.BigEndian.Uint32(args[off:]))
 	off += 4
-	if len(args) < off+flen {
+	if flen < 0 || len(args)-off < flen {
 		return "", vtypes.Filter{}, 0, 0, ErrVectorArgsTruncated
 	}
 	if flen > 0 {
@@ -3268,7 +3271,7 @@ func readScrollOrderBlock(args []byte, off int) (order *ScrollOrder, newOff int,
 	}
 	kl := int(binary.BigEndian.Uint32(args[off:]))
 	off += 4
-	if len(args) < off+kl+1 {
+	if kl < 0 || kl > len(args)-off-1 {
 		return nil, off, ErrVectorArgsTruncated
 	}
 	o.Key = string(args[off : off+kl])
@@ -3491,7 +3494,7 @@ func DecodeDeleteByFilterArgs(args []byte) (string, vtypes.Filter, error) {
 	off := 1 + colLen
 	flen := int(binary.BigEndian.Uint32(args[off:]))
 	off += 4
-	if len(args) < off+flen {
+	if flen < 0 || len(args)-off < flen {
 		return "", vtypes.Filter{}, ErrVectorArgsTruncated
 	}
 	var filter vtypes.Filter
@@ -3952,7 +3955,7 @@ func decodeGroupSearchArgsN(args []byte) (collection string, k int, query []floa
 	off += gbLen
 	dim := int(binary.BigEndian.Uint32(args[off:]))
 	off += 4
-	if len(args) < off+4*dim+4 {
+	if !CountFitsIn(dim, len(args)-off, 4) {
 		return fail()
 	}
 	query = make([]float32, dim)
@@ -3960,9 +3963,12 @@ func decodeGroupSearchArgsN(args []byte) (collection string, k int, query []floa
 		query[i] = math.Float32frombits(binary.BigEndian.Uint32(args[off:]))
 		off += 4
 	}
+	if len(args) < off+4 {
+		return fail()
+	}
 	flen := int(binary.BigEndian.Uint32(args[off:]))
 	off += 4
-	if len(args) < off+flen {
+	if flen < 0 || len(args)-off < flen {
 		return fail()
 	}
 	if flen > 0 {
@@ -4557,7 +4563,9 @@ func DecodeVectorGetBatchArgs(args []byte) (collection string, ids []uint64, fla
 	off++
 	n := int(binary.BigEndian.Uint32(args[off:]))
 	off += 4
-	if n < 0 || len(args) < off+8*n {
+	// Each id costs 8 bytes; the divide-form bound rejects a widened-negative or
+	// absurd n before the make (8*n cannot overflow int here).
+	if !CountFitsIn(n, len(args)-off, 8) {
 		return "", nil, 0, ErrVectorArgsTruncated
 	}
 	ids = make([]uint64, n)
@@ -4786,7 +4794,7 @@ func readKeyTTLBlock(args []byte, off int) (keyTTLMs map[string]int64, next int,
 	}
 	klen := int(binary.BigEndian.Uint32(args[off:]))
 	off += 4
-	if len(args) < off+klen {
+	if klen < 0 || len(args)-off < klen {
 		return nil, off, ErrVectorArgsTruncated
 	}
 	km := make(map[string]int64)
@@ -4932,7 +4940,7 @@ func DecodeSetPayloadArgsOpts(args []byte) (collection string, id uint64, meta v
 	off += 8
 	mlen := int(binary.BigEndian.Uint32(args[off:]))
 	off += 4
-	if len(args) < off+mlen {
+	if mlen < 0 || len(args)-off < mlen {
 		return "", 0, nil, nil, ErrVectorArgsTruncated
 	}
 	if mlen > 0 {
@@ -4958,7 +4966,7 @@ func DecodeSetPayloadArgsOpts(args []byte) (collection string, id uint64, meta v
 	}
 	klen := int(binary.BigEndian.Uint32(args[off:]))
 	off += 4
-	if len(args) < off+klen {
+	if klen < 0 || len(args)-off < klen {
 		return "", 0, nil, nil, ErrVectorArgsTruncated
 	}
 	km := make(map[string]int64)
@@ -4992,7 +5000,7 @@ func DecodeSetPayloadArgsCAS(args []byte) (collection string, id uint64, meta vt
 	off += 8
 	mlen := int(binary.BigEndian.Uint32(args[off:]))
 	off += 4
-	if len(args) < off+mlen {
+	if mlen < 0 || len(args)-off < mlen {
 		return "", 0, nil, nil, 0, false, ErrVectorArgsTruncated
 	}
 	if mlen > 0 {
@@ -5015,7 +5023,7 @@ func DecodeSetPayloadArgsCAS(args []byte) (collection string, id uint64, meta vt
 		}
 		klen := int(binary.BigEndian.Uint32(args[off:]))
 		off += 4
-		if len(args) < off+klen {
+		if klen < 0 || len(args)-off < klen {
 			return "", 0, nil, nil, 0, false, ErrVectorArgsTruncated
 		}
 		km := make(map[string]int64)
@@ -5108,6 +5116,11 @@ func DecodeDeletePayloadKeysArgsCAS(args []byte) (collection string, id uint64, 
 	off += 8
 	nKeys := int(binary.BigEndian.Uint32(args[off:]))
 	off += 4
+	// Each key costs >= 2 bytes ([keyLen:u16] with an empty key); the divide-form
+	// bound rejects a widened-negative or absurd nKeys before the make cap.
+	if !CountFitsIn(nKeys, len(args)-off, 2) {
+		return "", 0, nil, 0, false, ErrVectorArgsTruncated
+	}
 	if nKeys > 0 {
 		keys = make([]string, 0, nKeys)
 	}

--- a/sdk/wire/vector.go
+++ b/sdk/wire/vector.go
@@ -429,7 +429,7 @@ func decodeVectorInsertArgsCASInto(dst []float32, args []byte) (collection strin
 		}
 		mlen := int(binary.BigEndian.Uint32(args[off:]))
 		off += 4
-		if len(args) < off+mlen {
+		if mlen < 0 || len(args)-off < mlen {
 			return "", 0, nil, 0, nil, nil, 0, 0, false, ErrVectorArgsTruncated
 		}
 		meta = make(vtypes.Metadata)
@@ -519,7 +519,7 @@ func decodeVectorInsertArgsKeyTTLInto(dst []float32, args []byte) (collection st
 	}
 	klen := int(binary.BigEndian.Uint32(args[off:]))
 	off += 4
-	if len(args) < off+klen {
+	if klen < 0 || len(args)-off < klen {
 		return "", 0, nil, 0, nil, nil, 0, 0, false, nil, ErrVectorArgsTruncated
 	}
 	km := make(map[string]int64)
@@ -616,7 +616,7 @@ func DecodeVectorInsertArgsKeyExpiresInto(dst []float32, args []byte) (collectio
 		}
 		kl := int(binary.BigEndian.Uint32(args[off:]))
 		off += 4
-		if len(args) < off+kl+8 {
+		if kl < 0 || kl > len(args)-off-8 {
 			return "", 0, nil, 0, nil, nil, 0, 0, false, nil, nil, ErrVectorArgsTruncated
 		}
 		key := string(args[off : off+kl])
@@ -740,7 +740,7 @@ func DecodeVectorSearchArgsInto(args []byte, dst []float32) (collection string, 
 		}
 		flen := int(binary.BigEndian.Uint32(args[off:]))
 		off += 4
-		if len(args) < off+flen {
+		if flen < 0 || len(args)-off < flen {
 			return "", 0, nil, vtypes.Filter{}, ErrVectorArgsTruncated
 		}
 		if err := json.Unmarshal(args[off:off+flen], &filter); err != nil {
@@ -810,7 +810,7 @@ func DecodeVectorSearchArgsOpts(args []byte) (collection string, k int, query []
 		}
 		flen := int(binary.BigEndian.Uint32(args[off:]))
 		off += 4
-		if len(args) < off+flen {
+		if flen < 0 || len(args)-off < flen {
 			return "", 0, nil, vtypes.Filter{}, 0, 0, 0, ErrVectorArgsTruncated
 		}
 		if uerr := json.Unmarshal(args[off:off+flen], &filter); uerr != nil {
@@ -1137,7 +1137,7 @@ func decodeHybridSearchArgsN(args []byte) (collection string, dense []float32, k
 		}
 		flen := int(binary.BigEndian.Uint32(args[off:]))
 		off += 4
-		if len(args) < off+flen {
+		if flen < 0 || len(args)-off < flen {
 			return "", nil, 0, sparse, opts, 0, ErrVectorArgsTruncated
 		}
 		if uerr := json.Unmarshal(args[off:off+flen], &opts.Filter); uerr != nil {
@@ -2255,14 +2255,14 @@ func frameVectorDocsN(body []byte) ([]vtypes.RawDocument, int, error) {
 		off += 4
 		clen := int(binary.BigEndian.Uint32(body[off:]))
 		off += 4
-		if len(body) < off+clen+4 {
+		if clen < 0 || clen > len(body)-off-4 {
 			return nil, 0, ErrVectorArgsTruncated
 		}
 		d.Content = string(body[off : off+clen])
 		off += clen
 		mlen := int(binary.BigEndian.Uint32(body[off:]))
 		off += 4
-		if len(body) < off+mlen {
+		if mlen < 0 || len(body)-off < mlen {
 			return nil, 0, ErrVectorArgsTruncated
 		}
 		if mlen > 0 {
@@ -2690,7 +2690,11 @@ func DecodeScanVectorsResult(body []byte) ([]vtypes.ScanRecord, error) {
 		off += 8
 		dim := int(binary.BigEndian.Uint32(body[off:]))
 		off += 4
-		if len(body) < off+4*dim+8+4 {
+		// CountFitsIn (divide-form) instead of len(body) < off+4*dim+8+4: on 386
+		// a hostile dim near MaxInt32 makes 4*dim widen negative/zero and slip the
+		// additive check, then make([]float32, dim) panics. -(8+4) reserves the
+		// trailing ttl(u64)+next(u32) exactly as the old check did.
+		if !CountFitsIn(dim, len(body)-off-(8+4), 4) {
 			return nil, ErrVectorArgsTruncated
 		}
 		r.Vec = make([]float32, dim)
@@ -2703,7 +2707,7 @@ func DecodeScanVectorsResult(body []byte) ([]vtypes.ScanRecord, error) {
 		r.TTL = time.Duration(ttlMs) * time.Millisecond
 		mlen := int(binary.BigEndian.Uint32(body[off:]))
 		off += 4
-		if len(body) < off+mlen {
+		if mlen < 0 || len(body)-off < mlen {
 			return nil, ErrVectorArgsTruncated
 		}
 		if mlen > 0 {
@@ -2754,7 +2758,7 @@ func DecodeScanVectorsResult(body []byte) ([]vtypes.ScanRecord, error) {
 					}
 					klen := int(binary.BigEndian.Uint32(body[off:]))
 					off += 4
-					if len(body) < off+klen+8 {
+					if klen < 0 || klen > len(body)-off-8 {
 						return nil, ErrVectorArgsTruncated
 					}
 					key := string(body[off : off+klen])
@@ -3332,7 +3336,7 @@ func readScrollOrderBlock(args []byte, off int) (order *ScrollOrder, newOff int,
 			}
 			sl := int(binary.BigEndian.Uint32(args[off:]))
 			off += 4
-			if sl < 0 || len(args) < off+sl {
+			if sl < 0 || len(args)-off < sl {
 				return nil, off, ErrVectorArgsTruncated
 			}
 			o.ResumeStr = string(args[off : off+sl])
@@ -3363,7 +3367,7 @@ func readScrollOrderBlock(args []byte, off int) (order *ScrollOrder, newOff int,
 			}
 			kl2 := int(binary.BigEndian.Uint32(args[off:]))
 			off += 4
-			if kl2 < 0 || len(args) < off+kl2+1 {
+			if kl2 < 0 || kl2 > len(args)-off-1 {
 				return nil, off, ErrVectorArgsTruncated
 			}
 			tk := ScrollOrderKey{Key: string(args[off : off+kl2])}
@@ -3399,7 +3403,7 @@ func readScrollOrderBlock(args []byte, off int) (order *ScrollOrder, newOff int,
 					}
 					sl := int(binary.BigEndian.Uint32(args[off:]))
 					off += 4
-					if sl < 0 || sl > scrollCursorStringMaxLen || len(args) < off+sl {
+					if sl < 0 || sl > scrollCursorStringMaxLen || len(args)-off < sl {
 						return nil, off, ErrVectorArgsTruncated
 					}
 					o.ResumeKeys[i] = ScrollOrderVal{Str: string(args[off : off+sl]), Kind: vtypes.OrderString}
@@ -3948,7 +3952,7 @@ func decodeGroupSearchArgsN(args []byte) (collection string, k int, query []floa
 	off += 4
 	gbLen := int(binary.BigEndian.Uint16(args[off:]))
 	off += 2
-	if len(args) < off+gbLen+4 {
+	if gbLen < 0 || gbLen > len(args)-off-4 {
 		return fail()
 	}
 	opts.GroupBy = string(args[off : off+gbLen])
@@ -4135,7 +4139,7 @@ func frameGroupsN(body []byte) ([]framedGroup, int, error) {
 		}
 		klen := int(binary.BigEndian.Uint32(body[off:]))
 		off += 4
-		if len(body) < off+klen+4 {
+		if klen < 0 || klen > len(body)-off-4 {
 			return nil, 0, ErrVectorArgsTruncated
 		}
 		var g framedGroup
@@ -4143,7 +4147,7 @@ func frameGroupsN(body []byte) ([]framedGroup, int, error) {
 		off += klen
 		dlen := int(binary.BigEndian.Uint32(body[off:]))
 		off += 4
-		if len(body) < off+dlen {
+		if dlen < 0 || len(body)-off < dlen {
 			return nil, 0, ErrVectorArgsTruncated
 		}
 		g.hits = body[off : off+dlen]
@@ -4457,7 +4461,7 @@ func decodeGetResultAtArena(body []byte, off int, versionFramed bool, arena []fl
 		}
 		mlen := int(binary.BigEndian.Uint32(body[off:]))
 		off += 4
-		if len(body) < off+mlen {
+		if mlen < 0 || len(body)-off < mlen {
 			return false, nil, nil, 0, nil, 0, off, arena, ErrVectorArgsTruncated
 		}
 		m := make(vtypes.Metadata)
@@ -5130,7 +5134,7 @@ func DecodeDeletePayloadKeysArgsCAS(args []byte) (collection string, id uint64, 
 		}
 		klen := int(binary.BigEndian.Uint16(args[off:]))
 		off += 2
-		if len(args) < off+klen {
+		if klen < 0 || len(args)-off < klen {
 			return "", 0, nil, 0, false, ErrVectorArgsTruncated
 		}
 		keys = append(keys, string(args[off:off+klen]))


### PR DESCRIPTION
## What

Fixes a class of 32-bit integer-overflow panics in the wire decoders, and closes the coverage gap in the hostile-decode sweep that was hiding them.

A decoder reads a length with `int(binary.BigEndian.Uint32(...))`. On 64-bit that is exact; on 32-bit (`GOARCH=386`, where `int` is 32-bit) any value above `MaxInt32` widens **negative**, and a negative length — or a positive one whose `off+n` / `n*size` overflows — slips a `len(args) < off+n` bounds check. The decode then proceeds into a slice bound or a `make()` and **panics**. On the replicated path every applying node decodes the write, so one hostile frame is a **cluster-wide crash** on a 32-bit build. This is exactly the class the `test-386` CI lane exists to catch.

## Why the existing sweep missed it

`TestNoDecoderPanicsOnHostileBytes` fed all-`0xFF` frames, which can only reach a decoder's **first** length field — a `0xFF` preamble makes that length huge and the decoder bails before any later field. This PR adds **byte-by-byte-swept, zero-based frames** to `hostileBodies()` so the sweep reaches length fields sitting behind a small/zero preamble. That surfaced **46 panicking decoders**.

## The fix

Every changed check is made 32-bit-safe by keeping the untrusted length off the additive/multiplicative side of every comparison and slice:

- **Byte fields** `[len u32][bytes]`: `if n < 0 || len(args)-off < n { err }`, slice, advance, then check any trailing fixed fields **separately**.
- **Count × element-size**: route through `CountFitsIn` (divide-form `n <= remaining/size`, which cannot overflow) before `make`/loop.

Two decoders that already had a `< 0` guard still overflowed on a **positive** count — `DecodeVectorGetBatchArgs` (`8*n` multiply) and `DecodeWCEnvelope` (`off+argsLen` add) — confirming a `< 0` guard alone is insufficient; both now use the overflow-free form.

Most fixes funnel through shared helpers (`readSparse`, `readKeyTTLBlock`, `readScrollOrderBlock`, `readScrollTail`, `decodeNamedInsertArgsN`, `decodeMVAddArgsN`, …), so one edit fixes many op variants.

**Valid frames decode byte-identically** — only hostile input changes, from a panic to the decoder's own error. Verified by an independent review pass (0 findings) plus the amd64 regression suite.

## Verification

- `go build ./...`, `go vet ./ops/... ./sdk/...` — clean
- `GOARCH=386 go test ./ops/ -run TestNoDecoderPanicsOnHostileBytes` — **green, 0 panics** (was 46)
- Full CI `test-386` scope (`GOARCH=386 -short ./ops/... ./vector/... ./httpapi/... ./server/...`) — green
- `go test ./ops/... ./sdk/...` (amd64, valid-input round-trips) — green

7 files, +71 / −33.
