### PR TITLE
chore(release): cut v0.5.0 + rostam-client 0.4.0

### DIFF
--- a/clients/python/pyproject.toml
+++ b/clients/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "rostam-client"
-version = "0.3.0"
+version = "0.4.0"
 description = "Dependency-free Python client and LangChain adapter for the Rostam vector store"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/clients/python/rostam/__init__.py
+++ b/clients/python/rostam/__init__.py
@@ -59,4 +59,4 @@ __all__ = [
 # anything asking rostam.__version__ was told the wrong release, and nothing
 # noticed. It is a literal rather than an importlib.metadata lookup so that
 # importing the package stays free of a dist-info read.
-__version__ = "0.3.0"
+__version__ = "0.4.0"

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -5,6 +5,8 @@ Notable user-visible changes. Entries that alter existing behaviour are marked
 
 ## Unreleased
 
+## v0.5.0 — 2026-08-30
+
 - **Eight new key-value ops: `exists`, `getdel`, `getset`, `persist`, `ttl`,
   `incr_ex`, compare-and-expire, and `mget`.** The KV store gains the everyday
   Redis-style verbs: `exists` reports whether a key is present, `getdel`
@@ -73,6 +75,17 @@ Notable user-visible changes. Entries that alter existing behaviour are marked
   to pin it. Selecting a model by its full Hugging Face id instead of its
   catalog short name uses a distinct cache scope key, so pick one form and keep
   it.
+- **Reliability: a failed mmap slab grow no longer bricks a collection.** When a
+  persistent vector collection needs to grow its on-disk slab and the OS grow
+  fails (disk full, address-space exhaustion), the index now re-maps its existing
+  data and stays fully usable — only the one write that triggered the grow errors
+  and can be retried once space frees. Previously the collection was left in a
+  terminal error state.
+- **Hardening: the wire decoders reject hostile length fields on 32-bit builds.**
+  A crafted request could previously panic a decoder on a 32-bit target via an
+  integer-width overflow; every decoder now bounds-checks in an overflow-safe
+  form. No effect on the shipped 64-bit binaries; closes the class the 32-bit CI
+  lane exists to catch.
 
 ## v0.4.1 — 2026-08-24
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -50,8 +50,9 @@ Notable user-visible changes. Entries that alter existing behaviour are marked
   so a lock re-acquires cleanly once its TTL lapses. Available on the Go client
   as `SetNX` / `CAS` / `CompareAndDelete` and on the Python client
   (`rostam-client`) as `set_nx` / `cas` / `compare_and_delete`.
-- **Python client: Mem0, Semantic Router, CrewAI, and DSPy adapters
-  (`rostam-client` 0.3.0).** Framework integrations join the existing LangChain,
+- **Python client: Mem0, Semantic Router, CrewAI, and DSPy adapters.** (First
+  shipped in `rostam-client` 0.3.0; this release cuts the client at 0.4.0 for the
+  new KV methods listed above.) Framework integrations join the existing LangChain,
   LlamaIndex, and Haystack adapters, each an optional in-package submodule behind
   its own extra so the base `import rostam` stays standard-library only:
   `rostam.mem0` (`RostamVectorStore`, a Mem0 vector-store provider),
@@ -75,12 +76,14 @@ Notable user-visible changes. Entries that alter existing behaviour are marked
   to pin it. Selecting a model by its full Hugging Face id instead of its
   catalog short name uses a distinct cache scope key, so pick one form and keep
   it.
-- **Reliability: a failed mmap slab grow no longer bricks a collection.** When a
-  persistent vector collection needs to grow its on-disk slab and the OS grow
-  fails (disk full, address-space exhaustion), the index now re-maps its existing
-  data and stays fully usable — only the one write that triggered the grow errors
-  and can be retried once space frees. Previously the collection was left in a
-  terminal error state.
+- **Reliability: a failed vector-slab grow no longer bricks a collection.** When
+  a persistent collection must grow its on-disk vector slab and the OS grow fails
+  (disk full, address-space exhaustion), the index re-maps its existing vectors
+  and stays usable — only the write that triggered the grow errors, and it can be
+  retried once space frees (previously the whole collection went to a terminal
+  error state). A failure while growing the smaller graph-edge slab, which happens
+  after the point is already committed, still takes the collection terminal, since
+  there is no safe rollback from that half-committed point.
 - **Hardening: the wire decoders reject hostile length fields on 32-bit builds.**
   A crafted request could previously panic a decoder on a 32-bit target via an
   integer-width overflow; every decoder now bounds-checks in an overflow-safe

--- a/ops/hostile_decode_test.go
+++ b/ops/hostile_decode_test.go
@@ -141,6 +141,7 @@ var hostileDecoders = []struct {
 	{"DecodeNamedSparseSearchArgs", DecodeNamedSparseSearchArgs},
 	{"DecodeNamedSparseSearchArgsOpts", DecodeNamedSparseSearchArgsOpts},
 	{"DecodePayloadResult", DecodePayloadResult},
+	{"DecodePutArgs", DecodePutArgs},
 	{"DecodePutBatchArgs", DecodePutBatchArgs},
 	{"DecodePutBatchResult", DecodePutBatchResult},
 	{"DecodeQueryArgs", DecodeQueryArgs},
@@ -245,7 +246,7 @@ func TestNoDecoderPanicsOnHostileBytes(t *testing.T) {
 	// A floor on the roster, because the failure mode of this sweep is silent:
 	// deleting entries makes it pass faster, not fail. Raise it when decoders are
 	// added; only lower it deliberately, when an op is genuinely removed.
-	const minDecoders = 143
+	const minDecoders = 144
 	if len(hostileDecoders) < minDecoders {
 		t.Fatalf("only %d decoders in the sweep (floor %d) — entries were removed, "+
 			"which narrows the coverage without failing anything", len(hostileDecoders), minDecoders)

--- a/sdk/wire/builtin.go
+++ b/sdk/wire/builtin.go
@@ -136,11 +136,17 @@ func DecodePutArgs(args []byte) (key, val []byte, ttl time.Duration, err error) 
 	off := 2 + klen
 	vlen := int(binary.BigEndian.Uint32(args[off : off+4]))
 	off += 4
-	if len(args) < off+vlen+8 {
+	// Overflow-safe: never add the untrusted vlen into the comparison. On 32-bit a
+	// vlen above MaxInt32 widens negative and slips an additive `off+vlen+8` check,
+	// then panics the slice. Check the value bytes and the trailing ttl separately.
+	if vlen < 0 || len(args)-off < vlen {
 		return nil, nil, 0, ErrShortArgs
 	}
 	val = args[off : off+vlen]
 	off += vlen
+	if len(args)-off < 8 {
+		return nil, nil, 0, ErrShortArgs
+	}
 	ttl = time.Duration(binary.BigEndian.Uint64(args[off:off+8])) * time.Millisecond //nolint:gosec // safe: u64 from wire is milliseconds, always positive
 	return key, val, ttl, nil
 }


### PR DESCRIPTION
Release prep for **server v0.5.0** and **rostam-client 0.4.0**.

- Stamps the Unreleased changelog as `v0.5.0 — 2026-08-30` (Windows persistence, atomic KV writes `set_nx`/`cas`/`cad`, 8 new KV ops, in-process rembed embeddings) + adds notes for the two reliability items that landed without one (mmap grow-restore, 32-bit decoder hardening).
- Bumps the Python client to `0.4.0` (`pyproject.toml` + `__version__`) for the new KV methods and the conditional-write replay fix.

After merge: tag `v0.5.0` (→ binaries + container image) and `py-v0.4.0` (→ PyPI) at the merge commit. No code changes; docs + version only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Releases**
  * Updated the Python client package to version 0.4.0.

* **Bug Fixes**
  * Prevented failed memory-mapped storage growth from permanently putting persistent collections into an error state; the triggering write now fails safely and can be retried.
  * Added safer bounds checking for wire-format length fields, preventing potential crashes on 32-bit systems.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->