### PR TITLE
feat(dashboard): embedded web UI for vector + KV management and monitoring

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -18,3 +18,10 @@
 .vscode
 .idea
 .DS_Store
+
+# UI: the Dockerfile's ui stage runs its own npm ci/build inside the image, so
+# a locally installed node_modules or a stale local dist/ would only bloat the
+# build context (and dist/ specifically must NOT be copied in, since the ui
+# stage's own build output is what gets COPYed into dashboard/dist/).
+ui/node_modules
+ui/dist

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,6 +39,14 @@ jobs:
           go-version-file: go.mod
           cache: true
 
+      # goreleaser's before.hooks run `make ui` (builds the Vite dashboard and
+      # syncs it into dashboard/dist/), which needs npm on PATH.
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: ui/package-lock.json
+
       - uses: goreleaser/goreleaser-action@v6
         with:
           version: "~> v2"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,8 +21,33 @@ permissions:
   contents: read
 
 jobs:
+  # A manual dispatch takes inputs.tag straight into actions/checkout as the
+  # ref, and the build then runs `make ui` (npm lifecycle scripts) and a
+  # Docker build — both execute code from that ref with privileged tokens
+  # (contents: write, packages: write). Reject anything that is not a release
+  # tag BEFORE either job checks out the ref, so a dispatch against an
+  # arbitrary branch/SHA cannot run untrusted code with those credentials.
+  # Skipped entirely on the normal `push: tags: v*` trigger, where the ref is
+  # already a real tag by construction.
+  validate-tag:
+    name: validate release tag
+    if: github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Reject a non-release tag
+        env:
+          TAG: ${{ inputs.tag }}
+        run: |
+          set -euo pipefail
+          if ! [[ "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+([-.].*)?$ ]]; then
+            echo "::error::inputs.tag '$TAG' is not a release tag (expected vX.Y.Z, e.g. v0.1.0 or v0.1.0-rc1)"
+            exit 1
+          fi
+
   binaries:
     name: binaries
+    needs: [validate-tag]
+    if: ${{ always() && (needs.validate-tag.result == 'success' || needs.validate-tag.result == 'skipped') }}
     runs-on: ubuntu-latest
     permissions:
       contents: write # create the release and upload artifacts
@@ -65,6 +90,8 @@ jobs:
   # once, at merge time, rather than twice and racing.
   image:
     name: image (${{ matrix.platform }})
+    needs: [validate-tag]
+    if: ${{ always() && (needs.validate-tag.result == 'success' || needs.validate-tag.result == 'skipped') }}
     strategy:
       fail-fast: false
       matrix:

--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,7 @@ perf-desktop.png
 # Python client artifacts
 __pycache__/
 *.pyc
+
 clients/python/.venv/
 clients/python/dist/
 clients/python/build/
@@ -61,3 +62,16 @@ site/
 
 # goreleaser build output
 dist/
+
+# Built dashboard (Vite) output. dashboard/dist/ is a staging dir the go:embed
+# reads from; `make ui` syncs the compiled Vite output into it. Only the .gitkeep
+# is tracked — it keeps the directory present so `go:embed all:dist` compiles
+# without a node build (the handler then serves a built-in placeholder). Every
+# real asset (index.html + hashed assets/) is generated and stays ignored.
+# The generic dist/ rule above (goreleaser) also matches dashboard/dist/ and would
+# exclude the whole directory — negations for files inside an excluded directory
+# are ignored — so we must re-include the directory FIRST (this rule wins as it is
+# later), re-ignore its contents, then keep only the .gitkeep.
+!dashboard/dist/
+dashboard/dist/*
+!dashboard/dist/.gitkeep

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -25,6 +25,10 @@ git:
 before:
   hooks:
     - go mod download
+    # Builds the Vite dashboard and syncs it into dashboard/dist/ (the
+    # go:embed'd tree) so a released binary ships the real UI instead of the
+    # unbuilt placeholder. Requires Node/npm on the release runner's PATH.
+    - make ui
 
 builds:
   - id: rostam-server

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,6 @@
-.PHONY: all build docker lint test test-serial race bench test-python dist-python publish-python tidy clean
+.PHONY: all build ui docker lint test test-serial race bench test-python dist-python publish-python tidy clean
+
+NPM ?= npm
 
 GO ?= go
 PYTHON ?= python3
@@ -13,6 +15,16 @@ all: lint test race bench
 # themselves build with CGO_ENABLED=0 if you only need the library.
 build:
 	$(GO) build -trimpath -ldflags="-s -w" -o $(BIN) ./cmd/rostam-server
+
+# Build the embedded web dashboard and sync it into the go:embed staging dir
+# (dashboard/dist/). Run this before `make build`/goreleaser to bake the real UI
+# into the binary; without it the server serves a build-me placeholder. The sync
+# clears only assets/ (hashed filenames accumulate otherwise) and preserves the
+# tracked .gitkeep. Requires Node/npm on PATH.
+ui:
+	cd ui && $(NPM) ci && $(NPM) run build
+	rm -rf dashboard/dist/assets
+	cp -R ui/dist/. dashboard/dist/
 
 # Build the container image. Context is the repo root; the Dockerfile lives with
 # the server command.

--- a/authz/authorizer.go
+++ b/authz/authorizer.go
@@ -220,12 +220,14 @@ var adminOps = map[string]struct{}{
 }
 
 // readOps is the small set of cluster-introspection ops that are explicitly
-// "read": __ping__ (liveness) and __topology__ (cluster map). Both are also
-// registered OpReadOnly, but enumerating them keeps the classification explicit
-// and independent of registration order.
+// "read": __ping__ (liveness), __topology__ (cluster map) and __collections__
+// (the dashboard's dense-collection list). All are also registered OpReadOnly,
+// but enumerating them keeps the classification explicit and independent of
+// registration order.
 var readOps = map[string]struct{}{
-	"__ping__":     {},
-	"__topology__": {},
+	"__ping__":        {},
+	"__topology__":    {},
+	"__collections__": {},
 }
 
 // actionFor returns the required action ("read"|"write"|"admin") for op.

--- a/cmd/rostam-server/Dockerfile
+++ b/cmd/rostam-server/Dockerfile
@@ -3,6 +3,17 @@
 #
 # cgo is required (wasmtime-go is pulled in transitively), so the build image
 # carries a C toolchain and the runtime image is debian-slim (not scratch).
+#
+# Dashboard UI: built in its own Node stage and copied into dashboard/dist/
+# (the go:embed'd tree) before the Go build, so the shipped binary embeds the
+# real Vite output instead of the checked-in .gitkeep placeholder.
+FROM node:20-bookworm AS ui
+WORKDIR /ui
+COPY ui/package.json ui/package-lock.json ./
+RUN npm ci
+COPY ui/ ./
+RUN npm run build
+
 FROM golang:1.26-bookworm AS build
 WORKDIR /src
 COPY go.mod go.sum go.work go.work.sum ./
@@ -10,6 +21,9 @@ COPY sdk/go.mod sdk/go.sum ./sdk/
 COPY client/go.mod client/go.sum ./client/
 RUN go mod download
 COPY . .
+# Overwrites the placeholder dashboard/dist/ (just .gitkeep in a checkout) with
+# the real built assets from the ui stage above.
+COPY --from=ui /ui/dist/. ./dashboard/dist/
 RUN CGO_ENABLED=1 go build -trimpath -ldflags="-s -w" -o /out/rostam-server ./cmd/rostam-server
 
 FROM debian:bookworm-slim

--- a/cmd/rostam-server/main.go
+++ b/cmd/rostam-server/main.go
@@ -576,6 +576,28 @@ func main() {
 			// block before this assignment takes effect.)
 			Authenticator: cfg.Authenticator,
 		}
+
+		// Register a single-node __topology__ so the discovery op works WITHOUT
+		// -cluster: the dashboard's cluster view (and any smart client's
+		// IsLeader/LeaderAddr accessors) then see one node that leads its one
+		// logical shard, instead of the op 500-ing as "not registered". In -cluster
+		// mode cluster.Node registers the real, live topology on this same registry;
+		// this branch never builds a cluster.Node, so there is no double-register.
+		selfAddr := *tcpAddr
+		if selfAddr == "" {
+			selfAddr = *httpAddr
+		}
+		selfID := *nodeID
+		if err := ops.RegisterTopology(reg, func() (ops.Topology, error) {
+			return ops.Topology{
+				NumShards: 1,
+				Members:   []ops.TopologyMember{{NodeID: selfID, ServerAddr: selfAddr}},
+				Leaders:   []string{selfAddr},
+				Placement: [][]string{{selfID}},
+			}, nil
+		}); err != nil {
+			fatal("register single-node topology failed", "err", err)
+		}
 	}
 
 	// OPT-IN S3 tier (backup cron + cold-tier sweeper + admin REST surface). Build

--- a/cmd/rostam-server/main.go
+++ b/cmd/rostam-server/main.go
@@ -577,22 +577,28 @@ func main() {
 			Authenticator: cfg.Authenticator,
 		}
 
-		// Register a single-node __topology__ so the discovery op works WITHOUT
-		// -cluster: the dashboard's cluster view (and any smart client's
-		// IsLeader/LeaderAddr accessors) then see one node that leads its one
-		// logical shard, instead of the op 500-ing as "not registered". In -cluster
+		// Register a single-node __topology__ so the discovery op resolves WITHOUT
+		// -cluster: the dashboard's cluster view then sees one node owning its one
+		// logical shard, instead of the op erroring as "not registered". In -cluster
 		// mode cluster.Node registers the real, live topology on this same registry;
 		// this branch never builds a cluster.Node, so there is no double-register.
-		selfAddr := *tcpAddr
-		if selfAddr == "" {
-			selfAddr = *httpAddr
-		}
+		//
+		// ServerAddr and Leaders are deliberately EMPTY. A smart client caches this
+		// topology and, in pickInitialTarget, would DIAL a non-empty Leaders[shard]
+		// / owner ServerAddr — but the server's bind address (e.g. ":7000",
+		// "0.0.0.0:7000", or the httpAddr fallback) is not a dialable target and is
+		// not a reliable advertised address. Leaving them empty makes OwnerAddr
+		// return "" so the client falls back to its own configured server target —
+		// byte-identical to the pre-registration behavior (where the op was absent
+		// and the topology cache stayed nil) — while still giving the dashboard the
+		// node id + placement it renders. (A multi-node deployment uses -cluster,
+		// which advertises real peer addresses.)
 		selfID := *nodeID
 		if err := ops.RegisterTopology(reg, func() (ops.Topology, error) {
 			return ops.Topology{
 				NumShards: 1,
-				Members:   []ops.TopologyMember{{NodeID: selfID, ServerAddr: selfAddr}},
-				Leaders:   []string{selfAddr},
+				Members:   []ops.TopologyMember{{NodeID: selfID, ServerAddr: ""}},
+				Leaders:   []string{""},
 				Placement: [][]string{{selfID}},
 			}, nil
 		}); err != nil {

--- a/dashboard/embed.go
+++ b/dashboard/embed.go
@@ -115,6 +115,9 @@ func serveFile(w http.ResponseWriter, fsys fs.FS, name string) bool {
 	} else {
 		w.Header().Set("Cache-Control", "no-cache")
 	}
+	//nolint:gosec // G705: data is read only from the build-time embedded dist FS
+	// (see the go:embed above), and name is sanitized by path.Clean + fs.Sub in
+	// Handler, so it cannot select anything outside the embedded assets.
 	_, _ = w.Write(data)
 	return true
 }

--- a/dashboard/embed.go
+++ b/dashboard/embed.go
@@ -1,0 +1,120 @@
+// SPDX-License-Identifier: Apache-2.0
+
+// Package dashboard embeds Rostam's web dashboard (a static single-page app) and
+// serves it over HTTP. The compiled Vite output lives under dist/ and is baked
+// into the binary with go:embed, so a release ships the UI with no runtime asset
+// dependency. This package deliberately imports NOTHING from the rest of Rostam:
+// the assets are inert HTML/JS/CSS and all data access goes through the authed
+// /v1 REST endpoints, so the httpapi package can mount Handler() without forming
+// an import cycle back into the engine.
+package dashboard
+
+import (
+	"embed"
+	"io/fs"
+	"mime"
+	"net/http"
+	"path"
+	"strings"
+)
+
+// dist holds the built SPA. The all: prefix embeds every file including those
+// whose names start with '.', so the checked-in dist/.gitkeep (the only tracked
+// file — the Vite output is git-ignored and synced in by `make ui`) is enough
+// for the embed to resolve and `go build ./...` to compile without a node build.
+// When only the .gitkeep is present, Handler serves the unbuiltPage placeholder.
+//
+//go:embed all:dist
+var dist embed.FS
+
+// Handler serves the embedded SPA. It serves a real asset file when the request
+// path names one, and otherwise falls back to dist/index.html so client-side
+// routing (deep links like /dashboard/collections/docs) resolves to the app
+// shell rather than a 404. Content-Type is set from the file extension.
+//
+// Auth is intentionally NOT enforced here: the assets carry no data (every read
+// goes through the authed /v1 endpoints), so gating the static shell would only
+// break the login/landing experience without protecting anything.
+func Handler() http.Handler {
+	// Root the FS at dist/ so request paths map directly onto asset names
+	// ("/app.js" -> "app.js") without the embed's dist/ prefix leaking in.
+	sub, err := fs.Sub(dist, "dist")
+	if err != nil {
+		// Unreachable: dist is embedded at build time, so the subtree always exists.
+		panic("dashboard: embed dist subtree: " + err.Error())
+	}
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Normalize to a clean, rooted asset name. A leading "/" is stripped because
+		// the embedded FS is not rooted; "" means the index.
+		name := strings.TrimPrefix(path.Clean("/"+r.URL.Path), "/")
+		if name == "" {
+			name = "index.html"
+		}
+		if serveFile(w, sub, name) {
+			return
+		}
+		// A missing file under assets/ is a genuine 404: those names are
+		// content-hashed by Vite, so a miss means the asset never existed or was
+		// purged, not a client-side route. Falling back to the SPA shell here
+		// would mask that with a misleading 200 (e.g. a stale HTML page still
+		// referencing a JS bundle that has since been rebuilt under a new hash).
+		if strings.HasPrefix(name, "assets/") {
+			http.NotFound(w, r)
+			return
+		}
+		// Unknown non-asset path: hand back the SPA shell so the client router
+		// takes over.
+		if serveFile(w, sub, "index.html") {
+			return
+		}
+		// No index.html means the Vite output was never synced into dist/ (a bare
+		// `go build` without `make ui`). dist/ still embeds via the .gitkeep, so we
+		// are here rather than failing the build; serve a friendly placeholder that
+		// tells the operator how to build the real UI instead of a bare 500.
+		w.Header().Set("Content-Type", "text/html; charset=utf-8")
+		w.Header().Set("Cache-Control", "no-cache")
+		_, _ = w.Write([]byte(unbuiltPage))
+	})
+}
+
+// unbuiltPage is served for /dashboard/ when the compiled SPA has not been synced
+// into dist/ (i.e. the binary was built without running `make ui`). It is a valid
+// standalone HTML page — no external assets — so it renders even with an otherwise
+// empty embed.
+const unbuiltPage = `<!doctype html>
+<html lang="en">
+<head><meta charset="utf-8"><title>Rostam dashboard</title>
+<style>body{font:15px/1.6 ui-sans-serif,system-ui,sans-serif;max-width:34rem;margin:12vh auto;padding:0 1.5rem;color:#111419;background:#fff}code{background:#f0b429;color:#111419;padding:.1rem .4rem;border-radius:.25rem;font-family:ui-monospace,monospace}</style>
+</head>
+<body>
+<h1>Rostam dashboard</h1>
+<p>The web UI has not been built into this binary. Build the assets and rebuild the server:</p>
+<p><code>make ui &amp;&amp; make build</code></p>
+<p>The REST API is unaffected and available under <code>/v1</code>.</p>
+</body>
+</html>
+`
+
+// serveFile writes name from fsys with a Content-Type derived from its
+// extension and a Cache-Control appropriate to the SPA build's naming scheme:
+// content-hashed files under assets/ never change under a given name, so they
+// are cached for a year as immutable; everything else (index.html, and any
+// other top-level file) is mutable and served no-cache. Returns true when the
+// file existed and was served. A directory is treated as a miss (there is no
+// directory listing), so it falls through to the SPA shell.
+func serveFile(w http.ResponseWriter, fsys fs.FS, name string) bool {
+	data, err := fs.ReadFile(fsys, name)
+	if err != nil {
+		return false
+	}
+	if ct := mime.TypeByExtension(path.Ext(name)); ct != "" {
+		w.Header().Set("Content-Type", ct)
+	}
+	if strings.HasPrefix(name, "assets/") {
+		w.Header().Set("Cache-Control", "public, max-age=31536000, immutable")
+	} else {
+		w.Header().Set("Cache-Control", "no-cache")
+	}
+	_, _ = w.Write(data)
+	return true
+}

--- a/dashboard/embed_test.go
+++ b/dashboard/embed_test.go
@@ -1,0 +1,72 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package dashboard
+
+import (
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// do issues a GET against Handler() and returns the recorder, mirroring the
+// httpapi package's own request helper but staying local to this package (the
+// embed reads dashboard/dist at compile time, so these assertions must hold
+// whether that tree is the checked-in placeholder or a real `make ui` build).
+func do(t *testing.T, path string) *httptest.ResponseRecorder {
+	t.Helper()
+	req := httptest.NewRequest("GET", path, nil)
+	rec := httptest.NewRecorder()
+	Handler().ServeHTTP(rec, req)
+	return rec
+}
+
+// TestHandlerServesIndex proves the app shell is served at "/" as 200 text/html.
+func TestHandlerServesIndex(t *testing.T) {
+	rec := do(t, "/")
+	if rec.Code != 200 {
+		t.Fatalf("/ = %d, want 200 (%s)", rec.Code, rec.Body)
+	}
+	if ct := rec.Header().Get("Content-Type"); !strings.HasPrefix(ct, "text/html") {
+		t.Fatalf("/ content-type = %q, want text/html", ct)
+	}
+}
+
+// TestHandlerSPAFallback proves an unknown, non-asset path (a client-side
+// route) falls back to the same index.html shell rather than 404ing.
+func TestHandlerSPAFallback(t *testing.T) {
+	index := do(t, "/")
+	rec := do(t, "/collections/docs")
+	if rec.Code != 200 {
+		t.Fatalf("/collections/docs = %d, want 200 (%s)", rec.Code, rec.Body)
+	}
+	if ct := rec.Header().Get("Content-Type"); !strings.HasPrefix(ct, "text/html") {
+		t.Fatalf("/collections/docs content-type = %q, want text/html", ct)
+	}
+	if rec.Body.String() != index.Body.String() {
+		t.Fatalf("/collections/docs body != index.html body")
+	}
+}
+
+// TestHandlerTraversalContained proves a "../" path segment cannot escape the
+// embedded dist tree: the response is either the SPA shell (200) or a 404,
+// never the contents of a real host file like /etc/passwd.
+func TestHandlerTraversalContained(t *testing.T) {
+	rec := do(t, "/../../etc/passwd")
+	if rec.Code != 200 && rec.Code != 404 {
+		t.Fatalf("traversal = %d, want 200 or 404 (%s)", rec.Code, rec.Body)
+	}
+	if strings.Contains(rec.Body.String(), "root:") {
+		t.Fatalf("traversal response leaked host file contents: %s", rec.Body)
+	}
+}
+
+// TestHandlerMissingAssetIs404 proves a request under assets/ for a name that
+// does not exist in the embed gets a genuine 404, not the SPA shell — Vite
+// asset names are content-hashed, so a miss means the file never existed
+// (never the client-side-routing case the SPA fallback exists for).
+func TestHandlerMissingAssetIs404(t *testing.T) {
+	rec := do(t, "/assets/does-not-exist-0123456789.js")
+	if rec.Code != 404 {
+		t.Fatalf("missing assets/ file = %d, want 404 (%s)", rec.Code, rec.Body)
+	}
+}

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -5,6 +5,14 @@ Notable user-visible changes. Entries that alter existing behaviour are marked
 
 ## Unreleased
 
+- **Embedded web dashboard.** The server now ships a browser UI at
+  `/dashboard/` for inspecting and operating on a running instance — vector
+  collections, cluster topology, and KV keys — with no separate install. It
+  reads over new REST endpoints: `GET /v1/topology`, `GET /v1/collections`,
+  and `GET /v1/collections/{name}`. The KV store also gains a REST data
+  plane alongside the existing binary protocol: `GET`, `PUT`, and `DELETE
+  /v1/kv/{key}`.
+
 ## v0.5.0 — 2026-08-30
 
 - **Eight new key-value ops: `exists`, `getdel`, `getset`, `persist`, `ttl`,

--- a/httpapi/dashboard.go
+++ b/httpapi/dashboard.go
@@ -1,0 +1,209 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package httpapi
+
+import (
+	"net/http"
+
+	"github.com/rostamlabs/rostam/ops"
+	"github.com/rostamlabs/rostam/vector"
+)
+
+// topologyMember is one node in the topology JSON: its NodeID + client-facing
+// ServerAddr (the Raft transport addr is intentionally never exposed).
+type topologyMember struct {
+	NodeID     string `json:"node_id"`
+	ServerAddr string `json:"server_addr"`
+}
+
+// topologyResponse is the JSON shape of GET /v1/topology: the cluster routing
+// snapshot the dashboard renders (shard count, members, per-shard leader addr,
+// per-shard owner placement).
+type topologyResponse struct {
+	NumShards int              `json:"num_shards"`
+	Members   []topologyMember `json:"members"`
+	Leaders   []string         `json:"leaders"`
+	Placement [][]string       `json:"placement"`
+}
+
+// topology serves the cluster routing snapshot as JSON. It dispatches the
+// existing __topology__ read op (scope-gated like any other read via a.call —
+// open when no authenticator is configured), decodes the gob-encoded result the
+// smart client uses, and renders it. In single-node / Direct mode the op reports
+// a one-member, single-shard map.
+func (a *api) topology(w http.ResponseWriter, r *http.Request) {
+	body, ok := a.call(w, r, "__topology__", nil)
+	if !ok {
+		return
+	}
+	t, err := ops.DecodeTopology(body)
+	if err != nil {
+		writeInternalError(w, "__topology__ decode", err)
+		return
+	}
+	members := make([]topologyMember, 0, len(t.Members))
+	for _, m := range t.Members {
+		members = append(members, topologyMember{NodeID: m.NodeID, ServerAddr: m.ServerAddr})
+	}
+	// Normalize the two shard-indexed slices to non-nil so the JSON carries [] not
+	// null on an empty/legacy map — a stable shape for the dashboard to consume.
+	leaders := t.Leaders
+	if leaders == nil {
+		leaders = []string{}
+	}
+	placement := t.Placement
+	if placement == nil {
+		placement = [][]string{}
+	}
+	writeJSON(w, http.StatusOK, topologyResponse{
+		NumShards: t.NumShards,
+		Members:   members,
+		Leaders:   leaders,
+		Placement: placement,
+	})
+}
+
+// collectionRef names one collection in the GET /v1/collections list. It is a
+// struct (not a bare string) so the shape can grow per-collection fields later
+// without breaking the response contract.
+type collectionRef struct {
+	Name string `json:"name"`
+}
+
+// collections lists this node's dense collections as {"collections":[{"name":..}]}.
+// It dispatches the __collections__ read op (scope-gated via a.call, mirroring
+// a.metrics) which reads the SAME CollectionStore.CollectionNames() source the
+// Prometheus __metrics__ op enumerates, so the two never disagree.
+func (a *api) collections(w http.ResponseWriter, r *http.Request) {
+	body, ok := a.call(w, r, ops.CollectionsOp, nil)
+	if !ok {
+		return
+	}
+	names, err := ops.DecodeCollectionsResult(body)
+	if err != nil {
+		writeInternalError(w, "__collections__ decode", err)
+		return
+	}
+	refs := make([]collectionRef, 0, len(names))
+	for _, n := range names {
+		refs = append(refs, collectionRef{Name: n})
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"collections": refs})
+}
+
+// collectionConfigView serves a single collection's configuration as JSON. It
+// wraps the existing vector_get_config read op (scope-gated via a.call), decodes
+// the engine Config, and renders it through the same friendly collectionConfig
+// shape create accepts — metric/quant/index_type as readable strings. An unknown
+// collection surfaces as the op's 404 through the standard dispatch-error mapping.
+func (a *api) collectionConfigView(w http.ResponseWriter, r *http.Request) {
+	name := r.PathValue("name")
+	body, ok := a.call(w, r, "vector_get_config", ops.EncodeGetConfigArgs(name))
+	if !ok {
+		return
+	}
+	cfg, err := ops.DecodeGetConfigResult(body)
+	if err != nil {
+		writeInternalError(w, "vector_get_config decode", err)
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"name": name, "config": fromConfig(cfg)})
+}
+
+// fromConfig renders an engine vector.Config into the friendly collectionConfig
+// (the inverse of collectionConfig.toConfig): the integer metric/quant/index-type
+// enums become the readable strings the create API accepts, and the remaining
+// index-build knobs are copied straight across. It is the read-side companion to
+// toConfig so a config round-trips (GET then re-POST) through the HTTP surface.
+func fromConfig(c vector.Config) collectionConfig {
+	var fullText *fullTextConfig
+	if c.FullText != nil {
+		fullText = &fullTextConfig{Analyzer: c.FullText.Analyzer, K1: c.FullText.K1, B: c.FullText.B}
+	}
+	return collectionConfig{
+		Dim:                   c.Dim,
+		Metric:                metricString(c.Metric),
+		M:                     c.M,
+		EfConstruction:        c.EfConstruction,
+		EfSearch:              c.EfSearch,
+		Seed:                  c.Seed,
+		Quant:                 quantString(c.Quant),
+		Persistent:            c.Persistent,
+		RescoreFactor:         c.RescoreFactor,
+		SQBits:                c.SQBits,
+		PRQLayers:             c.PRQLayers,
+		Partitions:            c.Partitions,
+		ExtendCandidates:      c.ExtendCandidates,
+		ExtendCandidatesMax:   c.ExtendCandidatesMax,
+		Level0FullDegree:      c.Level0FullDegree,
+		QuantizedBuild:        c.QuantizedBuild,
+		IndexType:             indexTypeString(c.IndexType),
+		IVFNlist:              c.IVFNlist,
+		IVFNprobe:             c.IVFNprobe,
+		VamanaR:               c.VamanaR,
+		VamanaL:               c.VamanaL,
+		VamanaAlpha:           c.VamanaAlpha,
+		IVFPQ:                 c.IVFPQ,
+		IVFPQM:                c.IVFPQM,
+		IVFRerank:             c.IVFRerank,
+		QuantPQM:              c.QuantPQM,
+		OPQ:                   c.OPQ,
+		OPQIters:              c.OPQIters,
+		PQDropVecs:            c.PQDropVecs,
+		IVFTrainThreshold:     c.IVFTrainThreshold,
+		IVFDriftRetrain:       c.IVFDriftRetrain,
+		IVFDriftGrowthFactor:  c.IVFDriftGrowthFactor,
+		IVFDriftFactor:        c.IVFDriftFactor,
+		FilterFirstRelativeBP: c.FilterFirstRelativeBP,
+		FullText:              fullText,
+		AnisotropicEta:        c.AnisotropicEta,
+		SOAR:                  c.SOAR,
+		SOARLambda:            c.SOARLambda,
+		PQNBits:               c.PQNBits,
+	}
+}
+
+// metricString is the inverse of parseMetric: the readable name for a metric
+// enum. An unrecognized value falls back to the default "cosine".
+func metricString(m vector.Metric) string {
+	switch m {
+	case vector.L2:
+		return "l2"
+	case vector.DotProduct:
+		return "dot"
+	default:
+		return "cosine"
+	}
+}
+
+// quantString is the inverse of parseQuant: the readable name for a quant enum.
+// QuantNone renders as "none". An unrecognized value falls back to "none".
+func quantString(q vector.QuantMode) string {
+	switch q {
+	case vector.QuantSQ8:
+		return "sq8"
+	case vector.QuantBQ1:
+		return "bq1"
+	case vector.QuantPQ:
+		return "pq"
+	case vector.QuantSQ:
+		return "sq"
+	case vector.QuantPRQ:
+		return "prq"
+	default:
+		return "none"
+	}
+}
+
+// indexTypeString is the inverse of parseIndexType: the readable name for an
+// index-type enum. An unrecognized value falls back to the default "hnsw".
+func indexTypeString(t vector.IndexType) string {
+	switch t {
+	case vector.IndexIVF:
+		return "ivf"
+	case vector.IndexVamana:
+		return "vamana"
+	default:
+		return "hnsw"
+	}
+}

--- a/httpapi/dashboard_test.go
+++ b/httpapi/dashboard_test.go
@@ -1,0 +1,226 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package httpapi
+
+import (
+	"net/http"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/rostamlabs/rostam/ops"
+	"github.com/rostamlabs/rostam/vector"
+)
+
+// TestHTTPTopology proves GET /v1/topology dispatches __topology__ and renders
+// the decoded routing snapshot: shard count, members (node_id + server_addr),
+// per-shard leader addrs, and per-shard owner placement. The recording dispatcher
+// returns a canned gob-encoded Topology so the JSON shape is asserted at the edge.
+func TestHTTPTopology(t *testing.T) {
+	topo := ops.Topology{
+		NumShards: 2,
+		Members: []ops.TopologyMember{
+			{NodeID: "n1", ServerAddr: "10.0.0.1:6543"},
+			{NodeID: "n2", ServerAddr: "10.0.0.2:6543"},
+		},
+		Leaders:   []string{"10.0.0.1:6543", "10.0.0.2:6543"},
+		Placement: [][]string{{"n1", "n2"}, {"n2", "n1"}},
+	}
+	enc, err := ops.EncodeTopology(topo)
+	if err != nil {
+		t.Fatalf("encode topology: %v", err)
+	}
+	disp := &recordingDispatcher{result: enc}
+	h := Handler(disp, Options{})
+
+	var out topologyResponse
+	rec := do(t, h, "GET", "/v1/topology", "", &out)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("topology = %d, want 200 (%s)", rec.Code, rec.Body)
+	}
+	if len(disp.calls) != 1 || disp.calls[0].name != "__topology__" {
+		t.Fatalf("calls = %+v, want one __topology__", disp.calls)
+	}
+	if out.NumShards != 2 {
+		t.Fatalf("num_shards = %d, want 2", out.NumShards)
+	}
+	if len(out.Members) != 2 || out.Members[0].NodeID != "n1" || out.Members[0].ServerAddr != "10.0.0.1:6543" {
+		t.Fatalf("members = %+v", out.Members)
+	}
+	if len(out.Leaders) != 2 || out.Leaders[0] != "10.0.0.1:6543" {
+		t.Fatalf("leaders = %+v", out.Leaders)
+	}
+	if len(out.Placement) != 2 || len(out.Placement[0]) != 2 || out.Placement[0][0] != "n1" {
+		t.Fatalf("placement = %+v", out.Placement)
+	}
+}
+
+// TestHTTPCollections covers GET /v1/collections: after creating two collections
+// they both appear in the {"collections":[{"name":..}]} list, sourced from the
+// same enumeration __metrics__ uses.
+func TestHTTPCollections(t *testing.T) {
+	h, cleanup := newTestAPI(t)
+	defer cleanup()
+
+	for _, name := range []string{"docs", "images"} {
+		rec := do(t, h, "POST", "/v1/collections",
+			`{"name":"`+name+`","config":{"dim":3,"metric":"l2"}}`, nil)
+		if rec.Code != http.StatusCreated {
+			t.Fatalf("create %s = %d (%s)", name, rec.Code, rec.Body)
+		}
+	}
+
+	var out struct {
+		Collections []collectionRef `json:"collections"`
+	}
+	rec := do(t, h, "GET", "/v1/collections", "", &out)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("collections = %d, want 200 (%s)", rec.Code, rec.Body)
+	}
+	got := make([]string, 0, len(out.Collections))
+	for _, c := range out.Collections {
+		got = append(got, c.Name)
+	}
+	sort.Strings(got)
+	// The enumeration source is CollectionStore.CollectionNames() — the SAME one
+	// __metrics__ labels — so names are tenant-qualified ("default/<name>"),
+	// matching the Prometheus collection="default/docs" labels.
+	if len(got) != 2 || got[0] != "default/docs" || got[1] != "default/images" {
+		t.Fatalf("collections = %v, want [default/docs default/images]", got)
+	}
+}
+
+// TestHTTPCollectionsEmpty proves the list is a non-nil empty array on a store
+// with no collections (JSON [] not null).
+func TestHTTPCollectionsEmpty(t *testing.T) {
+	h, cleanup := newTestAPI(t)
+	defer cleanup()
+	rec := do(t, h, "GET", "/v1/collections", "", nil)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("collections = %d, want 200 (%s)", rec.Code, rec.Body)
+	}
+	if body := strings.TrimSpace(rec.Body.String()); !strings.Contains(body, `"collections":[]`) {
+		t.Fatalf("empty collections body = %q, want []", body)
+	}
+}
+
+// TestHTTPCollectionConfig covers GET /v1/collections/{name}: it wraps
+// vector_get_config and renders the config with readable metric/quant/index_type
+// strings, round-tripping the values a create set.
+func TestHTTPCollectionConfig(t *testing.T) {
+	h, cleanup := newTestAPI(t)
+	defer cleanup()
+
+	rec := do(t, h, "POST", "/v1/collections",
+		`{"name":"docs","config":{"dim":8,"metric":"dot","m":12,"ef_construction":80,"ef_search":40,"quant":"sq8"}}`, nil)
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("create = %d (%s)", rec.Code, rec.Body)
+	}
+
+	var out struct {
+		Name   string           `json:"name"`
+		Config collectionConfig `json:"config"`
+	}
+	rec = do(t, h, "GET", "/v1/collections/docs", "", &out)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("get config = %d, want 200 (%s)", rec.Code, rec.Body)
+	}
+	if out.Name != "docs" {
+		t.Fatalf("name = %q, want docs", out.Name)
+	}
+	if out.Config.Dim != 8 {
+		t.Fatalf("dim = %d, want 8", out.Config.Dim)
+	}
+	if out.Config.Metric != "dot" {
+		t.Fatalf("metric = %q, want dot", out.Config.Metric)
+	}
+	if out.Config.Quant != "sq8" {
+		t.Fatalf("quant = %q, want sq8", out.Config.Quant)
+	}
+	if out.Config.M != 12 || out.Config.EfConstruction != 80 || out.Config.EfSearch != 40 {
+		t.Fatalf("m/efc/efs = %d/%d/%d, want 12/80/40", out.Config.M, out.Config.EfConstruction, out.Config.EfSearch)
+	}
+	// A default (unspecified) index type renders as the readable "hnsw".
+	if out.Config.IndexType != "hnsw" {
+		t.Fatalf("index_type = %q, want hnsw", out.Config.IndexType)
+	}
+}
+
+// TestHTTPCollectionConfigUnknown proves an unknown collection surfaces the op's
+// 404 through the standard dispatch-error mapping.
+func TestHTTPCollectionConfigUnknown(t *testing.T) {
+	h, cleanup := newTestAPI(t)
+	defer cleanup()
+	rec := do(t, h, "GET", "/v1/collections/nope", "", nil)
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("unknown collection config = %d, want 404 (%s)", rec.Code, rec.Body)
+	}
+}
+
+// TestHTTPDashboardStatic covers the embedded SPA mount: the bare /dashboard
+// 301-redirects to /dashboard/, the index is served at the root, and an unknown
+// deep link falls back to the same index.html (client-side routing) rather than
+// 404ing. The checked-in placeholder is enough to assert the fallback wiring.
+func TestHTTPDashboardStatic(t *testing.T) {
+	h, cleanup := newTestAPI(t)
+	defer cleanup()
+
+	// /dashboard -> 301 /dashboard/.
+	rec := do(t, h, "GET", "/dashboard", "", nil)
+	if rec.Code != http.StatusMovedPermanently {
+		t.Fatalf("/dashboard = %d, want 301 (%s)", rec.Code, rec.Body)
+	}
+	if loc := rec.Header().Get("Location"); loc != "/dashboard/" {
+		t.Fatalf("/dashboard Location = %q, want /dashboard/", loc)
+	}
+
+	// Root serves the SPA shell. The marker "Rostam" is build-agnostic: it is in
+	// both the compiled index.html (<title>Rostam Dashboard</title>) and the
+	// built-in unbuilt placeholder, so this passes whether or not `make ui` ran.
+	rec = do(t, h, "GET", "/dashboard/", "", nil)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("/dashboard/ = %d, want 200 (%s)", rec.Code, rec.Body)
+	}
+	if !strings.Contains(rec.Body.String(), "Rostam") {
+		t.Fatalf("/dashboard/ body missing shell marker:\n%s", rec.Body)
+	}
+	if ct := rec.Header().Get("Content-Type"); !strings.HasPrefix(ct, "text/html") {
+		t.Fatalf("/dashboard/ content-type = %q, want text/html", ct)
+	}
+
+	// An unknown deep link (client-side route) falls back to the SPA shell.
+	rec = do(t, h, "GET", "/dashboard/collections/docs", "", nil)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("deep link = %d, want 200 (%s)", rec.Code, rec.Body)
+	}
+	if !strings.Contains(rec.Body.String(), "Rostam") {
+		t.Fatalf("deep-link fallback missing SPA shell:\n%s", rec.Body)
+	}
+}
+
+// TestFromConfigEnumStrings proves the reverse enum helpers map every metric,
+// quant and index-type enum onto the readable string the create API accepts, so a
+// config round-trips (fromConfig -> toConfig) without loss.
+func TestFromConfigEnumStrings(t *testing.T) {
+	metrics := map[vector.Metric]string{vector.Cosine: "cosine", vector.L2: "l2", vector.DotProduct: "dot"}
+	for m, want := range metrics {
+		if got := metricString(m); got != want {
+			t.Errorf("metricString(%v) = %q, want %q", m, got, want)
+		}
+	}
+	quants := map[vector.QuantMode]string{
+		vector.QuantNone: "none", vector.QuantSQ8: "sq8", vector.QuantBQ1: "bq1",
+		vector.QuantPQ: "pq", vector.QuantSQ: "sq", vector.QuantPRQ: "prq",
+	}
+	for q, want := range quants {
+		if got := quantString(q); got != want {
+			t.Errorf("quantString(%v) = %q, want %q", q, got, want)
+		}
+	}
+	indexes := map[vector.IndexType]string{vector.IndexHNSW: "hnsw", vector.IndexIVF: "ivf", vector.IndexVamana: "vamana"}
+	for it, want := range indexes {
+		if got := indexTypeString(it); got != want {
+			t.Errorf("indexTypeString(%v) = %q, want %q", it, got, want)
+		}
+	}
+}

--- a/httpapi/httpapi.go
+++ b/httpapi/httpapi.go
@@ -16,6 +16,7 @@ import (
 	"strings"
 
 	"github.com/rostamlabs/rostam/authz"
+	"github.com/rostamlabs/rostam/dashboard"
 	"github.com/rostamlabs/rostam/ops"
 	"github.com/rostamlabs/rostam/vector"
 )
@@ -136,6 +137,18 @@ func Handler(disp Dispatcher, opts Options) http.Handler {
 	// min-ISR / per-backup lag as JSON via the __repl_metrics__ read op.
 	// Auth-exempt like /v1/ready — an ops/infra probe carries no token.
 	mux.HandleFunc("GET /v1/replication", a.replication)
+	// Dashboard read surface: the cluster routing map, the dense-collection list,
+	// and a single collection's config. All are scope-gated reads (via a.call), the
+	// data plane the embedded web dashboard renders.
+	mux.HandleFunc("GET /v1/topology", a.topology)
+	mux.HandleFunc("GET /v1/collections", a.collections)
+	mux.HandleFunc("GET /v1/collections/{name}", a.collectionConfigView)
+	// KV data plane over REST (no KV HTTP routes existed before). The {key} is a
+	// URL-encoded UTF-8 path segment (arbitrary bytes on the wire); the 512-byte
+	// cap is enforced in-handler since nameLenGuard does not cover /v1/kv/.
+	mux.HandleFunc("GET /v1/kv/{key}", a.kvGet)
+	mux.HandleFunc("PUT /v1/kv/{key}", a.kvPut)
+	mux.HandleFunc("DELETE /v1/kv/{key}", a.kvDelete)
 	mux.HandleFunc("POST /v1/collections", a.createCollection)
 	mux.HandleFunc("DELETE /v1/collections/{name}", a.dropCollection)
 	mux.HandleFunc("POST /v1/collections/{name}/points", a.putPoint)
@@ -225,6 +238,16 @@ func Handler(disp Dispatcher, opts Options) http.Handler {
 	mux.HandleFunc("GET /v1/admin/backups", a.listBackups)
 	mux.HandleFunc("POST /v1/collections/{name}/evict", a.evictCollection)
 	mux.HandleFunc("POST /v1/collections/{name}/restore", a.restoreCollection)
+
+	// Embedded web dashboard (static SPA). Served UNDER /dashboard/ with no auth —
+	// the assets are inert HTML/JS/CSS and every data read goes through the authed
+	// /v1 endpoints above. The bare /dashboard 301-redirects to /dashboard/ so the
+	// SPA's relative asset URLs resolve. The dashboard package imports nothing from
+	// rostam, so mounting it here forms no import cycle.
+	mux.Handle("GET /dashboard/", http.StripPrefix("/dashboard", dashboard.Handler()))
+	mux.HandleFunc("GET /dashboard", func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, "/dashboard/", http.StatusMovedPermanently)
+	})
 	return nameLenGuard(mux)
 }
 

--- a/httpapi/kv.go
+++ b/httpapi/kv.go
@@ -4,8 +4,8 @@ package httpapi
 
 import (
 	"encoding/base64"
+	"math"
 	"net/http"
-	"net/url"
 	"strings"
 	"time"
 	"unicode/utf8"
@@ -21,18 +21,21 @@ import (
 // guards the collection/alias routes), so this cap is enforced here.
 const maxKVKeyLen = 512
 
-// kvKey decodes the {key} path segment: it is URL-encoded (a KV key is arbitrary
-// bytes addressed as a UTF-8 string), so it is percent-decoded here, then bounded
-// at maxKVKeyLen. Returns ok=false (after writing the 400) on a malformed encoding
-// or an over-long key.
+// maxTTLMs is the largest ttl_ms that survives the *time.Millisecond
+// conversion to time.Duration (an int64 count of nanoseconds) without
+// overflowing: math.MaxInt64 / int64(time.Millisecond). A value above this
+// wraps to a negative or truncated duration and would silently store the
+// wrong TTL instead of failing loud, so kvPut rejects it as a 400.
+const maxTTLMs = int64(math.MaxInt64) / int64(time.Millisecond)
+
+// kvKey decodes the {key} path segment. net/http's ServeMux already unescapes
+// a {wildcard} match before PathValue returns it, so raw is the literal key —
+// unescaping it again would merge distinct keys (a literal "a/b" and the
+// encoded "a%2Fb" both decode to "a/b") and reject a valid key that merely
+// contains a bare '%' (e.g. "%ZZ"). Only the length is bounded here, at
+// maxKVKeyLen. Returns ok=false (after writing the 400) on an over-long key.
 func kvKey(w http.ResponseWriter, r *http.Request) ([]byte, bool) {
-	raw := r.PathValue("key")
-	dec, err := url.PathUnescape(raw)
-	if err != nil {
-		writeError(w, http.StatusBadRequest, "invalid key encoding: "+err.Error())
-		return nil, false
-	}
-	key := []byte(dec)
+	key := []byte(r.PathValue("key"))
 	if len(key) > maxKVKeyLen {
 		writeError(w, http.StatusBadRequest, "key too long")
 		return nil, false
@@ -152,6 +155,10 @@ func (a *api) kvPut(w http.ResponseWriter, r *http.Request) {
 	}
 	if req.TTLMs < 0 {
 		writeError(w, http.StatusBadRequest, "ttl_ms must be non-negative")
+		return
+	}
+	if req.TTLMs > maxTTLMs {
+		writeError(w, http.StatusBadRequest, "ttl_ms too large")
 		return
 	}
 	ttl := time.Duration(req.TTLMs) * time.Millisecond

--- a/httpapi/kv.go
+++ b/httpapi/kv.go
@@ -1,0 +1,177 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package httpapi
+
+import (
+	"encoding/base64"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+	"unicode/utf8"
+
+	"github.com/rostamlabs/rostam/ops"
+)
+
+// maxKVKeyLen caps the KV key length the REST surface accepts. Keys are arbitrary
+// bytes on the wire, but v1 addresses them as a URL-encoded UTF-8 path segment,
+// and the get/put/del wire codecs length-prefix the key with a u16 — so an
+// over-long key is a client mistake with an obvious remedy (shorten it), rejected
+// 400 in-handler. The /v1/kv/ prefix is NOT covered by nameLenGuard (which only
+// guards the collection/alias routes), so this cap is enforced here.
+const maxKVKeyLen = 512
+
+// kvKey decodes the {key} path segment: it is URL-encoded (a KV key is arbitrary
+// bytes addressed as a UTF-8 string), so it is percent-decoded here, then bounded
+// at maxKVKeyLen. Returns ok=false (after writing the 400) on a malformed encoding
+// or an over-long key.
+func kvKey(w http.ResponseWriter, r *http.Request) ([]byte, bool) {
+	raw := r.PathValue("key")
+	dec, err := url.PathUnescape(raw)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, "invalid key encoding: "+err.Error())
+		return nil, false
+	}
+	key := []byte(dec)
+	if len(key) > maxKVKeyLen {
+		writeError(w, http.StatusBadRequest, "key too long")
+		return nil, false
+	}
+	return key, true
+}
+
+// kvGetResponse is the GET /v1/kv/{key} body. ValueB64 carries the raw bytes
+// (always present when found, including an empty-but-present value); ValueUTF8
+// is the string form, emitted ONLY when the bytes are valid UTF-8 (omitted
+// otherwise so a client never mistakes lossy bytes for text). Both are pointers
+// so an empty string ("") still marshals rather than being dropped by
+// omitempty — omitempty only elides a nil pointer, which is how a miss keeps
+// both fields absent. TTLMs is present only when ?with_ttl=1 was requested.
+type kvGetResponse struct {
+	Found     bool    `json:"found"`
+	ValueB64  *string `json:"value_b64,omitempty"`
+	ValueUTF8 *string `json:"value_utf8,omitempty"`
+	TTLMs     *int64  `json:"ttl_ms,omitempty"`
+}
+
+// isKVNotFound reports whether a dispatch error is the cache's key-miss sentinel
+// (cache.ErrNotFound, "cache: not found"). Matched by message so it covers both
+// the in-process path (the sentinel verbatim) and the clustered path where it is
+// stringified across the Raft boundary — the KV analog of statusForError's
+// string fallbacks. A miss is rendered as {"found":false}, NOT a 404.
+func isKVNotFound(err error) bool {
+	return strings.Contains(err.Error(), "cache: not found")
+}
+
+// kvGet reads a KV key → {found, value_b64, value_utf8?}. A key miss is
+// found=false (200), not a 404, so a client distinguishes "absent" from a real
+// error without inspecting status codes. With ?with_ttl=1 it also dispatches the
+// ttl op and includes ttl_ms (-1 = no expiry, -2 = absent, per the ttl op's
+// convention).
+func (a *api) kvGet(w http.ResponseWriter, r *http.Request) {
+	key, ok := kvKey(w, r)
+	if !ok {
+		return
+	}
+	args := ops.EncodeKeyArgs(key)
+	// Authorize then dispatch directly (not via a.call) so a key MISS can be
+	// intercepted and rendered found=false rather than written out as an error.
+	if !a.authorize(w, r, "get", args) {
+		return
+	}
+	body, err := a.disp.Call("get", args)
+	var resp kvGetResponse
+	switch {
+	case err == nil:
+		resp.Found = true
+		b64 := base64.StdEncoding.EncodeToString(body)
+		resp.ValueB64 = &b64
+		if utf8.Valid(body) {
+			utf8Val := string(body)
+			resp.ValueUTF8 = &utf8Val
+		}
+	case isKVNotFound(err):
+		resp.Found = false
+	default:
+		writeDispatchError(w, "get", err)
+		return
+	}
+	if r.URL.Query().Get("with_ttl") == "1" {
+		ttlBody, ok := a.call(w, r, "ttl", ops.EncodeKeyArgs(key))
+		if !ok {
+			return
+		}
+		ms, err := ops.DecodeTTLResult(ttlBody)
+		if err != nil {
+			writeInternalError(w, "ttl decode", err)
+			return
+		}
+		resp.TTLMs = &ms
+	}
+	writeJSON(w, http.StatusOK, resp)
+}
+
+// kvPutReq is the PUT /v1/kv/{key} body. Exactly one of ValueB64 / Value must be
+// set (base64-encoded raw bytes, or a UTF-8 string); TTLMs is optional (0 or
+// absent = no TTL). ValueB64 and Value are pointers so "" is distinguishable from
+// absent — an explicit empty value is a valid (empty) write, and the both/neither
+// guard needs to know which fields were actually present.
+type kvPutReq struct {
+	ValueB64 *string `json:"value_b64"`
+	Value    *string `json:"value"`
+	TTLMs    int64   `json:"ttl_ms"`
+}
+
+// kvPut writes a KV key. The value arrives as EITHER value_b64 (raw bytes) OR
+// value (a UTF-8 string) — exactly one; both or neither is a 400. An optional
+// ttl_ms sets a relative expiry (0/absent = permanent). Dispatched via callWrite
+// with the default (no write-consistency) path.
+func (a *api) kvPut(w http.ResponseWriter, r *http.Request) {
+	key, ok := kvKey(w, r)
+	if !ok {
+		return
+	}
+	var req kvPutReq
+	if !decodeBody(w, r, &req) {
+		return
+	}
+	if (req.ValueB64 == nil) == (req.Value == nil) {
+		writeError(w, http.StatusBadRequest, "exactly one of value_b64 or value must be set")
+		return
+	}
+	var val []byte
+	if req.ValueB64 != nil {
+		dec, err := base64.StdEncoding.DecodeString(*req.ValueB64)
+		if err != nil {
+			writeError(w, http.StatusBadRequest, "invalid value_b64: "+err.Error())
+			return
+		}
+		val = dec
+	} else {
+		val = []byte(*req.Value)
+	}
+	if req.TTLMs < 0 {
+		writeError(w, http.StatusBadRequest, "ttl_ms must be non-negative")
+		return
+	}
+	ttl := time.Duration(req.TTLMs) * time.Millisecond
+	if _, ok := a.callWrite(w, r, "put", ops.EncodePutArgs(key, val, ttl), 0, true); !ok {
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]bool{"ok": true})
+}
+
+// kvDelete removes a KV key → {"deleted":bool} (false when the key was already
+// absent). Dispatched via callWrite with the default (no write-consistency) path.
+func (a *api) kvDelete(w http.ResponseWriter, r *http.Request) {
+	key, ok := kvKey(w, r)
+	if !ok {
+		return
+	}
+	body, ok := a.callWrite(w, r, "del", ops.EncodeKeyArgs(key), 0, true)
+	if !ok {
+		return
+	}
+	deleted := len(body) > 0 && body[0] == 1
+	writeJSON(w, http.StatusOK, map[string]bool{"deleted": deleted})
+}

--- a/httpapi/kv_test.go
+++ b/httpapi/kv_test.go
@@ -4,6 +4,7 @@ package httpapi
 
 import (
 	"encoding/base64"
+	"fmt"
 	"net/http"
 	"strings"
 	"testing"
@@ -224,5 +225,58 @@ func TestHTTPKVKeyCap(t *testing.T) {
 	rec := do(t, h, "PUT", atCap, `{"value":"x"}`, nil)
 	if rec.Code != http.StatusOK {
 		t.Fatalf("at-cap key PUT = %d, want 200 (%s)", rec.Code, rec.Body)
+	}
+}
+
+// TestHTTPKVKeyEncoding proves the {key} wildcard is used as-is: net/http's
+// ServeMux already unescapes a matched wildcard segment before PathValue
+// returns it, so a second url.PathUnescape must NOT run. Two regressions that
+// a second decode would cause: an encoded slash getting decoded again (merging
+// distinct keys), and a key that merely contains a bare '%' (not a valid
+// escape) being rejected as malformed.
+func TestHTTPKVKeyEncoding(t *testing.T) {
+	h, cleanup := newTestAPI(t)
+	defer cleanup()
+
+	// %2F in the request path is the ONE decode (by ServeMux) that turns into a
+	// literal '/' inside the key value.
+	rec := do(t, h, "PUT", "/v1/kv/a%2Fb", `{"value":"slash"}`, nil)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("put a%%2Fb = %d, want 200 (%s)", rec.Code, rec.Body)
+	}
+	var out kvGetResponse
+	do(t, h, "GET", "/v1/kv/a%2Fb", "", &out)
+	if !out.Found || out.ValueUTF8 == nil || *out.ValueUTF8 != "slash" {
+		t.Fatalf("get a%%2Fb: found=%v value=%v, want found value=slash", out.Found, out.ValueUTF8)
+	}
+
+	// %25ZZ decodes (once) to the literal key "%ZZ", which is not itself a
+	// valid percent-escape — a second PathUnescape would reject it.
+	rec = do(t, h, "PUT", "/v1/kv/%25ZZ", `{"value":"pct"}`, nil)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("put %%25ZZ = %d, want 200 (%s)", rec.Code, rec.Body)
+	}
+	out = kvGetResponse{}
+	do(t, h, "GET", "/v1/kv/%25ZZ", "", &out)
+	if !out.Found || out.ValueUTF8 == nil || *out.ValueUTF8 != "pct" {
+		t.Fatalf("get %%25ZZ: found=%v value=%v, want found value=pct", out.Found, out.ValueUTF8)
+	}
+}
+
+// TestHTTPKVPutTTLOverflow proves ttl_ms is rejected 400 once it would
+// overflow time.Duration on the *time.Millisecond conversion, rather than
+// wrapping into an incorrect (e.g. negative) stored TTL.
+func TestHTTPKVPutTTLOverflow(t *testing.T) {
+	h, cleanup := newTestAPI(t)
+	defer cleanup()
+
+	rec := do(t, h, "PUT", "/v1/kv/ttl-at-max", fmt.Sprintf(`{"value":"x","ttl_ms":%d}`, maxTTLMs), nil)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("put at max ttl_ms (%d) = %d, want 200 (%s)", maxTTLMs, rec.Code, rec.Body)
+	}
+
+	rec = do(t, h, "PUT", "/v1/kv/ttl-overflow", fmt.Sprintf(`{"value":"x","ttl_ms":%d}`, maxTTLMs+1), nil)
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("put over-max ttl_ms (%d) = %d, want 400 (%s)", maxTTLMs+1, rec.Code, rec.Body)
 	}
 }

--- a/httpapi/kv_test.go
+++ b/httpapi/kv_test.go
@@ -1,0 +1,228 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package httpapi
+
+import (
+	"encoding/base64"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+// TestHTTPKVPutGetUTF8 covers a UTF-8 value round-trip: PUT with a "value"
+// string, then GET returns found + both value_b64 (raw bytes) and value_utf8
+// (the string, present because the bytes are valid UTF-8).
+func TestHTTPKVPutGetUTF8(t *testing.T) {
+	h, cleanup := newTestAPI(t)
+	defer cleanup()
+
+	rec := do(t, h, "PUT", "/v1/kv/greeting", `{"value":"hello"}`, nil)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("put = %d, want 200 (%s)", rec.Code, rec.Body)
+	}
+
+	var out kvGetResponse
+	rec = do(t, h, "GET", "/v1/kv/greeting", "", &out)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("get = %d, want 200 (%s)", rec.Code, rec.Body)
+	}
+	if !out.Found {
+		t.Fatalf("found = false, want true")
+	}
+	if out.ValueUTF8 == nil || *out.ValueUTF8 != "hello" {
+		t.Fatalf("value_utf8 = %v, want hello", out.ValueUTF8)
+	}
+	if want := base64.StdEncoding.EncodeToString([]byte("hello")); out.ValueB64 == nil || *out.ValueB64 != want {
+		t.Fatalf("value_b64 = %v, want %q", out.ValueB64, want)
+	}
+}
+
+// TestHTTPKVPutGetBinary covers a binary value: PUT with value_b64 of bytes that
+// are NOT valid UTF-8, then GET returns value_b64 but OMITS value_utf8.
+func TestHTTPKVPutGetBinary(t *testing.T) {
+	h, cleanup := newTestAPI(t)
+	defer cleanup()
+
+	raw := []byte{0xff, 0xfe, 0x00, 0x01}
+	b64 := base64.StdEncoding.EncodeToString(raw)
+	rec := do(t, h, "PUT", "/v1/kv/blob", `{"value_b64":"`+b64+`"}`, nil)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("put = %d, want 200 (%s)", rec.Code, rec.Body)
+	}
+
+	var out kvGetResponse
+	rec = do(t, h, "GET", "/v1/kv/blob", "", &out)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("get = %d, want 200 (%s)", rec.Code, rec.Body)
+	}
+	if !out.Found || out.ValueB64 == nil || *out.ValueB64 != b64 {
+		t.Fatalf("found/value_b64 = %v/%v, want true/%q", out.Found, out.ValueB64, b64)
+	}
+	if out.ValueUTF8 != nil {
+		t.Fatalf("value_utf8 = %v, want omitted (binary bytes)", out.ValueUTF8)
+	}
+}
+
+// TestHTTPKVPutGetEmpty covers an empty-but-present value: PUT with "" must
+// round-trip as found=true with BOTH value_b64 and value_utf8 present (empty
+// strings), not omitted as if the key were absent — an empty value is valid
+// UTF-8 and distinct from a miss.
+func TestHTTPKVPutGetEmpty(t *testing.T) {
+	h, cleanup := newTestAPI(t)
+	defer cleanup()
+
+	rec := do(t, h, "PUT", "/v1/kv/empty", `{"value":""}`, nil)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("put = %d, want 200 (%s)", rec.Code, rec.Body)
+	}
+
+	var out kvGetResponse
+	rec = do(t, h, "GET", "/v1/kv/empty", "", &out)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("get = %d, want 200 (%s)", rec.Code, rec.Body)
+	}
+	if !out.Found {
+		t.Fatalf("found = false, want true")
+	}
+	if out.ValueB64 == nil || *out.ValueB64 != "" {
+		t.Fatalf("value_b64 = %v, want present and empty", out.ValueB64)
+	}
+	if out.ValueUTF8 == nil || *out.ValueUTF8 != "" {
+		t.Fatalf("value_utf8 = %v, want present and empty", out.ValueUTF8)
+	}
+
+	// A genuine miss still omits both value fields.
+	var missOut kvGetResponse
+	do(t, h, "GET", "/v1/kv/nope-not-there", "", &missOut)
+	if missOut.Found {
+		t.Fatalf("found = true, want false for a missing key")
+	}
+	if missOut.ValueB64 != nil || missOut.ValueUTF8 != nil {
+		t.Fatalf("value_b64/value_utf8 = %v/%v, want both nil on a miss", missOut.ValueB64, missOut.ValueUTF8)
+	}
+}
+
+// TestHTTPKVGetNotFound proves a key miss is {"found":false} at HTTP 200, NOT a
+// 404 — a client distinguishes absent from error without status-code parsing.
+func TestHTTPKVGetNotFound(t *testing.T) {
+	h, cleanup := newTestAPI(t)
+	defer cleanup()
+
+	var out kvGetResponse
+	rec := do(t, h, "GET", "/v1/kv/missing", "", &out)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("get missing = %d, want 200 (%s)", rec.Code, rec.Body)
+	}
+	if out.Found {
+		t.Fatalf("found = true, want false for a missing key")
+	}
+}
+
+// TestHTTPKVGetWithTTL covers ?with_ttl=1: a key written WITHOUT a TTL reports
+// ttl_ms = -1 (no expiry), and one written WITH a ttl_ms reports a positive
+// remaining budget.
+func TestHTTPKVGetWithTTL(t *testing.T) {
+	h, cleanup := newTestAPI(t)
+	defer cleanup()
+
+	// No TTL -> -1 (the ttl op's no-expiry convention).
+	do(t, h, "PUT", "/v1/kv/perm", `{"value":"x"}`, nil)
+	var out kvGetResponse
+	do(t, h, "GET", "/v1/kv/perm?with_ttl=1", "", &out)
+	if out.TTLMs == nil || *out.TTLMs != -1 {
+		t.Fatalf("ttl_ms = %v, want -1 (no expiry)", out.TTLMs)
+	}
+
+	// With TTL -> a positive remaining budget.
+	do(t, h, "PUT", "/v1/kv/temp", `{"value":"x","ttl_ms":60000}`, nil)
+	out = kvGetResponse{}
+	do(t, h, "GET", "/v1/kv/temp?with_ttl=1", "", &out)
+	if out.TTLMs == nil || *out.TTLMs <= 0 {
+		t.Fatalf("ttl_ms = %v, want > 0", out.TTLMs)
+	}
+
+	// Without the flag, ttl_ms is omitted.
+	out = kvGetResponse{}
+	do(t, h, "GET", "/v1/kv/perm", "", &out)
+	if out.TTLMs != nil {
+		t.Fatalf("ttl_ms = %v, want omitted without ?with_ttl", out.TTLMs)
+	}
+}
+
+// TestHTTPKVPutValidation covers the both/neither value guard: a body with BOTH
+// value and value_b64, and one with NEITHER, are each rejected 400.
+func TestHTTPKVPutValidation(t *testing.T) {
+	h, cleanup := newTestAPI(t)
+	defer cleanup()
+
+	rec := do(t, h, "PUT", "/v1/kv/k", `{"value":"a","value_b64":"YQ=="}`, nil)
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("both value+value_b64 = %d, want 400 (%s)", rec.Code, rec.Body)
+	}
+	rec = do(t, h, "PUT", "/v1/kv/k", `{}`, nil)
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("neither value nor value_b64 = %d, want 400 (%s)", rec.Code, rec.Body)
+	}
+	// A malformed base64 value is also a 400.
+	rec = do(t, h, "PUT", "/v1/kv/k", `{"value_b64":"not!base64"}`, nil)
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("bad value_b64 = %d, want 400 (%s)", rec.Code, rec.Body)
+	}
+}
+
+// TestHTTPKVDelete covers DELETE: an existing key reports deleted=true and is
+// then a miss; a second delete reports deleted=false (idempotent).
+func TestHTTPKVDelete(t *testing.T) {
+	h, cleanup := newTestAPI(t)
+	defer cleanup()
+
+	do(t, h, "PUT", "/v1/kv/gone", `{"value":"x"}`, nil)
+
+	var del struct {
+		Deleted bool `json:"deleted"`
+	}
+	rec := do(t, h, "DELETE", "/v1/kv/gone", "", &del)
+	if rec.Code != http.StatusOK || !del.Deleted {
+		t.Fatalf("delete = %d deleted=%v, want 200 true (%s)", rec.Code, del.Deleted, rec.Body)
+	}
+
+	var out kvGetResponse
+	do(t, h, "GET", "/v1/kv/gone", "", &out)
+	if out.Found {
+		t.Fatalf("key still found after delete")
+	}
+
+	del.Deleted = true
+	rec = do(t, h, "DELETE", "/v1/kv/gone", "", &del)
+	if rec.Code != http.StatusOK || del.Deleted {
+		t.Fatalf("second delete = %d deleted=%v, want 200 false (%s)", rec.Code, del.Deleted, rec.Body)
+	}
+}
+
+// TestHTTPKVKeyCap proves a key over the 512-byte cap is rejected 400 on every
+// KV verb, before any dispatch.
+func TestHTTPKVKeyCap(t *testing.T) {
+	h, cleanup := newTestAPI(t)
+	defer cleanup()
+
+	long := "/v1/kv/" + strings.Repeat("a", maxKVKeyLen+1)
+	for _, m := range []struct {
+		method, body string
+	}{
+		{"GET", ""},
+		{"PUT", `{"value":"x"}`},
+		{"DELETE", ""},
+	} {
+		rec := do(t, h, m.method, long, m.body, nil)
+		if rec.Code != http.StatusBadRequest {
+			t.Fatalf("%s over-long key = %d, want 400 (%s)", m.method, rec.Code, rec.Body)
+		}
+	}
+
+	// A key exactly at the cap is accepted (boundary is inclusive).
+	atCap := "/v1/kv/" + strings.Repeat("a", maxKVKeyLen)
+	rec := do(t, h, "PUT", atCap, `{"value":"x"}`, nil)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("at-cap key PUT = %d, want 200 (%s)", rec.Code, rec.Body)
+	}
+}

--- a/ops/builtin.go
+++ b/ops/builtin.go
@@ -97,6 +97,11 @@ var builtinHandlers = map[string]Handler{
 	// __ready__ is overridden. Read-only, no args; result is a JSON body served
 	// as-is by the HTTP /v1/replication handler.
 	wire.ReplMetricsOp: handleReplMetrics,
+	// __collections__ is shardless: it enumerates the local node's dense
+	// collections, reading the SAME CollectionStore.CollectionNames() source
+	// __metrics__ renders, so the two never disagree about which collections exist.
+	// Served as JSON by the HTTP /v1/collections handler.
+	wire.CollectionsOp: handleCollections,
 
 	// Vector ops. Routing (kind/wire.KeyExtractor/wire.RouteLayout) lives in
 	// wire.BuiltinOps; only the handler binding happens here.
@@ -616,6 +621,18 @@ func handleMetrics(tx *TxContext, _ []byte) ([]byte, error) {
 // a valid body the /v1/replication handler serves verbatim.
 func handleReplMetrics(_ *TxContext, _ []byte) ([]byte, error) {
 	return []byte(`{"shards":[]}`), nil
+}
+
+// handleCollections enumerates every dense collection on this node and returns
+// the name list. It is read-only, takes no args, and reads the SAME
+// CollectionStore.CollectionNames() source handleMetrics renders — the shardless
+// counterpart of __metrics__ for the dashboard's collection list. A node with no
+// vector store (KV-only) returns ErrVectorsNotAvailable.
+func handleCollections(tx *TxContext, _ []byte) ([]byte, error) {
+	if tx.vectors == nil {
+		return nil, ErrVectorsNotAvailable
+	}
+	return wire.EncodeCollectionsResult(tx.vectors.CollectionNames()), nil
 }
 
 func handleVectorCreateCollection(tx *TxContext, args []byte) ([]byte, error) {

--- a/ops/wire_aliases.go
+++ b/ops/wire_aliases.go
@@ -54,6 +54,7 @@ const (
 	GetFlagsBoth                = wire.GetFlagsBoth
 	MaxCollectionNameWire       = wire.MaxCollectionNameWire
 	MaxPutBatchSize             = wire.MaxPutBatchSize
+	CollectionsOp               = wire.CollectionsOp
 	MetricsOp                   = wire.MetricsOp
 	OpKeysAdd                   = wire.OpKeysAdd
 	OpKeysList                  = wire.OpKeysList
@@ -118,6 +119,8 @@ var (
 	EncodeGetDelResult                        = wire.EncodeGetDelResult
 	DecodeTTLResult                           = wire.DecodeTTLResult
 	EncodeTTLResult                           = wire.EncodeTTLResult
+	DecodeCollectionsResult                   = wire.DecodeCollectionsResult
+	EncodeCollectionsResult                   = wire.EncodeCollectionsResult
 	DecodeIncrExArgs                          = wire.DecodeIncrExArgs
 	EncodeIncrExArgs                          = wire.EncodeIncrExArgs
 	DecodeMGetArgs                            = wire.DecodeMGetArgs

--- a/sdk/wire/builtin.go
+++ b/sdk/wire/builtin.go
@@ -64,6 +64,61 @@ const MetricsOp = "__metrics__"
 // per-hosted-shard replication state (mode / primary / ISR / min-ISR / lag).
 const ReplMetricsOp = "__repl_metrics__"
 
+// CollectionsOp is the shardless op that enumerates the local node's dense
+// collections. Its result is the name list (EncodeCollectionsResult); the HTTP
+// /v1/collections handler renders it as JSON. Like __metrics__ it reads the SAME
+// CollectionStore.CollectionNames() source, so the two never disagree about which
+// collections exist.
+const CollectionsOp = "__collections__"
+
+// EncodeCollectionsResult serializes a collection-name list as
+// "{count u32}({nameLen u16}{name})*". Mirrors the MGet wire framing so the
+// decoder can bound the declared count before allocating.
+func EncodeCollectionsResult(names []string) []byte {
+	total := 4
+	for _, n := range names {
+		total += 2 + len(n)
+	}
+	buf := make([]byte, 4, total)
+	binary.BigEndian.PutUint32(buf[0:4], uint32(len(names))) //nolint:gosec // count bounded by the store's collection count
+	var nl [2]byte
+	for _, n := range names {
+		binary.BigEndian.PutUint16(nl[:], uint16(len(n))) //nolint:gosec // bounded by MaxCollectionNameWire
+		buf = append(buf, nl[:]...)
+		buf = append(buf, n...)
+	}
+	return buf
+}
+
+// DecodeCollectionsResult reads a result produced by EncodeCollectionsResult. The
+// declared count is CountFitsIn-bounded (each name costs >= its 2-byte length
+// prefix) before any allocation, and every nameLen is checked in the 32-bit-safe
+// form. Names are copied out so they outlive the response buffer.
+func DecodeCollectionsResult(b []byte) ([]string, error) {
+	if len(b) < 4 {
+		return nil, ErrShortArgs
+	}
+	n := int(binary.BigEndian.Uint32(b[0:4]))
+	off := 4
+	if !CountFitsIn(n, len(b)-off, 2) {
+		return nil, ErrShortArgs
+	}
+	names := make([]string, 0, n)
+	for range n {
+		if len(b)-off < 2 {
+			return nil, ErrShortArgs
+		}
+		nl := int(binary.BigEndian.Uint16(b[off : off+2]))
+		off += 2
+		if len(b)-off < nl {
+			return nil, ErrShortArgs
+		}
+		names = append(names, string(b[off:off+nl]))
+		off += nl
+	}
+	return names, nil
+}
+
 // EncodeKeyArgs encodes "{keyLen u16}{key}" used by get and del.
 func EncodeKeyArgs(key []byte) []byte {
 	return AppendKeyArgs(nil, key)

--- a/sdk/wire/builtin_routing.go
+++ b/sdk/wire/builtin_routing.go
@@ -53,11 +53,12 @@ var BuiltinOps = []BuiltinOp{
 	// the read counterpart of put_batch. The client groups keys by owning shard
 	// before it calls, so every key in one mget hashes to the same shard.
 	{"mget", OpReadOnly, mgetKeyExtractor, RouteLayoutNone, false},
-	// __ping__/__ready__/__metrics__/__repl_metrics__ are shardless (nil KeyExtractor).
+	// __ping__/__ready__/__metrics__/__repl_metrics__/__collections__ are shardless (nil KeyExtractor).
 	{"__ping__", OpReadOnly, nil, RouteLayoutNone, false},
 	{ReadyOp, OpReadOnly, nil, RouteLayoutNone, false},
 	{MetricsOp, OpReadOnly, nil, RouteLayoutNone, false},
 	{ReplMetricsOp, OpReadOnly, nil, RouteLayoutNone, false},
+	{CollectionsOp, OpReadOnly, nil, RouteLayoutNone, false},
 
 	{"vector_create_collection", OpReadWrite, routeAt1.ke, routeAt1.layout, false},
 	{"vector_drop_collection", OpReadWrite, routeAt1.ke, routeAt1.layout, false},

--- a/ui/.gitignore
+++ b/ui/.gitignore
@@ -1,0 +1,7 @@
+node_modules
+dist
+dist-ssr
+*.local
+*.tsbuildinfo
+.playwright-mcp
+.DS_Store

--- a/ui/README.md
+++ b/ui/README.md
@@ -1,0 +1,54 @@
+# Rostam Dashboard
+
+Embedded web UI for managing and monitoring a Rostam server (vector database +
+sub-microsecond KV store). Built as a static SPA that the Go server serves under
+the `/dashboard/` path prefix, talking to the same-origin HTTP API.
+
+## Stack
+
+- React 18 + TypeScript, Vite 5
+- Tailwind CSS 3.4 (classic config)
+- react-router-dom 6 (HashRouter — no server-side rewrite needed)
+- lucide-react icons
+- Hand-rolled SVG sparklines and a defensive Prometheus text parser (no chart
+  or metrics dependencies) to keep the embedded bundle small
+
+## Develop
+
+```bash
+npm install
+npm run dev        # dev server on :5273, proxies /v1 and /metrics
+```
+
+Point the dev proxy at a running server with `ROSTAM_API`:
+
+```bash
+ROSTAM_API=http://127.0.0.1:8080 npm run dev
+```
+
+## Build
+
+```bash
+npm run build      # tsc type-check, then vite build → dist/
+```
+
+`vite.config.ts` sets `base: './'` so assets load with relative URLs under the
+`/dashboard/` prefix. The output directory is `dist/`; the maintainer wires the
+final embed path at integration.
+
+## Layout
+
+- `src/api/` — typed client (`client.ts`), endpoint wrappers (`endpoints.ts`),
+  response types, and the Prometheus parser (`prom.ts`).
+- `src/context/` — API-key (Bearer token, sessionStorage), theme, and settings.
+- `src/hooks/` — `useMetrics` (polls `/metrics`, derives QPS/p99), `useHealth`
+  (`/v1/ready` dot), `useAsync`.
+- `src/components/` — layout chrome and reusable UI primitives.
+- `src/pages/` — Overview, Collections, Search, KV, Admin.
+
+## Auth
+
+On load the app probes the auth-exempt `GET /v1/ready`. Data calls send
+`Authorization: Bearer <key>` when a key is set. A `401` opens a non-blocking
+prompt; the key is stored in **sessionStorage** (clears when the tab closes) —
+never localStorage. Open (loopback, no-auth) servers work with no prompt.

--- a/ui/index.html
+++ b/ui/index.html
@@ -1,0 +1,31 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="color-scheme" content="dark light" />
+    <title>Rostam Dashboard</title>
+    <script>
+      // Resolve theme before paint to avoid a flash of the wrong palette.
+      (function () {
+        try {
+          var stored = localStorage.getItem('rostam-theme');
+          var dark =
+            stored === 'dark' ||
+            (stored !== 'light' &&
+              window.matchMedia('(prefers-color-scheme: dark)').matches);
+          document.documentElement.setAttribute(
+            'data-theme',
+            dark ? 'dark' : 'light',
+          );
+        } catch (e) {
+          document.documentElement.setAttribute('data-theme', 'dark');
+        }
+      })();
+    </script>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -1,0 +1,2778 @@
+{
+  "name": "rostam-dashboard",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "rostam-dashboard",
+      "version": "0.1.0",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "lucide-react": "0.451.0",
+        "react": "18.3.1",
+        "react-dom": "18.3.1",
+        "react-router-dom": "6.26.2"
+      },
+      "devDependencies": {
+        "@types/node": "^20.16.11",
+        "@types/react": "18.3.11",
+        "@types/react-dom": "18.3.0",
+        "@vitejs/plugin-react": "4.3.2",
+        "autoprefixer": "10.4.20",
+        "postcss": "8.4.47",
+        "tailwindcss": "3.4.13",
+        "typescript": "5.6.2",
+        "vite": "5.4.8"
+      }
+    },
+    "node_modules/@alloc/quick-lru": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@alloc/quick-lru/-/quick-lru-5.2.0.tgz",
+      "integrity": "sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@babel/code-frame": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
+      "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/compat-data": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.7.tgz",
+      "integrity": "sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/core": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.7.tgz",
+      "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-compilation-targets": "^7.29.7",
+        "@babel/helper-module-transforms": "^7.29.7",
+        "@babel/helpers": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7",
+        "@jridgewell/remapping": "^2.3.5",
+        "convert-source-map": "^2.0.0",
+        "debug": "^4.1.0",
+        "gensync": "^1.0.0-beta.2",
+        "json5": "^2.2.3",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/babel"
+      }
+    },
+    "node_modules/@babel/generator": {
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.8.tgz",
+      "integrity": "sha512-gZbepsdh3WDtgZKWL+vTPh71LSBrm/Y4/QDZBVCcYfmeTEEuoOYwlSy+G1StfJg+/Zy550u/3TATbm7qDbbMtg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.8",
+        "@babel/types": "^7.29.8",
+        "@jridgewell/gen-mapping": "^0.3.12",
+        "@jridgewell/trace-mapping": "^0.3.28",
+        "jsesc": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.29.7.tgz",
+      "integrity": "sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/compat-data": "^7.29.7",
+        "@babel/helper-validator-option": "^7.29.7",
+        "browserslist": "^4.24.0",
+        "lru-cache": "^5.1.1",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-globals": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.29.7.tgz",
+      "integrity": "sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-imports": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.29.7.tgz",
+      "integrity": "sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-transforms": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.29.7.tgz",
+      "integrity": "sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-module-imports": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "@babel/traverse": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/helper-plugin-utils": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.29.7.tgz",
+      "integrity": "sha512-G7sHYigPY17oO5SYWnfD/0MTBwVR781S/JI643e/JhUYgVgWE/61SoW3NH9KWUKyKq5LVh3npif99Wkt6j86Jw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+      "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-option": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.29.7.tgz",
+      "integrity": "sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helpers": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.7.tgz",
+      "integrity": "sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.8.tgz",
+      "integrity": "sha512-E8lTAYNB1KW+FH+VGJuZM1ioAx2E6oVlvQFRrf5P8ZZmsiJXYAD9vTFV7yyEURNzgh1dFqMZuO6tUwcARbqFCA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.29.8"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-react-jsx-self": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-self/-/plugin-transform-react-jsx-self-7.29.7.tgz",
+      "integrity": "sha512-TL0hMc9xzy86VD31nUiwzd5otRAcyEPcsegCxolO0PvcXuH1v0kECe/UIznYFihpkvU5wg/jk4v0TTEFfm53fw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-react-jsx-source": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-source/-/plugin-transform-react-jsx-source-7.29.7.tgz",
+      "integrity": "sha512-06IyK09H3wi4cGbhDBwp5gUGo0IKtnYa8tyTiephirPCK6fbobVGiXMMI5zLQ4aKEYP3wZ3ArU44o+8KMrSG/Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/template": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.29.7.tgz",
+      "integrity": "sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/traverse": {
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.8.tgz",
+      "integrity": "sha512-I5z7H3bf/41ktsNVLtpN0wAa336HkqIHQ5BuPLEhTkt1jVSyZpeNKIzTgEWmlxjdg81R0IgUCcaE+Ok3NvrfZg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.8",
+        "@babel/helper-globals": "^7.29.7",
+        "@babel/parser": "^7.29.8",
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.8",
+        "debug": "^4.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.8.tgz",
+      "integrity": "sha512-Vj1jF3cPfxg7OAfoI7QnVKLoILlm2JF9pnVHrX8qx7AHMiYWT+NDAA7jChlNgRS4WTLc/fD1lXLmPixluj+3Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
+      "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
+      "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
+      "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
+      "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
+      "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
+      "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
+      "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
+      "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
+      "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
+      "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
+      "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
+      "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
+      "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
+      "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
+      "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
+      "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
+      "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
+      "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
+      "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/remapping": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
+      "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.6.0.tgz",
+      "integrity": "sha512-T7jf+5zgsZHwNJ4lvQ7/aezbyk0nNX+zJVWpmHA7VYsEx7a7qr5Rg5IbtJFqkgze5Y2sruq1RUY8Q837Od7iFw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@napi-rs/lzma-linux-x64-gnu": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@napi-rs/lzma-linux-x64-gnu/-/lzma-linux-x64-gnu-1.5.1.tgz",
+      "integrity": "sha512-oTXEIha4SsuXdTA4Iyskj0kpdx2yVXdhd75c2v3xGrHFfVMsbhTPZU/nMPL4sWKo4pBHm3aucLaqGlF696dTyQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^22.20 || ^24.12 || >=25"
+      }
+    },
+    "node_modules/@nodelib/fs.scandir": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
+      "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.stat": "2.0.5",
+        "run-parallel": "^1.1.9"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.stat": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
+      "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.walk": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
+      "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.scandir": "2.1.5",
+        "fastq": "^1.6.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@remix-run/router": {
+      "version": "1.19.2",
+      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.19.2.tgz",
+      "integrity": "sha512-baiMx18+IMuD1yyvOGaHM9QrVUPGGG0jC+z+IPHnRJWUAUvaKuWKyE8gjDj2rzv3sz9zOGoRSPgeBVHRhZnBlA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.63.1.tgz",
+      "integrity": "sha512-UZ8sUxPTiHWYX9QNdJedb1kDZSpS1t/VPWBWGSgqHNi9w3Cu6IXvu2mzbhiTiPvtrqgTQJ+zqiAq2iPIPilpaQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.63.1.tgz",
+      "integrity": "sha512-cQ4nFQABN5cDvDpbvJ7bMStCpnaVxynZrRMfUJYgxcIk9Sh54FIO1vtfkg0B69REjER77ioZ/ov+eAApx/KmLQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.63.1.tgz",
+      "integrity": "sha512-FQNqd1lRy/0QhDk3xeRIkSBiCpXCiDnZO3YLVdcDKN1UBiKToNftCzcXYNLshmPDUMlu2TdeS8tGcsU6f3YF1Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.63.1.tgz",
+      "integrity": "sha512-pvD16V939D3CloK0+qikpGaxiPrDUXTe7Y5cWOMkMSy7m1cawa8EGy/kXYi/G/cKAC4HDAbSnzCIk1WmsoOKXg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.63.1.tgz",
+      "integrity": "sha512-pcFGeL2345VwdTnJhA6zLbew+YgWB0qBG2+dMtXjCicf6+rm6kO6cOoh5VnTe0ZMrMRgRyuHmCJxZWrIdzYuOw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.63.1.tgz",
+      "integrity": "sha512-mRJlqSRulVzcKq/LKA6ICSIc3K/l4fzlVn/gePn2nXIHy8seRi5z/eeRE0d/XMBxcMldiXtQTSpRj0tkkC3g8Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.63.1.tgz",
+      "integrity": "sha512-YDUNvVM85TI3g/1OpnqKP1h4NeW/j64DfWMf+G3M809xNk1bJSnpFp4sh83NpmVE5DXnkh8ULor4LTVZKoYLHw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.63.1.tgz",
+      "integrity": "sha512-7Mcn71p9ZuQFAj+h+dhQXy/yeLePRS2yKRnmW1DijA9thKO5qap0GNOIQK4yQ6iP3SU0Mrb/yWo8h8vgRba8lw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.63.1.tgz",
+      "integrity": "sha512-4YiLQTX6U4CSl0L9cluep9A9W6UmTfqBDc2/CH6wlu54pl4E7Jn3cOD8oxzvBDEGk/JMKgJ47C8g+radF7mwvg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.63.1.tgz",
+      "integrity": "sha512-2ra8F7w8OquwZN9z2/fKFnli69wa8PLwaVzRMIPGb13ByMJwC28Fbp8YcVGoUhlYMTt7j5j9bNgpysrN2UM+vw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.63.1.tgz",
+      "integrity": "sha512-Sy20ncyhjmBP0Ml+UvQbimjlk6VFgjW5uNP+qqwHB00mTE8Bl2C1TuHTlRwK2YoXeZbee5lP2XevBWVkAQAtSQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.63.1.tgz",
+      "integrity": "sha512-noITLp8oNjYliPnGWmLyelIHwULGqbHloQHGw1rtxbWhTuWooRpnZarZQJ1y9EUC4szuCusCc+HEpUtxpIwYvA==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.63.1.tgz",
+      "integrity": "sha512-hlxxXd+F1mWiAcaFR7Sv9ZQT6m6UfI8+Vy/kFJzztq2pDMU/0wZ9sish0iszNZvsQDo8Gc0i5yuFEOz5dDf6fA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.63.1.tgz",
+      "integrity": "sha512-EF7OpqQTQ/BvGqLzUi4rEHuagCV9MugAUXSHemwPW5vxZ75RR+jxO/2j95Ph2dalMpFHSVECjRoioHZgA9zOYA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.63.1.tgz",
+      "integrity": "sha512-wQO3JesW9PRkwlabQ27y7sPfVOOTLRG73I4F2UYHG5PXun3J9U3y+b7ezVKSYbsvSKGQ1k1cq8Qlun4C9kLt3w==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.63.1.tgz",
+      "integrity": "sha512-ouAGwhO6wHRXdnOVCOsB0tRFkA7nhNB2Nwax6oECXN0YiN8EYUTBAOudADOB1PI+yDL61TeNx/u7MVCzksNbkQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.63.1.tgz",
+      "integrity": "sha512-q2R38Sn+1J8RxhfJ+T54wSWmyKXWec+9jgDfqO2AtArEqHO5R2aeayp5H5OYLr5UYDVGsVaZPEFUooMhYCdz5A==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.63.1.tgz",
+      "integrity": "sha512-gfI5T24WLLuFfSKw7Go/zDXjAAV0fny0swTaDv+WjK7vqcw4cRhFfdsyKL1n+ukI+ooBxn3bVQnyrn06WpI50w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.63.1.tgz",
+      "integrity": "sha512-4h6XqthmB4Hspji84wvgk+ElodTsGj+dbZqHJHHtKxj4mYq0ANSEEPX9ys3moJueqsRjwpaJYH7874Itwnj2ow==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.63.1.tgz",
+      "integrity": "sha512-dlfCOa87o1VAYegLQ9EKilx2JCeRofiyPGhTCmqnuXZ6bMPiycO1rq1+sKoulAp7pGLIsTIw+1x5R+zgh5LhhA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.63.1.tgz",
+      "integrity": "sha512-cjkLbOlfcm3QGhMM1J5zaZjsw1GggbN6rw9UTSSRrPrR1KkcXnN7Uq9rPw34xImQ9VOY9GN+6u2Zj80B9ptkcw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.63.1.tgz",
+      "integrity": "sha512-Li1KdUnWGE4N3e1F/B4RTB1ms+nG4WBgjByO46pkeBVX/2UBsY53xf5vK9WygVmnH3RwncIST7lkSdLSY6P9lg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.63.1.tgz",
+      "integrity": "sha512-t4ZYOSoLTgwhuFMrmTMLx/+i1DQVK7HYqMc6kY46EApwi8X0nIVphzdNoThU3xt6n+N5urG1/gxBdCaKDLavfg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.63.1.tgz",
+      "integrity": "sha512-RgroPfMmKlD1RzSDxvwgcPiy2HNQKoYV7OmwIXDsk73uKW5t6B/V8KIy27SMv/FNXFo/oSBtWc9J0X7t91ezZg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.63.1.tgz",
+      "integrity": "sha512-at8QVep6S3h5Y6gSbdGU06bRY5WJkf6WUduM9YtvYMbYhB1MOFfUgc6kehitQXzOtMSaT70q7f9ydPhpqu821w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@types/babel__core": {
+      "version": "7.20.5",
+      "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
+      "integrity": "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.20.7",
+        "@babel/types": "^7.20.7",
+        "@types/babel__generator": "*",
+        "@types/babel__template": "*",
+        "@types/babel__traverse": "*"
+      }
+    },
+    "node_modules/@types/babel__generator": {
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.27.0.tgz",
+      "integrity": "sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/@types/babel__template": {
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.4.4.tgz",
+      "integrity": "sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.1.0",
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/@types/babel__traverse": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.28.0.tgz",
+      "integrity": "sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.28.2"
+      }
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "20.16.11",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.16.11.tgz",
+      "integrity": "sha512-y+cTCACu92FyA5fgQSAI8A1H429g7aSK2HsO7K4XYUWc4dY5IUz55JSDIYT6/VsOLfGy8vmvQYC2hfb0iF16Uw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.19.2"
+      }
+    },
+    "node_modules/@types/prop-types": {
+      "version": "15.7.15",
+      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
+      "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/react": {
+      "version": "18.3.11",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.11.tgz",
+      "integrity": "sha512-r6QZ069rFTjrEYgFdOck1gK7FLVsgJE7tTz0pQBczlBNUhBNk0MQH4UbnFSwjpQLMkLzgqvBBa+qGpLje16eTQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/prop-types": "*",
+        "csstype": "^3.0.2"
+      }
+    },
+    "node_modules/@types/react-dom": {
+      "version": "18.3.0",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.0.tgz",
+      "integrity": "sha512-EhwApuTmMBmXuFOikhQLIBUn6uFg81SwLMOAUgodJF14SOBOCMdU04gDoYi0WOJJHD144TL32z4yDqCW3dnkQg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/react": "*"
+      }
+    },
+    "node_modules/@vitejs/plugin-react": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-4.3.2.tgz",
+      "integrity": "sha512-hieu+o05v4glEBucTcKMK3dlES0OeJlD9YVOAPraVMOInBCwzumaIFiUjr4bHK7NPgnAHgiskUoceKercrN8vg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.25.2",
+        "@babel/plugin-transform-react-jsx-self": "^7.24.7",
+        "@babel/plugin-transform-react-jsx-source": "^7.24.7",
+        "@types/babel__core": "^7.20.5",
+        "react-refresh": "^0.14.2"
+      },
+      "engines": {
+        "node": "^14.18.0 || >=16.0.0"
+      },
+      "peerDependencies": {
+        "vite": "^4.2.0 || ^5.0.0"
+      }
+    },
+    "node_modules/any-promise": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
+      "integrity": "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/anymatch": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
+      "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "normalize-path": "^3.0.0",
+        "picomatch": "^2.0.4"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/arg": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-5.0.2.tgz",
+      "integrity": "sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/autoprefixer": {
+      "version": "10.4.20",
+      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.20.tgz",
+      "integrity": "sha512-XY25y5xSv/wEoqzDyXXME4AFfkZI0P23z6Fs3YgymDnKJkCGOnkL0iTxCa85UTqaSgfcqyf3UA6+c7wUvx/16g==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/autoprefixer"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "browserslist": "^4.23.3",
+        "caniuse-lite": "^1.0.30001646",
+        "fraction.js": "^4.3.7",
+        "normalize-range": "^0.1.2",
+        "picocolors": "^1.0.1",
+        "postcss-value-parser": "^4.2.0"
+      },
+      "bin": {
+        "autoprefixer": "bin/autoprefixer"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      },
+      "peerDependencies": {
+        "postcss": "^8.1.0"
+      }
+    },
+    "node_modules/baseline-browser-mapping": {
+      "version": "2.11.20",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.11.20.tgz",
+      "integrity": "sha512-H0ulySigv6icDJ1F7SjtdCD6PrhTpdYCmP0CactWy1+ekh0AFd0o1Wn5T8b+hnTmdBx19u9yhL6wvCylXMY7zw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "baseline-browser-mapping": "dist/cli.cjs"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/binary-extensions": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
+      "integrity": "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/braces": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fill-range": "^7.1.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/browserslist": {
+      "version": "4.28.8",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.8.tgz",
+      "integrity": "sha512-V2NpofLblG64mfOtSgDhOJESZEGogzDMBv/q+W6oc4LXWP/q75eOXoOaaOu1EOadB9U4Bwx/e0yzbvwKH8zalA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "baseline-browser-mapping": "^2.11.12",
+        "caniuse-lite": "^1.0.30001809",
+        "electron-to-chromium": "^1.5.402",
+        "node-releases": "^2.0.53",
+        "update-browserslist-db": "^1.3.0"
+      },
+      "bin": {
+        "browserslist": "cli.js"
+      },
+      "engines": {
+        "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/camelcase-css": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/camelcase-css/-/camelcase-css-2.0.1.tgz",
+      "integrity": "sha512-QOSvevhslijgYwRx6Rv7zKdMF8lbRmx+uQGx2+vDc+KI/eBnsy9kit5aj23AgGu3pa4t9AgwbnXWqS+iOY+2aA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/caniuse-lite": {
+      "version": "1.0.30001810",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001810.tgz",
+      "integrity": "sha512-TITQPUkaz+aVk5GL6NhOdwk1aEaNTSDPsGFWrTuhKGtjTF70jL/Oht2W4c6rXUe5fu7Ie19VIahAXHIIiWWNeg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "CC-BY-4.0"
+    },
+    "node_modules/chokidar": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
+      "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "anymatch": "~3.1.2",
+        "braces": "~3.0.2",
+        "glob-parent": "~5.1.2",
+        "is-binary-path": "~2.1.0",
+        "is-glob": "~4.0.1",
+        "normalize-path": "~3.0.0",
+        "readdirp": "~3.6.0"
+      },
+      "engines": {
+        "node": ">= 8.10.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/chokidar/node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/commander": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
+      "integrity": "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cssesc": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
+      "integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "cssesc": "bin/cssesc"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/csstype": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/didyoumean": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/didyoumean/-/didyoumean-1.2.2.tgz",
+      "integrity": "sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/dlv": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/dlv/-/dlv-1.1.3.tgz",
+      "integrity": "sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/electron-to-chromium": {
+      "version": "1.5.416",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.416.tgz",
+      "integrity": "sha512-K6bvB2BjnNrugtIih6ewlbBI9DXa976jIdiIlRLHhBoEI9a4JaQjjHyF+A1IQI543aQYR4LnmOrT/K5fZj0aPA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
+      "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.21.5",
+        "@esbuild/android-arm": "0.21.5",
+        "@esbuild/android-arm64": "0.21.5",
+        "@esbuild/android-x64": "0.21.5",
+        "@esbuild/darwin-arm64": "0.21.5",
+        "@esbuild/darwin-x64": "0.21.5",
+        "@esbuild/freebsd-arm64": "0.21.5",
+        "@esbuild/freebsd-x64": "0.21.5",
+        "@esbuild/linux-arm": "0.21.5",
+        "@esbuild/linux-arm64": "0.21.5",
+        "@esbuild/linux-ia32": "0.21.5",
+        "@esbuild/linux-loong64": "0.21.5",
+        "@esbuild/linux-mips64el": "0.21.5",
+        "@esbuild/linux-ppc64": "0.21.5",
+        "@esbuild/linux-riscv64": "0.21.5",
+        "@esbuild/linux-s390x": "0.21.5",
+        "@esbuild/linux-x64": "0.21.5",
+        "@esbuild/netbsd-x64": "0.21.5",
+        "@esbuild/openbsd-x64": "0.21.5",
+        "@esbuild/sunos-x64": "0.21.5",
+        "@esbuild/win32-arm64": "0.21.5",
+        "@esbuild/win32-ia32": "0.21.5",
+        "@esbuild/win32-x64": "0.21.5"
+      }
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/fast-glob": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
+      "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.stat": "^2.0.2",
+        "@nodelib/fs.walk": "^1.2.3",
+        "glob-parent": "^5.1.2",
+        "merge2": "^1.3.0",
+        "micromatch": "^4.0.8"
+      },
+      "engines": {
+        "node": ">=8.6.0"
+      }
+    },
+    "node_modules/fast-glob/node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/fastq": {
+      "version": "1.20.3",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.3.tgz",
+      "integrity": "sha512-XKv5nnLs6nLF71NgiKJLIZFLkPyIEuOselLG7ujZnGrRfQK8HpvY+WqKhAJUAdLomwVHErVS4LfxFlPq0/FTAw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "reusify": "^1.0.4"
+      }
+    },
+    "node_modules/fill-range": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "to-regex-range": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/fraction.js": {
+      "version": "4.3.7",
+      "resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-4.3.7.tgz",
+      "integrity": "sha512-ZsDfxO51wGAXREY55a7la9LScWpwv9RxIrYABrlvOFBlH/ShPnrtsXeuUIfXKKOVicNxQ+o8JTbJvjS4M89yew==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "type": "patreon",
+        "url": "https://github.com/sponsors/rawify"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/gensync": {
+      "version": "1.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
+      "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/glob-parent": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
+      "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/is-binary-path": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
+      "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "binary-extensions": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-core-module": {
+      "version": "2.16.2",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.2.tgz",
+      "integrity": "sha512-evOr8xfXKxE6qSR0hSXL2r3sd7ALj8+7jQEUvPYcm5sgZFdJ+AYzT6yNmJenvIYQBgIGwfwz08sL8zoL7yq2BA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "hasown": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-number": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.12.0"
+      }
+    },
+    "node_modules/jiti": {
+      "version": "1.21.7",
+      "resolved": "https://registry.npmjs.org/jiti/-/jiti-1.21.7.tgz",
+      "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "jiti": "bin/jiti.js"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "license": "MIT"
+    },
+    "node_modules/jsesc": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
+      "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "jsesc": "bin/jsesc"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/json5": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "json5": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/lilconfig": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-2.1.0.tgz",
+      "integrity": "sha512-utWOt/GHzuUxnLKxB6dk81RoOeoNeHgbrXiuGk4yyF5qlRz+iIVWu56E2fqGHFrXz0QNUhLB/8nKqvRH66JKGQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/lines-and-columns": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
+      "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      },
+      "bin": {
+        "loose-envify": "cli.js"
+      }
+    },
+    "node_modules/lru-cache": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/lucide-react": {
+      "version": "0.451.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.451.0.tgz",
+      "integrity": "sha512-OwQ3uljZLp2cerj8sboy5rnhtGTCl9UCJIhT1J85/yOuGVlEH+xaUPR7tvNdddPvmV5M5VLdr7cQuWE3hzA4jw==",
+      "license": "ISC",
+      "peerDependencies": {
+        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0-rc"
+      }
+    },
+    "node_modules/merge2": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
+      "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/micromatch": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "braces": "^3.0.3",
+        "picomatch": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=8.6"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/mz": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/mz/-/mz-2.7.0.tgz",
+      "integrity": "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "any-promise": "^1.0.0",
+        "object-assign": "^4.0.1",
+        "thenify-all": "^1.0.0"
+      }
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/node-releases": {
+      "version": "2.0.54",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.54.tgz",
+      "integrity": "sha512-YHs7BmmcsdAI5Ozuf8JZo6PT0mv2GIWC9vMfvUC3dp65M8hn7Ux8CPL+2oBI7juNuj9d0ndhTcznq2ODBps9cQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/normalize-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/normalize-range": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/normalize-range/-/normalize-range-0.1.2.tgz",
+      "integrity": "sha512-bdok/XvKII3nUpklnV6P2hxtMNrCboOjAcyBuQnWEhO665FwrSNRxU+AqpsyvO6LgGYPspN+lu5CLtw4jPRKNA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-hash": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-3.0.0.tgz",
+      "integrity": "sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/path-parse": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/pirates": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.7.tgz",
+      "integrity": "sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.4.47",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.47.tgz",
+      "integrity": "sha512-56rxCq7G/XfB4EkXq9Egn5GCqugWvDFjafDOThIdMBsI15iqPqR5r15TfSr1YPYeEI19YeaXMCbY6u88Y76GLQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.7",
+        "picocolors": "^1.1.0",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/postcss-import": {
+      "version": "15.1.0",
+      "resolved": "https://registry.npmjs.org/postcss-import/-/postcss-import-15.1.0.tgz",
+      "integrity": "sha512-hpr+J05B2FVYUAXHeK1YyI267J/dDDhMU6B6civm8hSY1jYJnBXxzKDKDswzJmtLHryrjhnDjqqp/49t8FALew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "postcss-value-parser": "^4.0.0",
+        "read-cache": "^1.0.0",
+        "resolve": "^1.1.7"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.0.0"
+      }
+    },
+    "node_modules/postcss-js": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/postcss-js/-/postcss-js-4.1.0.tgz",
+      "integrity": "sha512-oIAOTqgIo7q2EOwbhb8UalYePMvYoIeRY2YKntdpFQXNosSu3vLrniGgmH9OKs/qAkfoj5oB3le/7mINW1LCfw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "camelcase-css": "^2.0.1"
+      },
+      "engines": {
+        "node": "^12 || ^14 || >= 16"
+      },
+      "peerDependencies": {
+        "postcss": "^8.4.21"
+      }
+    },
+    "node_modules/postcss-load-config": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/postcss-load-config/-/postcss-load-config-4.0.2.tgz",
+      "integrity": "sha512-bSVhyJGL00wMVoPUzAVAnbEoWyqRxkjv64tUl427SKnPrENtq6hJwUojroMz2VB+Q1edmi4IfrAPpami5VVgMQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "lilconfig": "^3.0.0",
+        "yaml": "^2.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      },
+      "peerDependencies": {
+        "postcss": ">=8.0.9",
+        "ts-node": ">=9.0.0"
+      },
+      "peerDependenciesMeta": {
+        "postcss": {
+          "optional": true
+        },
+        "ts-node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/postcss-load-config/node_modules/lilconfig": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-3.1.3.tgz",
+      "integrity": "sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antonk52"
+      }
+    },
+    "node_modules/postcss-nested": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/postcss-nested/-/postcss-nested-6.2.0.tgz",
+      "integrity": "sha512-HQbt28KulC5AJzG+cZtj9kvKB93CFCdLvog1WFLf1D+xmMvPGlBstkpTEZfK5+AN9hfJocyBFCNiqyS48bpgzQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "postcss-selector-parser": "^6.1.1"
+      },
+      "engines": {
+        "node": ">=12.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.2.14"
+      }
+    },
+    "node_modules/postcss-selector-parser": {
+      "version": "6.1.4",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.1.4.tgz",
+      "integrity": "sha512-bIoJLOmjCO1S9XdY/DcnR5hJxvrDir1PbGChrzXG3vw0/FOliy/fA3dmdhQ441kah4gKv+TwckGzex6wNS5cnQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cssesc": "^3.0.0",
+        "util-deprecate": "^1.0.2"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/postcss-value-parser": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
+      "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/queue-microtask": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
+      "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/react": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
+      "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-dom": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
+      "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0",
+        "scheduler": "^0.23.2"
+      },
+      "peerDependencies": {
+        "react": "^18.3.1"
+      }
+    },
+    "node_modules/react-refresh": {
+      "version": "0.14.2",
+      "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.14.2.tgz",
+      "integrity": "sha512-jCvmsr+1IUSMUyzOkRcvnVbX3ZYC6g9TDrDbFuFmRDq7PD4yaGbLKNQL6k2jnArV8hjYxh7hVhAZB6s9HDGpZA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-router": {
+      "version": "6.26.2",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.26.2.tgz",
+      "integrity": "sha512-tvN1iuT03kHgOFnLPfLJ8V95eijteveqdOSk+srqfePtQvqCExB8eHOYnlilbOcyJyKnYkr1vJvf7YqotAJu1A==",
+      "license": "MIT",
+      "dependencies": {
+        "@remix-run/router": "1.19.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8"
+      }
+    },
+    "node_modules/react-router-dom": {
+      "version": "6.26.2",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.26.2.tgz",
+      "integrity": "sha512-z7YkaEW0Dy35T3/QKPYB1LjMK2R1fxnHO8kWpUMTBdfVzZrWOiY9a7CtN8HqdWtDUWd5FY6Dl8HFsqVwH4uOtQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@remix-run/router": "1.19.2",
+        "react-router": "6.26.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
+      }
+    },
+    "node_modules/read-cache": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/read-cache/-/read-cache-1.0.2.tgz",
+      "integrity": "sha512-/peqiBB/n07gQGLsWaHho3WfvUyRscw0gYTsEFMhrIe/nWLkYaf5SbKYjGYqtRV3aPwykJgF2VEMo1ac4bnsGA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/readdirp": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
+      "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "picomatch": "^2.2.1"
+      },
+      "engines": {
+        "node": ">=8.10.0"
+      }
+    },
+    "node_modules/resolve": {
+      "version": "1.22.12",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.12.tgz",
+      "integrity": "sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "is-core-module": "^2.16.1",
+        "path-parse": "^1.0.7",
+        "supports-preserve-symlinks-flag": "^1.0.0"
+      },
+      "bin": {
+        "resolve": "bin/resolve"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/reusify": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
+      "integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "iojs": ">=1.0.0",
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.63.1.tgz",
+      "integrity": "sha512-3Df9jsstwhccuEfmAMi9l8XUh/GOkVObmFTU7CCVBysEbcOZLl84jCtaAZMcPiMz2EGKsATzQcU+Xr3n/wU6cg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.9"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@napi-rs/lzma-linux-x64-gnu": "1.5.1",
+        "@rollup/rollup-android-arm-eabi": "4.63.1",
+        "@rollup/rollup-android-arm64": "4.63.1",
+        "@rollup/rollup-darwin-arm64": "4.63.1",
+        "@rollup/rollup-darwin-x64": "4.63.1",
+        "@rollup/rollup-freebsd-arm64": "4.63.1",
+        "@rollup/rollup-freebsd-x64": "4.63.1",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.63.1",
+        "@rollup/rollup-linux-arm-musleabihf": "4.63.1",
+        "@rollup/rollup-linux-arm64-gnu": "4.63.1",
+        "@rollup/rollup-linux-arm64-musl": "4.63.1",
+        "@rollup/rollup-linux-loong64-gnu": "4.63.1",
+        "@rollup/rollup-linux-loong64-musl": "4.63.1",
+        "@rollup/rollup-linux-ppc64-gnu": "4.63.1",
+        "@rollup/rollup-linux-ppc64-musl": "4.63.1",
+        "@rollup/rollup-linux-riscv64-gnu": "4.63.1",
+        "@rollup/rollup-linux-riscv64-musl": "4.63.1",
+        "@rollup/rollup-linux-s390x-gnu": "4.63.1",
+        "@rollup/rollup-linux-x64-gnu": "4.63.1",
+        "@rollup/rollup-linux-x64-musl": "4.63.1",
+        "@rollup/rollup-openbsd-x64": "4.63.1",
+        "@rollup/rollup-openharmony-arm64": "4.63.1",
+        "@rollup/rollup-win32-arm64-msvc": "4.63.1",
+        "@rollup/rollup-win32-ia32-msvc": "4.63.1",
+        "@rollup/rollup-win32-x64-gnu": "4.63.1",
+        "@rollup/rollup-win32-x64-msvc": "4.63.1",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/run-parallel": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
+      "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "queue-microtask": "^1.2.2"
+      }
+    },
+    "node_modules/scheduler": {
+      "version": "0.23.2",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
+      "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      }
+    },
+    "node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/sucrase": {
+      "version": "3.35.1",
+      "resolved": "https://registry.npmjs.org/sucrase/-/sucrase-3.35.1.tgz",
+      "integrity": "sha512-DhuTmvZWux4H1UOnWMB3sk0sbaCVOoQZjv8u1rDoTV0HTdGem9hkAZtl4JZy8P2z4Bg0nT+YMeOFyVr4zcG5Tw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.2",
+        "commander": "^4.0.0",
+        "lines-and-columns": "^1.1.6",
+        "mz": "^2.7.0",
+        "pirates": "^4.0.1",
+        "tinyglobby": "^0.2.11",
+        "ts-interface-checker": "^0.1.9"
+      },
+      "bin": {
+        "sucrase": "bin/sucrase",
+        "sucrase-node": "bin/sucrase-node"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/supports-preserve-symlinks-flag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
+      "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/tailwindcss": {
+      "version": "3.4.13",
+      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.13.tgz",
+      "integrity": "sha512-KqjHOJKogOUt5Bs752ykCeiwvi0fKVkr5oqsFNt/8px/tA8scFPIlkygsf6jXrfCqGHz7VflA6+yytWuM+XhFw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@alloc/quick-lru": "^5.2.0",
+        "arg": "^5.0.2",
+        "chokidar": "^3.5.3",
+        "didyoumean": "^1.2.2",
+        "dlv": "^1.1.3",
+        "fast-glob": "^3.3.0",
+        "glob-parent": "^6.0.2",
+        "is-glob": "^4.0.3",
+        "jiti": "^1.21.0",
+        "lilconfig": "^2.1.0",
+        "micromatch": "^4.0.5",
+        "normalize-path": "^3.0.0",
+        "object-hash": "^3.0.0",
+        "picocolors": "^1.0.0",
+        "postcss": "^8.4.23",
+        "postcss-import": "^15.1.0",
+        "postcss-js": "^4.0.1",
+        "postcss-load-config": "^4.0.1",
+        "postcss-nested": "^6.0.1",
+        "postcss-selector-parser": "^6.0.11",
+        "resolve": "^1.22.2",
+        "sucrase": "^3.32.0"
+      },
+      "bin": {
+        "tailwind": "lib/cli.js",
+        "tailwindcss": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/thenify": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.1.tgz",
+      "integrity": "sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "any-promise": "^1.0.0"
+      }
+    },
+    "node_modules/thenify-all": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/thenify-all/-/thenify-all-1.6.0.tgz",
+      "integrity": "sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "thenify": ">= 3.1.0 < 4"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyglobby/node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/tinyglobby/node_modules/picomatch": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.7.tgz",
+      "integrity": "sha512-qcJu88Q2IWqJsDD529JKMdwGm/dvInW4HvQnRwiH9JtihJvzGOscDtHE3x1pBKeUOTysQ8kVmLnJ2kJu7yhcGA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/to-regex-range": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-number": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
+    "node_modules/ts-interface-checker": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz",
+      "integrity": "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/typescript": {
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.6.2.tgz",
+      "integrity": "sha512-NW8ByodCSNCwZeghjN3o+JX5OFH0Ojg6sadjEKY4huZ52TqbJTJnDo5+Tw98lSy63NZvi4n+ez5m2u5d4PkZyw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.19.8",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
+      "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/update-browserslist-db": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.3.2.tgz",
+      "integrity": "sha512-UQ+MSxlhRm1bzjhU+DcuXfjFO1FzNtqhK5+9Yvlp90ItDLk5vT932A0rFu619nf7RVS+Y/VeaUW1jaRDqZ8VJw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "escalade": "^3.2.0",
+        "picocolors": "^1.1.1"
+      },
+      "bin": {
+        "update-browserslist-db": "cli.js"
+      },
+      "peerDependencies": {
+        "browserslist": ">= 4.21.0"
+      }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/vite": {
+      "version": "5.4.8",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.8.tgz",
+      "integrity": "sha512-FqrItQ4DT1NC4zCUqMB4c4AZORMKIa0m8/URVCZ77OZ/QSNeJ54bU1vrFADbDsuwfIPcgknRkmqakQcgnL4GiQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.21.3",
+        "postcss": "^8.4.43",
+        "rollup": "^4.20.0"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/yallist": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/yaml": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
+      }
+    }
+  }
+}

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "rostam-dashboard",
+  "private": true,
+  "version": "0.1.0",
+  "type": "module",
+  "description": "Embedded web dashboard for the Rostam vector + KV database.",
+  "license": "Apache-2.0",
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc -b && vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "lucide-react": "0.451.0",
+    "react": "18.3.1",
+    "react-dom": "18.3.1",
+    "react-router-dom": "6.26.2"
+  },
+  "devDependencies": {
+    "@types/node": "^20.16.11",
+    "@types/react": "18.3.11",
+    "@types/react-dom": "18.3.0",
+    "@vitejs/plugin-react": "4.3.2",
+    "autoprefixer": "10.4.20",
+    "postcss": "8.4.47",
+    "tailwindcss": "3.4.13",
+    "typescript": "5.6.2",
+    "vite": "5.4.8"
+  }
+}

--- a/ui/postcss.config.js
+++ b/ui/postcss.config.js
@@ -1,0 +1,6 @@
+export default {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -1,0 +1,22 @@
+import { Navigate, Route, Routes } from 'react-router-dom';
+import { Layout } from './components/Layout';
+import { Overview } from './pages/Overview';
+import { Collections } from './pages/Collections';
+import { SearchPage } from './pages/Search';
+import { KVPage } from './pages/KV';
+import { Admin } from './pages/Admin';
+
+export default function App() {
+  return (
+    <Routes>
+      <Route element={<Layout />}>
+        <Route index element={<Overview />} />
+        <Route path="collections" element={<Collections />} />
+        <Route path="search" element={<SearchPage />} />
+        <Route path="kv" element={<KVPage />} />
+        <Route path="admin" element={<Admin />} />
+        <Route path="*" element={<Navigate to="/" replace />} />
+      </Route>
+    </Routes>
+  );
+}

--- a/ui/src/api/client.ts
+++ b/ui/src/api/client.ts
@@ -1,0 +1,124 @@
+// Typed same-origin API client for the Rostam server.
+//
+// Every data call goes through fetchJSON, which injects the Bearer header when
+// an API key is present, parses the `{ "error": "..." }` JSON body the server
+// returns on non-2xx, and throws an ApiError carrying the HTTP status so
+// callers can branch on 401 (auth), 412/404 (feature unavailable), etc.
+
+export class ApiError extends Error {
+  status: number;
+  /** Parsed server error string, when the body carried `{ "error": "..." }`. */
+  serverMessage?: string;
+
+  constructor(status: number, message: string, serverMessage?: string) {
+    super(message);
+    this.name = 'ApiError';
+    this.status = status;
+    this.serverMessage = serverMessage;
+  }
+
+  get isAuth(): boolean {
+    return this.status === 401 || this.status === 403;
+  }
+
+  /** The server has the route but the feature is not configured/enabled. */
+  get isUnavailable(): boolean {
+    return this.status === 412 || this.status === 404 || this.status === 501;
+  }
+}
+
+/** Thrown when fetch itself fails (server down, CORS, network). */
+export class NetworkError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'NetworkError';
+  }
+}
+
+// The current API key. Held in a module-level closure and mirrored to
+// sessionStorage (a secret — deliberately NOT localStorage) by the key context.
+let apiKey: string | null = null;
+
+export function setApiKey(key: string | null): void {
+  apiKey = key && key.trim() !== '' ? key.trim() : null;
+}
+
+export function getApiKey(): string | null {
+  return apiKey;
+}
+
+function authHeaders(extra?: HeadersInit): Headers {
+  const h = new Headers(extra);
+  if (apiKey) h.set('Authorization', `Bearer ${apiKey}`);
+  return h;
+}
+
+async function parseError(res: Response): Promise<ApiError> {
+  let serverMessage: string | undefined;
+  try {
+    const body = await res.json();
+    if (body && typeof body.error === 'string') serverMessage = body.error;
+    else if (body && typeof body.detail === 'string') serverMessage = body.detail;
+  } catch {
+    // Non-JSON error body (e.g. a proxy 502). Fall through to the status text.
+  }
+  const message = serverMessage || res.statusText || `HTTP ${res.status}`;
+  return new ApiError(res.status, message, serverMessage);
+}
+
+export interface RequestOptions {
+  method?: string;
+  body?: unknown;
+  signal?: AbortSignal;
+  /** Skip auth header injection (auth-exempt probes like /v1/ready). */
+  noAuth?: boolean;
+}
+
+/** Fetch + parse JSON, throwing ApiError on non-2xx and NetworkError on fetch failure. */
+export async function fetchJSON<T>(
+  path: string,
+  opts: RequestOptions = {},
+): Promise<T> {
+  const headers = opts.noAuth ? new Headers() : authHeaders();
+  let init: RequestInit = { method: opts.method || 'GET', headers, signal: opts.signal };
+  if (opts.body !== undefined) {
+    headers.set('Content-Type', 'application/json');
+    init.body = JSON.stringify(opts.body);
+  }
+
+  let res: Response;
+  try {
+    res = await fetch(path, init);
+  } catch (e) {
+    if (e instanceof DOMException && e.name === 'AbortError') throw e;
+    throw new NetworkError(
+      e instanceof Error ? e.message : 'network request failed',
+    );
+  }
+
+  if (!res.ok) throw await parseError(res);
+  if (res.status === 204) return undefined as T;
+
+  const text = await res.text();
+  if (text === '') return undefined as T;
+  return JSON.parse(text) as T;
+}
+
+/** Fetch a text body (Prometheus exposition, etc.) with the same auth + error handling. */
+export async function fetchText(
+  path: string,
+  opts: RequestOptions = {},
+): Promise<string> {
+  const headers = opts.noAuth ? new Headers() : authHeaders();
+  let res: Response;
+  try {
+    res = await fetch(path, { method: opts.method || 'GET', headers, signal: opts.signal });
+  } catch (e) {
+    if (e instanceof DOMException && e.name === 'AbortError') throw e;
+    throw new NetworkError(
+      e instanceof Error ? e.message : 'network request failed',
+    );
+  }
+  if (!res.ok) throw await parseError(res);
+  return res.text();
+}

