### PR TITLE
feat(vector): reserve and commit slabs in place on Windows

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -13,6 +13,18 @@ Notable user-visible changes. Entries that alter existing behaviour are marked
   plane alongside the existing binary protocol: `GET`, `PUT`, and `DELETE
   /v1/kv/{key}`.
 
+- **Slabs grow in place on Windows too (heap-backed).** The address-space
+  reservation that removed the multi-hundred-millisecond reader stall at a slab
+  growth boundary now exists on 64-bit Windows, built on `VirtualAlloc`'s native
+  reserve/commit split. It covers the heap-backed slabs — `arena.vecs` and the
+  level-0 graph in heap mode, and the quantization codes always — which is where
+  the larger stall was measured (1.502 s to 10.2 ms on Linux, against 188.9 ms to
+  17.1 ms for the mmap-backed ones). An **mmap-backed** slab on Windows still
+  grows the old copy/remap way: committing a file view into the middle of an
+  existing reservation needs the Windows 10 1803 placeholder API, which is not
+  wired up. Nothing changes for Linux, and a reservation remains an optimization
+  — where it cannot be made, growth simply falls back.
+
 ## v0.5.0 — 2026-08-30
 
 - **Eight new key-value ops: `exists`, `getdel`, `getset`, `persist`, `ttl`,

--- a/vector/grow_inplace_test.go
+++ b/vector/grow_inplace_test.go
@@ -244,6 +244,10 @@ func TestGrowInPlaceEquivalentHeap(t *testing.T) {
 	})
 }
 
+// TestGrowInPlaceEquivalentMmap is the file-backed half of that differential.
+// It needs a platform where an mmap-backed slab can itself be
+// reservation-backed, which is not every platform that maps files at all —
+// see requireFileBackedReservations.
 func TestGrowInPlaceEquivalentMmap(t *testing.T) {
 	requireFileBackedReservations(t)
 	testGrowEquivalent(t, 5000, 64, mmapGrowConfig(24, 9))
@@ -260,6 +264,9 @@ func TestGrowRelocationEquivalentHeap(t *testing.T) {
 	})
 }
 
+// TestGrowRelocationEquivalentMmap drives the relocation path on file-backed
+// slabs, where the copy is between two MAPPINGS rather than two heap
+// allocations. Skipped where those slabs never take a reservation.
 func TestGrowRelocationEquivalentMmap(t *testing.T) {
 	requireFileBackedReservations(t)
 	testGrowEquivalent(t, 5000, 1, mmapGrowConfig(24, 4))
@@ -378,6 +385,9 @@ func TestGrowInPlaceConcurrentHeap(t *testing.T) {
 	}
 }
 
+// TestGrowInPlaceConcurrentMmap is the same race coverage for file-backed
+// slabs, whose commit maps a new tail over the reservation instead of
+// re-protecting anonymous pages. Skipped where that is unavailable.
 func TestGrowInPlaceConcurrentMmap(t *testing.T) {
 	requireFileBackedReservations(t)
 	withSmallReservations(t, 64<<10, 64<<10, 64)

--- a/vector/grow_inplace_test.go
+++ b/vector/grow_inplace_test.go
@@ -49,6 +49,18 @@ func withSmallReservations(t *testing.T, threshold, minReserve, factor int64) {
 	})
 }
 
