### PR TITLE
feat(kv): atomic conditional writes — set_nx, cas, compare-and-delete

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -212,6 +212,40 @@ func (c *Client) Call(ctx context.Context, op string, args []byte) ([]byte, erro
 	return nil, fmt.Errorf("client: NotLeader exceeded %d hops", maxHops)
 }
 
+// SetNX sets key to value only if the key is currently absent or expired — the
+// atomic set-if-absent primitive. Returns true if the value was stored, false if
+// the key was already present. ttl > 0 sets an expiry on the stored value.
+func (c *Client) SetNX(ctx context.Context, key, value []byte, ttl time.Duration) (bool, error) {
+	res, err := c.Call(ctx, "set_nx", wire.EncodeSetNXArgs(key, value, ttl))
+	if err != nil {
+		return false, err
+	}
+	return wire.DecodeCASResult(res)
+}
+
+// CAS is compare-and-swap: it sets key to value only if the key's current value
+// equals expected. Returns true if the value was stored, false on a mismatch (or
+// if the key is absent). ttl > 0 sets an expiry on the stored value. To store only
+// when the key is absent, use SetNX.
+func (c *Client) CAS(ctx context.Context, key, value, expected []byte, ttl time.Duration) (bool, error) {
+	res, err := c.Call(ctx, "cas", wire.EncodeCASArgs(key, value, true, expected, ttl))
+	if err != nil {
+		return false, err
+	}
+	return wire.DecodeCASResult(res)
+}
+
+// CompareAndDelete deletes key only if its current value equals expected — the
+// safe-unlock primitive (release a lock only if you still hold it). Returns true
+// if the key was deleted, false on a value mismatch or an absent key.
+func (c *Client) CompareAndDelete(ctx context.Context, key, expected []byte) (bool, error) {
+	res, err := c.Call(ctx, "cad", wire.EncodeCADArgs(key, expected))
+	if err != nil {
+		return false, err
+	}
+	return wire.DecodeCASResult(res)
+}
+
 // PutBatch writes many key/value pairs as bulk put_batch ops — the ~10x
 // bulk-insert fast path. It groups entries by their owning shard (the same hash
 // as pickInitialTarget) so each shard receives ONE Raft log entry per chunk, and

--- a/client/client.go
+++ b/client/client.go
@@ -101,7 +101,11 @@ func (c *Client) callAddrPipelined(ctx context.Context, op string, args []byte, 
 	}
 	status, payload, callErr := pc.call(ctx, op, args)
 	if callErr != nil {
-		return nil, callErr
+		// Post-transmission: the pipelined request may have committed before
+		// its response was lost. Mark it ambiguous so Call won't replay a
+		// conditional write. The pick() error above is pre-transmission and
+		// stays unwrapped.
+		return nil, &ambiguousError{err: callErr}
 	}
 	return mapCallStatus(op, status, payload)
 }