--- a/ui/src/api/endpoints.ts
+++ b/ui/src/api/endpoints.ts
@@ -1,0 +1,106 @@
+// Typed endpoint wrappers over fetchJSON. Paths are same-origin relative so the
+// dashboard talks to whichever server serves it.
+
+import { fetchJSON, fetchText } from './client';
+import type {
+  BackupsResponse,
+  CollectionConfig,
+  CollectionListResponse,
+  CreateCollectionBody,
+  KvGetResponse,
+  KvPutBody,
+  ReadyResponse,
+  ReplicationResponse,
+  SearchResponse,
+  TopologyResponse,
+} from './types';
+
+// --- Observability (auth-exempt probes) --------------------------------------
+
+export const getReady = (signal?: AbortSignal) =>
+  fetchJSON<ReadyResponse>('/v1/ready', { noAuth: true, signal });
+
+export const getMetricsText = (signal?: AbortSignal) =>
+  fetchText('/metrics', { signal });
+
+export const getReplication = (signal?: AbortSignal) =>
+  fetchJSON<ReplicationResponse>('/v1/replication', { noAuth: true, signal });
+
+// /v1/topology is scope-gated (served through the authed op path, unlike the
+// exempt /v1/ready and /v1/replication probes), so it must carry the API key
+// when one is configured — otherwise the cluster view 401s under auth.
+export const getTopology = (signal?: AbortSignal) =>
+  fetchJSON<TopologyResponse>('/v1/topology', { signal });
+
+// --- Collections -------------------------------------------------------------
+
+export const listCollections = (signal?: AbortSignal) =>
+  fetchJSON<CollectionListResponse>('/v1/collections', { signal });
+
+export const getCollection = (name: string, signal?: AbortSignal) =>
+  fetchJSON<CollectionConfig>(`/v1/collections/${encodeURIComponent(name)}`, { signal });
+
+export const createCollection = (body: CreateCollectionBody) =>
+  fetchJSON<{ name: string }>('/v1/collections', { method: 'POST', body });
+
+export const dropCollection = (name: string) =>
+  fetchJSON<{ dropped: string }>(`/v1/collections/${encodeURIComponent(name)}`, {
+    method: 'DELETE',
+  });
+
+export const reshardCollection = (name: string, newPartitions: number) =>
+  fetchJSON<{ name: string; new_partitions: number }>(
+    `/v1/collections/${encodeURIComponent(name)}/reshard`,
+    { method: 'POST', body: { new_partitions: newPartitions } },
+  );
+
+// --- Search ------------------------------------------------------------------
+
+export const vectorSearch = (
+  name: string,
+  query: number[],
+  k: number,
+  filter: unknown | null,
+) =>
+  fetchJSON<SearchResponse>(
+    `/v1/collections/${encodeURIComponent(name)}/points/search`,
+    { method: 'POST', body: { query, k, filter } },
+  );
+
+// The server's text-search body uses `text` (not `query`) and returns
+// `documents`. A 400 with "full text disabled" means the collection has no BM25.
+export const textSearch = (
+  name: string,
+  text: string,
+  k: number,
+  filter: unknown | null,
+) =>
+  fetchJSON<SearchResponse>(
+    `/v1/collections/${encodeURIComponent(name)}/points/search/text`,
+    { method: 'POST', body: { text, k, filter } },
+  );
+
+// --- KV ----------------------------------------------------------------------
+
+export const kvGet = (key: string, signal?: AbortSignal) =>
+  fetchJSON<KvGetResponse>(
+    `/v1/kv/${encodeURIComponent(key)}?with_ttl=1`,
+    { signal },
+  );
+
+export const kvPut = (key: string, body: KvPutBody) =>
+  fetchJSON<unknown>(`/v1/kv/${encodeURIComponent(key)}`, {
+    method: 'PUT',
+    body,
+  });
+
+export const kvDelete = (key: string) =>
+  fetchJSON<unknown>(`/v1/kv/${encodeURIComponent(key)}`, { method: 'DELETE' });
+
+// --- Admin -------------------------------------------------------------------
+
+export const triggerBackup = () =>
+  fetchJSON<BackupsResponse>('/v1/admin/backup', { method: 'POST' });
+
+export const listBackups = (signal?: AbortSignal) =>
+  fetchJSON<BackupsResponse>('/v1/admin/backups', { signal });

