### PR TITLE
feat(vector): restore a valid mapping on a failed mmap grow (no more bricking on disk-full)

### DIFF
--- a/vector/arena.go
+++ b/vector/arena.go
@@ -155,6 +155,14 @@ const mmapInitVectors = 1024
 // the platform files and is visible to the platform-agnostic test.
 var growVecMmapFailpoint func() error
 
+// growVecMmapRestoreFailpoint is the second seam: when non-nil, the real
+// growVecMmap impls consult it right before the RESTORE remap and, on a non-nil
+// return, skip that remap so it fails too — driving the (region==nil) terminal
+// tri-state (grow AND restore both failed). Same test-only, nil-in-production
+// contract and platform coverage as growVecMmapFailpoint; used together with it
+// to exercise the double-failure poison + errors.Join path.
+var growVecMmapRestoreFailpoint func() error
+
 // floatsOver reinterprets a byte region as a []float32 spanning its full
 // length (len == cap == len(region)/4). The region must outlive the slice;
 // arena rebuilds this header whenever the mapping moves.

--- a/vector/arena.go
+++ b/vector/arena.go
@@ -80,11 +80,22 @@ type arena struct {
 	mmapF      *os.File
 	mmapRegion []byte
 
-	// poisoned marks a TERMINAL failure of an mmap slab growth (growVecs or the
-	// graph's growLevel0). growVecMmap unmaps the old view BEFORE it truncates and
-	// remaps, so a failure partway through leaves the old region freed and the
-	// aliasing slice header (vecs / level0) nil'd — there is no valid mapping to
-	// fall back to. The guard is LAYERED so no op dereferences the freed region:
+	// poisoned marks a TERMINAL failure of an mmap slab growth. growVecMmap unmaps
+	// the old view BEFORE it truncates and remaps; a grow that fails there now FIRST
+	// tries to restore a mapping of the old (intact, append-only) data. What that
+	// buys depends on WHICH slab was growing, because the two grows sit on opposite
+	// sides of the point commit:
+	//   - arena.growVecs (the vecs slab) runs INSIDE arena.Insert, BEFORE the point
+	//     is committed. A restored failure aborts that Insert as a clean no-op, so
+	//     the index stays fully usable and this flag is NOT set — only the single op
+	//     errors. Poison is reached only in the rare DOUBLE failure (restore also
+	//     fails), leaving the region freed and vecs nil'd.
+	//   - hnsw.growLevel0 (the graph slab) runs from setNode, AFTER the point is
+	//     committed to idMap/indexes, with no clean rollback. A grow failure there is
+	//     ALWAYS terminal (poison) even when the mapping was restored, because
+	//     "restored but usable" would leave a torn half-committed insert — strictly
+	//     worse than poison. See growLevel0's error branch for the full rationale.
+	// Either way, once set the guard is LAYERED so no op dereferences a freed region:
 	//   - write / persist / snapshot chokepoints (insertBody, SavePersist,
 	//     Snapshot) check the flag at the top and return ErrIndexPoisoned;
 	//   - read chokepoints check UNDER h.mu, which also closes the TOCTOU against a
@@ -132,6 +143,17 @@ type arena struct {
 // first mapped. Growth is geometric from there, so this only bounds the number
 // of early remaps.
 const mmapInitVectors = 1024
+
+// growVecMmapFailpoint, when non-nil, is invoked by the real growVecMmap impls
+// (mmap_linux.go and mmap_windows.go — the mmap_other.go stub has no mapping to
+// grow and never consults it) right after the old view is unmapped; its returned
+// error (if any) forces the grow to fail there — the Truncate/mmap is skipped and
+// control goes straight to the restore path with that error. It exists ONLY so a
+// test can deterministically simulate a Truncate/mmap failure (disk-full,
+// address-space exhaustion) without one actually occurring; it is nil in
+// production. Declared here (untagged) so the single definition is shared across
+// the platform files and is visible to the platform-agnostic test.
+var growVecMmapFailpoint func() error
 
 // floatsOver reinterprets a byte region as a []float32 spanning its full
 // length (len == cap == len(region)/4). The region must outlive the slice;
@@ -454,12 +476,20 @@ func (a *arena) growVecs(needFloats int) error {
 	if a.mmapF != nil {
 		region, err := growVecMmap(a.mmapF, a.mmapRegion, newBytes)
 		if err != nil {
-			// growVecMmap unmaps the old view BEFORE truncate+remap; on error the old
-			// backing is already gone, so a.mmapRegion/a.vecs (which aliases it) point
-			// at an unmapped region. Poison the index so every public op rejects with
+			if region != nil {
+				// Grow failed, but growVecMmap restored a valid mapping of the OLD data
+				// (grow only appends, so bytes [0,oldLen) are intact). Rebind to it at the
+				// old logical length: the index stays fully usable and only THIS operation
+				// fails. len(region) == oldLen*4 bytes, so the reslice is in-bounds. No poison.
+				a.mmapRegion = region
+				a.vecs = floatsOver(region)[:oldLen]
+				return err
+			}
+			// Grow AND restore both failed: the old backing is gone with nothing valid to
+			// fall back to. Poison the index so every public op rejects with
 			// ErrIndexPoisoned, and nil the headers (belt-and-suspenders) so a bug that
 			// bypasses the guard faults cleanly instead of reading unmapped memory.
-			// (a.codes has no file backing — leave it.)
+			// (a.codes has no file backing — leave it.) This is now the rare backstop.
 			a.poisoned.Store(true)
 			a.mmapRegion = nil
 			a.vecs = nil

--- a/vector/graph.go
+++ b/vector/graph.go
@@ -173,16 +173,39 @@ func (h *hnsw) growLevel0(needU32 int) error {
 	if h.graphMmapF != nil {
 		region, err := growVecMmap(h.graphMmapF, h.graphRegion, newBytes)
 		if err != nil {
-			// growVecMmap unmaps the old view BEFORE truncate+remap; on error the old
-			// backing is already gone, so h.graphRegion/h.level0 (which aliases it)
-			// point at an unmapped region. Poison the index (via the arena, which is
-			// always present and holds the single terminal flag) so every public op
-			// rejects with ErrIndexPoisoned, and nil the headers (belt-and-suspenders)
-			// so a bug that bypasses the guard faults cleanly instead of reading
-			// unmapped memory. (h.nodes/h.level0Len are heap-backed — leave them.)
+			// A graph-slab grow failure is TERMINAL — even when growVecMmap restored a
+			// valid mapping of the old edges. This is the deliberate ASYMMETRY with
+			// arena.growVecs, and the reason is WHEN each grow runs relative to the point
+			// commit:
+			//
+			//   - arena.growVecs grows INSIDE arena.Insert, BEFORE the point is committed,
+			//     so a restored failure aborts that Insert as a clean no-op and the index
+			//     stays consistent → non-terminal, no poison.
+			//   - growLevel0 runs from setNode, AFTER placeLockedAt has already committed
+			//     the point: idMap/ids/Size, its version, the payload/sparse/bm25 indexes,
+			//     bytesUsed, and ensureGraphSlot has already extended h.nodes with a nil
+			//     entry + h.level0Len. There is NO clean rollback from here.
+			//
+			// Returning "restored, usable" would therefore leave a TORN insert: the point
+			// is present in the id set and secondary indexes but has a nil graph node —
+			// invisible to Search, un-retryable (arena.Insert would report ErrDuplicateID),
+			// reported to the caller as a failed insert (WAL / replica divergence), and a
+			// latent nil-deref of h.nodes[slot] in Snapshot. Poisoning is strictly safer
+			// than that half-committed state, so a graph-grow failure always goes terminal.
+			if region != nil {
+				// Rebind to the restored mapping anyway, so it is neither leaked nor left
+				// dangling: any access that slips past the poison guard then faults cleanly
+				// on real data rather than an unmapped region. (len(region) == oldLen*4.)
+				h.graphRegion = region
+				h.level0 = uint32sOver(region)[:oldLen]
+			} else {
+				h.graphRegion = nil
+				h.level0 = nil
+			}
+			// Poison via the arena (always present, holds the single terminal flag) so
+			// every public op rejects with ErrIndexPoisoned. (h.nodes/h.level0Len are
+			// heap-backed — leave them.)
 			h.arena.poisoned.Store(true)
-			h.graphRegion = nil
-			h.level0 = nil
 			return err
 		}
 		h.graphRegion = region

--- a/vector/grow_restore_test.go
+++ b/vector/grow_restore_test.go
@@ -49,6 +49,10 @@ func TestGrowFailureRestoresIndex(t *testing.T) {
 	if err != nil {
 		t.Fatalf("newHNSW(mmap): %v", err)
 	}
+	// Release the vector+graph mmaps at test end. On Windows a still-mapped
+	// graph.dat/vecs.dat blocks the t.TempDir RemoveAll ("being used by another
+	// process"), so this Close is what keeps the storage CI lane green.
+	t.Cleanup(func() { _ = h.Close() })
 
 	rng := rand.New(rand.NewSource(7))
 	vecs := make([][]float32, preN+1)
@@ -175,6 +179,9 @@ func TestGraphGrowFailurePoisonsIndex(t *testing.T) {
 	if err != nil {
 		t.Fatalf("newHNSW(graph-mmap): %v", err)
 	}
+	// Release the graph mmap at test end (see TestGrowFailureRestoresIndex) so the
+	// Windows t.TempDir cleanup can delete graph.dat.
+	t.Cleanup(func() { _ = h.Close() })
 
 	rng := rand.New(rand.NewSource(11))
 	mkVec := func() []float32 {
@@ -244,5 +251,94 @@ func TestGraphGrowFailurePoisonsIndex(t *testing.T) {
 		// No error return; the contract is panic-safety on the torn slot.
 		defer mustNotPanic(t)
 		_, _, _, _, _, _ = h.Get(1)
+	})
+}
+
+// TestGrowDoubleFailurePoisons exercises the terminal (region == nil) tri-state:
+// BOTH the original grow AND the restore remap fail. This is the one path where a
+// mmap-backed arena — otherwise the recoverable, pre-commit slab — must poison,
+// because after the restore fails there is genuinely no valid mapping to fall back
+// to. It also pins the errors.Join wrap: the returned error must carry BOTH the
+// grow cause and the restore cause reachably via errors.Is (a %v wrap of either
+// would break one of the two assertions below).
+func TestGrowDoubleFailurePoisons(t *testing.T) {
+	t.Cleanup(func() { growVecMmapFailpoint = nil; growVecMmapRestoreFailpoint = nil })
+
+	const (
+		dim  = 8
+		preN = mmapInitVectors
+	)
+
+	dir := t.TempDir()
+	cfg := Config{
+		Dim: dim, Metric: L2, M: 8, EfConstruction: 64, EfSearch: 32, Seed: 1,
+		Quant: QuantSQ8, RescoreFactor: 3,
+		QuantStorage:  QuantMmap,
+		MmapPath:      filepath.Join(dir, "vecs.dat"),
+		GraphMmapPath: filepath.Join(dir, "graph.dat"),
+	}
+	h, err := newHNSW(cfg)
+	if err != nil {
+		t.Fatalf("newHNSW(mmap): %v", err)
+	}
+	t.Cleanup(func() { _ = h.Close() })
+
+	rng := rand.New(rand.NewSource(13))
+	mkVec := func() []float32 {
+		v := make([]float32, dim)
+		for j := range v {
+			v[j] = float32(rng.NormFloat64())
+		}
+		return v
+	}
+	for i := 0; i < preN; i++ {
+		if _, _, err := h.Insert(uint64(i+1), mkVec(), 0, nil, nil, nil, CASCond{}); err != nil {
+			t.Fatalf("pre-grow insert %d: %v", i+1, err)
+		}
+	}
+	if h.arena.poisoned.Load() {
+		t.Fatalf("index poisoned before any grow failure")
+	}
+
+	// Arm BOTH seams with DISTINCT sentinels: the grow fails, then the restore remap
+	// also fails. The arena grow fires first (pre-commit), so this drives
+	// arena.growVecs into its (region == nil) terminal branch.
+	sentinelGrow := errors.New("injected grow failure (double)")
+	sentinelRestore := errors.New("injected restore failure (double)")
+	growVecMmapFailpoint = func() error { return sentinelGrow }
+	growVecMmapRestoreFailpoint = func() error { return sentinelRestore }
+
+	_, _, insErr := h.Insert(uint64(preN+1), mkVec(), 0, nil, nil, nil, CASCond{})
+	if insErr == nil {
+		t.Fatalf("grow-triggering insert: got nil err, want a double failure")
+	}
+
+	// Terminal: both mappings are gone, so the index must be poisoned.
+	if !h.arena.poisoned.Load() {
+		t.Fatalf("index NOT poisoned after a grow+restore double failure")
+	}
+
+	// The wrap must keep BOTH causes reachable (this is what errors.Join buys over
+	// a %v of either cause).
+	if !errors.Is(insErr, sentinelGrow) {
+		t.Fatalf("returned error does not wrap the GROW cause reachably: %v", insErr)
+	}
+	if !errors.Is(insErr, sentinelRestore) {
+		t.Fatalf("returned error does not wrap the RESTORE cause reachably: %v", insErr)
+	}
+
+	// And the index rejects cleanly from here on.
+	t.Run("Search", func(t *testing.T) {
+		defer mustNotPanic(t)
+		if _, err := h.Search(make([]float32, dim), 5); !errors.Is(err, ErrIndexPoisoned) {
+			t.Fatalf("Search: got %v, want ErrIndexPoisoned", err)
+		}
+	})
+	t.Run("Snapshot", func(t *testing.T) {
+		defer mustNotPanic(t)
+		var buf bytes.Buffer
+		if err := h.Snapshot(&buf); !errors.Is(err, ErrIndexPoisoned) {
+			t.Fatalf("Snapshot: got %v, want ErrIndexPoisoned", err)
+		}
 	})
 }

--- a/vector/grow_restore_test.go
+++ b/vector/grow_restore_test.go
@@ -1,0 +1,248 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package vector
+
+import (
+	"bytes"
+	"errors"
+	"math/rand"
+	"path/filepath"
+	"testing"
+)
+
+// TestGrowFailureRestoresIndex proves the non-terminal grow-failure contract: a
+// transient failure of the mmap slab grow (disk-full / address-space exhaustion)
+// no longer bricks the collection. growVecMmap restores a mapping of the old
+// (append-only, therefore intact) data, the caller rebinds to it, and only the
+// single operation that triggered the grow fails — the index stays un-poisoned
+// and fully usable, and a later grow succeeds once the transient condition lifts.
+//
+// The failure is injected deterministically via growVecMmapFailpoint (the arena
+// slab is mmap-backed here; the graph is heap-backed, so the failure lands in
+// arena.growVecs, which fails BEFORE any side-array/idMap mutation — a clean,
+// consistent no-op insert).
+func TestGrowFailureRestoresIndex(t *testing.T) {
+	t.Cleanup(func() { growVecMmapFailpoint = nil })
+
+	// preN fills the initial mmap capacity exactly, so the next insert (id preN+1)
+	// is the first that must grow the slab.
+	const (
+		dim  = 8
+		preN = mmapInitVectors
+	)
+
+	// Both slabs are mmap-backed (MmapPath + GraphMmapPath), which SavePersist
+	// requires. Within an insert, arena.Insert (and its grow) runs BEFORE
+	// setNode/growLevel0, and both slabs share the same mmapInitVectors initial
+	// capacity, so on the grow-triggering insert the arena grow fires the failpoint
+	// first and Insert bails before the graph grow is reached — the injected failure
+	// lands deterministically in arena.growVecs, a clean pre-mutation no-op.
+	dir := t.TempDir()
+	cfg := Config{
+		Dim: dim, Metric: L2, M: 8, EfConstruction: 64, EfSearch: 32, Seed: 1,
+		Quant: QuantSQ8, RescoreFactor: 3,
+		QuantStorage:  QuantMmap,
+		MmapPath:      filepath.Join(dir, "vecs.dat"),
+		GraphMmapPath: filepath.Join(dir, "graph.dat"),
+	}
+	h, err := newHNSW(cfg)
+	if err != nil {
+		t.Fatalf("newHNSW(mmap): %v", err)
+	}
+
+	rng := rand.New(rand.NewSource(7))
+	vecs := make([][]float32, preN+1)
+	mkVec := func() []float32 {
+		v := make([]float32, dim)
+		for j := range v {
+			v[j] = float32(rng.NormFloat64())
+		}
+		return v
+	}
+
+	// Fill the initial mmap capacity. None of these should grow the slab.
+	for i := 0; i < preN; i++ {
+		vecs[i] = mkVec()
+		if _, _, err := h.Insert(uint64(i+1), vecs[i], 0, nil, nil, nil, CASCond{}); err != nil {
+			t.Fatalf("pre-grow insert %d: %v", i+1, err)
+		}
+	}
+	if h.arena.poisoned.Load() {
+		t.Fatalf("index poisoned before any grow failure")
+	}
+	if got := h.arena.Size(); got != preN {
+		t.Fatalf("Size after pre-grow inserts = %d, want %d", got, preN)
+	}
+
+	// Arm the failpoint and drive the grow: the next insert crosses the initial
+	// capacity, so arena.growVecs → growVecMmap fires the failpoint.
+	errInjected := errors.New("injected grow failure")
+	growVecMmapFailpoint = func() error { return errInjected }
+
+	vecs[preN] = mkVec()
+	if _, _, err := h.Insert(uint64(preN+1), vecs[preN], 0, nil, nil, nil, CASCond{}); !errors.Is(err, errInjected) {
+		t.Fatalf("grow-triggering insert: got err %v, want errInjected", err)
+	}
+
+	// Contract 1: the index must NOT be poisoned — the restore path kept it valid.
+	if h.arena.poisoned.Load() {
+		t.Fatalf("index poisoned after a RESTORABLE grow failure; want it to remain valid")
+	}
+
+	// Contract 2: the failed insert was a clean no-op — the pre-grow points are all
+	// still present, and the failed id never landed.
+	if got := h.arena.Size(); got != preN {
+		t.Fatalf("Size after failed grow = %d, want %d (failed insert must be a no-op)", got, preN)
+	}
+	if _, ok := h.arena.Slot(uint64(preN + 1)); ok {
+		t.Fatalf("failed insert id %d is present in the arena; want it absent", preN+1)
+	}
+
+	// Contract 3: Search still returns the pre-grow vectors correctly (reads go
+	// through the restored mapping). Query with an exact stored vector; it must
+	// come back as the nearest neighbour.
+	res, err := h.Search(vecs[0], 5)
+	if err != nil {
+		t.Fatalf("Search after restored grow failure: %v", err)
+	}
+	if len(res) == 0 {
+		t.Fatalf("Search returned no results after restored grow failure")
+	}
+	if res[0].ID != 1 {
+		t.Fatalf("Search top hit = id %d, want id 1 (exact query vector)", res[0].ID)
+	}
+
+	// Contract 4: persistence paths work — the collection is fully serializable.
+	var buf bytes.Buffer
+	if err := h.Snapshot(&buf); err != nil {
+		t.Fatalf("Snapshot after restored grow failure: %v", err)
+	}
+	if buf.Len() == 0 {
+		t.Fatalf("Snapshot wrote 0 bytes after restored grow failure")
+	}
+	if err := h.SavePersist(filepath.Join(t.TempDir(), "meta")); err != nil {
+		t.Fatalf("SavePersist after restored grow failure: %v", err)
+	}
+
+	// Contract 5: recovery is complete, not a dead end. Clear the failpoint and
+	// retry the same insert — the grow now succeeds and the new vector is
+	// searchable, proving the slab genuinely grew.
+	growVecMmapFailpoint = nil
+	if _, _, err := h.Insert(uint64(preN+1), vecs[preN], 0, nil, nil, nil, CASCond{}); err != nil {
+		t.Fatalf("retry insert after clearing failpoint: %v", err)
+	}
+	if got := h.arena.Size(); got != preN+1 {
+		t.Fatalf("Size after successful retry = %d, want %d", got, preN+1)
+	}
+	res, err = h.Search(vecs[preN], 5)
+	if err != nil {
+		t.Fatalf("Search for post-recovery vector: %v", err)
+	}
+	if len(res) == 0 || res[0].ID != uint64(preN+1) {
+		t.Fatalf("post-recovery Search top hit = %+v, want id %d", res, preN+1)
+	}
+}
+
+// TestGraphGrowFailurePoisonsIndex is the counterpart to TestGrowFailureRestoresIndex
+// for the OTHER slab: the level-0 GRAPH slab, whose grow runs POST-commit. Here a
+// restored grow failure must NOT be treated as recoverable — the point has already
+// been committed to idMap/indexes by the time growLevel0 runs (via setNode), so a
+// "restored but usable" outcome would leave a torn half-insert. The contract under
+// test is therefore the opposite of the arena path: after a graph-grow failure the
+// index must be cleanly POISONED and every op must reject with ErrIndexPoisoned
+// (never nil-deref h.nodes[slot] / read the unmapped region), which is strictly
+// safer than the torn state.
+//
+// Only the graph slab is mmap-backed (GraphMmapPath); the arena is heap-backed (no
+// QuantMmap), so growVecMmap — and thus the failpoint — is reached ONLY from
+// growLevel0, never from arena.growVecs. Both slabs start at mmapInitVectors
+// capacity, and the arena's heap grow does not go through growVecMmap, so the
+// failpoint armed after preN inserts fires precisely on the graph grow at preN+1.
+func TestGraphGrowFailurePoisonsIndex(t *testing.T) {
+	t.Cleanup(func() { growVecMmapFailpoint = nil })
+
+	const (
+		dim  = 8
+		preN = mmapInitVectors
+	)
+
+	cfg := Config{
+		Dim: dim, Metric: L2, M: 8, EfConstruction: 64, EfSearch: 32, Seed: 1,
+		// No QuantMmap → heap arena. Graph slab is the only mmap-backed slab.
+		GraphMmapPath: filepath.Join(t.TempDir(), "graph.dat"),
+	}
+	h, err := newHNSW(cfg)
+	if err != nil {
+		t.Fatalf("newHNSW(graph-mmap): %v", err)
+	}
+
+	rng := rand.New(rand.NewSource(11))
+	mkVec := func() []float32 {
+		v := make([]float32, dim)
+		for j := range v {
+			v[j] = float32(rng.NormFloat64())
+		}
+		return v
+	}
+
+	for i := 0; i < preN; i++ {
+		if _, _, err := h.Insert(uint64(i+1), mkVec(), 0, nil, nil, nil, CASCond{}); err != nil {
+			t.Fatalf("pre-grow insert %d: %v", i+1, err)
+		}
+	}
+	if h.arena.poisoned.Load() {
+		t.Fatalf("index poisoned before any grow failure")
+	}
+
+	// Arm the failpoint and drive the graph grow: the arena's heap grow does not go
+	// through growVecMmap, so this fires only in growLevel0, AFTER the point has been
+	// committed to the arena.
+	errInjected := errors.New("injected graph grow failure")
+	growVecMmapFailpoint = func() error { return errInjected }
+
+	if _, _, err := h.Insert(uint64(preN+1), mkVec(), 0, nil, nil, nil, CASCond{}); err == nil {
+		t.Fatalf("grow-triggering insert: got nil err, want a failure")
+	}
+
+	// Contract: a POST-commit graph-grow failure is terminal. The index must be
+	// poisoned — NOT left in a torn/half-committed state.
+	if !h.arena.poisoned.Load() {
+		t.Fatalf("index NOT poisoned after a post-commit graph-grow failure; a restored-but-usable graph slab would leave a torn insert")
+	}
+
+	// Every op must reject cleanly with ErrIndexPoisoned (and never nil-deref the
+	// nil graph node / read the region), proving the guard covers the torn point.
+	t.Run("Search", func(t *testing.T) {
+		defer mustNotPanic(t)
+		if _, err := h.Search([]float32{1, 0, 0, 0, 0, 0, 0, 0}, 5); !errors.Is(err, ErrIndexPoisoned) {
+			t.Fatalf("Search: got %v, want ErrIndexPoisoned", err)
+		}
+	})
+	t.Run("Insert", func(t *testing.T) {
+		defer mustNotPanic(t)
+		if _, _, err := h.Insert(uint64(preN+2), []float32{0, 1, 0, 0, 0, 0, 0, 0}, 0, nil, nil, nil, CASCond{}); !errors.Is(err, ErrIndexPoisoned) {
+			t.Fatalf("Insert: got %v, want ErrIndexPoisoned", err)
+		}
+	})
+	t.Run("Snapshot", func(t *testing.T) {
+		defer mustNotPanic(t)
+		var buf bytes.Buffer
+		if err := h.Snapshot(&buf); !errors.Is(err, ErrIndexPoisoned) {
+			t.Fatalf("Snapshot: got %v, want ErrIndexPoisoned", err)
+		}
+		if buf.Len() != 0 {
+			t.Fatalf("Snapshot wrote %d bytes on a poisoned index; want a clean refusal", buf.Len())
+		}
+	})
+	t.Run("SavePersist", func(t *testing.T) {
+		defer mustNotPanic(t)
+		if err := h.SavePersist(t.TempDir() + "/meta"); !errors.Is(err, ErrIndexPoisoned) {
+			t.Fatalf("SavePersist: got %v, want ErrIndexPoisoned", err)
+		}
+	})
+	t.Run("Get", func(t *testing.T) {
+		// No error return; the contract is panic-safety on the torn slot.
+		defer mustNotPanic(t)
+		_, _, _, _, _, _ = h.Get(1)
+	})
+}

--- a/vector/mmap_linux.go
+++ b/vector/mmap_linux.go
@@ -4,6 +4,7 @@
 package vector
 
 import (
+	"errors"
 	"fmt"
 	"os"
 
@@ -31,24 +32,72 @@ func openVecMmap(path string, size int64) (*os.File, []byte, error) {
 	return f, region, nil
 }
 
-// growVecMmap unmaps old, grows the file to newSize bytes, and remaps it.
-// Returns the new region. The caller must rebuild any slice headers that
-// aliased the old region (the mapping address changes).
+// growVecMmap unmaps old, grows the file to newSize bytes, and remaps it. The
+// caller must rebuild any slice headers that aliased the old region (the mapping
+// address changes). The unmap comes first, so once it has run the old view is
+// gone and a later failure would otherwise leave nothing mapped — hence the
+// restore step below and the TRI-STATE return:
+//
+//   - (region != nil, err == nil): grew successfully; region covers newSize bytes.
+//   - (region != nil, err != nil): the grow failed, but a mapping of the OLD data
+//     was restored (grow only ever appends, so bytes [0,oldSize) are intact).
+//     len(region) == oldSize; the caller MUST rebind its header to region at the
+//     old logical length so the valid mapping is neither leaked nor left dangling.
+//     Whether the failure is then RECOVERABLE is the caller's call, and the two
+//     callers differ: arena.growVecs grows pre-commit, so it treats this as
+//     non-terminal (only the one op fails); hnsw.growLevel0 grows post-commit with
+//     no clean rollback, so it rebinds AND poisons. See each call site.
+//   - (region == nil, err != nil): the grow AND the restore both failed; no valid
+//     mapping remains, so the backing is unusable and the caller must go terminal.
 func growVecMmap(f *os.File, old []byte, newSize int64) ([]byte, error) {
-	if len(old) > 0 {
+	oldSize := int64(len(old))
+	if oldSize > 0 {
 		if err := unix.Munmap(old); err != nil {
 			return nil, fmt.Errorf("vector: munmap (grow): %w", err)
 		}
 	}
-	if err := f.Truncate(newSize); err != nil {
-		return nil, fmt.Errorf("vector: truncate (grow) to %d: %w", newSize, err)
-	}
 	fd := int(f.Fd()) //nolint:gosec // uintptr->int: fd values are small and positive on Linux
-	region, err := unix.Mmap(fd, 0, int(newSize), unix.PROT_READ|unix.PROT_WRITE, unix.MAP_SHARED)
-	if err != nil {
-		return nil, fmt.Errorf("vector: mmap (grow) to %d: %w", newSize, err)
+
+	// gErr is the original grow failure (nil until something fails). truncated
+	// records whether the file was already extended to newSize, so the restore can
+	// shrink it back before remapping the old extent.
+	var gErr error
+	truncated := false
+	if fp := growVecMmapFailpoint; fp != nil {
+		gErr = fp() // test-only: simulate a Truncate/mmap failure past the unmap.
 	}
-	return region, nil
+	if gErr == nil {
+		if err := f.Truncate(newSize); err != nil {
+			gErr = fmt.Errorf("vector: truncate (grow) to %d: %w", newSize, err)
+		} else {
+			truncated = true
+			region, err := unix.Mmap(fd, 0, int(newSize), unix.PROT_READ|unix.PROT_WRITE, unix.MAP_SHARED)
+			if err != nil {
+				gErr = fmt.Errorf("vector: mmap (grow) to %d: %w", newSize, err)
+			} else {
+				return region, nil
+			}
+		}
+	}
+
+	// The grow failed after the old view was unmapped. If there was nothing mapped
+	// to begin with (first grow from empty), there is nothing to restore.
+	if oldSize == 0 {
+		return nil, gErr
+	}
+	// Reclaim the just-added tail if the truncate had succeeded (best-effort — a
+	// failure to shrink does not stop us mapping the old extent), then map the old
+	// data back so the index stays valid.
+	if truncated {
+		_ = f.Truncate(oldSize)
+	}
+	restored, rerr := unix.Mmap(fd, 0, int(oldSize), unix.PROT_READ|unix.PROT_WRITE, unix.MAP_SHARED)
+	if rerr != nil {
+		// Both the grow and the restore failed. Join them so errors.Is can reach EITHER
+		// cause (the restore failure is primary, the original grow failure secondary).
+		return nil, fmt.Errorf("vector: mmap (grow-restore) to %d: %w", oldSize, errors.Join(rerr, gErr))
+	}
+	return restored, gErr
 }
 
 // syncVecMmap flushes dirty pages of region to its backing file, so a

--- a/vector/mmap_linux.go
+++ b/vector/mmap_linux.go
@@ -39,10 +39,12 @@ func openVecMmap(path string, size int64) (*os.File, []byte, error) {
 // restore step below and the TRI-STATE return:
 //
 //   - (region != nil, err == nil): grew successfully; region covers newSize bytes.
-//   - (region != nil, err != nil): the grow failed, but a mapping of the OLD data
-//     was restored (grow only ever appends, so bytes [0,oldSize) are intact).
-//     len(region) == oldSize; the caller MUST rebind its header to region at the
-//     old logical length so the valid mapping is neither leaked nor left dangling.
+//   - (region != nil, err != nil): the grow failed, but a valid mapping of the OLD
+//     data remains — either the initial unmap itself failed (so old is still mapped
+//     and is handed straight back), or the later steps failed and a fresh mapping of
+//     the old extent was restored (grow only ever appends, so bytes [0,oldSize) are
+//     intact). len(region) == oldSize; the caller MUST rebind its header to region
+//     at the old logical length so the valid mapping is neither leaked nor dangling.
 //     Whether the failure is then RECOVERABLE is the caller's call, and the two
 //     callers differ: arena.growVecs grows pre-commit, so it treats this as
 //     non-terminal (only the one op fails); hnsw.growLevel0 grows post-commit with
@@ -53,7 +55,11 @@ func growVecMmap(f *os.File, old []byte, newSize int64) ([]byte, error) {
 	oldSize := int64(len(old))
 	if oldSize > 0 {
 		if err := unix.Munmap(old); err != nil {
-			return nil, fmt.Errorf("vector: munmap (grow): %w", err)
+			// The unmap FAILED, so old is still mapped and valid. Return it as the
+			// "middle" tri-state (region non-nil at the OLD extent) rather than nil:
+			// nothing was grown, but the caller can rebind to old and stay usable, and
+			// old — the only slice that can later unmap this view — is not dropped.
+			return old, fmt.Errorf("vector: munmap (grow): %w", err)
 		}
 	}
 	fd := int(f.Fd()) //nolint:gosec // uintptr->int: fd values are small and positive on Linux
@@ -91,7 +97,14 @@ func growVecMmap(f *os.File, old []byte, newSize int64) ([]byte, error) {
 	if truncated {
 		_ = f.Truncate(oldSize)
 	}
-	restored, rerr := unix.Mmap(fd, 0, int(oldSize), unix.PROT_READ|unix.PROT_WRITE, unix.MAP_SHARED)
+	var rerr error
+	if fp := growVecMmapRestoreFailpoint; fp != nil {
+		rerr = fp() // test-only: simulate the restore remap ALSO failing.
+	}
+	var restored []byte
+	if rerr == nil {
+		restored, rerr = unix.Mmap(fd, 0, int(oldSize), unix.PROT_READ|unix.PROT_WRITE, unix.MAP_SHARED)
+	}
 	if rerr != nil {
 		// Both the grow and the restore failed. Join them so errors.Is can reach EITHER
 		// cause (the restore failure is primary, the original grow failure secondary).

--- a/vector/mmap_windows.go
+++ b/vector/mmap_windows.go
@@ -47,10 +47,12 @@ func openVecMmap(path string, size int64) (*os.File, []byte, error) {
 // and the TRI-STATE return (kept mirror-identical to mmap_linux.go):
 //
 //   - (region != nil, err == nil): grew successfully; region covers newSize bytes.
-//   - (region != nil, err != nil): the grow failed, but a mapping of the OLD data
-//     was restored (grow only ever appends, so bytes [0,oldSize) are intact).
-//     len(region) == oldSize; the caller MUST rebind its header to region at the
-//     old logical length so the valid mapping is neither leaked nor left dangling.
+//   - (region != nil, err != nil): the grow failed, but a valid mapping of the OLD
+//     data remains — either the initial unmap itself failed (so old is still mapped
+//     and is handed straight back), or the later steps failed and a fresh mapping of
+//     the old extent was restored (grow only ever appends, so bytes [0,oldSize) are
+//     intact). len(region) == oldSize; the caller MUST rebind its header to region
+//     at the old logical length so the valid mapping is neither leaked nor dangling.
 //     Whether the failure is then RECOVERABLE is the caller's call, and the two
 //     callers differ: arena.growVecs grows pre-commit, so it treats this as
 //     non-terminal (only the one op fails); hnsw.growLevel0 grows post-commit with
@@ -61,7 +63,11 @@ func growVecMmap(f *os.File, old []byte, newSize int64) ([]byte, error) {
 	oldSize := int64(len(old))
 	if oldSize > 0 {
 		if err := windows.UnmapViewOfFile(vecRegionAddr(old)); err != nil {
-			return nil, fmt.Errorf("vector: UnmapViewOfFile (grow): %w", err)
+			// The unmap FAILED, so old is still mapped and valid. Return it as the
+			// "middle" tri-state (region non-nil at the OLD extent) rather than nil:
+			// nothing was grown, but the caller can rebind to old and stay usable, and
+			// old — the only slice that can later unmap this view — is not dropped.
+			return old, fmt.Errorf("vector: UnmapViewOfFile (grow): %w", err)
 		}
 	}
 
@@ -98,7 +104,14 @@ func growVecMmap(f *os.File, old []byte, newSize int64) ([]byte, error) {
 	if truncated {
 		_ = f.Truncate(oldSize)
 	}
-	restored, rerr := mapVecView(f, oldSize)
+	var rerr error
+	if fp := growVecMmapRestoreFailpoint; fp != nil {
+		rerr = fp() // test-only: simulate the restore remap ALSO failing.
+	}
+	var restored []byte
+	if rerr == nil {
+		restored, rerr = mapVecView(f, oldSize)
+	}
 	if rerr != nil {
 		// Both the grow and the restore failed. Join them so errors.Is can reach EITHER
 		// cause (the restore failure is primary, the original grow failure secondary).

--- a/vector/mmap_windows.go
+++ b/vector/mmap_windows.go
@@ -4,6 +4,7 @@
 package vector
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"unsafe"
@@ -34,28 +35,76 @@ func openVecMmap(path string, size int64) (*os.File, []byte, error) {
 	return f, region, nil
 }
 
-// growVecMmap unmaps old, grows the file to newSize bytes, and remaps it.
-// Returns the new region. The caller must rebuild any slice headers that
-// aliased the old region (the mapping address changes).
+// growVecMmap unmaps old, grows the file to newSize bytes, and remaps it. The
+// caller must rebuild any slice headers that aliased the old region (the mapping
+// address changes).
 //
 // The unmap has to come first for a second reason here that it does not have on
 // Linux: Windows refuses to change the length of a file that still has a view
 // mapped (ERROR_USER_MAPPED_FILE), so the Truncate below would fail outright
-// rather than merely racing readers.
+// rather than merely racing readers. Because the unmap runs first, a later
+// failure would otherwise leave nothing mapped — hence the restore step below
+// and the TRI-STATE return (kept mirror-identical to mmap_linux.go):
+//
+//   - (region != nil, err == nil): grew successfully; region covers newSize bytes.
+//   - (region != nil, err != nil): the grow failed, but a mapping of the OLD data
+//     was restored (grow only ever appends, so bytes [0,oldSize) are intact).
+//     len(region) == oldSize; the caller MUST rebind its header to region at the
+//     old logical length so the valid mapping is neither leaked nor left dangling.
+//     Whether the failure is then RECOVERABLE is the caller's call, and the two
+//     callers differ: arena.growVecs grows pre-commit, so it treats this as
+//     non-terminal (only the one op fails); hnsw.growLevel0 grows post-commit with
+//     no clean rollback, so it rebinds AND poisons. See each call site.
+//   - (region == nil, err != nil): the grow AND the restore both failed; no valid
+//     mapping remains, so the backing is unusable and the caller must go terminal.
 func growVecMmap(f *os.File, old []byte, newSize int64) ([]byte, error) {
-	if len(old) > 0 {
+	oldSize := int64(len(old))
+	if oldSize > 0 {
 		if err := windows.UnmapViewOfFile(vecRegionAddr(old)); err != nil {
 			return nil, fmt.Errorf("vector: UnmapViewOfFile (grow): %w", err)
 		}
 	}
-	if err := f.Truncate(newSize); err != nil {
-		return nil, fmt.Errorf("vector: truncate (grow) to %d: %w", newSize, err)
+
+	// gErr is the original grow failure (nil until something fails). truncated
+	// records whether the file was already extended to newSize, so the restore can
+	// shrink it back before remapping the old extent.
+	var gErr error
+	truncated := false
+	if fp := growVecMmapFailpoint; fp != nil {
+		gErr = fp() // test-only: simulate a Truncate/mmap failure past the unmap.
 	}
-	region, err := mapVecView(f, newSize)
-	if err != nil {
-		return nil, fmt.Errorf("vector: mmap (grow) to %d: %w", newSize, err)
+	if gErr == nil {
+		if err := f.Truncate(newSize); err != nil {
+			gErr = fmt.Errorf("vector: truncate (grow) to %d: %w", newSize, err)
+		} else {
+			truncated = true
+			region, err := mapVecView(f, newSize)
+			if err != nil {
+				gErr = fmt.Errorf("vector: mmap (grow) to %d: %w", newSize, err)
+			} else {
+				return region, nil
+			}
+		}
 	}
-	return region, nil
+
+	// The grow failed after the old view was unmapped. If there was nothing mapped
+	// to begin with (first grow from empty), there is nothing to restore.
+	if oldSize == 0 {
+		return nil, gErr
+	}
+	// Reclaim the just-added tail if the truncate had succeeded (best-effort — a
+	// failure to shrink does not stop us mapping the old extent), then map the old
+	// data back so the index stays valid.
+	if truncated {
+		_ = f.Truncate(oldSize)
+	}
+	restored, rerr := mapVecView(f, oldSize)
+	if rerr != nil {
+		// Both the grow and the restore failed. Join them so errors.Is can reach EITHER
+		// cause (the restore failure is primary, the original grow failure secondary).
+		return nil, fmt.Errorf("vector: mmap (grow-restore) to %d: %w", oldSize, errors.Join(rerr, gErr))
+	}
+	return restored, gErr
 }
 
 // syncVecMmap flushes dirty pages of region to its backing file, so a


### PR DESCRIPTION
Follow-up to #56: make a failed mmap grow non-terminal instead of bricking the collection, closing the poisoned-state read-panics at the source.

## The problem
On #56, a failed `growVecMmap` (disk full / address-space exhaustion mid-grow) unmapped the old view, nil'd the backing, and poisoned the whole index — so the entire collection became a terminal `ErrIndexPoisoned`. That also left a class of non-main-path scorers recover-panicking into an opaque error (the known residual we tracked). Poisoning is a big hammer for a transient failure.

## The fix
`growVecMmap` now **restores a mapping of the old data** on failure — grow only appends, so `[0, oldSize)` is intact — and returns a tri-state:

| result | meaning |
| --- | --- |
| `(region!=nil, err==nil)` | grew |
| `(region!=nil, err!=nil)` | grow failed, old extent remapped & **still valid** |
| `(region==nil, err!=nil)` | grow *and* restore failed — unusable |

The two callers treat the middle state differently, **by design** (the subtle part a reviewer caught):
- **`arena.growVecs`** grows *inside* `arena.Insert`, **before** the point is committed → a restored failure aborts the insert as a clean no-op. **Non-terminal, no poison.** A disk-full grow of the (large) vector slab no longer bricks the collection — the insert just errors and can be retried once space frees.
- **`hnsw.growLevel0`** runs **after** the point is committed (idMap / secondary indexes / Size / `h.nodes`). A restored-but-usable outcome there would leave a **torn insert** (present in the id set, nil graph node → invisible, un-retryable, nil-deref on Snapshot), so a graph-grow failure stays **terminal** (poison). The restored mapping is rebound only so it isn't leaked. Poison also remains the backstop for the double-failure case.

Both platform impls (`mmap_linux`, `mmap_windows`) are mirror-identical: `truncated` flag + best-effort shrink-back to `oldSize` before remapping; `errors.Join` both causes on double failure.

## Tests
- `TestGrowFailureRestoresIndex` — arena-path grow failure: index stays not-poisoned, Search/Snapshot/SavePersist keep working, and the next (successful) grow makes the new vector searchable.
- `TestGraphGrowFailurePoisonsIndex` — graph-path grow failure: index cleanly poisons (no torn/half-committed state), all ops reject with `ErrIndexPoisoned`. Both use an unexported `growVecMmapFailpoint` seam (nil in production).

Verified: `go build ./...`, `GOOS=windows` + `-tags cuda` builds, gofmt, the new tests + the existing poison/persist/grow suites, and `./vector/ -short`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved resilience when memory-mapped storage growth fails.
  * Recoverable failures now preserve the existing index, allowing searches, snapshots, persistence, and later retries to continue working.
  * Irrecoverable growth failures now safely mark the index unavailable and prevent further operations instead of risking invalid memory access.
  * Error reporting now retains both the original growth failure and any restoration failure.

* **Tests**
  * Added coverage for recoverable failures, terminal failures, and restoration errors across supported platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->