+// requireFileBackedReservations skips a test whose subject is an MMAP-BACKED
+// slab growing in place. Where only anonymous reservations exist (Windows), an
+// mmap-backed slab falls back to copy/remap, so a stable base — and everything
+// downstream of it — is not a property the platform has. The heap variants of
+// these same tests still run there and cover the reservation machinery itself.
+func requireFileBackedReservations(t *testing.T) {
+	t.Helper()
+	if !fileBackedSlabReservationsSupported {
+		t.Skip("file-backed slabs use the copy/remap growth path on this platform")
+	}
+}
+
 func vecsBase(h *hnsw) unsafe.Pointer {
 	if len(h.arena.vecs) == 0 {
 		return nil
@@ -191,6 +203,7 @@ func TestGrowInPlaceStableBaseHeap(t *testing.T) {
 // not merely slow but a SIGBUS risk for any reader still walking the old range.
 func TestGrowInPlaceStableBaseMmap(t *testing.T) {
 	withSmallReservations(t, 64<<10, 64<<10, 64)
+	requireFileBackedReservations(t)
 	dir := t.TempDir()
 	cfg := Config{
 		Dim: 32, Metric: L2, M: 8, EfConstruction: 32, EfSearch: 16, Seed: 5,
@@ -232,6 +245,7 @@ func TestGrowInPlaceEquivalentHeap(t *testing.T) {
 }
 
 func TestGrowInPlaceEquivalentMmap(t *testing.T) {
+	requireFileBackedReservations(t)
 	testGrowEquivalent(t, 5000, 64, mmapGrowConfig(24, 9))
 }
 
@@ -247,6 +261,7 @@ func TestGrowRelocationEquivalentHeap(t *testing.T) {
 }
 
 func TestGrowRelocationEquivalentMmap(t *testing.T) {
+	requireFileBackedReservations(t)
 	testGrowEquivalent(t, 5000, 1, mmapGrowConfig(24, 4))
 }
 
@@ -364,6 +379,7 @@ func TestGrowInPlaceConcurrentHeap(t *testing.T) {
 }
 
 func TestGrowInPlaceConcurrentMmap(t *testing.T) {
+	requireFileBackedReservations(t)
 	withSmallReservations(t, 64<<10, 64<<10, 64)
 	dir := t.TempDir()
 	cfg := Config{

--- a/vector/reserve.go
+++ b/vector/reserve.go
@@ -92,12 +92,21 @@ import (
 // heap-backed configuration too.
 //
 // FALLBACK, EVERYWHERE. A reservation is an optimization, never a requirement.
-// Only 64-bit Linux has newSlabReservation — Windows maps files too but keeps
-// the copy/remap growth path (see mmap_windows.go), and the platforms in
-// mmap_other.go have no mmap storage at all — a reservation that cannot be made
-// is simply
-// not made, and a reservation that runs out of reserved range relocates once to
-// a bigger one — paying the old copy/remap exactly there. Every one of those
+// Where one cannot be made it simply is not made, and a reservation that runs
+// out of reserved range relocates once to a bigger one — paying the old
+// copy/remap exactly there.
+//
+// Which is available is now two questions rather than one, because Windows
+// answers them differently. slabReservationsSupported says whether ANONYMOUS
+// slabs can be reserved: true on 64-bit Linux and 64-bit Windows, where
+// VirtualAlloc splits reserve from commit natively. fileBackedSlabReservations-
+// Supported says whether an MMAP-BACKED slab can be, and that is 64-bit Linux
+// alone: committing one means mapping the new tail over its slice of the
+// reservation, which Linux does with MAP_FIXED and Windows has no equivalent
+// for outside the placeholder API (see reserve_windows.go). So an mmap-backed
+// slab on Windows keeps the copy/remap growth path while its anonymous
+// neighbours — arena.vecs and level-0 in heap mode, and the codes slab always —
+// grow in place. The platforms in mmap_other.go have neither. Every one of those
 // paths lands back on the pre-existing grow code, so behavior is identical and
 // only latency differs.
 

--- a/vector/reserve_leak_test.go
+++ b/vector/reserve_leak_test.go
@@ -190,6 +190,17 @@ func TestCloseReleasesEveryReservation(t *testing.T) {
 		{name: "heap", cfg: func(*testing.T) Config {
 			return Config{Dim: dim, Metric: L2, M: 8, EfConstruction: 32, EfSearch: 16, Seed: 5}
 		}},
+		// The codes slab is ALWAYS anonymous, so it takes a reservation
+		// wherever anonymous ones exist - including where file-backed ones do
+		// not. Without this case the mmap one below is the only quantized one,
+		// and skipping it would leave Close's release of the codes reservation
+		// unverified on exactly the platform this branch adds.
+		{name: "heap+codes", cfg: func(*testing.T) Config {
+			return Config{
+				Dim: dim, Metric: L2, M: 8, EfConstruction: 32, EfSearch: 16, Seed: 5,
+				Quant: QuantSQ8,
+			}
+		}},
 		{name: "mmap+codes", cfg: mmapGrowConfig(dim, 5), needsFileReservations: true},
 	} {
 		t.Run(tc.name, func(t *testing.T) {

--- a/vector/reserve_leak_test.go
+++ b/vector/reserve_leak_test.go
@@ -181,13 +181,21 @@ func TestCloseReleasesEveryReservation(t *testing.T) {
 	for _, tc := range []struct {
 		name string
 		cfg  func(*testing.T) Config
+		// needsFileReservations marks the case whose slabs are mmap-backed, and
+		// so only reservation-backed where a file-backed slab can be (Linux).
+		// Elsewhere those slabs never take a reservation, leaving nothing for
+		// this test's balance to say anything about.
+		needsFileReservations bool
 	}{
-		{"heap", func(*testing.T) Config {
+		{name: "heap", cfg: func(*testing.T) Config {
 			return Config{Dim: dim, Metric: L2, M: 8, EfConstruction: 32, EfSearch: 16, Seed: 5}
 		}},
-		{"mmap+codes", mmapGrowConfig(dim, 5)},
+		{name: "mmap+codes", cfg: mmapGrowConfig(dim, 5), needsFileReservations: true},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
+			if tc.needsFileReservations {
+				requireFileBackedReservations(t)
+			}
 			delta := reservationBalance(t, func() {
 				h, err := newHNSW(tc.cfg(t))
 				if err != nil {

--- a/vector/reserve_linux.go
+++ b/vector/reserve_linux.go
@@ -56,6 +56,14 @@ type slabReservation struct {
 // reservations skip rather than fail on a platform that has none.
 const slabReservationsSupported = true
 
+// fileBackedSlabReservationsSupported reports whether an mmap-backed slab can
+// live on a reservation too, not just an anonymous one. Linux commits a
+// file-backed slab by mapping the new tail over its slice of the reservation
+// with MAP_FIXED, so both backings get the in-place growth; Windows has no
+// equivalent that is safe to use (see reserve_windows.go), which is why the two
+// capabilities are separate constants rather than one.
+const fileBackedSlabReservationsSupported = true
+
 // mapped reports whether the reservation still holds its range. Portable
 // counterpart of the base pointer, so tests can assert "this was released"
 // without reaching into a platform-specific field.

--- a/vector/reserve_other.go
+++ b/vector/reserve_other.go
@@ -1,13 +1,14 @@
 // SPDX-License-Identifier: Apache-2.0
-//go:build !linux || !(amd64 || arm64)
+//go:build (!linux && !windows) || !(amd64 || arm64)
 
 package vector
 
 import "os"
 
 // slabReservation is the no-op stand-in wherever reserve-then-commit-in-place is
-// not available: every non-Linux target, plus 32-bit Linux, where the scheme's
-// free-address-space premise does not hold (see reserve_linux.go's build tag).
+// not available: every target that is neither 64-bit Linux nor 64-bit Windows,
+// plus the 32-bit builds of both, where the scheme's free-address-space premise
+// does not hold (see reserve_linux.go's build tag).
 // Every slab keeps the copy/remap growth path it had before — reserve.go's point
 // is that a reservation is an optimization, never a requirement. Where mmap
 // storage is unavailable (mmap_other.go) this only affects heap-backed slabs;
@@ -18,6 +19,10 @@ type slabReservation struct{}
 // slabReservationsSupported is false here, so tests that only mean something with
 // reservations skip instead of failing.
 const slabReservationsSupported = false
+
+// fileBackedSlabReservationsSupported is false for the same reason: there are
+// no reservations here at all.
+const fileBackedSlabReservationsSupported = false
 
 func (r *slabReservation) mapped() bool { return false }
 

--- a/vector/reserve_windows.go
+++ b/vector/reserve_windows.go
@@ -48,6 +48,9 @@ type slabReservation struct {
 	f      *os.File       // always nil here; see newSlabReservation
 }
 
+// mapped reports whether this slab is reservation-backed at all. A nil
+// receiver is the ordinary "no reservation" case, not a bug: newSlabReservation
+// returns one whenever the reservation could not be made.
 func (r *slabReservation) mapped() bool { return r != nil && r.base != nil }
 
 // pageAlign rounds n up to a whole number of pages. Commits are page-granular

--- a/vector/reserve_windows.go
+++ b/vector/reserve_windows.go
@@ -175,13 +175,19 @@ func (r *slabReservation) release() error {
 	if r == nil || r.base == nil {
 		return nil
 	}
-	base := uintptr(r.base)
-	r.base, r.commit, r.resLen = nil, 0, 0
-	liveSlabReservations.Add(-1)
 	// MEM_RELEASE requires a zero size and frees the entire region that was
 	// reserved at base, committed sub-ranges included.
-	if err := windows.VirtualFree(base, 0, windows.MEM_RELEASE); err != nil {
+	//
+	// The bookkeeping is cleared only AFTER the free succeeds. Doing it first
+	// would say "released" about a range still mapped: mapped() would report
+	// false, liveSlabReservations would under-count the very leak it exists to
+	// detect, and a second release would return early instead of retrying.
+	if err := windows.VirtualFree(uintptr(r.base), 0, windows.MEM_RELEASE); err != nil {
 		return fmt.Errorf("vector: release reservation: %w", err)
 	}
+
+	r.base, r.commit, r.resLen = nil, 0, 0
+	liveSlabReservations.Add(-1)
+
 	return nil
 }

--- a/vector/reserve_windows.go
+++ b/vector/reserve_windows.go
@@ -1,0 +1,184 @@
+// SPDX-License-Identifier: Apache-2.0
+//go:build windows && (amd64 || arm64)
+
+// The 64-bit premise is in the build tag for the same reason reserve_linux.go
+// puts it there: the scheme spends address space freely because there is a lot
+// of it, and on a 32-bit target (windows/386) a 64x over-reservation would
+// exhaust a 2 GiB user address space almost immediately. windows/386 keeps
+// reserve_other.go's stubs and the copy/remap growth path — mmap STORAGE still
+// works there, since mmap_windows.go's tag is plain `windows`.
+
+package vector
+
+import (
+	"fmt"
+	"os"
+	"unsafe"
+
+	"golang.org/x/sys/windows"
+)
+
+// slabReservationsSupported reports that this build can reserve address space
+// and commit it forward in place.
+const slabReservationsSupported = true
+
+// fileBackedSlabReservationsSupported is false: newSlabReservation refuses a
+// non-nil file, so an mmap-backed slab keeps the copy/remap growth path. See
+// newSlabReservation for what it would take to lift this.
+const fileBackedSlabReservationsSupported = false
+
+// slabReservation owns a contiguous range of reserved virtual address space plus
+// the prefix of it that is currently committed. See reserve.go for why the split
+// exists; this is the Win32 half of it.
+//
+// Reserve/commit is Windows' native model, so the anonymous case maps onto it
+// exactly: VirtualAlloc(MEM_RESERVE) takes address space without charging
+// memory, and VirtualAlloc(MEM_COMMIT) over a sub-range of that reservation
+// makes just that range usable, leaving the already-committed prefix — the
+// bytes readers are walking — untouched, unmoved and un-reprotected.
+//
+// OWNERSHIP — THERE IS NO FINALIZER, for the reason reserve_linux.go gives: a
+// finalizer could fire while a []float32 derived from the region is still in
+// flight, turning a missed Close from a leak into an access violation. Release
+// is explicit, from arena.Close / closeGraphMmap or the per-slab release paths.
+type slabReservation struct {
+	base   unsafe.Pointer // start of the reserved range; stable for the life of the reservation
+	resLen uintptr        // reserved bytes (address space)
+	commit uintptr        // committed bytes, always a prefix [base, base+commit)
+	f      *os.File       // always nil here; see newSlabReservation
+}
+
+func (r *slabReservation) mapped() bool { return r != nil && r.base != nil }
+
+// pageAlign rounds n up to a whole number of pages. Commits are page-granular
+// on Windows (the 64 KiB allocation granularity applies to where a reservation
+// STARTS, and VirtualAlloc picks that itself when the base is NULL), and
+// committing in page units is what lets the next commit start exactly where the
+// previous one ended.
+func pageAlign(n int64) int64 {
+	p := int64(os.Getpagesize())
+	if n <= 0 {
+		return 0
+	}
+	return (n + p - 1) / p * p
+}
+
+// newSlabReservation reserves reserveBytes of address space and commits the
+// first commitBytes of it.
+//
+// FILE-BACKED SLABS ARE NOT SUPPORTED HERE, and that is a platform limit rather
+// than an omission. Linux commits a file-backed slab by mapping the new tail
+// over its slice of the reservation with MAP_FIXED; Windows will not map a view
+// into a range it considers reserved — MapViewOfFileEx demands the target be
+// FREE, and releasing the reservation first opens a window in which another
+// thread can take the address. The supported way is the placeholder API
+// (VirtualAlloc2 with MEM_RESERVE_PLACEHOLDER, split with
+// MEM_PRESERVE_PLACEHOLDER, filled by MapViewOfFile3 with
+// MEM_REPLACE_PLACEHOLDER), which needs Windows 10 1803 or newer, hand-written
+// bindings — x/sys/windows binds none of the three — and per-view bookkeeping
+// that the single-munmap Linux release does not.
+//
+// So an mmap-backed slab gets errSlabReserveUnsupported and keeps the
+// copy/remap growth path it already had, which is exactly the contract
+// reserve.go states: a reservation is an optimization, never a requirement.
+// The heap-backed slabs — arena.vecs and the level-0 graph in heap mode, and
+// the quantization codes always — are where the larger stall was measured
+// anyway (1.502 s -> 10.2 ms, against 188.9 ms -> 17.1 ms for mmap).
+func newSlabReservation(f *os.File, reserveBytes, commitBytes int64) (*slabReservation, error) {
+	if f != nil {
+		return nil, errSlabReserveUnsupported
+	}
+	res := pageAlign(reserveBytes)
+	if com := pageAlign(commitBytes); res < com {
+		res = com
+	}
+	if res <= 0 {
+		return nil, errSlabReserveUnsupported
+	}
+	base, err := windows.VirtualAlloc(0, uintptr(res), windows.MEM_RESERVE, windows.PAGE_NOACCESS)
+	if err != nil {
+		return nil, fmt.Errorf("vector: reserve %d bytes of address space: %w", res, err)
+	}
+	//nolint:govet,gosec // unsafeptr: an OS reservation address, not a Go pointer
+	r := &slabReservation{base: unsafe.Pointer(base), resLen: uintptr(res)}
+	liveSlabReservations.Add(1)
+	if err := r.commitTo(commitBytes); err != nil {
+		_ = r.release()
+		return nil, err
+	}
+	return r, nil
+}
+
+// commitTo makes [0, n) of the reservation readable/writable, growing the
+// committed prefix in place. Shrinking is not supported (a smaller n is a
+// no-op). Returns errSlabReserveExhausted when n is past the reserved range, so
+// the caller can relocate rather than fail the insert.
+//
+// The call is issued against the DELTA only — this is the whole point: growing
+// a 3 GB slab by one page costs the same as growing an empty one. Committed
+// pages arrive zero-filled, as they do on Linux.
+//
+// One honest difference from Linux: MEM_COMMIT charges the system commit limit
+// (RAM + pagefile) for the delta immediately, where mprotect over a
+// MAP_NORESERVE range charges nothing until a page is touched. The RESERVATION
+// itself is free on both, so the over-reserve premise is unaffected; what
+// differs is that a committed-but-untouched tail counts against this machine's
+// commit budget. Commits track the slab's actual length, so that tail is at
+// most one growth step.
+func (r *slabReservation) commitTo(n int64) error {
+	want := uintptr(pageAlign(n))
+	if want <= r.commit {
+		return nil
+	}
+	if want > r.resLen {
+		return errSlabReserveExhausted
+	}
+	off, delta := r.commit, want-r.commit
+	addr := uintptr(r.base) + off
+	got, err := windows.VirtualAlloc(addr, delta, windows.MEM_COMMIT, windows.PAGE_READWRITE)
+	if err != nil {
+		return fmt.Errorf("vector: commit %d bytes at +%d: %w", delta, off, err)
+	}
+	if got != addr {
+		// Cannot happen for a commit inside an existing reservation, but a
+		// silently relocated base would hand every reader a stale pointer, so
+		// it is checked rather than assumed.
+		return fmt.Errorf("vector: commit relocated the range: got %#x, want %#x", got, addr)
+	}
+	r.commit = want
+	return nil
+}
+
+// region returns the committed prefix as a byte slice aliasing the reservation.
+func (r *slabReservation) region() []byte {
+	if r == nil || r.base == nil || r.commit == 0 {
+		return nil
+	}
+	// Audited: [base, base+commit) is committed readable/writable by
+	// construction, byte has no pointers so the GC never scans it, and the
+	// reservation outlives every slice derived from it (it is released only from
+	// Close, by which point the owning arena/index has dropped its headers).
+	//nolint:gosec // G103: reviewed unsafe view of the committed reservation.
+	return unsafe.Slice((*byte)(r.base), r.commit)
+}
+
+// sync is a no-op: only a file-backed reservation has anything to flush, and
+// newSlabReservation refuses those on this platform.
+func (r *slabReservation) sync() error { return nil }
+
+// release frees the whole reservation — committed prefix and reserved tail in
+// one call. Idempotent.
+func (r *slabReservation) release() error {
+	if r == nil || r.base == nil {
+		return nil
+	}
+	base := uintptr(r.base)
+	r.base, r.commit, r.resLen = nil, 0, 0
+	liveSlabReservations.Add(-1)
+	// MEM_RELEASE requires a zero size and frees the entire region that was
+	// reserved at base, committed sub-ranges included.
+	if err := windows.VirtualFree(base, 0, windows.MEM_RELEASE); err != nil {
+		return fmt.Errorf("vector: release reservation: %w", err)
+	}
+	return nil
+}


### PR DESCRIPTION
Follow-up to #56, which made Windows persist. This one makes it stop stalling.

## What this fixes

`vector/reserve.go` calls the growth stall it removed "the last known reader stall in the engine", and measures it:

```
                     before        after (in place)
heap  500k x 768d    1.502 s   ->  10.2 ms    (147x)
mmap  500k x 768d    188.9 ms  ->  17.1 ms    (11x)
```

That scheme is `linux && (amd64 || arm64)`. On Windows a slab still grows the old way — allocate a bigger one and copy, under `h.mu`'s write lock, with every reader excluded. At 1M x 768d that is the multi-hundred-millisecond window the reservation work existed to close, and it is fully open there.

## What changed

Reserve-then-commit is Windows' **native** memory model, so the anonymous half of the scheme maps onto it directly:

```
reserve   VirtualAlloc(NULL, res, MEM_RESERVE,  PAGE_NOACCESS)
commit    VirtualAlloc(base+committed, delta, MEM_COMMIT, PAGE_READWRITE)
```

Both are already bound in `golang.org/x/sys/windows` — no new dependency, no version gate, no `LazyDLL`. The reservation itself is free on Windows as it is on Linux, so the over-reserve premise is unaffected.

**File-backed slabs are deliberately not covered.** Linux commits one by mapping the new tail over its slice of the reservation with `MAP_FIXED`. Windows will not map a view into a range it considers reserved — `MapViewOfFileEx` demands the target be FREE, and releasing the reservation first opens a window for another thread to take the address. The supported route is the placeholder API (`VirtualAlloc2` with `MEM_RESERVE_PLACEHOLDER`, split with `MEM_PRESERVE_PLACEHOLDER`, filled by `MapViewOfFile3` with `MEM_REPLACE_PLACEHOLDER`), which needs Windows 10 1803, hand-written bindings for three symbols `x/sys/windows` binds none of, and per-view teardown that the single-`munmap` Linux release does not need.

So `newSlabReservation` refuses a non-nil file and those slabs keep the copy/remap path — which is the contract `reserve.go` already states: *a reservation is an optimization, never a requirement*. It is also the smaller half of the win (188.9 ms -> 17.1 ms, against 1.502 s -> 10.2 ms for heap).

## The capability stopped being one boolean

`slabReservationsSupported` alone would have told `grow_inplace_test.go` that the mmap variants apply on Windows. They do not, and five tests asserting a stable base for a file-backed slab failed until `fileBackedSlabReservationsSupported` gave them something honest to skip on. The two constants now say two different things, per platform.

## One difference from Linux, stated because it is real

`MEM_COMMIT` charges the system commit limit (RAM + pagefile) for the delta immediately, where `mprotect` over a `MAP_NORESERVE` range charges nothing until a page is touched. Commits track the slab's actual length, so the committed-but-untouched tail is at most one growth step.

## Testing

`go1.26.5 windows/amd64`, `CGO_ENABLED=0`, on real hardware:

| | before | after |
|---|---|---|
| `TestGrowInPlaceStableBaseHeap` | skipped | **pass** — base unmoved across ~12 doublings |
| `TestGrowInPlaceEquivalentHeap` / `...Relocation...` | skipped | **pass** — differential: identical stored vectors and identical search results vs the copy path |
| `TestGrowInPlaceConcurrentHeap` | skipped | **pass** |
| `TestCloseReleasesEveryReservation`, both restore-accumulation tests | skipped | **pass** |
| the four `*Mmap` variants | skipped | skipped, with a reason |

`./cache/...` and `./mcp/...` stay green; `./vector/...` has the same 15 pre-existing WAL/group-commit failures as `main` on Windows, no more. All ten GOOS/GOARCH targets build, `gofmt` clean, and the vector tests compile for linux/{amd64,386}, darwin and freebsd — the build tags partition without overlap or gap (windows/386 keeps the stubs, for the same 32-bit address-space reason `reserve_linux.go` gives).

Not run: the race detector, which needs cgo and a C toolchain I do not have on the Windows box. The CI lane covers it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved slab growth performance on 64-bit Windows by expanding heap-backed memory in place.
  * Added platform-aware handling for file-backed memory growth, preserving existing behavior where in-place expansion is unavailable.
  * Improved reservation tracking and release behavior across supported platforms.

* **Bug Fixes**
  * Prevented platform-specific growth and reservation tests from failing when required memory reservation support is unavailable.
  * Preserved accurate reservation state when memory unmapping fails.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->