--- a/ui/src/api/prom.ts
+++ b/ui/src/api/prom.ts
@@ -1,0 +1,127 @@
+// A small, defensive Prometheus text-exposition parser.
+//
+// It parses `# HELP` / `# TYPE` lines and sample lines of the form
+//   metric_name{label="v",other="w"} 12.3
+// It never throws on malformed input: unparseable lines are skipped. Metric
+// names carry a `rostam_vector_` prefix in this server, so callers match by
+// suffix (see suffixMatch) to stay robust to prefix changes.
+
+export interface Sample {
+  name: string;
+  labels: Record<string, string>;
+  value: number;
+}
+
+export interface ParsedMetrics {
+  samples: Sample[];
+  /** metric name -> HELP/TYPE metadata, best-effort. */
+  meta: Record<string, { help?: string; type?: string }>;
+}
+
+function parseLabels(raw: string): Record<string, string> {
+  const labels: Record<string, string> = {};
+  // Match key="value" pairs; value may contain escaped quotes/backslashes.
+  const re = /([a-zA-Z_][a-zA-Z0-9_]*)="((?:\\.|[^"\\])*)"/g;
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(raw)) !== null) {
+    labels[m[1]] = m[2]
+      .replace(/\\"/g, '"')
+      .replace(/\\n/g, '\n')
+      .replace(/\\\\/g, '\\');
+  }
+  return labels;
+}
+
+export function parsePrometheus(text: string): ParsedMetrics {
+  const samples: Sample[] = [];
+  const meta: Record<string, { help?: string; type?: string }> = {};
+
+  for (const rawLine of text.split('\n')) {
+    const line = rawLine.trim();
+    if (line === '') continue;
+
+    if (line.startsWith('#')) {
+      // "# HELP name text" or "# TYPE name type"
+      const parts = line.split(/\s+/);
+      const kind = parts[1];
+      const name = parts[2];
+      if (!name) continue;
+      if (kind === 'HELP') {
+        meta[name] = { ...meta[name], help: parts.slice(3).join(' ') };
+      } else if (kind === 'TYPE') {
+        meta[name] = { ...meta[name], type: parts[3] };
+      }
+      continue;
+    }
+
+    // sample: name{labels} value  OR  name value
+    const braceIdx = line.indexOf('{');
+    let name: string;
+    let labels: Record<string, string> = {};
+    let rest: string;
+
+    if (braceIdx >= 0) {
+      const closeIdx = line.lastIndexOf('}');
+      if (closeIdx < braceIdx) continue;
+      name = line.slice(0, braceIdx).trim();
+      labels = parseLabels(line.slice(braceIdx + 1, closeIdx));
+      rest = line.slice(closeIdx + 1).trim();
+    } else {
+      const sp = line.indexOf(' ');
+      if (sp < 0) continue;
+      name = line.slice(0, sp).trim();
+      rest = line.slice(sp + 1).trim();
+    }
+
+    if (name === '') continue;
+    // value is the first token after labels (ignore an optional timestamp).
+    const valTok = rest.split(/\s+/)[0];
+    const value = valTok === '+Inf' ? Infinity : valTok === '-Inf' ? -Infinity : Number(valTok);
+    if (Number.isNaN(value)) continue;
+
+    samples.push({ name, labels, value });
+  }
+
+  return { samples, meta };
+}
+
+/** Does a metric name end with the given suffix (prefix-robust matching)? */
+export function suffixMatch(name: string, suffix: string): boolean {
+  return name === suffix || name.endsWith('_' + suffix) || name.endsWith(suffix);
+}
+
+/**
+ * Estimate a quantile from cumulative histogram buckets.
+ * `buckets` is a list of { le, count } where count is the CUMULATIVE count at
+ * that upper bound (Prometheus convention). Returns the interpolated bound in
+ * the histogram's native unit (seconds here). Returns null when there is no data.
+ */
+export function histogramQuantile(
+  buckets: { le: number; count: number }[],
+  q: number,
+): number | null {
+  if (buckets.length === 0) return null;
+  const sorted = [...buckets].sort((a, b) => a.le - b.le);
+  const total = sorted[sorted.length - 1].count;
+  if (total <= 0) return null;
+  const target = q * total;
+
+  let prevCount = 0;
+  let prevLe = 0;
+  for (const b of sorted) {
+    if (b.count >= target) {
+      if (!Number.isFinite(b.le)) {
+        // Target falls in the +Inf bucket; best estimate is the last finite bound.
+        return prevLe > 0 ? prevLe : null;
+      }
+      const bucketCount = b.count - prevCount;
+      if (bucketCount <= 0) return b.le;
+      // Linear interpolation within the bucket [prevLe, le].
+      const frac = (target - prevCount) / bucketCount;
+      return prevLe + (b.le - prevLe) * frac;
+    }
+    prevCount = b.count;
+    prevLe = Number.isFinite(b.le) ? b.le : prevLe;
+  }
+  return prevLe > 0 ? prevLe : null;
+}