@@ -163,7 +167,11 @@ func New(cfg Config) (*Client, error) {
 // Call sends one request, following NotLeader hints up to cfg.MaxNotLeaderHops.
 // getOrCreatePool handles hinted addrs that are not in cfg.Servers.
 // Transport errors (dial refused, EOF, etc.) are retried against another
-// server within the same hop budget.
+// server within the same hop budget — EXCEPT that an outcome-returning
+// conditional write (set_nx/cas/cad) is NOT replayed across an AMBIGUOUS
+// failure (one that happened after the request was transmitted): the first
+// server may have committed before the response was lost, so a replay would
+// report a wrong result. Such a failure is returned to the caller instead.
 func (c *Client) Call(ctx context.Context, op string, args []byte) ([]byte, error) {
 	select {
 	case <-c.closed:
@@ -199,8 +207,10 @@ func (c *Client) Call(ctx context.Context, op string, args []byte) ([]byte, erro
 			continue
 		}
 		// Non-NotLeader error: if it's a transport error, rotate to
-		// another server and retry within the hop budget.
-		if isTransportError(err) && hop < maxHops {
+		// another server and retry within the hop budget — but never
+		// replay a non-replayable conditional write across an ambiguous
+		// (post-transmission) failure, which could report a wrong outcome.
+		if isTransportError(err) && hop < maxHops && !(nonReplayableOp(op) && isAmbiguous(err)) {
 			next := c.nextServer()
 			if next != "" && next != target {
 				target = next
@@ -215,6 +225,11 @@ func (c *Client) Call(ctx context.Context, op string, args []byte) ([]byte, erro
 // SetNX sets key to value only if the key is currently absent or expired — the
 // atomic set-if-absent primitive. Returns true if the value was stored, false if
 // the key was already present. ttl > 0 sets an expiry on the stored value.
+//
+// On an ambiguous transport failure (the request may have committed before the
+// response was lost) it returns a non-nil error rather than a possibly-wrong
+// false — the write is NOT transparently replayed against another server. A
+// caller that gets a transport error must re-check state itself.
 func (c *Client) SetNX(ctx context.Context, key, value []byte, ttl time.Duration) (bool, error) {
 	res, err := c.Call(ctx, "set_nx", wire.EncodeSetNXArgs(key, value, ttl))
 	if err != nil {
@@ -227,6 +242,9 @@ func (c *Client) SetNX(ctx context.Context, key, value []byte, ttl time.Duration
 // equals expected. Returns true if the value was stored, false on a mismatch (or
 // if the key is absent). ttl > 0 sets an expiry on the stored value. To store only
 // when the key is absent, use SetNX.
+//
+// Like SetNX, an ambiguous transport failure returns a non-nil error rather
+// than a possibly-wrong false; the write is not replayed against another server.
 func (c *Client) CAS(ctx context.Context, key, value, expected []byte, ttl time.Duration) (bool, error) {
 	res, err := c.Call(ctx, "cas", wire.EncodeCASArgs(key, value, true, expected, ttl))
 	if err != nil {
@@ -238,6 +256,9 @@ func (c *Client) CAS(ctx context.Context, key, value, expected []byte, ttl time.
 // CompareAndDelete deletes key only if its current value equals expected — the
 // safe-unlock primitive (release a lock only if you still hold it). Returns true
 // if the key was deleted, false on a value mismatch or an absent key.
+//
+// Like SetNX/CAS, an ambiguous transport failure returns a non-nil error rather
+// than a possibly-wrong false; the delete is not replayed against another server.
 func (c *Client) CompareAndDelete(ctx context.Context, key, expected []byte) (bool, error) {
 	res, err := c.Call(ctx, "cad", wire.EncodeCADArgs(key, expected))
 	if err != nil {
@@ -324,6 +345,37 @@ func groupEntriesByShard(entries []wire.PutEntry, numShards int) map[int][]wire.
 		groups[shard] = append(groups[shard], e)
 	}
 	return groups
+}
+
+// ambiguousError marks a transport failure that occurred AFTER a live
+// connection was obtained — the request may have reached the server and
+// committed before the response was lost. Replaying an outcome-returning
+// conditional write across it can report a wrong result, so Call refuses to.
+// It Unwraps to the underlying error so errors.Is/As (and isTransportError)
+// see straight through the wrapper.
+type ambiguousError struct{ err error }
+
+func (e *ambiguousError) Error() string { return e.err.Error() }
+func (e *ambiguousError) Unwrap() error { return e.err }
+
+// nonReplayableOp reports whether replaying op after an ambiguous transport
+// failure can corrupt its result. The conditional writes are outcome-returning:
+// if the first server committed but the response was lost, a replay sees the
+// key already changed and returns the wrong success bit.
+func nonReplayableOp(op string) bool {
+	switch op {
+	case "set_nx", "cas", "cad":
+		return true
+	}
+	return false
+}
+
+// isAmbiguous reports whether err is (or wraps) an ambiguousError — a
+// post-transmission transport failure that must not be blindly replayed for a
+// non-replayable op.
+func isAmbiguous(err error) bool {
+	var a *ambiguousError
+	return errors.As(err, &a)
 }
 
 // isTransportError reports whether err is a network-level transport
@@ -502,7 +554,9 @@ func (c *Client) CallFunc(ctx context.Context, op string, args []byte, fn func(p
 			}
 			continue
 		}
-		if isTransportError(err) && hop < maxHops {
+		// See Call: a non-replayable conditional write is not retried across
+		// an ambiguous (post-transmission) transport failure.
+		if isTransportError(err) && hop < maxHops && !(nonReplayableOp(op) && isAmbiguous(err)) {
 			next := c.nextServer()
 			if next != "" && next != target {
 				target = next
@@ -538,7 +592,11 @@ func (c *Client) callAddr(ctx context.Context, op string, args []byte, addr stri
 	if callErr != nil {
 		conn.poisoned = true
 		pool.release(res)
-		return nil, callErr
+		// The request may have been transmitted and committed before the
+		// response was lost — ambiguous, so Call won't replay a conditional
+		// write across it. getOrCreatePool/acquire failures above are left
+		// unwrapped: those happen before any bytes are sent (pre-transmission).
+		return nil, &ambiguousError{err: callErr}
 	}
 	switch status {
 	case StatusOK:
@@ -583,7 +641,9 @@ func (c *Client) callAddrFunc(ctx context.Context, op string, args []byte, addr 
 	if callErr != nil {
 		conn.poisoned = true
 		pool.release(res)
-		return callErr
+		// Post-transmission: mark ambiguous so CallFunc's retry guard refuses to
+		// replay a conditional write (parity with callAddr — see Call).
+		return &ambiguousError{err: callErr}
 	}
 	switch status {
 	case StatusOK:

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -323,6 +323,163 @@ func TestClientRefreshLoopFires(t *testing.T) {
 	t.Errorf("refresh fired %d times, want >= 2", calls.Load())
 }
 
+// startDropAfterReadServer starts a TCP server that reads exactly one framed
+// request, invokes onRequest (to count it / model "the op applied"), then CLOSES
+// the connection WITHOUT writing a response. The client's response read then
+// fails with io.EOF — an AMBIGUOUS, post-transmission transport error (the op may
+// have committed on the server before the reply was lost). Returns addr + stop.
+func startDropAfterReadServer(t *testing.T, onRequest func()) (addr string, stop func()) {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	go func() {
+		for {
+			conn, aerr := ln.Accept()
+			if aerr != nil {
+				return
+			}
+			go func(c net.Conn) {
+				defer func() { _ = c.Close() }()
+				r := bufio.NewReader(c)
+				var hdr [4]byte
+				if _, rerr := io.ReadFull(r, hdr[:]); rerr != nil {
+					return
+				}
+				n := binary.BigEndian.Uint32(hdr[:])
+				body := make([]byte, n)
+				if _, rerr := io.ReadFull(r, body); rerr != nil {
+					return
+				}
+				if onRequest != nil {
+					onRequest()
+				}
+				// Drop the response: close without replying.
+			}(conn)
+		}
+	}()
+	return ln.Addr().String(), func() { _ = ln.Close() }
+}
+
+// closedAddr returns an address whose listener is already closed, so any dial to
+// it is refused — a PRE-transmission transport error (nothing was ever sent).
+func closedAddr(t *testing.T) string {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	addr := ln.Addr().String()
+	_ = ln.Close()
+	return addr
+}
+
+// TestClientConditionalWriteNotReplayedAcrossAmbiguousFailure: server A receives
+// set_nx and drops the response AFTER the op would have applied (models "committed
+// but reply lost" → io.EOF). Server B has the key already present (as it would
+// after A's commit replicated) and would answer set_nx with false. The client must
+// NOT transparently replay onto B and surface a wrong (false, nil); it must return
+// the ambiguous transport error, and B must never be contacted.
+func TestClientConditionalWriteNotReplayedAcrossAmbiguousFailure(t *testing.T) {
+	var callA, callB atomic.Int32
+	addrA, stopA := startDropAfterReadServer(t, func() { callA.Add(1) })
+	defer stopA()
+	addrB, stopB := startFakeServer(t, func(_ []byte) (uint8, []byte) {
+		callB.Add(1)
+		return StatusOK, []byte{0} // set_nx result false: key already present
+	})
+	defer stopB()
+
+	// Ops=nil → pickInitialTarget round-robins from Servers[0]=A. Default
+	// MaxNotLeaderHops=3 gives a hop budget, so WITHOUT the fix the ambiguous
+	// EOF would replay onto B and return (false, nil).
+	c, err := New(Config{Servers: []string{addrA, addrB}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = c.Close() }()
+
+	ok, err := c.SetNX(context.Background(), []byte("lock"), []byte("me"), 0)
+	if err == nil {
+		t.Fatalf("SetNX returned (%v, nil); want a non-nil transport error, not a replayed false", ok)
+	}
+	if !isTransportError(err) {
+		t.Fatalf("SetNX err = %v; want a transport error", err)
+	}
+	if !isAmbiguous(err) {
+		t.Fatalf("SetNX err = %v; want an ambiguous (post-transmission) error", err)
+	}
+	if n := callA.Load(); n != 1 {
+		t.Fatalf("server A calls = %d, want 1", n)
+	}
+	if n := callB.Load(); n != 0 {
+		t.Fatalf("server B calls = %d, want 0 (conditional write must not replay across ambiguous failure)", n)
+	}
+}
+
+// TestClientConditionalWriteFailsOverOnPreTransmissionError: server A is
+// unreachable (dial refused → PRE-transmission error, nothing sent). A conditional
+// write MUST still fail over to server B — proving the fix restricts ONLY ambiguous
+// (post-transmission) failures, not all transport errors.
+func TestClientConditionalWriteFailsOverOnPreTransmissionError(t *testing.T) {
+	var callB atomic.Int32
+	badA := closedAddr(t)
+	addrB, stopB := startFakeServer(t, func(_ []byte) (uint8, []byte) {
+		callB.Add(1)
+		return StatusOK, []byte{1} // set_nx result true: acquired
+	})
+	defer stopB()
+
+	c, err := New(Config{Servers: []string{badA, addrB}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = c.Close() }()
+
+	ok, err := c.SetNX(context.Background(), []byte("lock"), []byte("me"), 0)
+	if err != nil {
+		t.Fatalf("SetNX: %v; want failover to B on a pre-transmission error", err)
+	}
+	if !ok {
+		t.Fatalf("SetNX = false; want true after failover to B")
+	}
+	if n := callB.Load(); n != 1 {
+		t.Fatalf("server B calls = %d, want 1 (failover expected)", n)
+	}
+}
+
+// TestClientIdempotentOpStillReplaysAcrossAmbiguousFailure: an ambiguous failure
+// on an IDEMPOTENT op (get) MUST still transparently replay — the fix must not
+// over-restrict. Server A drops the response (EOF); server B answers ok.
+func TestClientIdempotentOpStillReplaysAcrossAmbiguousFailure(t *testing.T) {
+	var callB atomic.Int32
+	addrA, stopA := startDropAfterReadServer(t, nil)
+	defer stopA()
+	addrB, stopB := startFakeServer(t, func(_ []byte) (uint8, []byte) {
+		callB.Add(1)
+		return StatusOK, []byte("ok")
+	})
+	defer stopB()
+
+	c, err := New(Config{Servers: []string{addrA, addrB}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = c.Close() }()
+
+	res, err := c.Call(context.Background(), "get", wire.EncodeKeyArgs([]byte("k")))
+	if err != nil {
+		t.Fatalf("get: %v; want transparent replay onto B for an idempotent op", err)
+	}
+	if string(res) != "ok" {
+		t.Fatalf("get result = %q, want ok", res)
+	}
+	if n := callB.Load(); n != 1 {
+		t.Fatalf("server B calls = %d, want 1 (idempotent replay expected)", n)
+	}
+}
+
 // TestClientRespectsCanceledContext: a pre-canceled context must cause Call to
 // return immediately with a context error, before any server dial is attempted
 // on the second hop.

--- a/client_integration_test.go
+++ b/client_integration_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"errors"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -128,6 +129,97 @@ func TestClientIncrAccumulates(t *testing.T) {
 	v, _ := wire.DecodeIncrResult(res)
 	if v != 5 {
 		t.Fatalf("incr accumulated = %d, want 5", v)
+	}
+}
+
+func TestClientConditionalWrites(t *testing.T) {
+	addr, stop := startTestStack(t)
+	defer stop()
+	c, _ := client.New(client.Config{Servers: []string{addr}})
+	defer func() { _ = c.Close() }()
+	ctx := context.Background()
+
+	// SetNX: first wins, second (key present) is refused.
+	stored, err := c.SetNX(ctx, []byte("k"), []byte("v1"), 0)
+	if err != nil {
+		t.Fatalf("SetNX: %v", err)
+	}
+	if !stored {
+		t.Fatal("first SetNX = false, want true")
+	}
+	stored, err = c.SetNX(ctx, []byte("k"), []byte("v2"), 0)
+	if err != nil {
+		t.Fatalf("SetNX 2: %v", err)
+	}
+	if stored {
+		t.Fatal("second SetNX on present key = true, want false")
+	}
+
+	// CAS: correct expected succeeds, wrong expected fails.
+	swapped, err := c.CAS(ctx, []byte("k"), []byte("v2"), []byte("v1"), 0)
+	if err != nil {
+		t.Fatalf("CAS: %v", err)
+	}
+	if !swapped {
+		t.Fatal("CAS with correct expected = false, want true")
+	}
+	swapped, err = c.CAS(ctx, []byte("k"), []byte("v3"), []byte("WRONG"), 0)
+	if err != nil {
+		t.Fatalf("CAS 2: %v", err)
+	}
+	if swapped {
+		t.Fatal("CAS with wrong expected = true, want false")
+	}
+
+	// CompareAndDelete: wrong token no-ops, right token deletes.
+	deleted, err := c.CompareAndDelete(ctx, []byte("k"), []byte("WRONG"))
+	if err != nil {
+		t.Fatalf("CompareAndDelete wrong: %v", err)
+	}
+	if deleted {
+		t.Fatal("CompareAndDelete with wrong token = true, want false")
+	}
+	deleted, err = c.CompareAndDelete(ctx, []byte("k"), []byte("v2"))
+	if err != nil {
+		t.Fatalf("CompareAndDelete right: %v", err)
+	}
+	if !deleted {
+		t.Fatal("CompareAndDelete with right token = false, want true")
+	}
+	if _, err := c.Call(ctx, "get", wire.EncodeKeyArgs([]byte("k"))); !errors.Is(err, client.ErrNotFound) {
+		t.Fatalf("post-delete get: err = %v, want ErrNotFound", err)
+	}
+}
+
+func TestClientSetNXExactlyOneWinner(t *testing.T) {
+	addr, stop := startTestStack(t)
+	defer stop()
+	c, _ := client.New(client.Config{Servers: []string{addr}, MaxConnsPerServer: 8})
+	defer func() { _ = c.Close() }()
+
+	const goroutines = 24
+	var wins atomic.Int64
+	var wg sync.WaitGroup
+	start := make(chan struct{})
+	for range goroutines {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			ok, err := c.SetNX(context.Background(), []byte("race-key"), []byte("mine"), 0)
+			if err != nil {
+				t.Errorf("SetNX: %v", err)
+				return
+			}
+			if ok {
+				wins.Add(1)
+			}
+		}()
+	}
+	close(start)
+	wg.Wait()
+	if got := wins.Load(); got != 1 {
+		t.Fatalf("SetNX winners = %d, want exactly 1", got)
 	}
 }
 

--- a/clients/python/rostam/_kv.py
+++ b/clients/python/rostam/_kv.py
@@ -77,6 +77,45 @@ class _KV:
         payload = self._t._call("incr", args)
         return struct.unpack(">q", payload)[0]
 
+    def set_nx(self, key: Key, value: Key, *, ttl_ms: int = 0) -> bool:
+        """Set only if the key is absent. Returns True if stored, False if it already exists.
+
+        Atomic on the server (the check and the store run under one shard write
+        lock). ``ttl_ms`` > 0 sets an expiry on the stored value.
+        """
+        k, v = _as_bytes(key), _as_bytes(value)
+        args = _enc_key(k) + struct.pack(">I", len(v)) + v + struct.pack(">Q", ttl_ms)
+        payload = self._t._call("set_nx", args)
+        return bool(payload and payload[0])
+
+    def cas(self, key: Key, value: Key, expected: Optional[Key], *, ttl_ms: int = 0) -> bool:
+        """Compare-and-swap: set only if current == expected (``expected=None`` ⇒ only if absent).
+
+        Returns True if the value was stored, False on a mismatch. ``ttl_ms`` > 0
+        sets an expiry on the stored value.
+        """
+        k, v = _as_bytes(key), _as_bytes(value)
+        has = expected is not None
+        e = _as_bytes(expected) if has else b""
+        args = (
+            _enc_key(k)
+            + struct.pack(">I", len(v))
+            + v
+            + struct.pack(">B", 1 if has else 0)
+            + struct.pack(">I", len(e))
+            + e
+            + struct.pack(">Q", ttl_ms)
+        )
+        payload = self._t._call("cas", args)
+        return bool(payload and payload[0])
+
+    def compare_and_delete(self, key: Key, expected: Key) -> bool:
+        """Delete only if current == expected (safe unlock). Returns True if deleted."""
+        k, e = _as_bytes(key), _as_bytes(expected)
+        args = _enc_key(k) + struct.pack(">I", len(e)) + e
+        payload = self._t._call("cad", args)
+        return bool(payload and payload[0])
+
     def expire(self, key: Key, ttl_ms: int) -> None:
         """Set a TTL (in milliseconds) on an existing key."""
         args = _enc_key(_as_bytes(key)) + struct.pack(">Q", ttl_ms)

--- a/clients/python/tests/test_cross_stack_kv.py
+++ b/clients/python/tests/test_cross_stack_kv.py
@@ -110,6 +110,30 @@ class CrossStackKVTest(unittest.TestCase):
         self.r.kv.put(key, val)
         self.assertEqual(self.r.kv.get(key), val)
 
+    def test_set_nx_stores_once(self):
+        self.assertTrue(self.r.kv.set_nx("k:nx", "first"))    # absent -> stored
+        self.assertFalse(self.r.kv.set_nx("k:nx", "second"))  # present -> refused
+        self.assertEqual(self.r.kv.get("k:nx"), b"first")     # unchanged
+
+    def test_cas_swaps_on_match(self):
+        self.r.kv.put("k:cas", "v1")
+        self.assertTrue(self.r.kv.cas("k:cas", "v2", "v1"))   # match -> swap
+        self.assertEqual(self.r.kv.get("k:cas"), b"v2")
+        self.assertFalse(self.r.kv.cas("k:cas", "v3", "WRONG"))  # mismatch -> no-op
+        self.assertEqual(self.r.kv.get("k:cas"), b"v2")
+
+    def test_cas_expect_absent(self):
+        self.assertTrue(self.r.kv.cas("k:casabs", "v1", None))  # absent -> store
+        self.assertEqual(self.r.kv.get("k:casabs"), b"v1")
+        self.assertFalse(self.r.kv.cas("k:casabs", "v2", None))  # present -> refuse
+
+    def test_compare_and_delete(self):
+        self.r.kv.put("k:cad", "tok")
+        self.assertFalse(self.r.kv.compare_and_delete("k:cad", "WRONG"))  # mismatch
+        self.assertEqual(self.r.kv.get("k:cad"), b"tok")
+        self.assertTrue(self.r.kv.compare_and_delete("k:cad", "tok"))     # match -> delete
+        self.assertIsNone(self.r.kv.get("k:cad"))
+
 
 @unittest.skipUnless(_BIN, _WHY)
 class CrossStackKVAuthTest(unittest.TestCase):

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -5,6 +5,17 @@ Notable user-visible changes. Entries that alter existing behaviour are marked
 
 ## Unreleased
 
+- **Atomic conditional KV writes: `set_nx`, `cas`, and compare-and-delete.**
+  Three new key-value ops give you an atomic conditional write, the primitive
+  needed for correct distributed locks, once-only writes, and idempotency keys:
+  `set_nx` stores a value only if the key is absent (or expired); `cas`
+  (compare-and-swap) stores only if the current value equals an expected value;
+  and compare-and-delete removes a key only if it still holds an expected value
+  (a safe lock release). Each is a single atomic operation — two writers racing
+  on the same key can no longer both win — and an expired key reads as absent,
+  so a lock re-acquires cleanly once its TTL lapses. Available on the Go client
+  as `SetNX` / `CAS` / `CompareAndDelete` and on the Python client
+  (`rostam-client`) as `set_nx` / `cas` / `compare_and_delete`.
 - **Python client: Mem0, Semantic Router, CrewAI, and DSPy adapters
   (`rostam-client` 0.3.0).** Framework integrations join the existing LangChain,
   LlamaIndex, and Haystack adapters, each an optional in-package submodule behind

--- a/ops/builtin.go
+++ b/ops/builtin.go
@@ -52,6 +52,12 @@ var builtinHandlers = map[string]Handler{
 	"del":    handleDel,
 	"expire": handleExpire,
 	"incr":   handleIncr,
+	// Conditional-write KV ops (atomic under the shard write lock held for the
+	// whole handler): set_nx = set-if-absent, cas = compare-and-swap, cad =
+	// compare-and-delete.
+	"set_nx": handleSetNX,
+	"cas":    handleCAS,
+	"cad":    handleCompareAndDel,
 	// put_batch packs N puts into one Raft log entry (one fsync / round-trip /
 	// apply for the whole batch). It routes by its FIRST key, so every key in a
 	// batch must hash to the same shard — the cluster fan-out (Node.PutBatch)
@@ -159,6 +165,9 @@ var builtinHandlers = map[string]Handler{
 //   - "del"    (read-write)  args: [keyLen u16][key]                    → 1-byte 0/1
 //   - "expire" (read-write)  args: [keyLen u16][key][ttlMs u64]
 //   - "incr"   (read-write)  args: [keyLen u16][key][delta i64]         → new value as i64 BE
+//   - "set_nx" (read-write)  args: [keyLen u16][key][valLen u32][val][ttlMs u64] → 1-byte 1=stored/0=present
+//   - "cas"    (read-write)  args: [keyLen u16][key][valLen u32][val][hasExpected u8][expLen u32][expected][ttlMs u64] → 1-byte 1=stored/0=mismatch
+//   - "cad"    (read-write)  args: [keyLen u16][key][expLen u32][expected] → 1-byte 1=deleted/0=mismatch|absent
 //   - "__ping__" (read-only) args: (ignored)                             → empty
 //
 // Routing metadata (kind/wire.KeyExtractor/wire.RouteLayout) comes from wire.BuiltinOps,
@@ -244,6 +253,85 @@ func handleIncr(tx *TxContext, args []byte) ([]byte, error) {
 		return nil, err
 	}
 	return wire.EncodeIncrResult(next), nil
+}
+
+// handleSetNX sets key only if it is currently absent or expired. Result: 1=stored,
+// 0=key already present. The whole Get→Put runs under the shard write lock, so the
+// check and the store are atomic; tx.Get uses the leader-stamped clock on the
+// replicated path, so every replica agrees on absent-vs-present.
+func handleSetNX(tx *TxContext, args []byte) ([]byte, error) {
+	key, val, ttl, err := wire.DecodePutArgs(args)
+	if err != nil {
+		return nil, err
+	}
+	switch _, err = tx.Get(key); {
+	case err == cache.ErrNotFound:
+		if err := tx.Put(key, val, ttl); err != nil {
+			return nil, err
+		}
+		return []byte{1}, nil
+	case err != nil:
+		return nil, err
+	default:
+		return []byte{0}, nil
+	}
+}
+
+// handleCAS sets key to val only if its current value equals expected (or, when
+// hasExpected is false, only if the key is currently absent). Result: 1=stored,
+// 0=mismatch. Atomic under the shard write lock; the liveness/compare read uses
+// the leader-stamped clock on the replicated path.
+func handleCAS(tx *TxContext, args []byte) ([]byte, error) {
+	key, val, hasExpected, expected, ttl, err := wire.DecodeCASArgs(args)
+	if err != nil {
+		return nil, err
+	}
+	cur, err := tx.Get(key)
+	switch {
+	case err == cache.ErrNotFound:
+		if hasExpected {
+			return []byte{0}, nil
+		}
+	case err != nil:
+		return nil, err
+	default:
+		if !hasExpected || !bytes.Equal(cur, expected) {
+			return []byte{0}, nil
+		}
+	}
+	if err := tx.Put(key, val, ttl); err != nil {
+		return nil, err
+	}
+	return []byte{1}, nil
+}
+
+// handleCompareAndDel deletes key only if its current value equals expected — the
+// safe-unlock primitive. Result: 1=deleted, 0=mismatch or absent. Atomic under the
+// shard write lock; the compare read uses the leader-stamped clock on the
+// replicated path.
+func handleCompareAndDel(tx *TxContext, args []byte) ([]byte, error) {
+	key, expected, err := wire.DecodeCADArgs(args)
+	if err != nil {
+		return nil, err
+	}
+	cur, err := tx.Get(key)
+	if err == cache.ErrNotFound {
+		return []byte{0}, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	if !bytes.Equal(cur, expected) {
+		return []byte{0}, nil
+	}
+	existed, err := tx.Del(key)
+	if err != nil {
+		return nil, err
+	}
+	if existed {
+		return []byte{1}, nil
+	}
+	return []byte{0}, nil
 }
 
 // handlePing is a no-op heartbeat used by the client pool's stale-conn check.

--- a/ops/builtin_test.go
+++ b/ops/builtin_test.go
@@ -153,6 +153,233 @@ func TestBuiltinIncrAccumulates(t *testing.T) {
 	}
 }
 
+func TestBuiltinSetNX(t *testing.T) {
+	r, tx := newTestSetup(t)
+	h, kind, _, ok := r.Lookup("set_nx")
+	if !ok {
+		t.Fatal("set_nx not registered")
+	}
+	if kind != OpReadWrite {
+		t.Fatalf("set_nx kind = %v, want OpReadWrite", kind)
+	}
+	getH, _, _, _ := r.Lookup("get")
+
+	// Stores when absent.
+	res, err := h(tx, EncodeSetNXArgs([]byte("k"), []byte("v1"), 0))
+	if err != nil {
+		t.Fatalf("set_nx: %v", err)
+	}
+	if stored, _ := DecodeCASResult(res); !stored {
+		t.Fatal("set_nx on absent key = false, want true (stored)")
+	}
+	got, _ := getH(tx, EncodeKeyArgs([]byte("k")))
+	if !bytes.Equal(got, []byte("v1")) {
+		t.Fatalf("value = %q, want v1", got)
+	}
+
+	// No-op when present: returns false and does NOT overwrite.
+	res, _ = h(tx, EncodeSetNXArgs([]byte("k"), []byte("v2"), 0))
+	if stored, _ := DecodeCASResult(res); stored {
+		t.Fatal("set_nx on present key = true, want false")
+	}
+	got, _ = getH(tx, EncodeKeyArgs([]byte("k")))
+	if !bytes.Equal(got, []byte("v1")) {
+		t.Fatalf("value overwritten to %q, want v1", got)
+	}
+}
+
+func TestBuiltinSetNXReacquiresAfterExpiry(t *testing.T) {
+	r, tx := newTestSetup(t)
+	h, _, _, _ := r.Lookup("set_nx")
+
+	res, _ := h(tx, EncodeSetNXArgs([]byte("lock"), []byte("a"), 10*time.Millisecond))
+	if stored, _ := DecodeCASResult(res); !stored {
+		t.Fatal("first set_nx not stored")
+	}
+	// While live, a second set_nx is refused.
+	res, _ = h(tx, EncodeSetNXArgs([]byte("lock"), []byte("b"), 10*time.Millisecond))
+	if stored, _ := DecodeCASResult(res); stored {
+		t.Fatal("set_nx acquired a still-live key")
+	}
+	// After expiry, set_nx re-acquires.
+	time.Sleep(30 * time.Millisecond)
+	res, _ = h(tx, EncodeSetNXArgs([]byte("lock"), []byte("c"), 0))
+	if stored, _ := DecodeCASResult(res); !stored {
+		t.Fatal("set_nx did not re-acquire after expiry")
+	}
+	getH, _, _, _ := r.Lookup("get")
+	got, _ := getH(tx, EncodeKeyArgs([]byte("lock")))
+	if !bytes.Equal(got, []byte("c")) {
+		t.Fatalf("value = %q, want c", got)
+	}
+}
+
+func TestBuiltinCAS(t *testing.T) {
+	r, tx := newTestSetup(t)
+	h, kind, _, ok := r.Lookup("cas")
+	if !ok {
+		t.Fatal("cas not registered")
+	}
+	if kind != OpReadWrite {
+		t.Fatalf("cas kind = %v, want OpReadWrite", kind)
+	}
+	putH, _, _, _ := r.Lookup("put")
+	getH, _, _, _ := r.Lookup("get")
+
+	_, _ = putH(tx, EncodePutArgs([]byte("k"), []byte("v1"), 0))
+
+	// Match writes.
+	res, err := h(tx, EncodeCASArgs([]byte("k"), []byte("v2"), true, []byte("v1"), 0))
+	if err != nil {
+		t.Fatalf("cas: %v", err)
+	}
+	if ok, _ := DecodeCASResult(res); !ok {
+		t.Fatal("cas match = false, want true")
+	}
+	got, _ := getH(tx, EncodeKeyArgs([]byte("k")))
+	if !bytes.Equal(got, []byte("v2")) {
+		t.Fatalf("value = %q, want v2", got)
+	}
+
+	// Mismatch no-ops.
+	res, _ = h(tx, EncodeCASArgs([]byte("k"), []byte("v3"), true, []byte("WRONG"), 0))
+	if ok, _ := DecodeCASResult(res); ok {
+		t.Fatal("cas mismatch = true, want false")
+	}
+	got, _ = getH(tx, EncodeKeyArgs([]byte("k")))
+	if !bytes.Equal(got, []byte("v2")) {
+		t.Fatalf("value changed on mismatch to %q, want v2", got)
+	}
+}
+
+func TestBuiltinCASExpectAbsent(t *testing.T) {
+	r, tx := newTestSetup(t)
+	h, _, _, _ := r.Lookup("cas")
+	getH, _, _, _ := r.Lookup("get")
+
+	// Expect-absent (hasExpected=false) succeeds on an absent key.
+	res, _ := h(tx, EncodeCASArgs([]byte("k"), []byte("v1"), false, nil, 0))
+	if ok, _ := DecodeCASResult(res); !ok {
+		t.Fatal("cas expect-absent on absent = false, want true")
+	}
+	got, _ := getH(tx, EncodeKeyArgs([]byte("k")))
+	if !bytes.Equal(got, []byte("v1")) {
+		t.Fatalf("value = %q, want v1", got)
+	}
+
+	// Expect-absent fails on a present key.
+	res, _ = h(tx, EncodeCASArgs([]byte("k"), []byte("v2"), false, nil, 0))
+	if ok, _ := DecodeCASResult(res); ok {
+		t.Fatal("cas expect-absent on present = true, want false")
+	}
+
+	// hasExpected=true fails on an absent key.
+	res, _ = h(tx, EncodeCASArgs([]byte("absent"), []byte("v"), true, []byte("anything"), 0))
+	if ok, _ := DecodeCASResult(res); ok {
+		t.Fatal("cas expect-value on absent = true, want false")
+	}
+}
+
+func TestBuiltinCompareAndDel(t *testing.T) {
+	r, tx := newTestSetup(t)
+	h, kind, _, ok := r.Lookup("cad")
+	if !ok {
+		t.Fatal("cad not registered")
+	}
+	if kind != OpReadWrite {
+		t.Fatalf("cad kind = %v, want OpReadWrite", kind)
+	}
+	putH, _, _, _ := r.Lookup("put")
+	getH, _, _, _ := r.Lookup("get")
+
+	_, _ = putH(tx, EncodePutArgs([]byte("k"), []byte("tok"), 0))
+
+	// Mismatch no-ops (key stays).
+	res, _ := h(tx, EncodeCADArgs([]byte("k"), []byte("WRONG")))
+	if ok, _ := DecodeCASResult(res); ok {
+		t.Fatal("cad mismatch = true, want false")
+	}
+	if _, err := getH(tx, EncodeKeyArgs([]byte("k"))); err != nil {
+		t.Fatalf("key deleted on mismatch: %v", err)
+	}
+
+	// Match deletes.
+	res, _ = h(tx, EncodeCADArgs([]byte("k"), []byte("tok")))
+	if ok, _ := DecodeCASResult(res); !ok {
+		t.Fatal("cad match = false, want true")
+	}
+	if _, err := getH(tx, EncodeKeyArgs([]byte("k"))); err != cache.ErrNotFound {
+		t.Fatalf("post-cad get: err = %v, want ErrNotFound", err)
+	}
+
+	// No-op on absent.
+	res, _ = h(tx, EncodeCADArgs([]byte("absent"), []byte("x")))
+	if ok, _ := DecodeCASResult(res); ok {
+		t.Fatal("cad on absent = true, want false")
+	}
+}
+
+func TestCASCADCodecs(t *testing.T) {
+	// Short-args rejection (never a panic) for the new decoders.
+	if _, _, _, _, _, err := DecodeCASArgs([]byte{0}); err != ErrShortArgs {
+		t.Fatalf("DecodeCASArgs short: err = %v, want ErrShortArgs", err)
+	}
+	if _, _, err := DecodeCADArgs([]byte{0}); err != ErrShortArgs {
+		t.Fatalf("DecodeCADArgs short: err = %v, want ErrShortArgs", err)
+	}
+	// A value-length claim with no body behind it is rejected, not read past.
+	if _, _, _, _, _, err := DecodeCASArgs([]byte{0, 0, 0, 0, 0, 5}); err != ErrShortArgs {
+		t.Fatalf("DecodeCASArgs truncated val: err = %v, want ErrShortArgs", err)
+	}
+	if _, _, err := DecodeCADArgs([]byte{0, 0, 0, 0, 0, 5}); err != ErrShortArgs {
+		t.Fatalf("DecodeCADArgs truncated expected: err = %v, want ErrShortArgs", err)
+	}
+	// A near-MaxInt32 expLen behind a valid zero preamble must be rejected, not
+	// read past. On 32-bit this is where an additive `elen+8` bounds check would
+	// overflow negative, slip the guard, and panic the slice — so the check must
+	// never add the untrusted length. Frame: klen=0, vlen=0, hasExpected=0,
+	// expLen=0x7FFFFFFF, nothing behind it.
+	casOverflow := []byte{0, 0 /*klen*/, 0, 0, 0, 0 /*vlen*/, 0 /*hasExpected*/, 0x7F, 0xFF, 0xFF, 0xFF /*expLen*/}
+	if _, _, _, _, _, err := DecodeCASArgs(casOverflow); err != ErrShortArgs {
+		t.Fatalf("DecodeCASArgs huge expLen: err = %v, want ErrShortArgs", err)
+	}
+	// DecodeCASResult shape.
+	if _, err := DecodeCASResult([]byte{}); err != ErrShortArgs {
+		t.Fatalf("DecodeCASResult empty: err = %v, want ErrShortArgs", err)
+	}
+	if ok, _ := DecodeCASResult([]byte{1}); !ok {
+		t.Fatal("DecodeCASResult([1]) = false, want true")
+	}
+	if ok, _ := DecodeCASResult([]byte{0}); ok {
+		t.Fatal("DecodeCASResult([0]) = true, want false")
+	}
+
+	// CAS roundtrip (expect-value).
+	k, v, has, exp, ttl, err := DecodeCASArgs(EncodeCASArgs([]byte("k"), []byte("v"), true, []byte("e"), 2*time.Second))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(k, []byte("k")) || !bytes.Equal(v, []byte("v")) || !has || !bytes.Equal(exp, []byte("e")) || ttl != 2*time.Second {
+		t.Fatalf("CAS roundtrip: k=%q v=%q has=%v exp=%q ttl=%v", k, v, has, exp, ttl)
+	}
+	// Expect-absent roundtrip drops the expected bytes.
+	_, _, has, exp, _, err = DecodeCASArgs(EncodeCASArgs([]byte("k"), []byte("v"), false, []byte("ignored"), 0))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if has || exp != nil {
+		t.Fatalf("expect-absent roundtrip: has=%v exp=%q, want false/nil", has, exp)
+	}
+	// CAD roundtrip.
+	dk, de, err := DecodeCADArgs(EncodeCADArgs([]byte("key"), []byte("expected")))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(dk, []byte("key")) || !bytes.Equal(de, []byte("expected")) {
+		t.Fatalf("CAD roundtrip: k=%q e=%q", dk, de)
+	}
+}
+
 func TestArgsCodecRoundtrip(t *testing.T) {
 	// EncodeKeyArgs ↔ DecodeKeyArgs
 	k := []byte("user:42")

--- a/ops/hostile_decode_test.go
+++ b/ops/hostile_decode_test.go
@@ -52,6 +52,8 @@ var hostileDecoders = []struct {
 	{"DecodeBulkBuildArgs", DecodeBulkBuildArgs},
 	{"DecodeBulkStageArgs", DecodeBulkStageArgs},
 	{"DecodeBulkStagePayloadArgs", DecodeBulkStagePayloadArgs},
+	{"DecodeCADArgs", DecodeCADArgs},
+	{"DecodeCASArgs", DecodeCASArgs},
 	{"DecodeClearPayloadArgs", DecodeClearPayloadArgs},
 	{"DecodeClearPayloadArgsCAS", DecodeClearPayloadArgsCAS},
 	{"DecodeCreateCollectionArgs", DecodeCreateCollectionArgs},
@@ -237,7 +239,7 @@ func TestNoDecoderPanicsOnHostileBytes(t *testing.T) {
 	// A floor on the roster, because the failure mode of this sweep is silent:
 	// deleting entries makes it pass faster, not fail. Raise it when decoders are
 	// added; only lower it deliberately, when an op is genuinely removed.
-	const minDecoders = 135
+	const minDecoders = 137
 	if len(hostileDecoders) < minDecoders {
 		t.Fatalf("only %d decoders in the sweep (floor %d) — entries were removed, "+
 			"which narrows the coverage without failing anything", len(hostileDecoders), minDecoders)

--- a/ops/wire_aliases.go
+++ b/ops/wire_aliases.go
@@ -109,6 +109,9 @@ var (
 	DecodeBulkBuildArgs                       = wire.DecodeBulkBuildArgs
 	DecodeBulkStageArgs                       = wire.DecodeBulkStageArgs
 	DecodeBulkStagePayloadArgs                = wire.DecodeBulkStagePayloadArgs
+	DecodeCADArgs                             = wire.DecodeCADArgs
+	DecodeCASArgs                             = wire.DecodeCASArgs
+	DecodeCASResult                           = wire.DecodeCASResult
 	DecodeClearPayloadArgs                    = wire.DecodeClearPayloadArgs
 	DecodeClearPayloadArgsCAS                 = wire.DecodeClearPayloadArgsCAS
 	DecodeCreateCollectionArgs                = wire.DecodeCreateCollectionArgs
@@ -259,6 +262,8 @@ var (
 	EncodeBulkBuildArgs                       = wire.EncodeBulkBuildArgs
 	EncodeBulkStageArgs                       = wire.EncodeBulkStageArgs
 	EncodeBulkStagePayloadArgs                = wire.EncodeBulkStagePayloadArgs
+	EncodeCADArgs                             = wire.EncodeCADArgs
+	EncodeCASArgs                             = wire.EncodeCASArgs
 	EncodeClearPayloadArgs                    = wire.EncodeClearPayloadArgs
 	EncodeClearPayloadArgsCAS                 = wire.EncodeClearPayloadArgsCAS
 	EncodeCreateCollectionArgs                = wire.EncodeCreateCollectionArgs
@@ -384,6 +389,7 @@ var (
 	EncodeSetPayloadArgs                      = wire.EncodeSetPayloadArgs
 	EncodeSetPayloadArgsCAS                   = wire.EncodeSetPayloadArgsCAS
 	EncodeSetPayloadArgsOpts                  = wire.EncodeSetPayloadArgsOpts
+	EncodeSetNXArgs                           = wire.EncodeSetNXArgs
 	EncodeVectorDeleteArgs                    = wire.EncodeVectorDeleteArgs
 	EncodeVectorDeleteArgsCAS                 = wire.EncodeVectorDeleteArgsCAS
 	EncodeVectorDocs                          = wire.EncodeVectorDocs

--- a/sdk/wire/builtin.go
+++ b/sdk/wire/builtin.go
@@ -183,6 +183,132 @@ func DecodeIncrResult(b []byte) (int64, error) {
 	return int64(binary.BigEndian.Uint64(b)), nil //nolint:gosec // safe: reinterpret stored u64 as i64 for binary read
 }
 
+// EncodeSetNXArgs encodes the args for set_nx. Its wire layout is IDENTICAL to
+// put's ("{keyLen u16}{key}{valLen u32}{val}{ttlMs u64}"), so it delegates to
+// EncodePutArgs; the server decodes it with DecodePutArgs.
+func EncodeSetNXArgs(key, val []byte, ttl time.Duration) []byte {
+	return EncodePutArgs(key, val, ttl)
+}
+
+// EncodeCASArgs encodes "{keyLen u16}{key}{valLen u32}{val}{hasExpected u8}
+// {expLen u32}{expected}{ttlMs u64}". hasExpected=false means "expect the key to
+// be absent"; the expected bytes are dropped (zero length) in that case.
+func EncodeCASArgs(key, val []byte, hasExpected bool, expected []byte, ttl time.Duration) []byte {
+	if !hasExpected {
+		expected = nil
+	}
+	buf := make([]byte, 2+len(key)+4+len(val)+1+4+len(expected)+8)
+	binary.BigEndian.PutUint16(buf[0:2], uint16(len(key))) //nolint:gosec // bounded by upstream key/value length limits
+	copy(buf[2:], key)
+	off := 2 + len(key)
+	binary.BigEndian.PutUint32(buf[off:off+4], uint32(len(val))) //nolint:gosec // bounded by upstream key/value length limits
+	copy(buf[off+4:], val)
+	off += 4 + len(val)
+	if hasExpected {
+		buf[off] = 1
+	}
+	off++
+	binary.BigEndian.PutUint32(buf[off:off+4], uint32(len(expected))) //nolint:gosec // bounded by upstream key/value length limits
+	copy(buf[off+4:], expected)
+	off += 4 + len(expected)
+	binary.BigEndian.PutUint64(buf[off:off+8], uint64(ttl/time.Millisecond)) //nolint:gosec // safe: duration to milliseconds always positive
+	return buf
+}
+
+// DecodeCASArgs reads args produced by EncodeCASArgs. Every variable-length field
+// is bounds-checked in the 32-bit-safe form `len(args)-off < need` with an
+// explicit `< 0` guard on each u32 length, so a hostile length that widens
+// NEGATIVE on GOARCH=386 (int is 32-bit there) is rejected instead of slipping
+// past an additive `off+need` check that could itself overflow. See the hostile
+// decoder sweep (ops.TestNoDecoderPanicsOnHostileBytes).
+func DecodeCASArgs(args []byte) (key, val []byte, hasExpected bool, expected []byte, ttl time.Duration, err error) {
+	if len(args) < 2 {
+		return nil, nil, false, nil, 0, ErrShortArgs
+	}
+	klen := int(binary.BigEndian.Uint16(args[0:2]))
+	off := 2
+	if len(args)-off < klen+4 { // key + valLen(4)
+		return nil, nil, false, nil, 0, ErrShortArgs
+	}
+	key = args[off : off+klen]
+	off += klen
+	vlen := int(binary.BigEndian.Uint32(args[off : off+4]))
+	off += 4
+	if vlen < 0 || len(args)-off < vlen {
+		return nil, nil, false, nil, 0, ErrShortArgs
+	}
+	val = args[off : off+vlen]
+	off += vlen
+	if len(args)-off < 1+4 { // hasExpected(1) + expLen(4)
+		return nil, nil, false, nil, 0, ErrShortArgs
+	}
+	hasExpected = args[off] != 0
+	off++
+	elen := int(binary.BigEndian.Uint32(args[off : off+4]))
+	off += 4
+	// Check expected and ttlMs separately: never add the untrusted elen to the
+	// need (elen+8 can overflow int to negative on 32-bit and slip past the
+	// guard, then panic the slice below — the exact contract TestNoDecoderPanics
+	// forbids). len(args)-off can't overflow (both bounded by real slice length).
+	if elen < 0 || len(args)-off < elen { // expected
+		return nil, nil, false, nil, 0, ErrShortArgs
+	}
+	expected = args[off : off+elen]
+	off += elen
+	if len(args)-off < 8 { // ttlMs(8)
+		return nil, nil, false, nil, 0, ErrShortArgs
+	}
+	ttl = time.Duration(binary.BigEndian.Uint64(args[off:off+8])) * time.Millisecond //nolint:gosec // safe: u64 from wire is milliseconds, always positive
+	if !hasExpected {
+		expected = nil
+	}
+	return key, val, hasExpected, expected, ttl, nil
+}
+
+// EncodeCADArgs encodes "{keyLen u16}{key}{expLen u32}{expected}" for cad
+// (compare-and-delete).
+func EncodeCADArgs(key, expected []byte) []byte {
+	buf := make([]byte, 2+len(key)+4+len(expected))
+	binary.BigEndian.PutUint16(buf[0:2], uint16(len(key))) //nolint:gosec // bounded by upstream key/value length limits
+	copy(buf[2:], key)
+	off := 2 + len(key)
+	binary.BigEndian.PutUint32(buf[off:off+4], uint32(len(expected))) //nolint:gosec // bounded by upstream key/value length limits
+	copy(buf[off+4:], expected)
+	return buf
+}
+
+// DecodeCADArgs reads args produced by EncodeCADArgs. Bounds-checked in the same
+// 32-bit-safe form as DecodeCASArgs.
+func DecodeCADArgs(args []byte) (key, expected []byte, err error) {
+	if len(args) < 2 {
+		return nil, nil, ErrShortArgs
+	}
+	klen := int(binary.BigEndian.Uint16(args[0:2]))
+	off := 2
+	if len(args)-off < klen+4 { // key + expLen(4)
+		return nil, nil, ErrShortArgs
+	}
+	key = args[off : off+klen]
+	off += klen
+	elen := int(binary.BigEndian.Uint32(args[off : off+4]))
+	off += 4
+	if elen < 0 || len(args)-off < elen {
+		return nil, nil, ErrShortArgs
+	}
+	expected = args[off : off+elen]
+	return key, expected, nil
+}
+
+// DecodeCASResult parses the 1-byte 0/1 result shared by set_nx, cas, and cad:
+// 1 = the write happened (stored / deleted), 0 = the condition failed (key
+// present / value mismatch / absent).
+func DecodeCASResult(b []byte) (bool, error) {
+	if len(b) != 1 {
+		return false, ErrShortArgs
+	}
+	return b[0] != 0, nil
+}
+
 // ScrollOrderToOrderBy maps the wire args ScrollOrder onto vector.OrderBy, including the
 // MULTI-KEY Tail (the secondary key specs) and the v4 resume TUPLE (ResumeKeys). A nil
 // or single-key ScrollOrder maps to the byte/behaviour-identical single-key vector.OrderBy

--- a/sdk/wire/builtin_routing.go
+++ b/sdk/wire/builtin_routing.go
@@ -30,6 +30,11 @@ var BuiltinOps = []BuiltinOp{
 	{"del", OpReadWrite, StdKeyExtractor, RouteLayoutNone, false},
 	{"expire", OpReadWrite, StdKeyExtractor, RouteLayoutNone, false},
 	{"incr", OpReadWrite, StdKeyExtractor, RouteLayoutNone, false},
+	// Conditional-write KV ops. All three lead with [keyLen u16][key], so they
+	// route by that key via StdKeyExtractor exactly like get/put/incr.
+	{"set_nx", OpReadWrite, StdKeyExtractor, RouteLayoutNone, false},
+	{"cas", OpReadWrite, StdKeyExtractor, RouteLayoutNone, false},
+	{"cad", OpReadWrite, StdKeyExtractor, RouteLayoutNone, false},
 	// put_batch packs N puts into one Raft log entry. It routes by its FIRST key,
 	// so every key in a batch must hash to the same shard — the cluster fan-out
 	// (Node.PutBatch) guarantees that by grouping before it calls.


### PR DESCRIPTION
Atomic conditional-write KV ops — `set_nx`, `cas`, and compare-and-delete — plus the client-side fix so they aren't replayed across an ambiguous transport failure.

(This replaces #58, which GitHub auto-closed when its stacked base branch `feat/harden-386-decoders` was deleted on merge of #57. Same commits, rebased onto current `main`; both review threads on #58 were addressed and resolved before it closed.)

## Ops
- **`set_nx`** — store only if the key is absent (or expired) → `Cache::add`, atomic lock acquire.
- **`cas`** — store only if the current value equals an expected value (`hasExpected=false` ⇒ expect-absent).
- **`cad`** — delete only if the current value equals an expected value → safe lock release.

No engine/store/Raft change: handlers already run under the shard lock inside `FSM.Apply` (so a Get→compare→Put is atomic), and the leader-stamped `GetAt`/`PutAt` make the store/no-store decision replica-deterministic. Closes the "`add()` isn't atomic / no CAS" gap.

## Client correctness fix
`Client.Call` transparently retried transport failures on another server, which for these outcome-returning writes could replay a possibly-committed write and return the wrong result (a lock the call actually took, reported as not-taken). The client now distinguishes pre-transmission failures (safe to fail over) from ambiguous post-transmission ones (a conditional write is not replayed across them — the caller gets the transport error to re-check state). Idempotent ops and NotLeader retries are unchanged. Includes a two-server dropped-response fault-injection test.

## Surface & tests
Wire codecs in `sdk/wire` (32-bit-safe bounds checks, hostile-decode sweep coverage); Go client `SetNX`/`CAS`/`CompareAndDelete`; Python `set_nx`/`cas`/`compare_and_delete`; handler unit tests, an exactly-one-winner race test through the full client→Raft→apply stack, and cross-stack Python↔Go tests. Changelog updated.