--- a/ui/src/api/types.ts
+++ b/ui/src/api/types.ts
@@ -1,0 +1,112 @@
+// Response shapes for the Rostam HTTP API.
+//
+// NOTE: shapes are intentionally permissive. The live server reconciles some
+// specifics at integration, and several endpoints (topology, collection list,
+// KV) are being added by the backend concurrently. Fields that may be absent
+// are optional, and generic config is kept as an index signature.
+
+export interface ReadyResponse {
+  status: string; // "ready" | "not ready"
+  detail?: string;
+}
+
+export interface HealthResponse {
+  status: string; // "ok"
+}
+
+export interface CollectionSummary {
+  name: string;
+  [k: string]: unknown;
+}
+
+export interface CollectionListResponse {
+  collections: CollectionSummary[];
+}
+
+/** Generic collection config: known fields surfaced, everything else preserved. */
+export interface CollectionConfig {
+  dim?: number;
+  metric?: string;
+  m?: number;
+  ef_construction?: number;
+  ef_search?: number;
+  quant?: string;
+  persistent?: boolean;
+  partitions?: number;
+  index_type?: string;
+  [k: string]: unknown;
+}
+
+export interface TopologyMember {
+  node_id: string;
+  server_addr: string;
+}
+
+export interface TopologyResponse {
+  num_shards: number;
+  members: TopologyMember[];
+  leaders: string[]; // leader server_addr per shard index
+  placement: string[][]; // per-shard list of node_ids
+}
+
+export interface BackupLag {
+  node_id?: string;
+  lag?: number;
+  [k: string]: unknown;
+}
+
+export interface ReplicationShard {
+  shard?: number;
+  mode?: string;
+  primary?: string;
+  isr?: number;
+  min_isr?: number;
+  backups?: BackupLag[];
+  [k: string]: unknown;
+}
+
+export interface ReplicationResponse {
+  shards: ReplicationShard[];
+}
+
+/** One search hit. Plain KNN returns id+distance; docs/fusion add score+payload. */
+export interface SearchHit {
+  id: number;
+  distance?: number;
+  score?: number;
+  payload?: Record<string, unknown> | null;
+  content?: string;
+  [k: string]: unknown;
+}
+
+export interface SearchResponse {
+  results?: SearchHit[];
+  documents?: SearchHit[];
+  degraded?: boolean;
+  missing?: unknown;
+}
+
+export interface CreateCollectionBody {
+  name: string;
+  config: CollectionConfig;
+}
+
+export interface KvGetResponse {
+  found: boolean;
+  value_b64?: string;
+  value_utf8?: string;
+  ttl_ms?: number;
+}
+
+export interface KvPutBody {
+  value?: string;
+  value_b64?: string;
+  ttl_ms?: number;
+}
+
+export interface BackupsResponse {
+  backups?: unknown[];
+  error?: string;
+}
+
+export type HealthState = 'ready' | 'notready' | 'down' | 'unknown';

--- a/ui/src/components/ApiKeyPrompt.tsx
+++ b/ui/src/components/ApiKeyPrompt.tsx
@@ -1,0 +1,70 @@
+import { useState } from 'react';
+import { KeyRound, Lock } from 'lucide-react';
+import { Modal } from './Modal';
+import { useApiKey } from '../context/ApiKeyContext';
+
+/**
+ * Non-blocking prompt shown when the server answered 401. The user pastes an
+ * API key; it is kept in sessionStorage (a secret) and used as a Bearer token.
+ */
+export function ApiKeyPrompt() {
+  const { needsKey, setApiKey } = useApiKey();
+  const [draft, setDraft] = useState('');
+
+  const submit = () => {
+    if (draft.trim()) setApiKey(draft.trim());
+  };
+
+  return (
+    <Modal
+      open={needsKey}
+      onClose={() => {
+        /* stays open until a key is provided or the user reloads */
+      }}
+      title="Authentication required"
+      footer={
+        <button
+          type="button"
+          className="btn-primary"
+          onClick={submit}
+          disabled={!draft.trim()}
+        >
+          Connect
+        </button>
+      }
+    >
+      <div className="flex items-start gap-3">
+        <div className="mt-0.5 rounded-lg bg-brand/10 p-2 text-brand">
+          <Lock size={18} />
+        </div>
+        <div className="flex-1">
+          <p className="text-sm text-muted">
+            The server returned <span className="font-mono text-ink">401</span>.
+            Enter an API key to continue.
+          </p>
+          <div className="relative mt-3">
+            <KeyRound
+              size={14}
+              className="pointer-events-none absolute left-2.5 top-1/2 -translate-y-1/2 text-faint"
+            />
+            <input
+              autoFocus
+              className="input pl-8 font-mono"
+              type="password"
+              placeholder="rostam_sk_…"
+              value={draft}
+              onChange={(e) => setDraft(e.target.value)}
+              onKeyDown={(e) => e.key === 'Enter' && submit()}
+              autoComplete="off"
+              spellCheck={false}
+            />
+          </div>
+          <p className="mt-2 text-2xs leading-relaxed text-faint">
+            Stored in sessionStorage — it clears when this tab closes. Sent as
+            <span className="font-mono text-muted"> Authorization: Bearer …</span>.
+          </p>
+        </div>
+      </div>
+    </Modal>
+  );
+}

--- a/ui/src/components/CollectionDetail.tsx
+++ b/ui/src/components/CollectionDetail.tsx
@@ -1,0 +1,282 @@
+import { useState } from 'react';
+import { Ruler, Trash2, Split, Fingerprint } from 'lucide-react';
+import { Drawer } from './Drawer';
+import { Modal, TypedConfirmModal } from './Modal';
+import { Badge, CopyButton } from './primitives';
+import { ErrorCard } from './StateView';
+import { useAsync } from '../hooks/useAsync';
+import { getCollection, dropCollection, reshardCollection } from '../api/endpoints';
+import { ApiError } from '../api/client';
+import { formatInt, formatLatency, formatNumber } from '../lib/format';
+import type { CollectionMetrics } from '../hooks/useMetrics';
+import type { CollectionConfig } from '../api/types';
+
+// Config keys surfaced prominently; the rest render in the generic table.
+const PROMINENT = new Set(['dim', 'metric']);
+
+export function CollectionDetail({
+  name,
+  metrics,
+  onClose,
+  onChanged,
+}: {
+  name: string;
+  metrics?: CollectionMetrics;
+  onClose: () => void;
+  onChanged: () => void;
+}) {
+  const cfg = useAsync<CollectionConfig>((s) => getCollection(name, s), [name]);
+  const [dropOpen, setDropOpen] = useState(false);
+  const [reshardOpen, setReshardOpen] = useState(false);
+  const [busy, setBusy] = useState(false);
+  const [actionError, setActionError] = useState<string | null>(null);
+
+  const doDrop = async () => {
+    setBusy(true);
+    setActionError(null);
+    try {
+      await dropCollection(name);
+      setBusy(false);
+      setDropOpen(false);
+      onChanged();
+      onClose();
+    } catch (e) {
+      setBusy(false);
+      setActionError(e instanceof Error ? e.message : 'Drop failed.');
+    }
+  };
+
+  const cfgUnavailable = cfg.error instanceof ApiError && cfg.error.isUnavailable;
+
+  return (
+    <Drawer
+      open
+      onClose={onClose}
+      title={<span className="font-mono">{name}</span>}
+      subtitle="Collection configuration &amp; live metrics"
+      footer={
+        <>
+          <button type="button" className="btn-ghost" onClick={() => setReshardOpen(true)}>
+            <Split size={14} /> Reshard
+          </button>
+          <button type="button" className="btn-danger" onClick={() => setDropOpen(true)}>
+            <Trash2 size={14} /> Drop
+          </button>
+        </>
+      }
+    >
+      {/* Prominent config */}
+      <div className="grid grid-cols-2 gap-3">
+        <Prominent
+          icon={<Ruler size={14} />}
+          label="Dimension"
+          value={cfg.data?.dim != null ? String(cfg.data.dim) : '—'}
+        />
+        <Prominent
+          icon={<Fingerprint size={14} />}
+          label="Metric"
+          value={cfg.data?.metric ?? '—'}
+        />
+      </div>
+
+      {/* Live metrics */}
+      <div className="mt-4 grid grid-cols-2 gap-3 sm:grid-cols-4">
+        <MetricTile label="Points" value={formatNumber(metrics?.size)} />
+        <MetricTile label="Tombstoned" value={formatInt(metrics?.tombstoned)} />
+        <MetricTile
+          label="Search QPS"
+          value={metrics?.searchQps == null ? '—' : formatNumber(metrics.searchQps)}
+        />
+        <MetricTile label="p99 search" value={formatLatency(metrics?.p99SearchSec)} />
+      </div>
+
+      {/* Full config */}
+      <div className="mt-5">
+        <div className="mb-2 text-xs font-medium text-muted">Configuration</div>
+        {cfg.error ? (
+          cfgUnavailable ? (
+            <p className="rounded-lg border border-line bg-panel-2 px-3 py-2 text-xs text-muted">
+              Config endpoint not available on this build.
+            </p>
+          ) : cfg.loading ? null : (
+            <ErrorCard error={cfg.error} onRetry={cfg.reload} />
+          )
+        ) : !cfg.data ? (
+          <div className="h-24 animate-pulse rounded-lg bg-panel-2" />
+        ) : (
+          <ConfigTable config={cfg.data} />
+        )}
+      </div>
+
+      {actionError && (
+        <p className="mt-4 rounded-lg border border-down/30 bg-down/10 px-3 py-2 font-mono text-xs text-down">
+          {actionError}
+        </p>
+      )}
+
+      <TypedConfirmModal
+        open={dropOpen}
+        onClose={() => setDropOpen(false)}
+        onConfirm={doDrop}
+        title="Drop collection"
+        phrase={name}
+        confirmLabel="Drop collection"
+        busy={busy}
+      >
+        <p className="text-sm text-muted">
+          This permanently deletes <span className="font-mono text-ink">{name}</span> and
+          all of its points. This cannot be undone.
+        </p>
+      </TypedConfirmModal>
+
+      <ReshardModal
+        open={reshardOpen}
+        name={name}
+        onClose={() => setReshardOpen(false)}
+        onDone={() => {
+          setReshardOpen(false);
+          onChanged();
+        }}
+      />
+    </Drawer>
+  );
+}
+
+function Prominent({
+  icon,
+  label,
+  value,
+}: {
+  icon: React.ReactNode;
+  label: string;
+  value: string;
+}) {
+  return (
+    <div className="rounded-lg border border-line bg-panel-2 px-3 py-2.5">
+      <div className="flex items-center gap-1.5 text-2xs text-faint">
+        {icon}
+        {label}
+      </div>
+      <div className="mt-1 font-mono text-lg font-semibold text-ink">{value}</div>
+    </div>
+  );
+}
+
+function MetricTile({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="rounded-lg border border-line px-3 py-2">
+      <div className="text-2xs text-faint">{label}</div>
+      <div className="mt-0.5 font-mono text-sm font-medium text-ink">{value}</div>
+    </div>
+  );
+}
+
+function ConfigTable({ config }: { config: CollectionConfig }) {
+  const entries = Object.entries(config).filter(([k]) => !PROMINENT.has(k));
+  return (
+    <div className="overflow-hidden rounded-lg border border-line">
+      <table className="w-full text-left text-xs">
+        <tbody>
+          {entries.map(([k, v], i) => (
+            <tr key={k} className={i % 2 ? 'bg-panel-2/40' : ''}>
+              <td className="w-1/2 py-1.5 pl-3 pr-2 font-mono text-muted">{k}</td>
+              <td className="py-1.5 pr-3 font-mono text-ink">
+                <div className="flex items-center justify-between gap-2">
+                  <span className="break-all">{renderVal(v)}</span>
+                  {typeof v !== 'object' && (
+                    <CopyButton value={String(v)} />
+                  )}
+                </div>
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+function renderVal(v: unknown): string {
+  if (v === null) return 'null';
+  if (typeof v === 'object') return JSON.stringify(v);
+  return String(v);
+}
+
+function ReshardModal({
+  open,
+  name,
+  onClose,
+  onDone,
+}: {
+  open: boolean;
+  name: string;
+  onClose: () => void;
+  onDone: () => void;
+}) {
+  const [parts, setParts] = useState('');
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const submit = async () => {
+    const n = Number(parts);
+    if (!Number.isInteger(n) || n <= 0) return setError('Enter a positive partition count.');
+    setBusy(true);
+    setError(null);
+    try {
+      await reshardCollection(name, n);
+      setBusy(false);
+      setParts('');
+      onDone();
+    } catch (e) {
+      setBusy(false);
+      setError(e instanceof Error ? e.message : 'Reshard failed.');
+    }
+  };
+
+  return (
+    <Modal
+      open={open}
+      onClose={() => !busy && onClose()}
+      title="Reshard collection"
+      footer={
+        <>
+          <button type="button" className="btn-ghost" onClick={onClose} disabled={busy}>
+            Cancel
+          </button>
+          <button type="button" className="btn-primary" onClick={submit} disabled={busy}>
+            {busy ? 'Resharding…' : 'Reshard'}
+          </button>
+        </>
+      }
+    >
+      <div className="space-y-3">
+        <div className="rounded-lg border border-warn/30 bg-warn/10 px-3 py-2 text-xs text-warn">
+          This is an <strong>online</strong> reshard — the collection keeps serving reads
+          and writes while partitions are rebuilt in the background.
+        </div>
+        <label className="block">
+          <span className="mb-1 block text-xs font-medium text-muted">
+            New partition count
+          </span>
+          <Badge tone="brand" mono>
+            {name}
+          </Badge>
+          <input
+            autoFocus
+            className="input mt-2 font-mono"
+            inputMode="numeric"
+            placeholder="e.g. 4"
+            value={parts}
+            onChange={(e) => setParts(e.target.value.replace(/[^\d]/g, ''))}
+            onKeyDown={(e) => e.key === 'Enter' && submit()}
+          />
+        </label>
+        {error && (
+          <p className="rounded-lg border border-down/30 bg-down/10 px-3 py-2 font-mono text-xs text-down">
+            {error}
+          </p>
+        )}
+      </div>
+    </Modal>
+  );
+}

--- a/ui/src/components/CreateCollectionForm.tsx
+++ b/ui/src/components/CreateCollectionForm.tsx
@@ -1,0 +1,220 @@
+import { useState } from 'react';
+import { ChevronDown } from 'lucide-react';
+import { Modal } from './Modal';
+import { createCollection } from '../api/endpoints';
+import { ApiError } from '../api/client';
+import type { CollectionConfig } from '../api/types';
+import { classNames } from '../lib/format';
+
+const METRICS = ['cosine', 'l2', 'dot'] as const;
+const QUANTS = ['none', 'sq8', 'bq1', 'pq', 'sq', 'prq'] as const;
+
+export function CreateCollectionForm({
+  open,
+  onClose,
+  onCreated,
+}: {
+  open: boolean;
+  onClose: () => void;
+  onCreated: (name: string) => void;
+}) {
+  const [name, setName] = useState('');
+  const [dim, setDim] = useState('768');
+  const [metric, setMetric] = useState<(typeof METRICS)[number]>('cosine');
+  const [advanced, setAdvanced] = useState(false);
+  const [m, setM] = useState('');
+  const [efc, setEfc] = useState('');
+  const [efs, setEfs] = useState('');
+  const [quant, setQuant] = useState<(typeof QUANTS)[number]>('none');
+  const [persistent, setPersistent] = useState(false);
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const reset = () => {
+    setName('');
+    setDim('768');
+    setMetric('cosine');
+    setAdvanced(false);
+    setM('');
+    setEfc('');
+    setEfs('');
+    setQuant('none');
+    setPersistent(false);
+    setError(null);
+  };
+
+  const close = () => {
+    if (!busy) {
+      reset();
+      onClose();
+    }
+  };
+
+  const submit = async () => {
+    setError(null);
+    const dimNum = Number(dim);
+    if (!name.trim()) return setError('Name is required.');
+    if (!Number.isInteger(dimNum) || dimNum <= 0)
+      return setError('Dimension must be a positive integer.');
+
+    const config: CollectionConfig = { dim: dimNum, metric };
+    if (quant !== 'none') config.quant = quant;
+    if (persistent) config.persistent = true;
+    if (advanced) {
+      if (m) config.m = Number(m);
+      if (efc) config.ef_construction = Number(efc);
+      if (efs) config.ef_search = Number(efs);
+    }
+
+    setBusy(true);
+    try {
+      await createCollection({ name: name.trim(), config });
+      setBusy(false);
+      onCreated(name.trim());
+      reset();
+      onClose();
+    } catch (e) {
+      setBusy(false);
+      setError(
+        e instanceof ApiError
+          ? e.message
+          : e instanceof Error
+            ? e.message
+            : 'Failed to create collection.',
+      );
+    }
+  };
+
+  return (
+    <Modal
+      open={open}
+      onClose={close}
+      title="Create collection"
+      footer={
+        <>
+          <button type="button" className="btn-ghost" onClick={close} disabled={busy}>
+            Cancel
+          </button>
+          <button type="button" className="btn-primary" onClick={submit} disabled={busy}>
+            {busy ? 'Creating…' : 'Create'}
+          </button>
+        </>
+      }
+    >
+      <div className="space-y-4">
+        <Row label="Name">
+          <input
+            autoFocus
+            className="input font-mono"
+            placeholder="documents"
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            spellCheck={false}
+          />
+        </Row>
+
+        <div className="grid grid-cols-2 gap-3">
+          <Row label="Dimension">
+            <input
+              className="input font-mono"
+              inputMode="numeric"
+              placeholder="768"
+              value={dim}
+              onChange={(e) => setDim(e.target.value.replace(/[^\d]/g, ''))}
+            />
+          </Row>
+          <Row label="Metric">
+            <Select value={metric} onChange={(v) => setMetric(v as (typeof METRICS)[number])} options={METRICS} />
+          </Row>
+        </div>
+
+        <button
+          type="button"
+          onClick={() => setAdvanced((a) => !a)}
+          className="flex items-center gap-1 text-xs font-medium text-muted hover:text-ink"
+        >
+          <ChevronDown
+            size={13}
+            className={classNames('transition-transform', advanced && 'rotate-180')}
+          />
+          Advanced index parameters
+        </button>
+
+        {advanced && (
+          <div className="animate-fade-in space-y-4 rounded-lg border border-line bg-panel-2/50 p-3">
+            <div className="grid grid-cols-3 gap-3">
+              <Row label="M (degree)">
+                <input className="input font-mono" placeholder="auto" value={m} onChange={(e) => setM(e.target.value.replace(/[^\d]/g, ''))} />
+              </Row>
+              <Row label="ef_construction">
+                <input className="input font-mono" placeholder="auto" value={efc} onChange={(e) => setEfc(e.target.value.replace(/[^\d]/g, ''))} />
+              </Row>
+              <Row label="ef_search">
+                <input className="input font-mono" placeholder="auto" value={efs} onChange={(e) => setEfs(e.target.value.replace(/[^\d]/g, ''))} />
+              </Row>
+            </div>
+            <div className="grid grid-cols-2 items-end gap-3">
+              <Row label="Quantization">
+                <Select value={quant} onChange={(v) => setQuant(v as (typeof QUANTS)[number])} options={QUANTS} />
+              </Row>
+              <label className="flex cursor-pointer items-center gap-2 pb-2 text-xs text-muted">
+                <input
+                  type="checkbox"
+                  checked={persistent}
+                  onChange={(e) => setPersistent(e.target.checked)}
+                  className="h-4 w-4 rounded border-line accent-brand"
+                />
+                Persistent (mmap-backed)
+              </label>
+            </div>
+          </div>
+        )}
+
+        {error && (
+          <p className="rounded-lg border border-down/30 bg-down/10 px-3 py-2 font-mono text-xs text-down">
+            {error}
+          </p>
+        )}
+      </div>
+    </Modal>
+  );
+}
+
+function Row({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <label className="block">
+      <span className="mb-1 block text-xs font-medium text-muted">{label}</span>
+      {children}
+    </label>
+  );
+}
+
+function Select({
+  value,
+  onChange,
+  options,
+}: {
+  value: string;
+  onChange: (v: string) => void;
+  options: readonly string[];
+}) {
+  return (
+    <div className="relative">
+      <select
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        className="input appearance-none pr-8 font-mono"
+      >
+        {options.map((o) => (
+          <option key={o} value={o}>
+            {o}
+          </option>
+        ))}
+      </select>
+      <ChevronDown
+        size={14}
+        className="pointer-events-none absolute right-2.5 top-1/2 -translate-y-1/2 text-faint"
+      />
+    </div>
+  );
+}

--- a/ui/src/components/Drawer.tsx
+++ b/ui/src/components/Drawer.tsx
@@ -1,0 +1,63 @@
+import { useEffect, type ReactNode } from 'react';
+import { X } from 'lucide-react';
+
+export function Drawer({
+  open,
+  onClose,
+  title,
+  subtitle,
+  children,
+  footer,
+}: {
+  open: boolean;
+  onClose: () => void;
+  title: ReactNode;
+  subtitle?: ReactNode;
+  children: ReactNode;
+  footer?: ReactNode;
+}) {
+  useEffect(() => {
+    if (!open) return;
+    const onKey = (e: KeyboardEvent) => e.key === 'Escape' && onClose();
+    document.addEventListener('keydown', onKey);
+    return () => document.removeEventListener('keydown', onKey);
+  }, [open, onClose]);
+
+  if (!open) return null;
+
+  return (
+    <div className="fixed inset-0 z-40 flex justify-end">
+      <div
+        className="absolute inset-0 bg-black/40 backdrop-blur-[2px]"
+        onClick={onClose}
+        aria-hidden
+      />
+      <div
+        role="dialog"
+        aria-modal="true"
+        className="relative flex h-full w-full max-w-lg animate-slide-in flex-col border-l border-line bg-panel shadow-pop"
+      >
+        <div className="flex items-start justify-between gap-3 border-b border-line px-5 py-4">
+          <div className="min-w-0">
+            <div className="truncate text-sm font-semibold text-ink">{title}</div>
+            {subtitle && <div className="mt-0.5 text-xs text-muted">{subtitle}</div>}
+          </div>
+          <button
+            type="button"
+            onClick={onClose}
+            aria-label="Close"
+            className="rounded-md p-1 text-faint transition-colors hover:bg-panel-2 hover:text-ink"
+          >
+            <X size={16} />
+          </button>
+        </div>
+        <div className="flex-1 overflow-y-auto px-5 py-4">{children}</div>
+        {footer && (
+          <div className="flex justify-end gap-2 border-t border-line px-5 py-3.5">
+            {footer}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/ui/src/components/HealthDot.tsx
+++ b/ui/src/components/HealthDot.tsx
@@ -1,0 +1,49 @@
+import { classNames } from '../lib/format';
+import type { HealthState } from '../api/types';
+
+const meta: Record<HealthState, { color: string; label: string; pulse: boolean }> = {
+  ready: { color: 'bg-ok', label: 'Ready', pulse: false },
+  notready: { color: 'bg-warn', label: 'Not ready', pulse: true },
+  down: { color: 'bg-down', label: 'Unreachable', pulse: true },
+  unknown: { color: 'bg-faint', label: 'Checking…', pulse: true },
+};
+
+export function HealthDot({
+  state,
+  detail,
+  showLabel = true,
+}: {
+  state: HealthState;
+  detail?: string;
+  showLabel?: boolean;
+}) {
+  const m = meta[state];
+  return (
+    <span
+      className="inline-flex items-center gap-2"
+      title={detail || m.label}
+      role="status"
+      aria-label={`Cluster status: ${m.label}`}
+    >
+      <span className="relative flex h-2.5 w-2.5">
+        {m.pulse && (
+          <span
+            className={classNames(
+              'absolute inline-flex h-full w-full rounded-full opacity-60 animate-ping',
+              m.color,
+            )}
+          />
+        )}
+        <span
+          className={classNames(
+            'relative inline-flex h-2.5 w-2.5 rounded-full',
+            m.color,
+          )}
+        />
+      </span>
+      {showLabel && (
+        <span className="text-xs font-medium text-muted">{m.label}</span>
+      )}
+    </span>
+  );
+}

--- a/ui/src/components/JsonView.tsx
+++ b/ui/src/components/JsonView.tsx
@@ -1,0 +1,117 @@
+import { useState } from 'react';
+import { ChevronRight } from 'lucide-react';
+import { classNames } from '../lib/format';
+
+// A compact, syntax-tinted JSON viewer with collapsible objects/arrays.
+export function JsonView({
+  data,
+  initialCollapsed = false,
+}: {
+  data: unknown;
+  initialCollapsed?: boolean;
+}) {
+  return (
+    <div className="font-mono text-xs leading-relaxed">
+      <Node value={data} depth={0} collapsed={initialCollapsed} />
+    </div>
+  );
+}
+
+function Node({
+  value,
+  depth,
+  keyName,
+  collapsed,
+}: {
+  value: unknown;
+  depth: number;
+  keyName?: string;
+  collapsed?: boolean;
+}) {
+  const [open, setOpen] = useState(!collapsed || depth < 1);
+  const prefix = keyName !== undefined && (
+    <span className="text-info">"{keyName}"</span>
+  );
+
+  if (value === null) return <Leaf prefix={prefix} className="text-faint">null</Leaf>;
+  if (typeof value === 'string')
+    return (
+      <Leaf prefix={prefix} className="text-ok break-all">
+        "{value}"
+      </Leaf>
+    );
+  if (typeof value === 'number')
+    return <Leaf prefix={prefix} className="text-brand">{String(value)}</Leaf>;
+  if (typeof value === 'boolean')
+    return <Leaf prefix={prefix} className="text-warn">{String(value)}</Leaf>;
+
+  const isArray = Array.isArray(value);
+  const entries = isArray
+    ? (value as unknown[]).map((v, i) => [String(i), v] as const)
+    : Object.entries(value as Record<string, unknown>);
+  const open1 = isArray ? '[' : '{';
+  const close1 = isArray ? ']' : '}';
+
+  if (entries.length === 0)
+    return (
+      <Leaf prefix={prefix} className="text-faint">
+        {open1}
+        {close1}
+      </Leaf>
+    );
+
+  return (
+    <div>
+      <button
+        type="button"
+        onClick={() => setOpen((o) => !o)}
+        className="inline-flex items-center gap-0.5 hover:text-ink"
+      >
+        <ChevronRight
+          size={11}
+          className={classNames('text-faint transition-transform', open && 'rotate-90')}
+        />
+        {prefix}
+        {keyName !== undefined && <span className="text-faint">: </span>}
+        <span className="text-faint">
+          {open1}
+          {!open && (
+            <span className="text-faint">
+              {' '}
+              {entries.length} {isArray ? 'items' : 'keys'}{' '}
+              {close1}
+            </span>
+          )}
+        </span>
+      </button>
+      {open && (
+        <div className="border-l border-line pl-3" style={{ marginLeft: 5 }}>
+          {entries.map(([k, v]) => (
+            <div key={k}>
+              <Node value={v} depth={depth + 1} keyName={isArray ? undefined : k} />
+            </div>
+          ))}
+        </div>
+      )}
+      {open && <div className="text-faint">{close1}</div>}
+    </div>
+  );
+}
+
+function Leaf({
+  prefix,
+  className,
+  children,
+}: {
+  prefix?: React.ReactNode;
+  className?: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <span>
+      {prefix}
+      {prefix && <span className="text-faint">: </span>}
+      <span className={className}>{children}</span>
+    </span>
+  );
+}

--- a/ui/src/components/Layout.tsx
+++ b/ui/src/components/Layout.tsx
@@ -1,0 +1,46 @@
+import { useState } from 'react';
+import { Outlet } from 'react-router-dom';
+import { Sidebar } from './Sidebar';
+import { TopBar } from './TopBar';
+import { SettingsPanel } from './SettingsPanel';
+import { ApiKeyPrompt } from './ApiKeyPrompt';
+
+export function Layout() {
+  const [settingsOpen, setSettingsOpen] = useState(false);
+
+  return (
+    <div className="flex h-screen overflow-hidden bg-surface text-ink">
+      <Sidebar />
+      <div className="flex min-w-0 flex-1 flex-col">
+        <TopBar onOpenSettings={() => setSettingsOpen(true)} />
+        <main className="flex-1 overflow-y-auto">
+          <div className="mx-auto max-w-7xl px-5 py-6">
+            <Outlet />
+          </div>
+        </main>
+      </div>
+      <SettingsPanel open={settingsOpen} onClose={() => setSettingsOpen(false)} />
+      <ApiKeyPrompt />
+    </div>
+  );
+}
+
+export function PageHeader({
+  title,
+  description,
+  actions,
+}: {
+  title: string;
+  description?: string;
+  actions?: React.ReactNode;
+}) {
+  return (
+    <div className="mb-6 flex items-end justify-between gap-4">
+      <div>
+        <h1 className="text-lg font-semibold tracking-tight text-ink">{title}</h1>
+        {description && <p className="mt-1 text-sm text-muted">{description}</p>}
+      </div>
+      {actions && <div className="flex items-center gap-2">{actions}</div>}
+    </div>
+  );
+}

--- a/ui/src/components/Modal.tsx
+++ b/ui/src/components/Modal.tsx
@@ -1,0 +1,140 @@
+import { useEffect, useRef, useState, type ReactNode } from 'react';
+import { X } from 'lucide-react';
+
+export function Modal({
+  open,
+  onClose,
+  title,
+  children,
+  footer,
+  wide,
+}: {
+  open: boolean;
+  onClose: () => void;
+  title: string;
+  children: ReactNode;
+  footer?: ReactNode;
+  wide?: boolean;
+}) {
+  const ref = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose();
+    };
+    document.addEventListener('keydown', onKey);
+    // Focus the dialog for keyboard users.
+    ref.current?.focus();
+    return () => document.removeEventListener('keydown', onKey);
+  }, [open, onClose]);
+
+  if (!open) return null;
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-start justify-center overflow-y-auto bg-black/50 p-4 pt-[10vh] backdrop-blur-sm"
+      onMouseDown={(e) => {
+        if (e.target === e.currentTarget) onClose();
+      }}
+    >
+      <div
+        ref={ref}
+        tabIndex={-1}
+        role="dialog"
+        aria-modal="true"
+        aria-label={title}
+        className={`card w-full ${wide ? 'max-w-2xl' : 'max-w-md'} animate-fade-in shadow-pop outline-none`}
+      >
+        <div className="flex items-center justify-between border-b border-line px-5 py-3.5">
+          <h2 className="text-sm font-semibold text-ink">{title}</h2>
+          <button
+            type="button"
+            onClick={onClose}
+            aria-label="Close dialog"
+            className="rounded-md p-1 text-faint transition-colors hover:bg-panel-2 hover:text-ink"
+          >
+            <X size={16} />
+          </button>
+        </div>
+        <div className="px-5 py-4">{children}</div>
+        {footer && (
+          <div className="flex justify-end gap-2 border-t border-line px-5 py-3.5">
+            {footer}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+/**
+ * A destructive-action modal that requires the user to type an exact
+ * confirmation phrase (e.g. the collection name) before the action arms.
+ */
+export function TypedConfirmModal({
+  open,
+  onClose,
+  onConfirm,
+  title,
+  phrase,
+  confirmLabel = 'Delete',
+  children,
+  busy,
+}: {
+  open: boolean;
+  onClose: () => void;
+  onConfirm: () => void;
+  title: string;
+  phrase: string;
+  confirmLabel?: string;
+  children?: ReactNode;
+  busy?: boolean;
+}) {
+  const [typed, setTyped] = useState('');
+  const armed = typed === phrase;
+
+  useEffect(() => {
+    if (open) setTyped('');
+  }, [open]);
+
+  return (
+    <Modal
+      open={open}
+      onClose={onClose}
+      title={title}
+      footer={
+        <>
+          <button type="button" className="btn-ghost" onClick={onClose}>
+            Cancel
+          </button>
+          <button
+            type="button"
+            className="btn-danger"
+            disabled={!armed || busy}
+            onClick={onConfirm}
+          >
+            {busy ? 'Working…' : confirmLabel}
+          </button>
+        </>
+      }
+    >
+      {children}
+      <label className="mt-3 block text-xs text-muted">
+        Type <span className="font-mono text-ink">{phrase}</span> to confirm
+      </label>
+      <input
+        autoFocus
+        className="input mt-1.5 font-mono"
+        value={typed}
+        onChange={(e) => setTyped(e.target.value)}
+        onKeyDown={(e) => {
+          if (e.key === 'Enter' && armed && !busy) onConfirm();
+        }}
+        placeholder={phrase}
+        spellCheck={false}
+        autoComplete="off"
+      />
+    </Modal>
+  );
+}

--- a/ui/src/components/SettingsPanel.tsx
+++ b/ui/src/components/SettingsPanel.tsx
@@ -1,0 +1,126 @@
+import { useState } from 'react';
+import { Eye, EyeOff, KeyRound, Trash2 } from 'lucide-react';
+import { Modal } from './Modal';
+import { Badge } from './primitives';
+import { useApiKey } from '../context/ApiKeyContext';
+import { useSettings } from '../context/SettingsContext';
+
+export function SettingsPanel({
+  open,
+  onClose,
+}: {
+  open: boolean;
+  onClose: () => void;
+}) {
+  const { apiKey, hasKey, setApiKey, clearApiKey, serverTarget } = useApiKey();
+  const { pollMs, setPollMs } = useSettings();
+  const [draft, setDraft] = useState('');
+  const [reveal, setReveal] = useState(false);
+
+  const save = () => {
+    if (draft.trim()) {
+      setApiKey(draft.trim());
+      setDraft('');
+    }
+  };
+
+  return (
+    <Modal open={open} onClose={onClose} title="Settings">
+      <div className="space-y-5">
+        <Field label="Server target">
+          <div className="flex items-center gap-2">
+            <code className="flex-1 truncate rounded-lg border border-line bg-panel-2 px-3 py-2 font-mono text-xs text-ink">
+              {serverTarget || '—'}
+            </code>
+            <Badge tone="neutral">same origin</Badge>
+          </div>
+        </Field>
+
+        <Field
+          label="API key"
+          hint="Sent as a Bearer token. Stored in sessionStorage — it clears when this tab closes."
+        >
+          {hasKey ? (
+            <div className="flex items-center gap-2">
+              <code className="flex-1 truncate rounded-lg border border-line bg-panel-2 px-3 py-2 font-mono text-xs text-ink">
+                {reveal ? apiKey : '•'.repeat(Math.min(24, (apiKey || '').length))}
+              </code>
+              <button
+                type="button"
+                className="btn-ghost !px-2"
+                onClick={() => setReveal((r) => !r)}
+                aria-label={reveal ? 'Hide key' : 'Reveal key'}
+              >
+                {reveal ? <EyeOff size={15} /> : <Eye size={15} />}
+              </button>
+              <button
+                type="button"
+                className="btn-danger !px-2"
+                onClick={clearApiKey}
+                aria-label="Clear key"
+              >
+                <Trash2 size={15} />
+              </button>
+            </div>
+          ) : (
+            <div className="flex items-center gap-2">
+              <div className="relative flex-1">
+                <KeyRound
+                  size={14}
+                  className="pointer-events-none absolute left-2.5 top-1/2 -translate-y-1/2 text-faint"
+                />
+                <input
+                  className="input pl-8 font-mono"
+                  type="password"
+                  placeholder="rostam_sk_…"
+                  value={draft}
+                  onChange={(e) => setDraft(e.target.value)}
+                  onKeyDown={(e) => e.key === 'Enter' && save()}
+                  autoComplete="off"
+                />
+              </div>
+              <button type="button" className="btn-primary" onClick={save} disabled={!draft.trim()}>
+                Save
+              </button>
+            </div>
+          )}
+        </Field>
+
+        <Field label="Refresh interval" hint="How often live metrics are polled.">
+          <div className="flex items-center gap-3">
+            <input
+              type="range"
+              min={1}
+              max={30}
+              step={1}
+              value={Math.round(pollMs / 1000)}
+              onChange={(e) => setPollMs(Number(e.target.value) * 1000)}
+              className="flex-1 accent-brand"
+            />
+            <span className="w-12 text-right font-mono text-sm text-ink tabular-nums">
+              {(pollMs / 1000).toFixed(0)}s
+            </span>
+          </div>
+        </Field>
+      </div>
+    </Modal>
+  );
+}
+
+function Field({
+  label,
+  hint,
+  children,
+}: {
+  label: string;
+  hint?: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <div>
+      <div className="mb-1.5 text-xs font-medium text-ink">{label}</div>
+      {children}
+      {hint && <p className="mt-1.5 text-2xs leading-relaxed text-faint">{hint}</p>}
+    </div>
+  );
+}

--- a/ui/src/components/Sidebar.tsx
+++ b/ui/src/components/Sidebar.tsx
@@ -1,0 +1,76 @@
+import { NavLink } from 'react-router-dom';
+import {
+  Boxes,
+  Database,
+  LayoutDashboard,
+  Search,
+  Server,
+  ShieldCheck,
+} from 'lucide-react';
+import { classNames } from '../lib/format';
+
+const nav = [
+  { to: '/', label: 'Overview', icon: LayoutDashboard, end: true },
+  { to: '/collections', label: 'Collections', icon: Boxes, end: false },
+  { to: '/search', label: 'Search', icon: Search, end: false },
+  { to: '/kv', label: 'KV', icon: Database, end: false },
+  { to: '/admin', label: 'Admin', icon: ShieldCheck, end: false },
+];
+
+export function Sidebar() {
+  return (
+    <aside className="flex w-56 shrink-0 flex-col border-r border-line bg-panel/60">
+      <div className="flex h-14 items-center gap-2.5 border-b border-line px-4">
+        <div className="grid h-7 w-7 place-items-center rounded-md bg-brand text-brand-ink shadow-sm">
+          <Server size={16} strokeWidth={2.5} />
+        </div>
+        <div className="leading-tight">
+          <div className="text-sm font-semibold tracking-tight text-ink">
+            Rostam
+          </div>
+          <div className="text-2xs text-faint">vector + kv</div>
+        </div>
+      </div>
+
+      <nav className="flex-1 space-y-0.5 p-2">
+        {nav.map(({ to, label, icon: Icon, end }) => (
+          <NavLink
+            key={to}
+            to={to}
+            end={end}
+            className={({ isActive }) =>
+              classNames(
+                'group relative flex items-center gap-2.5 rounded-lg px-3 py-2 text-sm font-medium transition-colors',
+                isActive
+                  ? 'bg-panel-2 text-ink'
+                  : 'text-muted hover:bg-panel-2/60 hover:text-ink',
+              )
+            }
+          >
+            {({ isActive }) => (
+              <>
+                <span
+                  className={classNames(
+                    'absolute left-0 top-1/2 h-4 w-0.5 -translate-y-1/2 rounded-r-full bg-brand transition-opacity',
+                    isActive ? 'opacity-100' : 'opacity-0',
+                  )}
+                />
+                <Icon
+                  size={16}
+                  className={isActive ? 'text-brand' : 'text-faint group-hover:text-muted'}
+                />
+                {label}
+              </>
+            )}
+          </NavLink>
+        ))}
+      </nav>
+
+      <div className="border-t border-line p-3 text-2xs text-faint">
+        <p className="leading-relaxed">
+          Self-hosted vector database &amp; sub-microsecond KV store.
+        </p>
+      </div>
+    </aside>
+  );
+}

--- a/ui/src/components/Sparkline.tsx
+++ b/ui/src/components/Sparkline.tsx
@@ -1,0 +1,102 @@
+// A tiny dependency-free SVG sparkline. Renders an area + line for a numeric
+// series, scaling to its own min/max. Keeps the embedded bundle small.
+
+export function Sparkline({
+  values,
+  width = 120,
+  height = 34,
+  strokeWidth = 1.5,
+  className,
+  color = 'rgb(var(--c-brand))',
+}: {
+  values: number[];
+  width?: number;
+  height?: number;
+  strokeWidth?: number;
+  className?: string;
+  color?: string;
+}) {
+  const pad = 2;
+  const w = width - pad * 2;
+  const h = height - pad * 2;
+
+  if (values.length < 2) {
+    return (
+      <svg
+        width={width}
+        height={height}
+        className={className}
+        role="img"
+        aria-label="sparkline (insufficient data)"
+      >
+        <line
+          x1={pad}
+          y1={height / 2}
+          x2={width - pad}
+          y2={height / 2}
+          stroke="var(--c-line-strong)"
+          strokeWidth={1}
+          strokeDasharray="3 3"
+        />
+      </svg>
+    );
+  }
+
+  const min = Math.min(...values);
+  const max = Math.max(...values);
+  const range = max - min || 1;
+  const step = w / (values.length - 1);
+
+  const pts = values.map((v, i) => {
+    const x = pad + i * step;
+    const y = pad + h - ((v - min) / range) * h;
+    return [x, y] as const;
+  });
+
+  const line = pts.map(([x, y], i) => `${i === 0 ? 'M' : 'L'}${x.toFixed(1)},${y.toFixed(1)}`).join(' ');
+  const area =
+    `${line} L${pts[pts.length - 1][0].toFixed(1)},${(height - pad).toFixed(1)}` +
+    ` L${pts[0][0].toFixed(1)},${(height - pad).toFixed(1)} Z`;
+  const gid = `spark-${Math.abs(hashSeries(values)).toString(36)}`;
+
+  return (
+    <svg
+      width={width}
+      height={height}
+      className={className}
+      role="img"
+      aria-label="sparkline"
+      preserveAspectRatio="none"
+    >
+      <defs>
+        <linearGradient id={gid} x1="0" y1="0" x2="0" y2="1">
+          <stop offset="0%" stopColor={color} stopOpacity="0.22" />
+          <stop offset="100%" stopColor={color} stopOpacity="0" />
+        </linearGradient>
+      </defs>
+      <path d={area} fill={`url(#${gid})`} />
+      <path
+        d={line}
+        fill="none"
+        stroke={color}
+        strokeWidth={strokeWidth}
+        strokeLinejoin="round"
+        strokeLinecap="round"
+      />
+      <circle
+        cx={pts[pts.length - 1][0]}
+        cy={pts[pts.length - 1][1]}
+        r={1.8}
+        fill={color}
+      />
+    </svg>
+  );
+}
+
+function hashSeries(values: number[]): number {
+  let h = 0;
+  for (let i = 0; i < values.length; i++) {
+    h = (h * 31 + Math.round(values[i] * 1000)) | 0;
+  }
+  return h + values.length;
+}

--- a/ui/src/components/Sparkline.tsx
+++ b/ui/src/components/Sparkline.tsx
@@ -1,6 +1,8 @@
 // A tiny dependency-free SVG sparkline. Renders an area + line for a numeric
 // series, scaling to its own min/max. Keeps the embedded bundle small.
 
+import { useId } from 'react';
+
 export function Sparkline({
   values,
   width = 120,
@@ -16,6 +18,10 @@ export function Sparkline({
   className?: string;
   color?: string;
 }) {
+  // useId() gives every Sparkline instance its own SVG id namespace, so two
+  // charts with identical values (and thus identical hashSeries output) never
+  // collide on the gradient id and steal each other's fill via url(#id).
+  const reactId = useId();
   const pad = 2;
   const w = width - pad * 2;
   const h = height - pad * 2;
@@ -57,7 +63,9 @@ export function Sparkline({
   const area =
     `${line} L${pts[pts.length - 1][0].toFixed(1)},${(height - pad).toFixed(1)}` +
     ` L${pts[0][0].toFixed(1)},${(height - pad).toFixed(1)} Z`;
-  const gid = `spark-${Math.abs(hashSeries(values)).toString(36)}`;
+  // useId()'s value contains colons, which are legal in an SVG id but awkward
+  // in a url(#...) reference in some tooling, so they are stripped.
+  const gid = `spark-${reactId.replace(/:/g, '')}-${Math.abs(hashSeries(values)).toString(36)}`;
 
   return (
     <svg

--- a/ui/src/components/StatCard.tsx
+++ b/ui/src/components/StatCard.tsx
@@ -1,0 +1,52 @@
+import type { ReactNode } from 'react';
+import { Card } from './primitives';
+import { Sparkline } from './Sparkline';
+import { classNames } from '../lib/format';
+
+export function StatCard({
+  label,
+  value,
+  unit,
+  icon,
+  series,
+  color,
+  hint,
+  loading,
+}: {
+  label: string;
+  value: ReactNode;
+  unit?: string;
+  icon?: ReactNode;
+  series?: number[];
+  color?: string;
+  hint?: string;
+  loading?: boolean;
+}) {
+  return (
+    <Card className="group relative overflow-hidden p-4 transition-colors hover:border-line-strong">
+      <div className="flex items-center justify-between">
+        <span className="flex items-center gap-1.5 text-xs font-medium text-muted">
+          {icon && <span className="text-faint">{icon}</span>}
+          {label}
+        </span>
+      </div>
+      <div className="mt-2 flex items-end justify-between gap-2">
+        <div className="min-w-0">
+          <span
+            className={classNames(
+              'font-mono text-2xl font-semibold tracking-tight text-ink tabular-nums',
+              loading && 'opacity-40',
+            )}
+          >
+            {value}
+          </span>
+          {unit && <span className="ml-1 text-xs text-faint">{unit}</span>}
+        </div>
+        {series && series.length > 1 && (
+          <Sparkline values={series} color={color} className="shrink-0 opacity-90" />
+        )}
+      </div>
+      {hint && <p className="mt-1 truncate text-2xs text-faint">{hint}</p>}
+    </Card>
+  );
+}

--- a/ui/src/components/StateView.tsx
+++ b/ui/src/components/StateView.tsx
@@ -1,0 +1,128 @@
+import type { ReactNode } from 'react';
+import { AlertTriangle, KeyRound, Inbox, RefreshCw } from 'lucide-react';
+import { ApiError } from '../api/client';
+import { Card, Spinner } from './primitives';
+
+export function ErrorCard({
+  error,
+  onRetry,
+  title,
+}: {
+  error: Error;
+  onRetry?: () => void;
+  title?: string;
+}) {
+  const status = error instanceof ApiError ? error.status : undefined;
+  return (
+    <Card className="animate-fade-in border-down/30 p-5">
+      <div className="flex items-start gap-3">
+        <div className="mt-0.5 rounded-lg bg-down/10 p-2 text-down">
+          <AlertTriangle size={18} />
+        </div>
+        <div className="min-w-0 flex-1">
+          <div className="flex items-center gap-2">
+            <h3 className="text-sm font-semibold text-ink">
+              {title || 'Request failed'}
+            </h3>
+            {status !== undefined && (
+              <span className="rounded-md border border-down/30 bg-down/10 px-1.5 py-0.5 font-mono text-2xs text-down">
+                HTTP {status}
+              </span>
+            )}
+          </div>
+          <p className="mt-1 break-words font-mono text-xs text-muted">
+            {error.message}
+          </p>
+          {onRetry && (
+            <button
+              type="button"
+              onClick={onRetry}
+              className="btn-ghost mt-3 !py-1.5 text-xs"
+            >
+              <RefreshCw size={13} /> Retry
+            </button>
+          )}
+        </div>
+      </div>
+    </Card>
+  );
+}
+
+export function EmptyState({
+  icon,
+  title,
+  hint,
+  action,
+}: {
+  icon?: ReactNode;
+  title: string;
+  hint?: string;
+  action?: ReactNode;
+}) {
+  return (
+    <div className="flex flex-col items-center justify-center gap-3 rounded-xl border border-dashed border-line bg-panel/40 px-6 py-14 text-center animate-fade-in">
+      <div className="rounded-xl bg-panel-2 p-3 text-faint">
+        {icon || <Inbox size={22} />}
+      </div>
+      <div>
+        <p className="text-sm font-medium text-ink">{title}</p>
+        {hint && <p className="mt-1 max-w-sm text-xs text-muted">{hint}</p>}
+      </div>
+      {action}
+    </div>
+  );
+}
+
+export function LoadingRows({ rows = 4 }: { rows?: number }) {
+  return (
+    <div className="flex flex-col gap-2">
+      {Array.from({ length: rows }).map((_, i) => (
+        <div
+          key={i}
+          className="h-11 animate-pulse rounded-lg bg-panel-2"
+          style={{ animationDelay: `${i * 70}ms` }}
+        />
+      ))}
+    </div>
+  );
+}
+
+export function CenterSpinner({ label }: { label?: string }) {
+  return (
+    <div className="flex items-center justify-center gap-2 py-14 text-sm text-muted">
+      <Spinner className="h-4 w-4" />
+      {label || 'Loading…'}
+    </div>
+  );
+}
+
+/**
+ * Standard loading / error / empty / content switch used by every data view.
+ */
+export function StateView<T>({
+  loading,
+  error,
+  data,
+  onRetry,
+  isEmpty,
+  empty,
+  skeleton,
+  children,
+}: {
+  loading: boolean;
+  error: Error | null;
+  data: T | null;
+  onRetry?: () => void;
+  isEmpty?: (data: T) => boolean;
+  empty?: ReactNode;
+  skeleton?: ReactNode;
+  children: (data: T) => ReactNode;
+}) {
+  if (error && !data) return <ErrorCard error={error} onRetry={onRetry} />;
+  if (loading && !data) return <>{skeleton || <CenterSpinner />}</>;
+  if (!data) return <>{skeleton || <CenterSpinner />}</>;
+  if (isEmpty && isEmpty(data)) return <>{empty || <EmptyState title="Nothing here yet" />}</>;
+  return <>{children(data)}</>;
+}
+
+export const AuthIcon = KeyRound;

--- a/ui/src/components/TopBar.tsx
+++ b/ui/src/components/TopBar.tsx
@@ -1,0 +1,50 @@
+import { Moon, Settings, Sun } from 'lucide-react';
+import { HealthDot } from './HealthDot';
+import { useHealth } from '../hooks/useHealth';
+import { useTheme } from '../context/ThemeContext';
+import { useApiKey } from '../context/ApiKeyContext';
+
+export function TopBar({ onOpenSettings }: { onOpenSettings: () => void }) {
+  const { state, detail } = useHealth();
+  const { theme, toggle } = useTheme();
+  const { serverTarget, hasKey } = useApiKey();
+  const host = serverTarget.replace(/^https?:\/\//, '') || 'localhost';
+
+  return (
+    <header className="flex h-14 shrink-0 items-center justify-between border-b border-line bg-panel/60 px-4 backdrop-blur">
+      <div className="flex items-center gap-3">
+        <div className="flex items-center gap-2 rounded-lg border border-line bg-panel px-2.5 py-1.5">
+          <HealthDot state={state} detail={detail} />
+        </div>
+        <div className="hidden items-center gap-1.5 rounded-lg border border-line bg-panel px-2.5 py-1.5 sm:flex">
+          <span className="text-2xs text-faint">target</span>
+          <span className="font-mono text-xs text-ink">{host}</span>
+          {hasKey && (
+            <span className="ml-1 rounded bg-brand/10 px-1 py-0.5 text-2xs font-medium text-brand">
+              authed
+            </span>
+          )}
+        </div>
+      </div>
+
+      <div className="flex items-center gap-1.5">
+        <button
+          type="button"
+          onClick={toggle}
+          className="grid h-9 w-9 place-items-center rounded-lg border border-line bg-panel text-muted transition-colors hover:text-ink"
+          aria-label={theme === 'dark' ? 'Switch to light mode' : 'Switch to dark mode'}
+        >
+          {theme === 'dark' ? <Sun size={16} /> : <Moon size={16} />}
+        </button>
+        <button
+          type="button"
+          onClick={onOpenSettings}
+          className="grid h-9 w-9 place-items-center rounded-lg border border-line bg-panel text-muted transition-colors hover:text-ink"
+          aria-label="Settings"
+        >
+          <Settings size={16} />
+        </button>
+      </div>
+    </header>
+  );
+}

--- a/ui/src/components/primitives.tsx
+++ b/ui/src/components/primitives.tsx
@@ -1,0 +1,123 @@
+import { useState, type ReactNode } from 'react';
+import { Check, Copy, Loader2 } from 'lucide-react';
+import { classNames } from '../lib/format';
+
+export function Card({
+  children,
+  className,
+}: {
+  children: ReactNode;
+  className?: string;
+}) {
+  return <div className={classNames('card', className)}>{children}</div>;
+}
+
+export function SectionTitle({
+  title,
+  subtitle,
+  right,
+}: {
+  title: string;
+  subtitle?: string;
+  right?: ReactNode;
+}) {
+  return (
+    <div className="flex items-start justify-between gap-3">
+      <div>
+        <h2 className="text-sm font-semibold tracking-tight text-ink">{title}</h2>
+        {subtitle && <p className="mt-0.5 text-xs text-muted">{subtitle}</p>}
+      </div>
+      {right}
+    </div>
+  );
+}
+
+export function Spinner({ className }: { className?: string }) {
+  return <Loader2 className={classNames('animate-spin', className)} aria-hidden />;
+}
+
+export function Skeleton({ className }: { className?: string }) {
+  return (
+    <div
+      className={classNames(
+        'relative overflow-hidden rounded-md bg-panel-2',
+        className,
+      )}
+    >
+      <div className="absolute inset-0 -translate-x-full animate-shimmer bg-gradient-to-r from-transparent via-black/5 to-transparent dark:via-white/5" />
+    </div>
+  );
+}
+
+type BadgeTone = 'neutral' | 'ok' | 'warn' | 'down' | 'brand' | 'info';
+
+const badgeTones: Record<BadgeTone, string> = {
+  neutral: 'border-line bg-panel-2 text-muted',
+  ok: 'border-ok/30 bg-ok/10 text-ok',
+  warn: 'border-warn/30 bg-warn/10 text-warn',
+  down: 'border-down/30 bg-down/10 text-down',
+  brand: 'border-brand/30 bg-brand/10 text-brand',
+  info: 'border-info/30 bg-info/10 text-info',
+};
+
+export function Badge({
+  children,
+  tone = 'neutral',
+  mono,
+}: {
+  children: ReactNode;
+  tone?: BadgeTone;
+  mono?: boolean;
+}) {
+  return (
+    <span
+      className={classNames(
+        'inline-flex items-center gap-1 rounded-md border px-1.5 py-0.5 text-2xs font-medium',
+        mono && 'font-mono',
+        badgeTones[tone],
+      )}
+    >
+      {children}
+    </span>
+  );
+}
+
+export function CopyButton({ value, label }: { value: string; label?: string }) {
+  const [copied, setCopied] = useState(false);
+  const copy = async () => {
+    try {
+      await navigator.clipboard.writeText(value);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1200);
+    } catch {
+      /* clipboard blocked; no-op */
+    }
+  };
+  return (
+    <button
+      type="button"
+      onClick={copy}
+      className="inline-flex items-center gap-1 rounded-md border border-line bg-panel px-1.5 py-1 text-2xs text-muted transition-colors hover:text-ink"
+      aria-label={label || 'Copy to clipboard'}
+    >
+      {copied ? (
+        <Check size={12} className="text-ok" />
+      ) : (
+        <Copy size={12} />
+      )}
+      {label}
+    </button>
+  );
+}
+
+export function Mono({
+  children,
+  className,
+}: {
+  children: ReactNode;
+  className?: string;
+}) {
+  return (
+    <span className={classNames('font-mono text-ink', className)}>{children}</span>
+  );
+}

--- a/ui/src/context/ApiKeyContext.tsx
+++ b/ui/src/context/ApiKeyContext.tsx
@@ -1,0 +1,91 @@
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+  type ReactNode,
+} from 'react';
+import { setApiKey as setClientKey } from '../api/client';
+
+const STORAGE_KEY = 'rostam-api-key';
+
+interface ApiKeyContextValue {
+  apiKey: string | null;
+  hasKey: boolean;
+  /** True after a 401 was observed and no working key is set. */
+  needsKey: boolean;
+  setApiKey: (key: string | null) => void;
+  clearApiKey: () => void;
+  reportUnauthorized: () => void;
+  /** Server target the dashboard is talking to (this origin). */
+  serverTarget: string;
+}
+
+const ApiKeyContext = createContext<ApiKeyContextValue | null>(null);
+
+// The key is a secret, so it lives in sessionStorage (clears when the tab
+// closes) — deliberately NOT localStorage.
+function readStored(): string | null {
+  try {
+    return sessionStorage.getItem(STORAGE_KEY);
+  } catch {
+    return null;
+  }
+}
+
+export function ApiKeyProvider({ children }: { children: ReactNode }) {
+  const [apiKey, setKeyState] = useState<string | null>(() => {
+    const k = readStored();
+    setClientKey(k);
+    return k;
+  });
+  const [needsKey, setNeedsKey] = useState(false);
+
+  const setApiKey = useCallback((key: string | null) => {
+    const clean = key && key.trim() !== '' ? key.trim() : null;
+    setClientKey(clean);
+    setKeyState(clean);
+    setNeedsKey(false);
+    try {
+      if (clean) sessionStorage.setItem(STORAGE_KEY, clean);
+      else sessionStorage.removeItem(STORAGE_KEY);
+    } catch {
+      // sessionStorage unavailable (private mode); the in-memory key still works.
+    }
+  }, []);
+
+  const clearApiKey = useCallback(() => setApiKey(null), [setApiKey]);
+
+  const reportUnauthorized = useCallback(() => setNeedsKey(true), []);
+
+  // Keep the module-level client key in sync if the state was hydrated.
+  useEffect(() => {
+    setClientKey(apiKey);
+  }, [apiKey]);
+
+  const value = useMemo<ApiKeyContextValue>(
+    () => ({
+      apiKey,
+      hasKey: apiKey !== null,
+      needsKey,
+      setApiKey,
+      clearApiKey,
+      reportUnauthorized,
+      serverTarget:
+        typeof window !== 'undefined' ? window.location.origin : '',
+    }),
+    [apiKey, needsKey, setApiKey, clearApiKey, reportUnauthorized],
+  );
+
+  return (
+    <ApiKeyContext.Provider value={value}>{children}</ApiKeyContext.Provider>
+  );
+}
+
+export function useApiKey(): ApiKeyContextValue {
+  const ctx = useContext(ApiKeyContext);
+  if (!ctx) throw new Error('useApiKey must be used within ApiKeyProvider');
+  return ctx;
+}

--- a/ui/src/context/SettingsContext.tsx
+++ b/ui/src/context/SettingsContext.tsx
@@ -1,0 +1,58 @@
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useMemo,
+  useState,
+  type ReactNode,
+} from 'react';
+
+const STORAGE_KEY = 'rostam-poll-ms';
+const DEFAULT_POLL_MS = 4000;
+const MIN_POLL_MS = 1000;
+const MAX_POLL_MS = 60000;
+
+interface SettingsContextValue {
+  pollMs: number;
+  setPollMs: (ms: number) => void;
+}
+
+const SettingsContext = createContext<SettingsContextValue | null>(null);
+
+function readStored(): number {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (raw) {
+      const n = Number(raw);
+      if (Number.isFinite(n)) return Math.min(MAX_POLL_MS, Math.max(MIN_POLL_MS, n));
+    }
+  } catch {
+    /* ignore */
+  }
+  return DEFAULT_POLL_MS;
+}
+
+export function SettingsProvider({ children }: { children: ReactNode }) {
+  const [pollMs, setPollMsState] = useState<number>(readStored);
+
+  const setPollMs = useCallback((ms: number) => {
+    const clamped = Math.min(MAX_POLL_MS, Math.max(MIN_POLL_MS, Math.round(ms)));
+    setPollMsState(clamped);
+    try {
+      localStorage.setItem(STORAGE_KEY, String(clamped));
+    } catch {
+      /* ignore */
+    }
+  }, []);
+
+  const value = useMemo(() => ({ pollMs, setPollMs }), [pollMs, setPollMs]);
+  return (
+    <SettingsContext.Provider value={value}>{children}</SettingsContext.Provider>
+  );
+}
+
+export function useSettings(): SettingsContextValue {
+  const ctx = useContext(SettingsContext);
+  if (!ctx) throw new Error('useSettings must be used within SettingsProvider');
+  return ctx;
+}

--- a/ui/src/context/ThemeContext.tsx
+++ b/ui/src/context/ThemeContext.tsx
@@ -1,0 +1,66 @@
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+  type ReactNode,
+} from 'react';
+
+type Theme = 'light' | 'dark';
+const STORAGE_KEY = 'rostam-theme';
+
+interface ThemeContextValue {
+  theme: Theme;
+  toggle: () => void;
+  setTheme: (t: Theme) => void;
+}
+
+const ThemeContext = createContext<ThemeContextValue | null>(null);
+
+function resolveInitial(): Theme {
+  try {
+    const stored = localStorage.getItem(STORAGE_KEY);
+    if (stored === 'light' || stored === 'dark') return stored;
+  } catch {
+    /* ignore */
+  }
+  if (
+    typeof window !== 'undefined' &&
+    window.matchMedia('(prefers-color-scheme: dark)').matches
+  )
+    return 'dark';
+  return 'dark'; // dark-mode-first default
+}
+
+export function ThemeProvider({ children }: { children: ReactNode }) {
+  const [theme, setThemeState] = useState<Theme>(resolveInitial);
+
+  useEffect(() => {
+    document.documentElement.setAttribute('data-theme', theme);
+  }, [theme]);
+
+  const setTheme = useCallback((t: Theme) => {
+    setThemeState(t);
+    try {
+      localStorage.setItem(STORAGE_KEY, t);
+    } catch {
+      /* ignore */
+    }
+  }, []);
+
+  const toggle = useCallback(
+    () => setTheme(theme === 'dark' ? 'light' : 'dark'),
+    [theme, setTheme],
+  );
+
+  const value = useMemo(() => ({ theme, toggle, setTheme }), [theme, toggle, setTheme]);
+  return <ThemeContext.Provider value={value}>{children}</ThemeContext.Provider>;
+}
+
+export function useTheme(): ThemeContextValue {
+  const ctx = useContext(ThemeContext);
+  if (!ctx) throw new Error('useTheme must be used within ThemeProvider');
+  return ctx;
+}

--- a/ui/src/hooks/useAsync.ts
+++ b/ui/src/hooks/useAsync.ts
@@ -1,0 +1,59 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { ApiError } from '../api/client';
+import { useApiKey } from '../context/ApiKeyContext';
+
+export interface AsyncState<T> {
+  data: T | null;
+  error: Error | null;
+  loading: boolean;
+  /** Re-run the loader. */
+  reload: () => void;
+}
+
+/**
+ * Run an async loader on mount and whenever a dep changes. Aborts the in-flight
+ * request on unmount/reload, and routes a 401 to the API-key prompt.
+ */
+export function useAsync<T>(
+  loader: (signal: AbortSignal) => Promise<T>,
+  deps: unknown[],
+): AsyncState<T> {
+  const [data, setData] = useState<T | null>(null);
+  const [error, setError] = useState<Error | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [nonce, setNonce] = useState(0);
+  const { reportUnauthorized } = useApiKey();
+  const loaderRef = useRef(loader);
+  loaderRef.current = loader;
+
+  const reload = useCallback(() => setNonce((n) => n + 1), []);
+
+  useEffect(() => {
+    const ctrl = new AbortController();
+    let active = true;
+    setLoading(true);
+    setError(null);
+    loaderRef
+      .current(ctrl.signal)
+      .then((res) => {
+        if (!active) return;
+        setData(res);
+        setError(null);
+      })
+      .catch((e) => {
+        if (!active || ctrl.signal.aborted) return;
+        if (e instanceof ApiError && e.status === 401) reportUnauthorized();
+        setError(e instanceof Error ? e : new Error(String(e)));
+      })
+      .finally(() => {
+        if (active) setLoading(false);
+      });
+    return () => {
+      active = false;
+      ctrl.abort();
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [...deps, nonce]);
+
+  return { data, error, loading, reload };
+}

--- a/ui/src/hooks/useAsync.ts
+++ b/ui/src/hooks/useAsync.ts
@@ -22,7 +22,7 @@ export function useAsync<T>(
   const [error, setError] = useState<Error | null>(null);
   const [loading, setLoading] = useState(true);
   const [nonce, setNonce] = useState(0);
-  const { reportUnauthorized } = useApiKey();
+  const { apiKey, reportUnauthorized } = useApiKey();
   const loaderRef = useRef(loader);
   loaderRef.current = loader;
 
@@ -53,7 +53,7 @@ export function useAsync<T>(
       ctrl.abort();
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [...deps, nonce]);
+  }, [...deps, nonce, apiKey]);
 
   return { data, error, loading, reload };
 }

--- a/ui/src/hooks/useHealth.ts
+++ b/ui/src/hooks/useHealth.ts
@@ -17,9 +17,15 @@ export function useHealth(intervalMs = 5000): {
   useEffect(() => {
     let active = true;
     let timer: number | undefined;
+    // Hoisted so cleanup can abort an in-flight request, and reused as the
+    // re-entrancy guard: tick() is self-scheduling (setTimeout, not
+    // setInterval) so a slow/unreachable server can never let an older
+    // response settle after a newer one — the next tick is scheduled only
+    // once the current one finishes. Mirrors useMetrics.ts's polling loop.
+    let ctrl: AbortController | undefined;
 
     const tick = async () => {
-      const ctrl = new AbortController();
+      ctrl = new AbortController();
       try {
         const res = await getReady(ctrl.signal);
         if (!active) return;
@@ -35,14 +41,16 @@ export function useHealth(intervalMs = 5000): {
           setState('notready');
           setDetail(e instanceof Error ? e.message : undefined);
         }
+      } finally {
+        if (active) timer = window.setTimeout(tick, intervalMs);
       }
     };
 
     tick();
-    timer = window.setInterval(tick, intervalMs);
     return () => {
       active = false;
-      if (timer) window.clearInterval(timer);
+      ctrl?.abort();
+      if (timer) window.clearTimeout(timer);
     };
   }, [intervalMs]);
 

--- a/ui/src/hooks/useHealth.ts
+++ b/ui/src/hooks/useHealth.ts
@@ -1,0 +1,50 @@
+import { useEffect, useState } from 'react';
+import { getReady } from '../api/endpoints';
+import { NetworkError } from '../api/client';
+import type { HealthState } from '../api/types';
+
+/**
+ * Poll the auth-exempt /v1/ready probe for the cluster health dot.
+ * 200 -> ready, 503 -> notready, fetch failure -> down.
+ */
+export function useHealth(intervalMs = 5000): {
+  state: HealthState;
+  detail?: string;
+} {
+  const [state, setState] = useState<HealthState>('unknown');
+  const [detail, setDetail] = useState<string | undefined>();
+
+  useEffect(() => {
+    let active = true;
+    let timer: number | undefined;
+
+    const tick = async () => {
+      const ctrl = new AbortController();
+      try {
+        const res = await getReady(ctrl.signal);
+        if (!active) return;
+        setState(res.status === 'ready' ? 'ready' : 'notready');
+        setDetail(res.detail);
+      } catch (e) {
+        if (!active || (e instanceof DOMException && e.name === 'AbortError')) return;
+        // 503 comes back as a parsed body via ApiError; a fetch failure is "down".
+        if (e instanceof NetworkError) {
+          setState('down');
+          setDetail(e.message);
+        } else {
+          setState('notready');
+          setDetail(e instanceof Error ? e.message : undefined);
+        }
+      }
+    };
+
+    tick();
+    timer = window.setInterval(tick, intervalMs);
+    return () => {
+      active = false;
+      if (timer) window.clearInterval(timer);
+    };
+  }, [intervalMs]);
+
+  return { state, detail };
+}

--- a/ui/src/hooks/useMetrics.ts
+++ b/ui/src/hooks/useMetrics.ts
@@ -1,0 +1,294 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { getMetricsText } from '../api/endpoints';
+import { ApiError } from '../api/client';
+import {
+  histogramQuantile,
+  parsePrometheus,
+  suffixMatch,
+  type Sample,
+} from '../api/prom';
+import { useApiKey } from '../context/ApiKeyContext';
+import { useSettings } from '../context/SettingsContext';
+
+export interface CollectionMetrics {
+  name: string;
+  size: number;
+  tombstoned: number;
+  searchOps: number;
+  insertOps: number;
+  expired: number;
+  searchQps: number | null;
+  insertQps: number | null;
+  p99SearchSec: number | null;
+  p99InsertSec: number | null;
+}
+
+export interface AggregateMetrics {
+  totalPoints: number;
+  totalTombstoned: number;
+  collectionCount: number;
+  searchQps: number | null;
+  insertQps: number | null;
+  p99SearchSec: number | null;
+  cacheHitRate: number | null;
+  memoryUsedBytes: number | null;
+  memoryAllocatedBytes: number | null;
+}
+
+export interface MetricsSnapshot {
+  collections: CollectionMetrics[];
+  aggregate: AggregateMetrics;
+  at: number;
+}
+
+export interface HistoryPoint {
+  t: number;
+  points: number;
+  searchQps: number;
+  p99SearchMs: number;
+  hitRate: number;
+  memoryMiB: number;
+}
+
+const HISTORY_LEN = 60;
+
+interface RawByCollection {
+  size: number;
+  tombstoned: number;
+  searchOps: number;
+  insertOps: number;
+  expired: number;
+  searchBuckets: { le: number; count: number }[];
+  insertBuckets: { le: number; count: number }[];
+}
+
+function leValue(v: string): number {
+  return v === '+Inf' ? Infinity : Number(v);
+}
+
+// Group samples into per-collection raw counters + histogram buckets, plus a
+// best-effort cache view (the backend may or may not expose cache metrics here).
+function reduceSamples(samples: Sample[]) {
+  const byCol = new Map<string, RawByCollection>();
+  const ensure = (name: string): RawByCollection => {
+    let r = byCol.get(name);
+    if (!r) {
+      r = {
+        size: 0,
+        tombstoned: 0,
+        searchOps: 0,
+        insertOps: 0,
+        expired: 0,
+        searchBuckets: [],
+        insertBuckets: [],
+      };
+      byCol.set(name, r);
+    }
+    return r;
+  };
+
+  let cacheHits: number | null = null;
+  let cacheGets: number | null = null;
+  let bytesUsed: number | null = null;
+  let bytesAllocated: number | null = null;
+
+  for (const s of samples) {
+    const col = s.labels['collection'];
+    const isCache = s.name.includes('cache');
+
+    if (col !== undefined) {
+      const r = ensure(col);
+      if (suffixMatch(s.name, 'size')) r.size = s.value;
+      else if (suffixMatch(s.name, 'tombstoned')) r.tombstoned = s.value;
+      else if (suffixMatch(s.name, 'search_ops_total')) r.searchOps = s.value;
+      else if (suffixMatch(s.name, 'insert_ops_total')) r.insertOps = s.value;
+      else if (suffixMatch(s.name, 'expired_total')) r.expired = s.value;
+      else if (s.name.includes('search_latency_seconds_bucket') && s.labels['le'] !== undefined)
+        r.searchBuckets.push({ le: leValue(s.labels['le']), count: s.value });
+      else if (s.name.includes('insert_latency_seconds_bucket') && s.labels['le'] !== undefined)
+        r.insertBuckets.push({ le: leValue(s.labels['le']), count: s.value });
+    }
+
+    // Best-effort cache metrics (may be absent in the current server).
+    if (isCache) {
+      if (suffixMatch(s.name, 'hits') || suffixMatch(s.name, 'hits_total'))
+        cacheHits = (cacheHits ?? 0) + s.value;
+      else if (suffixMatch(s.name, 'gets') || suffixMatch(s.name, 'gets_total'))
+        cacheGets = (cacheGets ?? 0) + s.value;
+      else if (suffixMatch(s.name, 'bytes_used'))
+        bytesUsed = (bytesUsed ?? 0) + s.value;
+      else if (suffixMatch(s.name, 'bytes_allocated'))
+        bytesAllocated = (bytesAllocated ?? 0) + s.value;
+    }
+  }
+
+  const cacheHitRate =
+    cacheHits !== null && cacheGets !== null && cacheGets > 0
+      ? cacheHits / cacheGets
+      : null;
+
+  return { byCol, cacheHitRate, bytesUsed, bytesAllocated };
+}
+
+export interface UseMetricsResult {
+  snapshot: MetricsSnapshot | null;
+  history: HistoryPoint[];
+  error: Error | null;
+  loading: boolean;
+  paused: boolean;
+  reload: () => void;
+}
+
+/**
+ * Poll /metrics, diff against the previous sample to derive rates (QPS), and
+ * expose parsed per-collection + aggregate values plus a rolling history for
+ * sparklines. Polling pauses while the tab is hidden.
+ */
+export function useMetrics(): UseMetricsResult {
+  const { pollMs } = useSettings();
+  const { reportUnauthorized } = useApiKey();
+  const [snapshot, setSnapshot] = useState<MetricsSnapshot | null>(null);
+  const [history, setHistory] = useState<HistoryPoint[]>([]);
+  const [error, setError] = useState<Error | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [paused, setPaused] = useState(
+    typeof document !== 'undefined' && document.hidden,
+  );
+
+  const prevRef = useRef<{
+    at: number;
+    byCol: Map<string, RawByCollection>;
+  } | null>(null);
+  const [nonce, setNonce] = useState(0);
+  const reload = useCallback(() => setNonce((n) => n + 1), []);
+
+  useEffect(() => {
+    const onVis = () => setPaused(document.hidden);
+    document.addEventListener('visibilitychange', onVis);
+    return () => document.removeEventListener('visibilitychange', onVis);
+  }, []);
+
+  useEffect(() => {
+    if (paused) return;
+    let active = true;
+    let timer: number | undefined;
+    // Hoisted so cleanup can abort an in-flight request, and reused as the
+    // re-entrancy guard: tick() is self-scheduling (setTimeout, not
+    // setInterval) so a slow fetch can never overlap the next one — the next
+    // tick is scheduled only once the current one finishes.
+    let ctrl: AbortController | null = null;
+
+    const tick = async () => {
+      ctrl = new AbortController();
+      try {
+        const text = await getMetricsText(ctrl.signal);
+        if (!active) return;
+        const { samples } = parsePrometheus(text);
+        const { byCol, cacheHitRate, bytesUsed, bytesAllocated } =
+          reduceSamples(samples);
+        const now = Date.now();
+        const prev = prevRef.current;
+        const dt = prev ? (now - prev.at) / 1000 : 0;
+
+        const collections: CollectionMetrics[] = [];
+        let totalPoints = 0;
+        let totalTombstoned = 0;
+        let aggSearchQps: number | null = prev ? 0 : null;
+        let aggInsertQps: number | null = prev ? 0 : null;
+
+        for (const [name, r] of byCol) {
+          totalPoints += r.size;
+          totalTombstoned += r.tombstoned;
+          let searchQps: number | null = null;
+          let insertQps: number | null = null;
+          if (prev && dt > 0) {
+            const p = prev.byCol.get(name);
+            if (p) {
+              searchQps = Math.max(0, (r.searchOps - p.searchOps) / dt);
+              insertQps = Math.max(0, (r.insertOps - p.insertOps) / dt);
+              if (aggSearchQps !== null) aggSearchQps += searchQps;
+              if (aggInsertQps !== null) aggInsertQps += insertQps;
+            }
+          }
+          collections.push({
+            name,
+            size: r.size,
+            tombstoned: r.tombstoned,
+            searchOps: r.searchOps,
+            insertOps: r.insertOps,
+            expired: r.expired,
+            searchQps,
+            insertQps,
+            p99SearchSec: histogramQuantile(r.searchBuckets, 0.99),
+            p99InsertSec: histogramQuantile(r.insertBuckets, 0.99),
+          });
+        }
+        collections.sort((a, b) => b.size - a.size || a.name.localeCompare(b.name));
+
+        // Aggregate p99: fold every collection's search buckets together.
+        const allSearchBuckets = new Map<number, number>();
+        for (const r of byCol.values())
+          for (const b of r.searchBuckets)
+            allSearchBuckets.set(b.le, (allSearchBuckets.get(b.le) ?? 0) + b.count);
+        const aggP99 = histogramQuantile(
+          Array.from(allSearchBuckets, ([le, count]) => ({ le, count })),
+          0.99,
+        );
+
+        const aggregate: AggregateMetrics = {
+          totalPoints,
+          totalTombstoned,
+          collectionCount: byCol.size,
+          searchQps: aggSearchQps,
+          insertQps: aggInsertQps,
+          p99SearchSec: aggP99,
+          cacheHitRate,
+          memoryUsedBytes: bytesUsed,
+          memoryAllocatedBytes: bytesAllocated,
+        };
+
+        setSnapshot({ collections, aggregate, at: now });
+        setError(null);
+        setLoading(false);
+
+        if (prev) {
+          setHistory((h) => {
+            const next = [
+              ...h,
+              {
+                t: now,
+                points: totalPoints,
+                searchQps: aggSearchQps ?? 0,
+                p99SearchMs: (aggP99 ?? 0) * 1000,
+                hitRate: cacheHitRate ?? 0,
+                memoryMiB: (bytesUsed ?? 0) / (1024 * 1024),
+              },
+            ];
+            return next.length > HISTORY_LEN
+              ? next.slice(next.length - HISTORY_LEN)
+              : next;
+          });
+        }
+        prevRef.current = { at: now, byCol };
+      } catch (e) {
+        if (!active || (e instanceof DOMException && e.name === 'AbortError')) return;
+        if (e instanceof ApiError && e.status === 401) reportUnauthorized();
+        setError(e instanceof Error ? e : new Error(String(e)));
+        setLoading(false);
+      } finally {
+        ctrl = null;
+        if (active) timer = window.setTimeout(tick, pollMs);
+      }
+    };
+
+    tick();
+    return () => {
+      active = false;
+      if (timer) window.clearTimeout(timer);
+      ctrl?.abort();
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [pollMs, paused, nonce]);
+
+  return { snapshot, history, error, loading, paused, reload };
+}

--- a/ui/src/index.css
+++ b/ui/src/index.css
@@ -1,0 +1,134 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+/*
+  Rostam Dashboard theme tokens.
+  Dark-mode-first developer tool: a cool near-black slate base with a single
+  warm brand accent (Persian gold) reserved for identity, focus, and active
+  state. Status colors stay semantic (green / amber / red).
+
+  Colors are stored as space-separated RGB channels so Tailwind's alpha
+  modifiers (e.g. bg-brand/10) compose via `rgb(var(--c-x) / <alpha-value>)`.
+  The [data-theme] attribute is stamped by the inline script in index.html
+  before paint, so there is never a flash of the wrong palette.
+*/
+:root,
+:root[data-theme='light'] {
+  --c-surface: 247 248 250;
+  --c-panel: 255 255 255;
+  --c-panel-2: 241 243 246;
+  --c-line: 227 231 236;
+  --c-line-strong: 211 217 224;
+  --c-ink: 25 29 35;
+  --c-muted: 89 97 109;
+  --c-faint: 138 146 158;
+  --c-brand: 183 121 31;
+  --c-brand-soft: 251 241 222;
+  --c-brand-ink: 255 255 255;
+  --c-ok: 26 127 69;
+  --c-warn: 183 121 31;
+  --c-down: 207 47 54;
+  --c-info: 37 99 168;
+  --c-brand-ring: rgba(183, 121, 31, 0.28);
+}
+
+:root[data-theme='dark'] {
+  --c-surface: 10 12 16;
+  --c-panel: 17 20 25;
+  --c-panel-2: 23 27 33;
+  --c-line: 35 42 49;
+  --c-line-strong: 47 56 65;
+  --c-ink: 231 235 241;
+  --c-muted: 139 149 163;
+  --c-faint: 91 102 115;
+  --c-brand: 240 180 41;
+  --c-brand-soft: 42 36 17;
+  --c-brand-ink: 26 20 0;
+  --c-ok: 63 185 80;
+  --c-warn: 210 153 34;
+  --c-down: 248 81 73;
+  --c-info: 88 166 255;
+  --c-brand-ring: rgba(240, 180, 41, 0.32);
+}
+
+* {
+  border-color: rgb(var(--c-line));
+}
+
+html,
+body,
+#root {
+  height: 100%;
+}
+
+body {
+  margin: 0;
+  background: rgb(var(--c-surface));
+  color: rgb(var(--c-ink));
+  font-family: theme('fontFamily.sans');
+  -webkit-font-smoothing: antialiased;
+  text-rendering: optimizeLegibility;
+}
+
+@layer base {
+  :focus-visible {
+    outline: none;
+    box-shadow:
+      0 0 0 2px rgb(var(--c-surface)),
+      0 0 0 4px var(--c-brand-ring);
+    border-radius: 4px;
+  }
+}
+
+@layer components {
+  .card {
+    @apply rounded-xl border border-line bg-panel shadow-card;
+  }
+
+  .input {
+    @apply w-full rounded-lg border border-line bg-panel-2 px-3 py-2 text-sm text-ink
+      placeholder:text-faint transition-colors focus:border-brand focus:bg-panel;
+  }
+
+  .btn {
+    @apply inline-flex select-none items-center justify-center gap-1.5 rounded-lg
+      px-3 py-2 text-sm font-medium transition-all active:scale-[0.98]
+      disabled:pointer-events-none disabled:opacity-50;
+  }
+
+  .btn-primary {
+    @apply btn bg-brand text-brand-ink hover:brightness-110;
+  }
+
+  .btn-ghost {
+    @apply btn border border-line bg-panel text-ink hover:bg-panel-2;
+  }
+
+  .btn-danger {
+    @apply btn border border-down/40 bg-transparent text-down hover:bg-down/10;
+  }
+
+  .chip {
+    @apply inline-flex items-center gap-1 rounded-md border border-line bg-panel-2
+      px-1.5 py-0.5 font-mono text-2xs text-muted;
+  }
+}
+
+/* Thin, unobtrusive scrollbars that match the theme. */
+* {
+  scrollbar-width: thin;
+  scrollbar-color: rgb(var(--c-line-strong)) transparent;
+}
+*::-webkit-scrollbar {
+  width: 10px;
+  height: 10px;
+}
+*::-webkit-scrollbar-thumb {
+  background: rgb(var(--c-line-strong));
+  border-radius: 9999px;
+  border: 2px solid rgb(var(--c-surface));
+}
+*::-webkit-scrollbar-thumb:hover {
+  background: rgb(var(--c-faint));
+}

--- a/ui/src/lib/encoding.ts
+++ b/ui/src/lib/encoding.ts
@@ -1,0 +1,58 @@
+// Base64 / UTF-8 / hex conversions for the KV value viewer. All are tolerant:
+// they return null rather than throwing on invalid input.
+
+export function base64ToBytes(b64: string): Uint8Array | null {
+  try {
+    const bin = atob(b64);
+    const out = new Uint8Array(bin.length);
+    for (let i = 0; i < bin.length; i++) out[i] = bin.charCodeAt(i);
+    return out;
+  } catch {
+    return null;
+  }
+}
+
+export function bytesToBase64(bytes: Uint8Array): string {
+  let bin = '';
+  for (let i = 0; i < bytes.length; i++) bin += String.fromCharCode(bytes[i]);
+  return btoa(bin);
+}
+
+export function utf8ToBytes(s: string): Uint8Array {
+  return new TextEncoder().encode(s);
+}
+
+/** Decode bytes as UTF-8, returning null if the bytes are not valid UTF-8. */
+export function bytesToUtf8(bytes: Uint8Array): string | null {
+  try {
+    return new TextDecoder('utf-8', { fatal: true }).decode(bytes);
+  } catch {
+    return null;
+  }
+}
+
+export function bytesToHex(bytes: Uint8Array): string {
+  let out = '';
+  for (let i = 0; i < bytes.length; i++) {
+    out += bytes[i].toString(16).padStart(2, '0');
+    if (i < bytes.length - 1) out += i % 2 === 1 ? ' ' : '';
+  }
+  return out;
+}
+
+/** A canonical hex dump (offset | hex | ascii), 16 bytes per row. */
+export function hexDump(bytes: Uint8Array): string {
+  const rows: string[] = [];
+  for (let off = 0; off < bytes.length; off += 16) {
+    const slice = bytes.subarray(off, off + 16);
+    const hex = Array.from(slice)
+      .map((b) => b.toString(16).padStart(2, '0'))
+      .join(' ')
+      .padEnd(16 * 3 - 1, ' ');
+    const ascii = Array.from(slice)
+      .map((b) => (b >= 0x20 && b < 0x7f ? String.fromCharCode(b) : '.'))
+      .join('');
+    rows.push(`${off.toString(16).padStart(8, '0')}  ${hex}  ${ascii}`);
+  }
+  return rows.join('\n');
+}

--- a/ui/src/lib/format.ts
+++ b/ui/src/lib/format.ts
@@ -1,0 +1,60 @@
+// Small formatting helpers for metric numbers, bytes, durations, and latency.
+
+export function formatNumber(n: number | undefined | null): string {
+  if (n === undefined || n === null || Number.isNaN(n)) return '—';
+  if (!Number.isFinite(n)) return '∞';
+  if (Math.abs(n) >= 1_000_000_000)
+    return (n / 1_000_000_000).toFixed(n % 1_000_000_000 === 0 ? 0 : 1) + 'B';
+  if (Math.abs(n) >= 1_000_000)
+    return (n / 1_000_000).toFixed(n % 1_000_000 === 0 ? 0 : 1) + 'M';
+  if (Math.abs(n) >= 10_000) return (n / 1_000).toFixed(1) + 'k';
+  return n.toLocaleString();
+}
+
+export function formatInt(n: number | undefined | null): string {
+  if (n === undefined || n === null || Number.isNaN(n)) return '—';
+  return Math.round(n).toLocaleString();
+}
+
+export function formatBytes(bytes: number | undefined | null): string {
+  if (bytes === undefined || bytes === null || Number.isNaN(bytes)) return '—';
+  if (bytes === 0) return '0 B';
+  const units = ['B', 'KiB', 'MiB', 'GiB', 'TiB'];
+  const i = Math.min(
+    units.length - 1,
+    Math.floor(Math.log(Math.abs(bytes)) / Math.log(1024)),
+  );
+  const v = bytes / Math.pow(1024, i);
+  return `${v.toFixed(i === 0 ? 0 : v >= 100 ? 0 : 1)} ${units[i]}`;
+}
+
+export function formatPercent(frac: number | undefined | null, digits = 1): string {
+  if (frac === undefined || frac === null || Number.isNaN(frac)) return '—';
+  return `${(frac * 100).toFixed(digits)}%`;
+}
+
+/** Format a latency given in SECONDS as a human ms/µs/s string. */
+export function formatLatency(seconds: number | undefined | null): string {
+  if (seconds === undefined || seconds === null || Number.isNaN(seconds)) return '—';
+  if (seconds === 0) return '0';
+  const ms = seconds * 1000;
+  if (ms < 1) return `${(ms * 1000).toFixed(0)} µs`;
+  if (ms < 100) return `${ms.toFixed(2)} ms`;
+  if (ms < 1000) return `${ms.toFixed(0)} ms`;
+  return `${seconds.toFixed(2)} s`;
+}
+
+export function formatTtl(ms: number | undefined | null): string {
+  if (ms === undefined || ms === null) return 'no expiry';
+  if (ms < 0) return 'no expiry';
+  if (ms < 1000) return `${ms} ms`;
+  const s = ms / 1000;
+  if (s < 60) return `${s.toFixed(1)} s`;
+  if (s < 3600) return `${Math.floor(s / 60)}m ${Math.round(s % 60)}s`;
+  if (s < 86400) return `${Math.floor(s / 3600)}h ${Math.floor((s % 3600) / 60)}m`;
+  return `${Math.floor(s / 86400)}d ${Math.floor((s % 86400) / 3600)}h`;
+}
+
+export function classNames(...parts: (string | false | null | undefined)[]): string {
+  return parts.filter(Boolean).join(' ');
+}

--- a/ui/src/main.tsx
+++ b/ui/src/main.tsx
@@ -1,0 +1,25 @@
+import { StrictMode } from 'react';
+import { createRoot } from 'react-dom/client';
+import { HashRouter } from 'react-router-dom';
+import App from './App';
+import { ThemeProvider } from './context/ThemeContext';
+import { ApiKeyProvider } from './context/ApiKeyContext';
+import { SettingsProvider } from './context/SettingsContext';
+import './index.css';
+
+// HashRouter keeps client-side routing working under the /dashboard/ prefix
+// without any server-side rewrite — the maintainer only has to serve index.html
+// at one path.
+createRoot(document.getElementById('root')!).render(
+  <StrictMode>
+    <ThemeProvider>
+      <SettingsProvider>
+        <ApiKeyProvider>
+          <HashRouter>
+            <App />
+          </HashRouter>
+        </ApiKeyProvider>
+      </SettingsProvider>
+    </ThemeProvider>
+  </StrictMode>,
+);

--- a/ui/src/pages/Admin.tsx
+++ b/ui/src/pages/Admin.tsx
@@ -1,0 +1,117 @@
+import { useState } from 'react';
+import { Archive, DatabaseBackup, HardDriveDownload, RefreshCw } from 'lucide-react';
+import { PageHeader } from '../components/Layout';
+import { Card, SectionTitle } from '../components/primitives';
+import { EmptyState, ErrorCard } from '../components/StateView';
+import { JsonView } from '../components/JsonView';
+import { useAsync } from '../hooks/useAsync';
+import { listBackups, triggerBackup } from '../api/endpoints';
+import { ApiError } from '../api/client';
+import type { BackupsResponse } from '../api/types';
+
+export function Admin() {
+  const backups = useAsync<BackupsResponse>((s) => listBackups(s), []);
+  const [running, setRunning] = useState(false);
+  const [message, setMessage] = useState<{ tone: 'ok' | 'down'; text: string } | null>(null);
+
+  const unavailable = backups.error instanceof ApiError && backups.error.isUnavailable;
+
+  const runBackup = async () => {
+    setRunning(true);
+    setMessage(null);
+    try {
+      const res = await triggerBackup();
+      setMessage(
+        res.error
+          ? { tone: 'down', text: `Backup completed with errors: ${res.error}` }
+          : { tone: 'ok', text: 'Backup triggered successfully.' },
+      );
+      backups.reload();
+    } catch (e) {
+      const text =
+        e instanceof ApiError && e.isUnavailable
+          ? 'Object storage is not configured on this server.'
+          : e instanceof Error
+            ? e.message
+            : 'Backup failed.';
+      setMessage({ tone: 'down', text });
+    } finally {
+      setRunning(false);
+    }
+  };
+
+  const items = backups.data?.backups ?? [];
+
+  return (
+    <div className="animate-fade-in">
+      <PageHeader
+        title="Admin"
+        description="Object-storage backups and disaster-recovery snapshots."
+        actions={
+          <button type="button" className="btn-ghost" onClick={() => backups.reload()} aria-label="Refresh">
+            <RefreshCw size={14} />
+          </button>
+        }
+      />
+
+      <div className="grid grid-cols-1 gap-5 lg:grid-cols-3">
+        <Card className="p-4 lg:col-span-1">
+          <SectionTitle title="Trigger backup" subtitle="Snapshot every collection to object storage." />
+          <div className="mt-4 flex flex-col items-center gap-3 rounded-lg border border-dashed border-line bg-panel-2/40 px-4 py-6 text-center">
+            <div className="rounded-xl bg-brand/10 p-3 text-brand">
+              <DatabaseBackup size={22} />
+            </div>
+            <button type="button" className="btn-primary" onClick={runBackup} disabled={running}>
+              <HardDriveDownload size={15} />
+              {running ? 'Backing up…' : 'Back up now'}
+            </button>
+          </div>
+          {message && (
+            <p
+              className={
+                'mt-3 rounded-lg border px-3 py-2 text-xs ' +
+                (message.tone === 'ok'
+                  ? 'border-ok/30 bg-ok/10 text-ok'
+                  : 'border-down/30 bg-down/10 text-down')
+              }
+            >
+              {message.text}
+            </p>
+          )}
+        </Card>
+
+        <Card className="p-4 lg:col-span-2">
+          <SectionTitle
+            title="Backups"
+            subtitle="Snapshot objects under the configured tenant prefix."
+          />
+          <div className="mt-4">
+            {backups.error ? (
+              unavailable ? (
+                <EmptyState
+                  icon={<Archive size={20} />}
+                  title="Backups not configured"
+                  hint="This server has no object-storage backend configured, so backup and restore are unavailable."
+                />
+              ) : backups.loading ? null : (
+                <ErrorCard error={backups.error} onRetry={backups.reload} />
+              )
+            ) : !backups.data ? (
+              <div className="h-24 animate-pulse rounded-lg bg-panel-2" />
+            ) : items.length === 0 ? (
+              <EmptyState
+                icon={<Archive size={20} />}
+                title="No backups yet"
+                hint="Trigger a backup to create the first snapshot."
+              />
+            ) : (
+              <div className="overflow-x-auto rounded-lg border border-line bg-panel-2/40 p-3">
+                <JsonView data={items} initialCollapsed />
+              </div>
+            )}
+          </div>
+        </Card>
+      </div>
+    </div>
+  );
+}

--- a/ui/src/pages/Collections.tsx
+++ b/ui/src/pages/Collections.tsx
@@ -104,6 +104,14 @@ export function Collections() {
                   <tr
                     key={r.name}
                     onClick={() => setSelected(r.name)}
+                    role="button"
+                    tabIndex={0}
+                    onKeyDown={(e) => {
+                      if (e.key === 'Enter' || e.key === ' ') {
+                        if (e.key === ' ') e.preventDefault();
+                        setSelected(r.name);
+                      }
+                    }}
                     className="group cursor-pointer border-b border-line/50 transition-colors last:border-0 hover:bg-panel-2/50"
                   >
                     <td className="px-4 py-3">

--- a/ui/src/pages/Collections.tsx
+++ b/ui/src/pages/Collections.tsx
@@ -1,0 +1,154 @@
+import { useMemo, useState } from 'react';
+import { Boxes, ChevronRight, Plus, RefreshCw } from 'lucide-react';
+import { PageHeader } from '../components/Layout';
+import { Card } from '../components/primitives';
+import { EmptyState, ErrorCard, LoadingRows } from '../components/StateView';
+import { CreateCollectionForm } from '../components/CreateCollectionForm';
+import { CollectionDetail } from '../components/CollectionDetail';
+import { useAsync } from '../hooks/useAsync';
+import { useMetrics, type CollectionMetrics } from '../hooks/useMetrics';
+import { listCollections } from '../api/endpoints';
+import { ApiError } from '../api/client';
+import { formatInt, formatLatency, formatNumber } from '../lib/format';
+import type { CollectionListResponse } from '../api/types';
+
+interface Row {
+  name: string;
+  metrics?: CollectionMetrics;
+}
+
+export function Collections() {
+  const list = useAsync<CollectionListResponse>((s) => listCollections(s), []);
+  const { snapshot } = useMetrics();
+  const [createOpen, setCreateOpen] = useState(false);
+  const [selected, setSelected] = useState<string | null>(null);
+
+  const metricsByName = useMemo(() => {
+    const map = new Map<string, CollectionMetrics>();
+    snapshot?.collections.forEach((c) => map.set(c.name, c));
+    return map;
+  }, [snapshot]);
+
+  // Prefer the explicit collections list; fall back to names seen in /metrics
+  // when that endpoint is unavailable on this build.
+  const listUnavailable = list.error instanceof ApiError && list.error.isUnavailable;
+  const rows: Row[] = useMemo(() => {
+    const names = new Set<string>();
+    list.data?.collections?.forEach((c) => names.add(c.name));
+    if (listUnavailable || (!list.data && snapshot))
+      snapshot?.collections.forEach((c) => names.add(c.name));
+    return Array.from(names)
+      .sort((a, b) => a.localeCompare(b))
+      .map((name) => ({ name, metrics: metricsByName.get(name) }));
+  }, [list.data, listUnavailable, snapshot, metricsByName]);
+
+  const refresh = () => list.reload();
+
+  return (
+    <div className="animate-fade-in">
+      <PageHeader
+        title="Collections"
+        description="Vector collections on this server, with live throughput."
+        actions={
+          <>
+            <button type="button" className="btn-ghost" onClick={refresh} aria-label="Refresh">
+              <RefreshCw size={14} />
+            </button>
+            <button type="button" className="btn-primary" onClick={() => setCreateOpen(true)}>
+              <Plus size={15} /> Create collection
+            </button>
+          </>
+        }
+      />
+
+      {listUnavailable && (
+        <p className="mb-4 rounded-lg border border-line bg-panel-2 px-3 py-2 text-xs text-muted">
+          The collection list endpoint is not available on this build — showing
+          collections discovered from <span className="font-mono">/metrics</span> instead.
+        </p>
+      )}
+
+      {list.error && !listUnavailable && !list.data ? (
+        <ErrorCard error={list.error} onRetry={refresh} title="Could not list collections" />
+      ) : list.loading && !list.data && rows.length === 0 ? (
+        <Card className="p-4">
+          <LoadingRows rows={5} />
+        </Card>
+      ) : rows.length === 0 ? (
+        <EmptyState
+          icon={<Boxes size={22} />}
+          title="No collections yet"
+          hint="Create your first vector collection to start indexing embeddings."
+          action={
+            <button type="button" className="btn-primary" onClick={() => setCreateOpen(true)}>
+              <Plus size={15} /> Create collection
+            </button>
+          }
+        />
+      ) : (
+        <Card className="overflow-hidden">
+          <div className="overflow-x-auto">
+            <table className="w-full text-left text-sm">
+              <thead>
+                <tr className="border-b border-line text-2xs uppercase tracking-wide text-faint">
+                  <th className="px-4 py-2.5 font-medium">Collection</th>
+                  <th className="px-4 py-2.5 text-right font-medium">Points</th>
+                  <th className="px-4 py-2.5 text-right font-medium">Tombstoned</th>
+                  <th className="px-4 py-2.5 text-right font-medium">Search QPS</th>
+                  <th className="px-4 py-2.5 text-right font-medium">p99 search</th>
+                  <th className="w-8 px-4 py-2.5" />
+                </tr>
+              </thead>
+              <tbody>
+                {rows.map((r) => (
+                  <tr
+                    key={r.name}
+                    onClick={() => setSelected(r.name)}
+                    className="group cursor-pointer border-b border-line/50 transition-colors last:border-0 hover:bg-panel-2/50"
+                  >
+                    <td className="px-4 py-3">
+                      <span className="font-mono text-ink">{r.name}</span>
+                    </td>
+                    <td className="px-4 py-3 text-right font-mono text-ink tabular-nums">
+                      {formatNumber(r.metrics?.size)}
+                    </td>
+                    <td className="px-4 py-3 text-right font-mono text-muted tabular-nums">
+                      {formatInt(r.metrics?.tombstoned)}
+                    </td>
+                    <td className="px-4 py-3 text-right font-mono text-muted tabular-nums">
+                      {r.metrics?.searchQps == null ? '—' : formatNumber(r.metrics.searchQps)}
+                    </td>
+                    <td className="px-4 py-3 text-right font-mono text-muted tabular-nums">
+                      {formatLatency(r.metrics?.p99SearchSec)}
+                    </td>
+                    <td className="px-4 py-3 text-right">
+                      <ChevronRight
+                        size={15}
+                        className="text-faint transition-transform group-hover:translate-x-0.5 group-hover:text-muted"
+                      />
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </Card>
+      )}
+
+      <CreateCollectionForm
+        open={createOpen}
+        onClose={() => setCreateOpen(false)}
+        onCreated={() => refresh()}
+      />
+
+      {selected && (
+        <CollectionDetail
+          name={selected}
+          metrics={metricsByName.get(selected)}
+          onClose={() => setSelected(null)}
+          onChanged={refresh}
+        />
+      )}
+    </div>
+  );
+}

--- a/ui/src/pages/KV.tsx
+++ b/ui/src/pages/KV.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useRef, useState } from 'react';
 import { Clock, Database, Info, Save, Search, Trash2 } from 'lucide-react';
 import { PageHeader } from '../components/Layout';
 import { Card, Badge, CopyButton } from '../components/primitives';
@@ -21,16 +21,23 @@ export function KVPage() {
   const [view, setView] = useState<ValueView>('utf8');
   const [putOpen, setPutOpen] = useState(false);
   const [deleteOpen, setDeleteOpen] = useState(false);
+  // Tracks the most recently requested key, so a response from an older,
+  // slower lookup (e.g. "a" resolving after a newer lookup for "b" already
+  // started) can be told apart from the current one and discarded instead of
+  // being rendered as — or acted on as — the wrong key's data.
+  const latestKeyRef = useRef<string | null>(null);
 
   const doGet = async (k = key) => {
     const trimmed = k.trim();
     if (!trimmed) return;
+    latestKeyRef.current = trimmed;
     setLoading(true);
     setError(null);
     setResult(null);
     setNotFoundKey(null);
     try {
       const res = await kvGet(trimmed);
+      if (latestKeyRef.current !== trimmed) return;
       if (res.found) {
         setResult(res);
         setView(res.value_utf8 != null ? 'utf8' : 'base64');
@@ -38,9 +45,10 @@ export function KVPage() {
         setNotFoundKey(trimmed);
       }
     } catch (e) {
+      if (latestKeyRef.current !== trimmed) return;
       setError(e instanceof ApiError ? e.message : e instanceof Error ? e.message : 'Lookup failed.');
     } finally {
-      setLoading(false);
+      if (latestKeyRef.current === trimmed) setLoading(false);
     }
   };
 

--- a/ui/src/pages/KV.tsx
+++ b/ui/src/pages/KV.tsx
@@ -1,0 +1,383 @@
+import { useState } from 'react';
+import { Clock, Database, Info, Save, Search, Trash2 } from 'lucide-react';
+import { PageHeader } from '../components/Layout';
+import { Card, Badge, CopyButton } from '../components/primitives';
+import { EmptyState } from '../components/StateView';
+import { Modal } from '../components/Modal';
+import { kvDelete, kvGet, kvPut } from '../api/endpoints';
+import { ApiError } from '../api/client';
+import { base64ToBytes, hexDump, utf8ToBytes } from '../lib/encoding';
+import { classNames, formatTtl } from '../lib/format';
+import type { KvGetResponse } from '../api/types';
+
+type ValueView = 'utf8' | 'base64' | 'hex';
+
+export function KVPage() {
+  const [key, setKey] = useState('');
+  const [loading, setLoading] = useState(false);
+  const [result, setResult] = useState<KvGetResponse | null>(null);
+  const [notFoundKey, setNotFoundKey] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [view, setView] = useState<ValueView>('utf8');
+  const [putOpen, setPutOpen] = useState(false);
+  const [deleteOpen, setDeleteOpen] = useState(false);
+
+  const doGet = async (k = key) => {
+    const trimmed = k.trim();
+    if (!trimmed) return;
+    setLoading(true);
+    setError(null);
+    setResult(null);
+    setNotFoundKey(null);
+    try {
+      const res = await kvGet(trimmed);
+      if (res.found) {
+        setResult(res);
+        setView(res.value_utf8 != null ? 'utf8' : 'base64');
+      } else {
+        setNotFoundKey(trimmed);
+      }
+    } catch (e) {
+      setError(e instanceof ApiError ? e.message : e instanceof Error ? e.message : 'Lookup failed.');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const bytes = result?.value_b64 ? base64ToBytes(result.value_b64) : null;
+
+  return (
+    <div className="animate-fade-in">
+      <PageHeader
+        title="Key-Value"
+        description="Inspect and operate on individual keys in the KV store."
+      />
+
+      <div className="mb-4 flex items-start gap-2 rounded-lg border border-line bg-panel-2/60 px-3 py-2.5 text-xs text-muted">
+        <Info size={14} className="mt-0.5 shrink-0 text-faint" />
+        <span>
+          The KV store has no key listing or scan — you can only operate on a key you
+          name. Browsing all keys is not available yet.
+        </span>
+      </div>
+
+      {/* Key bar */}
+      <Card className="p-4">
+        <div className="flex flex-col gap-3 sm:flex-row sm:items-end">
+          <div className="flex-1">
+            <span className="mb-1 block text-xs font-medium text-muted">Key</span>
+            <div className="relative">
+              <Database
+                size={14}
+                className="pointer-events-none absolute left-2.5 top-1/2 -translate-y-1/2 text-faint"
+              />
+              <input
+                className="input pl-8 font-mono"
+                placeholder="session:abc123"
+                value={key}
+                onChange={(e) => setKey(e.target.value)}
+                onKeyDown={(e) => e.key === 'Enter' && doGet()}
+                spellCheck={false}
+              />
+            </div>
+          </div>
+          <div className="flex gap-2">
+            <button type="button" className="btn-primary" onClick={() => doGet()} disabled={loading || !key.trim()}>
+              <Search size={14} /> {loading ? 'Loading…' : 'Get'}
+            </button>
+            <button
+              type="button"
+              className="btn-ghost"
+              onClick={() => setPutOpen(true)}
+              disabled={!key.trim()}
+            >
+              <Save size={14} /> Set
+            </button>
+            <button
+              type="button"
+              className="btn-danger"
+              onClick={() => setDeleteOpen(true)}
+              disabled={!key.trim()}
+              aria-label="Delete key"
+            >
+              <Trash2 size={14} />
+            </button>
+          </div>
+        </div>
+
+        {error && (
+          <p className="mt-3 rounded-lg border border-down/30 bg-down/10 px-3 py-2 font-mono text-xs text-down">
+            {error}
+          </p>
+        )}
+      </Card>
+
+      {/* Result */}
+      <div className="mt-4">
+        {notFoundKey ? (
+          <EmptyState
+            icon={<Database size={20} />}
+            title="Key not found"
+            hint={`No value is stored at "${notFoundKey}".`}
+          />
+        ) : result ? (
+          <Card className="p-4">
+            <div className="mb-3 flex flex-wrap items-center justify-between gap-2">
+              <div className="flex items-center gap-2">
+                <span className="font-mono text-sm text-ink">{key.trim()}</span>
+                <Badge tone="ok">found</Badge>
+              </div>
+              <div className="flex items-center gap-2 text-xs text-muted">
+                <Clock size={13} className="text-faint" />
+                {formatTtl(result.ttl_ms)}
+              </div>
+            </div>
+
+            <div className="mb-2 flex items-center justify-between">
+              <div className="inline-flex gap-1 rounded-lg border border-line bg-panel-2 p-0.5">
+                {(['utf8', 'base64', 'hex'] as ValueView[]).map((v) => {
+                  const disabled = v === 'utf8' && result.value_utf8 == null;
+                  return (
+                    <button
+                      key={v}
+                      type="button"
+                      disabled={disabled}
+                      onClick={() => setView(v)}
+                      className={classNames(
+                        'rounded-md px-2.5 py-1 text-2xs font-medium transition-colors',
+                        view === v ? 'bg-panel text-ink shadow-sm' : 'text-muted hover:text-ink',
+                        disabled && 'cursor-not-allowed opacity-40',
+                      )}
+                    >
+                      {v === 'utf8' ? 'UTF-8' : v === 'base64' ? 'Base64' : 'Hex'}
+                    </button>
+                  );
+                })}
+              </div>
+              <CopyButton
+                value={currentText(view, result, bytes)}
+                label="Copy"
+              />
+            </div>
+
+            <pre className="max-h-96 overflow-auto rounded-lg border border-line bg-panel-2/60 p-3 font-mono text-xs text-ink">
+              {currentText(view, result, bytes)}
+            </pre>
+
+            {bytes && (
+              <p className="mt-2 text-2xs text-faint">{bytes.length} bytes</p>
+            )}
+          </Card>
+        ) : (
+          <EmptyState
+            icon={<Search size={20} />}
+            title="Look up a key"
+            hint="Enter a key and hit Get to inspect its value, encoding, and TTL."
+          />
+        )}
+      </div>
+
+      <PutModal
+        open={putOpen}
+        keyName={key.trim()}
+        onClose={() => setPutOpen(false)}
+        onDone={() => {
+          setPutOpen(false);
+          doGet();
+        }}
+      />
+
+      <DeleteModal
+        open={deleteOpen}
+        keyName={key.trim()}
+        onClose={() => setDeleteOpen(false)}
+        onDone={() => {
+          setDeleteOpen(false);
+          setResult(null);
+          setNotFoundKey(key.trim());
+        }}
+      />
+    </div>
+  );
+}
+
+function currentText(view: ValueView, res: KvGetResponse, bytes: Uint8Array | null): string {
+  if (view === 'utf8') return res.value_utf8 ?? '(not valid UTF-8)';
+  if (view === 'base64') return res.value_b64 ?? '';
+  if (!bytes) return '';
+  return hexDump(bytes);
+}
+
+// --- Set modal ---------------------------------------------------------------
+
+function PutModal({
+  open,
+  keyName,
+  onClose,
+  onDone,
+}: {
+  open: boolean;
+  keyName: string;
+  onClose: () => void;
+  onDone: () => void;
+}) {
+  const [encoding, setEncoding] = useState<'utf8' | 'base64'>('utf8');
+  const [value, setValue] = useState('');
+  const [ttl, setTtl] = useState('');
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const submit = async () => {
+    setError(null);
+    if (encoding === 'base64' && base64ToBytes(value) === null)
+      return setError('Value is not valid base64.');
+
+    setBusy(true);
+    try {
+      const body: { value?: string; value_b64?: string; ttl_ms?: number } =
+        encoding === 'utf8' ? { value } : { value_b64: value };
+      if (ttl.trim()) body.ttl_ms = Number(ttl);
+      await kvPut(keyName, body);
+      setBusy(false);
+      setValue('');
+      setTtl('');
+      onDone();
+    } catch (e) {
+      setBusy(false);
+      setError(e instanceof Error ? e.message : 'Set failed.');
+    }
+  };
+
+  const byteLen =
+    encoding === 'utf8'
+      ? utf8ToBytes(value).length
+      : base64ToBytes(value)?.length ?? 0;
+
+  return (
+    <Modal
+      open={open}
+      onClose={() => !busy && onClose()}
+      title="Set value"
+      footer={
+        <>
+          <button type="button" className="btn-ghost" onClick={onClose} disabled={busy}>
+            Cancel
+          </button>
+          <button type="button" className="btn-primary" onClick={submit} disabled={busy || !keyName}>
+            {busy ? 'Saving…' : 'Save'}
+          </button>
+        </>
+      }
+    >
+      <div className="space-y-3">
+        <div className="flex items-center gap-2">
+          <span className="text-xs text-muted">key</span>
+          <Badge tone="brand" mono>
+            {keyName || '(none)'}
+          </Badge>
+        </div>
+
+        <div className="inline-flex gap-1 rounded-lg border border-line bg-panel-2 p-0.5">
+          {(['utf8', 'base64'] as const).map((e) => (
+            <button
+              key={e}
+              type="button"
+              onClick={() => setEncoding(e)}
+              className={classNames(
+                'rounded-md px-2.5 py-1 text-2xs font-medium transition-colors',
+                encoding === e ? 'bg-panel text-ink shadow-sm' : 'text-muted hover:text-ink',
+              )}
+            >
+              {e === 'utf8' ? 'UTF-8' : 'Base64'}
+            </button>
+          ))}
+        </div>
+
+        <textarea
+          className="input h-28 resize-y font-mono text-xs"
+          placeholder={encoding === 'utf8' ? 'value text…' : 'base64…'}
+          value={value}
+          onChange={(e) => setValue(e.target.value)}
+          spellCheck={false}
+        />
+        <div className="flex items-center justify-between">
+          <label className="flex items-center gap-2 text-xs text-muted">
+            TTL (ms)
+            <input
+              className="input w-32 font-mono"
+              inputMode="numeric"
+              placeholder="none"
+              value={ttl}
+              onChange={(e) => setTtl(e.target.value.replace(/[^\d]/g, ''))}
+            />
+          </label>
+          <span className="font-mono text-2xs text-faint">{byteLen} bytes</span>
+        </div>
+
+        {error && (
+          <p className="rounded-lg border border-down/30 bg-down/10 px-3 py-2 font-mono text-xs text-down">
+            {error}
+          </p>
+        )}
+      </div>
+    </Modal>
+  );
+}
+
+// --- Delete modal ------------------------------------------------------------
+
+function DeleteModal({
+  open,
+  keyName,
+  onClose,
+  onDone,
+}: {
+  open: boolean;
+  keyName: string;
+  onClose: () => void;
+  onDone: () => void;
+}) {
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const submit = async () => {
+    setBusy(true);
+    setError(null);
+    try {
+      await kvDelete(keyName);
+      setBusy(false);
+      onDone();
+    } catch (e) {
+      setBusy(false);
+      setError(e instanceof Error ? e.message : 'Delete failed.');
+    }
+  };
+
+  return (
+    <Modal
+      open={open}
+      onClose={() => !busy && onClose()}
+      title="Delete key"
+      footer={
+        <>
+          <button type="button" className="btn-ghost" onClick={onClose} disabled={busy}>
+            Cancel
+          </button>
+          <button type="button" className="btn-danger" onClick={submit} disabled={busy}>
+            {busy ? 'Deleting…' : 'Delete'}
+          </button>
+        </>
+      }
+    >
+      <p className="text-sm text-muted">
+        Delete the key <span className="font-mono text-ink">{keyName}</span>? This
+        cannot be undone.
+      </p>
+      {error && (
+        <p className="mt-3 rounded-lg border border-down/30 bg-down/10 px-3 py-2 font-mono text-xs text-down">
+          {error}
+        </p>
+      )}
+    </Modal>
+  );
+}

--- a/ui/src/pages/Overview.tsx
+++ b/ui/src/pages/Overview.tsx
@@ -1,0 +1,322 @@
+import {
+  Activity,
+  Boxes,
+  Crown,
+  Database,
+  Gauge,
+  HardDrive,
+  Layers,
+  Timer,
+  Zap,
+} from 'lucide-react';
+import { PageHeader } from '../components/Layout';
+import { StatCard } from '../components/StatCard';
+import { Card, SectionTitle, Badge } from '../components/primitives';
+import { EmptyState, ErrorCard } from '../components/StateView';
+import { HealthDot } from '../components/HealthDot';
+import { useMetrics, type HistoryPoint } from '../hooks/useMetrics';
+import { useHealth } from '../hooks/useHealth';
+import { useAsync } from '../hooks/useAsync';
+import { getReplication, getTopology } from '../api/endpoints';
+import { ApiError } from '../api/client';
+import {
+  formatBytes,
+  formatInt,
+  formatLatency,
+  formatNumber,
+  formatPercent,
+} from '../lib/format';
+import type { ReplicationResponse, TopologyResponse } from '../api/types';
+
+const pick = (h: HistoryPoint[], key: keyof HistoryPoint) =>
+  h.map((p) => Number(p[key]) || 0);
+
+export function Overview() {
+  const { snapshot, history, error } = useMetrics();
+  const { state, detail } = useHealth();
+  const agg = snapshot?.aggregate;
+
+  const topo = useAsync<TopologyResponse>((s) => getTopology(s), []);
+  const repl = useAsync<ReplicationResponse>((s) => getReplication(s), []);
+
+  return (
+    <div className="animate-fade-in">
+      <PageHeader
+        title="Overview"
+        description="Live cluster health, throughput, and shard placement."
+        actions={
+          <div className="flex items-center gap-2 rounded-lg border border-line bg-panel px-3 py-2">
+            <HealthDot state={state} detail={detail} />
+          </div>
+        }
+      />
+
+      {error && !snapshot && (
+        <div className="mb-5">
+          <ErrorCard error={error} title="Could not load /metrics" />
+        </div>
+      )}
+
+      <div className="grid grid-cols-2 gap-3 lg:grid-cols-3 xl:grid-cols-6">
+        <StatCard
+          label="Points"
+          icon={<Layers size={13} />}
+          value={formatNumber(agg?.totalPoints)}
+          series={pick(history, 'points')}
+          loading={!snapshot}
+          hint={agg ? `${formatInt(agg.totalTombstoned)} tombstoned` : undefined}
+        />
+        <StatCard
+          label="Collections"
+          icon={<Boxes size={13} />}
+          value={formatInt(agg?.collectionCount)}
+          loading={!snapshot}
+        />
+        <StatCard
+          label="Search QPS"
+          icon={<Zap size={13} />}
+          value={agg?.searchQps == null ? '—' : formatNumber(agg.searchQps)}
+          series={pick(history, 'searchQps')}
+          color="rgb(var(--c-info))"
+          loading={!snapshot}
+          hint={agg?.insertQps != null ? `${formatNumber(agg.insertQps)} insert/s` : undefined}
+        />
+        <StatCard
+          label="p99 search"
+          icon={<Timer size={13} />}
+          value={formatLatency(agg?.p99SearchSec)}
+          series={pick(history, 'p99SearchMs')}
+          color="rgb(var(--c-warn))"
+          loading={!snapshot}
+        />
+        <StatCard
+          label="Cache hit rate"
+          icon={<Gauge size={13} />}
+          value={agg?.cacheHitRate == null ? 'n/a' : formatPercent(agg.cacheHitRate)}
+          series={agg?.cacheHitRate == null ? undefined : pick(history, 'hitRate')}
+          color="rgb(var(--c-ok))"
+          loading={!snapshot}
+          hint={agg?.cacheHitRate == null ? 'not exposed' : undefined}
+        />
+        <StatCard
+          label="Memory used"
+          icon={<HardDrive size={13} />}
+          value={agg?.memoryUsedBytes == null ? 'n/a' : formatBytes(agg.memoryUsedBytes)}
+          series={agg?.memoryUsedBytes == null ? undefined : pick(history, 'memoryMiB')}
+          loading={!snapshot}
+          hint={
+            agg?.memoryAllocatedBytes != null
+              ? `${formatBytes(agg.memoryAllocatedBytes)} allocated`
+              : agg?.memoryUsedBytes == null
+                ? 'not exposed'
+                : undefined
+          }
+        />
+      </div>
+
+      <div className="mt-5 grid grid-cols-1 gap-5 lg:grid-cols-3">
+        <div className="lg:col-span-2">
+          <PlacementCard topo={topo.data} error={topo.error} loading={topo.loading} onRetry={topo.reload} />
+        </div>
+        <NodesCard topo={topo.data} />
+      </div>
+
+      <div className="mt-5">
+        <ReplicationCard repl={repl.data} error={repl.error} loading={repl.loading} onRetry={repl.reload} />
+      </div>
+    </div>
+  );
+}
+
+// --- Shard placement grid ----------------------------------------------------
+
+function PlacementCard({
+  topo,
+  error,
+  loading,
+  onRetry,
+}: {
+  topo: TopologyResponse | null;
+  error: Error | null;
+  loading: boolean;
+  onRetry: () => void;
+}) {
+  const unavailable = error instanceof ApiError && error.isUnavailable;
+  return (
+    <Card className="p-4">
+      <SectionTitle
+        title="Shard placement"
+        subtitle="Each row is a shard; the leader replica is highlighted."
+      />
+      <div className="mt-4">
+        {error ? (
+          unavailable ? (
+            <EmptyState
+              icon={<Database size={20} />}
+              title="Topology not available"
+              hint="This node is running single-node, or the topology endpoint is not enabled."
+            />
+          ) : loading ? null : (
+            <ErrorCard error={error} onRetry={onRetry} />
+          )
+        ) : !topo ? (
+          <div className="h-24 animate-pulse rounded-lg bg-panel-2" />
+        ) : topo.num_shards === 0 ? (
+          <EmptyState title="No shards" hint="Single-node deployment." />
+        ) : (
+          <div className="space-y-1.5">
+            {Array.from({ length: topo.num_shards }).map((_, shard) => {
+              const nodes = topo.placement?.[shard] || [];
+              const leader = topo.leaders?.[shard];
+              return (
+                <div key={shard} className="flex items-center gap-2">
+                  <span className="w-16 shrink-0 font-mono text-2xs text-faint">
+                    shard {shard}
+                  </span>
+                  <div className="flex flex-wrap gap-1.5">
+                    {nodes.length === 0 && (
+                      <span className="text-2xs text-faint">unplaced</span>
+                    )}
+                    {nodes.map((nodeId) => {
+                      const isLeader = isLeaderNode(topo, nodeId, leader);
+                      return (
+                        <span
+                          key={nodeId}
+                          className={
+                            'inline-flex items-center gap-1 rounded-md border px-2 py-1 font-mono text-2xs ' +
+                            (isLeader
+                              ? 'border-brand/40 bg-brand/10 text-brand'
+                              : 'border-line bg-panel-2 text-muted')
+                          }
+                        >
+                          {isLeader && <Crown size={10} />}
+                          {nodeId}
+                        </span>
+                      );
+                    })}
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+        )}
+      </div>
+    </Card>
+  );
+}
+
+// The leaders array holds a server_addr; map it back to a node_id for highlight.
+function isLeaderNode(
+  topo: TopologyResponse,
+  nodeId: string,
+  leaderAddr: string | undefined,
+): boolean {
+  if (!leaderAddr) return false;
+  const member = topo.members?.find((m) => m.node_id === nodeId);
+  return member?.server_addr === leaderAddr || nodeId === leaderAddr;
+}
+
+// --- Node list ---------------------------------------------------------------
+
+function NodesCard({ topo }: { topo: TopologyResponse | null }) {
+  const members = topo?.members || [];
+  return (
+    <Card className="p-4">
+      <SectionTitle title="Nodes" subtitle={`${members.length} member${members.length === 1 ? '' : 's'}`} />
+      <div className="mt-4 space-y-2">
+        {!topo ? (
+          <div className="h-20 animate-pulse rounded-lg bg-panel-2" />
+        ) : members.length === 0 ? (
+          <EmptyState title="No members" hint="Single-node deployment." />
+        ) : (
+          members.map((m) => (
+            <div
+              key={m.node_id}
+              className="flex items-center justify-between rounded-lg border border-line bg-panel-2 px-3 py-2"
+            >
+              <div className="flex items-center gap-2">
+                <Activity size={13} className="text-ok" />
+                <span className="font-mono text-xs text-ink">{m.node_id}</span>
+              </div>
+              <span className="font-mono text-2xs text-faint">{m.server_addr}</span>
+            </div>
+          ))
+        )}
+      </div>
+    </Card>
+  );
+}
+
+// --- Replication -------------------------------------------------------------
+
+function ReplicationCard({
+  repl,
+  error,
+  loading,
+  onRetry,
+}: {
+  repl: ReplicationResponse | null;
+  error: Error | null;
+  loading: boolean;
+  onRetry: () => void;
+}) {
+  const shards = repl?.shards || [];
+  return (
+    <Card className="p-4">
+      <SectionTitle
+        title="Replication health"
+        subtitle="Primary / ISR vs min-ISR and per-backup lag for each hosted shard."
+      />
+      <div className="mt-4">
+        {error ? (
+          loading ? null : <ErrorCard error={error} onRetry={onRetry} />
+        ) : !repl ? (
+          <div className="h-16 animate-pulse rounded-lg bg-panel-2" />
+        ) : shards.length === 0 ? (
+          <EmptyState
+            title="No replicated shards"
+            hint="Single-node or Raft-replicated mode reports no primary-backup shards here."
+          />
+        ) : (
+          <div className="overflow-x-auto">
+            <table className="w-full text-left text-xs">
+              <thead className="text-2xs uppercase tracking-wide text-faint">
+                <tr className="border-b border-line">
+                  <th className="py-2 pr-4 font-medium">Shard</th>
+                  <th className="py-2 pr-4 font-medium">Mode</th>
+                  <th className="py-2 pr-4 font-medium">Primary</th>
+                  <th className="py-2 pr-4 font-medium">ISR</th>
+                  <th className="py-2 pr-4 font-medium">Backups / lag</th>
+                </tr>
+              </thead>
+              <tbody className="font-mono">
+                {shards.map((s, i) => {
+                  const healthy = s.isr != null && s.min_isr != null && s.isr >= s.min_isr;
+                  return (
+                    <tr key={i} className="border-b border-line/60">
+                      <td className="py-2 pr-4 text-ink">{s.shard ?? i}</td>
+                      <td className="py-2 pr-4 text-muted">{s.mode ?? '—'}</td>
+                      <td className="py-2 pr-4 text-muted">{s.primary ?? '—'}</td>
+                      <td className="py-2 pr-4">
+                        <Badge tone={healthy ? 'ok' : 'warn'} mono>
+                          {s.isr ?? '?'} / {s.min_isr ?? '?'}
+                        </Badge>
+                      </td>
+                      <td className="py-2 pr-4 text-muted">
+                        {(s.backups || []).length === 0
+                          ? '—'
+                          : (s.backups || [])
+                              .map((b) => `${b.node_id ?? '?'}:${b.lag ?? 0}`)
+                              .join('  ')}
+                      </td>
+                    </tr>
+                  );
+                })}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </div>
+    </Card>
+  );
+}

--- a/ui/src/pages/Overview.tsx
+++ b/ui/src/pages/Overview.tsx
@@ -178,7 +178,7 @@ function PlacementCard({
                       <span className="text-2xs text-faint">unplaced</span>
                     )}
                     {nodes.map((nodeId) => {
-                      const isLeader = isLeaderNode(topo, nodeId, leader);
+                      const isLeader = isLeaderNode(topo, nodeId, leader, nodes.length);
                       return (
                         <span
                           key={nodeId}
@@ -206,12 +206,18 @@ function PlacementCard({
 }
 
 // The leaders array holds a server_addr; map it back to a node_id for highlight.
+// A single-node deployment publishes an empty leader/server_addr (there is no
+// advertised address to hand a remote client — see cmd/rostam-server/main.go),
+// so an empty leaderAddr can't be matched by address. In that case the shard's
+// one owning node is, by construction, the leader: derive it instead of
+// leaving the row leaderless.
 function isLeaderNode(
   topo: TopologyResponse,
   nodeId: string,
   leaderAddr: string | undefined,
+  shardNodeCount: number,
 ): boolean {
-  if (!leaderAddr) return false;
+  if (!leaderAddr) return shardNodeCount === 1;
   const member = topo.members?.find((m) => m.node_id === nodeId);
   return member?.server_addr === leaderAddr || nodeId === leaderAddr;
 }
@@ -238,7 +244,9 @@ function NodesCard({ topo }: { topo: TopologyResponse | null }) {
                 <Activity size={13} className="text-ok" />
                 <span className="font-mono text-xs text-ink">{m.node_id}</span>
               </div>
-              <span className="font-mono text-2xs text-faint">{m.server_addr}</span>
+              <span className="font-mono text-2xs text-faint">
+                {m.server_addr || 'single node'}
+              </span>
             </div>
           ))
         )}

--- a/ui/src/pages/Search.tsx
+++ b/ui/src/pages/Search.tsx
@@ -1,0 +1,316 @@
+import { useMemo, useState } from 'react';
+import { Play, Search as SearchIcon, Type } from 'lucide-react';
+import { PageHeader } from '../components/Layout';
+import { Card } from '../components/primitives';
+import { EmptyState } from '../components/StateView';
+import { JsonView } from '../components/JsonView';
+import { useMetrics } from '../hooks/useMetrics';
+import { useAsync } from '../hooks/useAsync';
+import { listCollections, textSearch, vectorSearch } from '../api/endpoints';
+import { ApiError } from '../api/client';
+import { classNames } from '../lib/format';
+import type { CollectionListResponse, SearchHit, SearchResponse } from '../api/types';
+
+type Mode = 'vector' | 'text';
+
+export function SearchPage() {
+  const list = useAsync<CollectionListResponse>((s) => listCollections(s), []);
+  const { snapshot } = useMetrics();
+
+  const collectionNames = useMemo(() => {
+    const names = new Set<string>();
+    list.data?.collections?.forEach((c) => names.add(c.name));
+    snapshot?.collections.forEach((c) => names.add(c.name));
+    return Array.from(names).sort((a, b) => a.localeCompare(b));
+  }, [list.data, snapshot]);
+
+  const [mode, setMode] = useState<Mode>('vector');
+  const [collection, setCollection] = useState('');
+  const [vectorText, setVectorText] = useState('[0.1, 0.2, 0.3]');
+  const [queryText, setQueryText] = useState('');
+  const [k, setK] = useState('10');
+  const [filterText, setFilterText] = useState('');
+
+  const [running, setRunning] = useState(false);
+  const [result, setResult] = useState<SearchResponse | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [tookMs, setTookMs] = useState<number | null>(null);
+
+  const activeCollection = collection || collectionNames[0] || '';
+
+  const run = async () => {
+    setError(null);
+    setResult(null);
+    setTookMs(null);
+    if (!activeCollection) return setError('Select a collection.');
+
+    const kNum = Number(k) || 10;
+
+    let filter: unknown | null = null;
+    if (filterText.trim()) {
+      try {
+        filter = JSON.parse(filterText);
+      } catch {
+        return setError('Filter is not valid JSON.');
+      }
+    }
+
+    let body: number[] | undefined;
+    if (mode === 'vector') {
+      try {
+        const parsed = JSON.parse(vectorText);
+        if (!Array.isArray(parsed) || !parsed.every((n) => typeof n === 'number'))
+          throw new Error();
+        body = parsed as number[];
+      } catch {
+        return setError('Query vector must be a JSON array of numbers, e.g. [0.1, 0.2].');
+      }
+    } else if (!queryText.trim()) {
+      return setError('Enter query text.');
+    }
+
+    setRunning(true);
+    const started = performance.now();
+    try {
+      const res =
+        mode === 'vector'
+          ? await vectorSearch(activeCollection, body!, kNum, filter)
+          : await textSearch(activeCollection, queryText, kNum, filter);
+      setResult(res);
+      setTookMs(performance.now() - started);
+    } catch (e) {
+      if (
+        mode === 'text' &&
+        e instanceof ApiError &&
+        /full[\s-]?text|text.*disabl/i.test(e.message)
+      ) {
+        setError(
+          'Full-text search is disabled for this collection. It must be created with a BM25 text index.',
+        );
+      } else {
+        setError(e instanceof Error ? e.message : 'Search failed.');
+      }
+    } finally {
+      setRunning(false);
+    }
+  };
+
+  const hits: SearchHit[] = result?.results || result?.documents || [];
+
+  return (
+    <div className="animate-fade-in">
+      <PageHeader
+        title="Search"
+        description="Run vector or full-text queries against a collection."
+      />
+
+      <div className="grid grid-cols-1 gap-5 lg:grid-cols-[380px_1fr]">
+        {/* Query panel */}
+        <Card className="h-fit p-4">
+          <div className="mb-4 grid grid-cols-2 gap-1 rounded-lg border border-line bg-panel-2 p-1">
+            <TabButton active={mode === 'vector'} onClick={() => setMode('vector')} icon={<SearchIcon size={13} />}>
+              Vector
+            </TabButton>
+            <TabButton active={mode === 'text'} onClick={() => setMode('text')} icon={<Type size={13} />}>
+              Text
+            </TabButton>
+          </div>
+
+          <Label>Collection</Label>
+          {collectionNames.length === 0 ? (
+            <input
+              className="input font-mono"
+              placeholder="collection name"
+              value={collection}
+              onChange={(e) => setCollection(e.target.value)}
+            />
+          ) : (
+            <select
+              className="input font-mono"
+              value={activeCollection}
+              onChange={(e) => setCollection(e.target.value)}
+            >
+              {collectionNames.map((n) => (
+                <option key={n} value={n}>
+                  {n}
+                </option>
+              ))}
+            </select>
+          )}
+
+          {mode === 'vector' ? (
+            <>
+              <Label className="mt-3">Query vector (JSON array)</Label>
+              <textarea
+                className="input h-24 resize-y font-mono text-xs"
+                value={vectorText}
+                onChange={(e) => setVectorText(e.target.value)}
+                spellCheck={false}
+                placeholder="[0.12, -0.03, 0.98, …]"
+              />
+            </>
+          ) : (
+            <>
+              <Label className="mt-3">Query text</Label>
+              <textarea
+                className="input h-24 resize-y text-sm"
+                value={queryText}
+                onChange={(e) => setQueryText(e.target.value)}
+                placeholder="search phrase…"
+              />
+            </>
+          )}
+
+          <div className="mt-3 grid grid-cols-3 gap-3">
+            <div className="col-span-1">
+              <Label>k</Label>
+              <input
+                className="input font-mono"
+                inputMode="numeric"
+                value={k}
+                onChange={(e) => setK(e.target.value.replace(/[^\d]/g, ''))}
+              />
+            </div>
+          </div>
+
+          <Label className="mt-3">Filter (optional JSON)</Label>
+          <textarea
+            className="input h-20 resize-y font-mono text-xs"
+            value={filterText}
+            onChange={(e) => setFilterText(e.target.value)}
+            spellCheck={false}
+            placeholder='{"must": [{"key": "lang", "match": {"value": "en"}}]}'
+          />
+
+          <button
+            type="button"
+            className="btn-primary mt-4 w-full"
+            onClick={run}
+            disabled={running}
+          >
+            <Play size={14} /> {running ? 'Searching…' : 'Run search'}
+          </button>
+
+          {error && (
+            <p className="mt-3 rounded-lg border border-down/30 bg-down/10 px-3 py-2 font-mono text-xs text-down">
+              {error}
+            </p>
+          )}
+        </Card>
+
+        {/* Results panel */}
+        <div>
+          <div className="mb-2 flex items-center justify-between px-1">
+            <span className="text-xs font-medium text-muted">
+              {hits.length > 0 ? `${hits.length} result${hits.length === 1 ? '' : 's'}` : 'Results'}
+            </span>
+            <div className="flex items-center gap-2">
+              {result?.degraded && (
+                <span className="rounded-md border border-warn/30 bg-warn/10 px-1.5 py-0.5 text-2xs text-warn">
+                  degraded
+                </span>
+              )}
+              {tookMs != null && (
+                <span className="font-mono text-2xs text-faint">{tookMs.toFixed(1)} ms</span>
+              )}
+            </div>
+          </div>
+
+          {hits.length === 0 ? (
+            <EmptyState
+              icon={<SearchIcon size={20} />}
+              title={result ? 'No matches' : 'Run a query to see results'}
+              hint={
+                result
+                  ? 'The query returned no hits for this collection.'
+                  : 'Results appear here as a ranked table with expandable payloads.'
+              }
+            />
+          ) : (
+            <Card className="overflow-hidden">
+              <div className="divide-y divide-line/60">
+                {hits.map((hit, i) => (
+                  <ResultRow key={`${hit.id}-${i}`} rank={i + 1} hit={hit} />
+                ))}
+              </div>
+            </Card>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function ResultRow({ rank, hit }: { rank: number; hit: SearchHit }) {
+  const [open, setOpen] = useState(false);
+  const score = hit.score ?? hit.distance;
+  const scoreLabel = hit.score != null ? 'score' : hit.distance != null ? 'distance' : '';
+  const payload = hit.payload ?? (hit.content ? { content: hit.content } : null);
+
+  return (
+    <div className="px-4 py-3">
+      <div
+        className="flex cursor-pointer items-center gap-3"
+        onClick={() => payload && setOpen((o) => !o)}
+      >
+        <span className="w-6 shrink-0 text-right font-mono text-2xs text-faint">{rank}</span>
+        <span className="font-mono text-sm text-ink">#{hit.id}</span>
+        <div className="flex-1" />
+        {score != null && (
+          <span className="font-mono text-xs text-muted">
+            <span className="text-faint">{scoreLabel} </span>
+            {typeof score === 'number' ? score.toFixed(4) : String(score)}
+          </span>
+        )}
+      </div>
+      {payload && (
+        <button
+          type="button"
+          onClick={() => setOpen((o) => !o)}
+          className="mt-1 pl-9 text-2xs text-faint hover:text-muted"
+        >
+          {open ? 'hide payload' : 'show payload'}
+        </button>
+      )}
+      {open && payload && (
+        <div className="mt-2 overflow-x-auto rounded-lg border border-line bg-panel-2/60 p-3 pl-9">
+          <JsonView data={payload} />
+        </div>
+      )}
+    </div>
+  );
+}
+
+function TabButton({
+  active,
+  onClick,
+  icon,
+  children,
+}: {
+  active: boolean;
+  onClick: () => void;
+  icon: React.ReactNode;
+  children: React.ReactNode;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={classNames(
+        'flex items-center justify-center gap-1.5 rounded-md py-1.5 text-xs font-medium transition-colors',
+        active ? 'bg-panel text-ink shadow-sm' : 'text-muted hover:text-ink',
+      )}
+    >
+      {icon}
+      {children}
+    </button>
+  );
+}
+
+function Label({ children, className }: { children: React.ReactNode; className?: string }) {
+  return (
+    <span className={classNames('mb-1 block text-xs font-medium text-muted', className)}>
+      {children}
+    </span>
+  );
+}

--- a/ui/tailwind.config.js
+++ b/ui/tailwind.config.js
@@ -1,0 +1,77 @@
+/** @type {import('tailwindcss').Config} */
+export default {
+  content: ['./index.html', './src/**/*.{ts,tsx}'],
+  theme: {
+    extend: {
+      colors: {
+        surface: 'rgb(var(--c-surface) / <alpha-value>)',
+        panel: 'rgb(var(--c-panel) / <alpha-value>)',
+        'panel-2': 'rgb(var(--c-panel-2) / <alpha-value>)',
+        line: 'rgb(var(--c-line) / <alpha-value>)',
+        'line-strong': 'rgb(var(--c-line-strong) / <alpha-value>)',
+        ink: 'rgb(var(--c-ink) / <alpha-value>)',
+        muted: 'rgb(var(--c-muted) / <alpha-value>)',
+        faint: 'rgb(var(--c-faint) / <alpha-value>)',
+        brand: 'rgb(var(--c-brand) / <alpha-value>)',
+        'brand-soft': 'rgb(var(--c-brand-soft) / <alpha-value>)',
+        'brand-ink': 'rgb(var(--c-brand-ink) / <alpha-value>)',
+        ok: 'rgb(var(--c-ok) / <alpha-value>)',
+        warn: 'rgb(var(--c-warn) / <alpha-value>)',
+        down: 'rgb(var(--c-down) / <alpha-value>)',
+        info: 'rgb(var(--c-info) / <alpha-value>)',
+      },
+      fontFamily: {
+        sans: [
+          'Inter',
+          'system-ui',
+          '-apple-system',
+          'Segoe UI',
+          'Roboto',
+          'Helvetica Neue',
+          'sans-serif',
+        ],
+        mono: [
+          'JetBrains Mono',
+          'ui-monospace',
+          'SFMono-Regular',
+          'SF Mono',
+          'Menlo',
+          'Consolas',
+          'monospace',
+        ],
+      },
+      fontSize: {
+        '2xs': ['0.6875rem', { lineHeight: '1rem' }],
+      },
+      boxShadow: {
+        card: '0 1px 2px 0 rgb(0 0 0 / 0.04), 0 1px 3px 0 rgb(0 0 0 / 0.06)',
+        pop: '0 8px 30px -6px rgb(0 0 0 / 0.35)',
+        'ring-brand': '0 0 0 3px var(--c-brand-ring)',
+      },
+      keyframes: {
+        'fade-in': {
+          from: { opacity: '0', transform: 'translateY(4px)' },
+          to: { opacity: '1', transform: 'translateY(0)' },
+        },
+        'slide-in': {
+          from: { transform: 'translateX(100%)' },
+          to: { transform: 'translateX(0)' },
+        },
+        shimmer: {
+          '100%': { transform: 'translateX(100%)' },
+        },
+        'pulse-dot': {
+          '0%, 100%': { opacity: '1' },
+          '50%': { opacity: '0.35' },
+        },
+      },
+      animation: {
+        'fade-in': 'fade-in 0.24s cubic-bezier(0.16, 1, 0.3, 1) both',
+        'slide-in': 'slide-in 0.26s cubic-bezier(0.16, 1, 0.3, 1) both',
+        shimmer: 'shimmer 1.4s infinite',
+        'pulse-dot': 'pulse-dot 1.6s ease-in-out infinite',
+      },
+    },
+  },
+  plugins: [],
+};

--- a/ui/tsconfig.app.json
+++ b/ui/tsconfig.app.json
@@ -1,0 +1,22 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "useDefineForClassFields": true,
+    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "skipLibCheck": true,
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "moduleDetection": "force",
+    "noEmit": true,
+    "jsx": "react-jsx",
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true,
+    "forceConsistentCasingInFileNames": true
+  },
+  "include": ["src"]
+}

--- a/ui/tsconfig.json
+++ b/ui/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "files": [],
+  "references": [
+    { "path": "./tsconfig.app.json" },
+    { "path": "./tsconfig.node.json" }
+  ]
+}

--- a/ui/tsconfig.node.json
+++ b/ui/tsconfig.node.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["ES2023"],
+    "types": ["node"],
+    "module": "ESNext",
+    "skipLibCheck": true,
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "isolatedModules": true,
+    "moduleDetection": "force",
+    "noEmit": true,
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true
+  },
+  "include": ["vite.config.ts"]
+}

--- a/ui/vite.config.ts
+++ b/ui/vite.config.ts
@@ -1,0 +1,23 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+// base: './' emits relative asset URLs so the bundle works under the
+// /dashboard/ path prefix the Go server mounts it at. outDir stays the
+// default (ui/dist); the maintainer wires the final embed path at integration.
+export default defineConfig({
+  base: './',
+  plugins: [react()],
+  build: {
+    outDir: 'dist',
+    // The whole app is embedded in a Go binary; keep the bundle honest.
+    chunkSizeWarningLimit: 700,
+  },
+  server: {
+    port: 5273,
+    proxy: {
+      // Dev convenience: point the API host with ROSTAM_API (default loopback).
+      '/v1': process.env.ROSTAM_API || 'http://127.0.0.1:8080',
+      '/metrics': process.env.ROSTAM_API || 'http://127.0.0.1:8080',
+    },
+  },
+});


### PR DESCRIPTION
## Embedded web dashboard for vector + KV management and monitoring

Adds a self-hosted management/monitoring UI served at **`/dashboard/`**, baked into the binary with `go:embed` so a release ships the UI with no runtime asset dependency. The React app talks only to the existing authed `/v1` REST surface — nothing new is exposed unauthenticated.

### Backend (`httpapi`) — all behind the existing auth
- `GET /v1/topology` — nodes, shard→node placement, per-shard leader
- `GET /v1/collections` — list dense collections (new shardless `__collections__` op, mirrors `__metrics__`)
- `GET /v1/collections/{name}` — per-collection config/stats (wraps `vector_get_config`)
- `GET/PUT/DELETE /v1/kv/{key}` (+ `?with_ttl=1`) — the first KV data plane over HTTP, wrapping the existing `get`/`put`/`del`/`ttl` ops (512-byte key cap, base64/utf8 value handling)

`__topology__` was cluster-only, so `/v1/topology` 500'd without `-cluster`. A single-node topology source is now registered in the non-cluster branch (one node leading one logical shard) so the cluster view works in the common single-node case. No double-register — cluster mode still registers the real live topology on the same registry.

### Frontend (`ui/`)
React 18 + Vite + TS + Tailwind, dark-mode-first. Pages: **Overview** (health, shard→leader map, live metric cards from a hand-rolled Prometheus parser), **Collections** (list/detail + create/drop/reshard), **Search** playground, **KV** console, **Admin**/backup. Bearer-key auth held in `sessionStorage`; `/metrics` polling pauses when the tab is hidden. Build is ~75 KB gzip JS with zero chart/runtime deps.

### Build & release
- `make ui` compiles the Vite app and syncs it into the `go:embed` staging dir (`dashboard/dist/`, only `.gitkeep` tracked; built assets git-ignored).
- Bare `go build` still works and serves a "run `make ui`" placeholder.
- Release artifacts now build the UI in: goreleaser `before` hook runs `make ui`, the binaries CI job gains `setup-node`, and the Dockerfile gains a `node:20` build stage. Verified with a live `docker build` (served the real UI with immutable caching on hashed assets and `no-cache` on `index.html`).

### Testing
- `go build ./...`, `go vet`, and tests across `dashboard`/`httpapi`/`ops`/`sdk/wire`/`authz` pass (20 new Go tests, incl. embed path-traversal containment and KV round-trips).
- `ui` builds with 0 TS errors.
- End-to-end verified on a live single-node server and inside the container image.
- Reviewed for security: the new `__collections__` op is **not** a tenant leak (a tenant-scoped principal is denied it, same as `/metrics`); auth wiring, KV input handling, and static-asset path-traversal are all safe.

### Known v1 boundaries (follow-ups)
- The **KV console is a key inspector**, not a browser — there is no key-scan/prefix-scan op yet. Adding one upgrades the console to a full key browser.
- Cache hit-rate / memory cards show "n/a" because those metrics aren't in `/metrics` yet.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a web dashboard with overview metrics, collections, search, KV management, and backup administration.
  * Added dashboard APIs for topology, collections, collection configuration, and key-value operations.
  * Added API-key prompts, theme settings, health indicators, live metrics, and responsive loading/error states.
  * Single-node deployments now expose topology information for discovery.
* **Bug Fixes**
  * Improved dashboard asset serving, routing, missing-asset handling, and release packaging.
* **Documentation**
  * Added dashboard setup, build, deployment, and usage documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->