### PR TITLE
feat(kv): global flush op — O(shards) keyspace wipe, replicated (#64)

### DIFF
--- a/authz/authorizer.go
+++ b/authz/authorizer.go
@@ -217,6 +217,16 @@ var adminOps = map[string]struct{}{
 	// it, and peers are exempt by the internal-token grant.
 	"__wasm_blob_put__": {},
 	"__wasm_blob_get__": {},
+	// The INTERNAL shard-scoped leg of the KV flush broadcast
+	// (cluster/flush_broadcast.go). It drives a flush into ONE group and is
+	// reachable only over the internal-token peer path in normal operation, but is
+	// enumerated here — rather than relying on absence from the ops registry — for
+	// the reason spelled out above __register_wasm_shard__: absence is a
+	// coincidence a future refactor can remove, not a classification. `flush` ITSELF
+	// is a global-WRITE op (registered OpReadWrite, empty resource); the wrapper
+	// pins the shard-scoped leg at admin so it can never be silently demoted to
+	// write and handed to any write:* key.
+	"__flush_shard__": {},
 }
 
 // readOps is the small set of cluster-introspection ops that are explicitly

--- a/authz/flush_authz_test.go
+++ b/authz/flush_authz_test.go
@@ -1,0 +1,79 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package authz
+
+import (
+	"testing"
+
+	"github.com/rostamlabs/rostam/ops"
+	"github.com/rostamlabs/rostam/vector"
+)
+
+// flush wipes the ENTIRE KV keyspace. It is registered OpReadWrite (no special
+// admin entry), so it inherits del's classification: ActionWrite against the EMPTY
+// (cluster) resource. That deliberately requires GLOBAL write authority — write:* /
+// *:* — because write authority already implies deleting any key and flush is only
+// the O(1) form. These tests pin that: a read-only key is denied, a
+// collection-scoped write:docs is denied (resource mismatch), and only a
+// cluster-wide write grants it. No authz code change backs this; it is pure default
+// classification.
+
+func newOpsRegForFlush(t *testing.T) *ops.Registry {
+	t.Helper()
+	r := ops.NewRegistry()
+	if err := ops.RegisterBuiltins(r); err != nil {
+		t.Fatalf("RegisterBuiltins: %v", err)
+	}
+	return r
+}
+
+func TestActionForFlushIsWrite(t *testing.T) {
+	reg := newOpsRegForFlush(t)
+	// Precondition: flush is a registered OpReadWrite op...
+	if _, kind, _, ok := reg.Lookup("flush"); !ok || kind != ops.OpReadWrite {
+		t.Fatalf("precondition: flush must be registered OpReadWrite (ok=%v kind=%v)", ok, kind)
+	}
+	// ...and is NOT in the admin allowlist, so it classifies as write (unlike
+	// __register_wasm__, which overrides its OpReadWrite registration to admin).
+	if got := actionFor("flush", reg); got != ActionWrite {
+		t.Fatalf("actionFor(flush)=%q want %q", got, ActionWrite)
+	}
+}
+
+func TestResourceForFlushIsEmpty(t *testing.T) {
+	// flush is keyless / not collection-scoped, so it targets the empty cluster
+	// resource — which only a "*" pattern (write:* / *:*) can cover.
+	if got := resourceFor("flush", nil); got != "" {
+		t.Fatalf("resourceFor(flush)=%q want empty (cluster resource)", got)
+	}
+}
+
+func TestRBACFlushRequiresGlobalWrite(t *testing.T) {
+	opsReg := newOpsRegForFlush(t)
+	reg := newRegWithKeys(t,
+		vector.APIKey{Token: "reader", Tenant: "acme", Scopes: []string{"read:*"}},
+		vector.APIKey{Token: "coll-writer", Tenant: "acme", Scopes: []string{"write:docs"}},
+		vector.APIKey{Token: "coll-writer-ns", Tenant: "acme", Scopes: []string{"write:acme/docs"}},
+		vector.APIKey{Token: "writer", Tenant: "acme", Scopes: []string{"write:*"}},
+		vector.APIKey{Token: "super", Tenant: "acme", Scopes: []string{"*:*"}},
+	)
+	auth := NewRBACAuthenticator(reg, opsReg, "INTERNAL-SVC-TOKEN")
+
+	cases := []struct {
+		token string
+		want  bool
+		desc  string
+	}{
+		{"reader", false, "a read-only key is denied a write op"},
+		{"coll-writer", false, "collection-scoped write:docs does not cover the empty cluster resource"},
+		{"coll-writer-ns", false, "namespace-scoped write:acme/docs does not cover the empty cluster resource"},
+		{"writer", true, "cluster-wide write:* covers the empty resource"},
+		{"super", true, "*:* covers everything"},
+	}
+	for _, c := range cases {
+		got := auth(AuthRequest{Token: c.token, Op: "flush", Args: nil})
+		if got != c.want {
+			t.Errorf("authorize(%s, flush)=%v want %v — %s", c.token, got, c.want, c.desc)
+		}
+	}
+}

--- a/cache/flush.go
+++ b/cache/flush.go
@@ -6,7 +6,6 @@ import (
 	"encoding/binary"
 	"fmt"
 	"hash/crc32"
-	"log/slog"
 	"os"
 	"path/filepath"
 )
@@ -69,6 +68,20 @@ func (c *Cache) Flush() error {
 //     same recovery path an mmap shard already relies on. So a running shard's
 //     BytesUsed stays non-zero after flush; its LIVE keyset is nonetheless empty
 //     (every Get misses, Iterate yields nothing).
+//
+// KNOWN LIMITATION — flush frees the KEYSPACE but not necessarily WRITE CAPACITY.
+// Because the page head/tail offsets above are deliberately left intact (the lock-
+// free reject-writes reader contract), a shard that was FULL stays full after flush:
+//   - Under PolicyRingbufEvict (the DEFAULT) this is invisible — the ring evicts to
+//     make room, so the next write reclaims the flushed space and succeeds.
+//   - Under PolicyRejectWrites it is visible: the next write can still return ErrFull
+//     even though the keyspace is now logically EMPTY. The space is reclaimed only by
+//     the next COLD COMPACTION — which runs for an mmap shard at open (a restart), and
+//     NEVER online for a heap shard (heap has no cold-compaction path), so a full heap
+//     reject-writes shard does not regain capacity until the process restarts.
+// Online reclaim under reject-writes is a separate, deeper change (it would have to
+// rendezvous with any lock-free reader still aliasing the pages) and is intentionally
+// NOT done here.
 func (s *shard) flush() error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -100,7 +113,15 @@ func (s *shard) flush() error {
 	// nothing to persist — skip the sidecar entirely.
 	if s.isMmap {
 		if err := s.writeFlushSidecar(floor); err != nil {
-			return err
+			// Wrap so the REPLICATED apply path can errors.Is this as ErrFlushNotDurable
+			// and classify it classFatal (shard/apply_class.go): a follower that could
+			// not durably record the watermark must HALT rather than advance its applied
+			// index past a flush it did not durably apply — advancing would resurrect
+			// pre-flush keys on a later failover and diverge it from peers whose sidecar
+			// landed. The multi-%w keeps both the sentinel and the underlying I/O cause
+			// visible through errors.Is. On the leader this still returns BEFORE the swap
+			// below, so the keyspace stays intact either way.
+			return fmt.Errorf("%w: %w", ErrFlushNotDurable, err)
 		}
 	}
 
@@ -219,26 +240,35 @@ func (s *shard) writeFlushSidecar(floor uint64) error {
 }
 
 // readFlushSidecar restores the flush watermark for a shard opening from dataDir.
-// A MISSING sidecar returns 0 — today's behaviour exactly, "nothing was ever
-// flushed". A present-but-invalid sidecar (torn write, CRC mismatch, foreign file)
-// ALSO returns 0 but is logged: the shard fails OPEN (pre-flush data may resurrect)
-// rather than refusing to start, mirroring readAppliedStamp/readPBFrontier, whose
-// 0-on-corruption is likewise the safe under-report.
-func readFlushSidecar(dataDir string) uint64 {
+// A genuinely ABSENT sidecar returns (0, nil) — today's behaviour exactly, "nothing
+// was ever flushed", and backward-compatible with a shard that predates the feature.
+//
+// A PRESENT-but-invalid sidecar (a read error other than not-exist, a torn write, a
+// CRC mismatch, or a foreign file) returns (0, error) and FAILS the shard open. This
+// deliberately does NOT mirror readAppliedStamp/readPBFrontier's 0-on-corruption:
+// their 0 triggers a REBUILD/recovery that reconverges, whereas a flush watermark of
+// 0 re-indexes every pre-flush entry PERMANENTLY. The applied index is already past
+// the flush op, so a warm restart never replays it (shard/fsm.go skips already-
+// applied indices), and this replica would silently diverge from peers whose sidecar
+// is intact. A corrupt watermark is a durability fault the operator must see, not a
+// silent resurrection — so we refuse to open rather than fabricate floor 0.
+func readFlushSidecar(dataDir string) (uint64, error) {
 	path := filepath.Join(dataDir, flushSidecarName)
 	b, err := os.ReadFile(path) //nolint:gosec // dataDir is caller-configured
 	if err != nil {
-		if !os.IsNotExist(err) {
-			slog.Warn("cache: cannot read flush sidecar; treating as no flush",
-				"component", "cache", "path", path, "err", err)
+		if os.IsNotExist(err) {
+			// Never flushed (or a pre-feature shard) — the sole backward-compatible
+			// "open normally at floor 0" path.
+			return 0, nil
 		}
-		return 0
+		// A present sidecar we cannot READ (permissions, I/O error) is as ambiguous as
+		// a corrupt one: we cannot prove nothing was flushed, so fail rather than
+		// under-report the watermark.
+		return 0, fmt.Errorf("cache: read flush sidecar %s: %w", path, err)
 	}
 	floor, ok := decodeFlushSidecar(b)
 	if !ok {
-		slog.Warn("cache: flush sidecar failed validation; treating as no flush (pre-flush data may resurrect)",
-			"component", "cache", "path", path)
-		return 0
+		return 0, fmt.Errorf("cache: flush sidecar %s failed validation (corrupt watermark; refusing to open lest pre-flush data resurrect and diverge this replica)", path)
 	}
-	return floor
+	return floor, nil
 }

--- a/cache/flush.go
+++ b/cache/flush.go
@@ -1,0 +1,241 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package cache
+
+import (
+	"encoding/binary"
+	"fmt"
+	"hash/crc32"
+	"log/slog"
+	"os"
+	"path/filepath"
+)
+
+// Flush wipes the ENTIRE KV keyspace of this cache in O(shards) — not O(keys) —
+// by swapping every shard's index table for a fresh empty one and recording a
+// per-shard durability watermark. After it returns, every Get/GetInto/Iterate on
+// a pre-flush key misses; post-flush writes proceed normally. Returns the first
+// shard error, if any.
+//
+// DURABILITY ORDERING CONTRACT (the reason the sidecar, not the index swap, is the
+// durable proof). The index swap is in-memory only; the crash-safe record of the
+// flush is each mmap shard's sidecar (dataDir/flushed.seq). shard.flush writes and
+// fsyncs that sidecar BEFORE it performs the swap (and thus before this method
+// returns), so a sidecar-write FAILURE aborts the flush with the keyspace intact —
+// never an ACKed-but-non-durable wipe (see shard.flush for why an errored handler
+// still advances the applied index, which makes that ordering load-bearing). On the
+// success path a replicated Flush OP applies through shard/fsm.go's Apply: the
+// handler runs to completion (syncing every sidecar) and only THEN does the deferred
+// f.cache.SetAppliedIndex(l.Index, …) persist the applied index (shard/fsm.go:287),
+// so the sidecar is always durable before the applied index can advance past the
+// flush op. That ordering is what prevents a crash from resurrecting flushed keys:
+// were the applied index persisted first, a crash could leave the log unable to
+// replay the flush (index already past it) while the pages still framed the wiped
+// entries — and the next rebuild would re-index them. Because the sidecar lands
+// first, the rebuild always sees the watermark and skips them.
+func (c *Cache) Flush() error {
+	var firstErr error
+	for _, s := range c.shards {
+		if err := s.flush(); err != nil && firstErr == nil {
+			firstErr = err
+		}
+	}
+	return firstErr
+}
+
+// flush wipes one shard's keyspace under the full write lock (like a resize).
+//
+// The mechanism is a single atomic index swap — the same O(1) idiom resize
+// (shard.go) and cold compaction (compact.go) use — so lock-free readers pick up
+// the empty table on their next tab.Load(); a reader still holding a pre-swap table
+// snapshot may resolve a pre-flush key until it reloads, which is the ordinary
+// lock-free read contract, not a flush-specific hazard.
+//
+// FIELDS RESET, AND WHY ONLY THESE. The only in-memory "live" accounting a shard
+// keeps is the indexTable's live/tomb slot counts, and the swap to newIndexTable(0)
+// replaces the whole table — so those reset for free with the swap and there is
+// nothing else to zero. Deliberately NOT reset:
+//   - writeSeq — a monotonic high-water; resetting it would hand out sequences the
+//     rebuild's max-seq contest could collide with. We CAPTURE it as the floor and
+//     leave it advancing.
+//   - the cumulative stat counters (gets/misses/puts/dels/expirations/evictions/
+//     rejects/pagesAlloc/compactions/…) — Stats reports them as lifetime totals, not
+//     live gauges; zeroing them would corrupt those semantics.
+//   - the page bytes and their persisted head/tail offsets — bytesUsed derives the
+//     live-byte figure from (tail-head), but the pages OWN that allocation and a
+//     lock-free reject-writes reader may still alias those bytes, so we must not
+//     overwrite or reuse them online. The physical bytes are reclaimed lazily by
+//     cold compaction at the next open (which drops every now-unindexed entry), the
+//     same recovery path an mmap shard already relies on. So a running shard's
+//     BytesUsed stays non-zero after flush; its LIVE keyset is nonetheless empty
+//     (every Get misses, Iterate yields nothing).
+func (s *shard) flush() error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	// Capture the floor: the current per-shard high-water sequence. Every entry now
+	// on the pages carries seq <= floor, so recording floor is exactly "wipe
+	// everything written so far". writeSeq itself is left untouched (monotonic).
+	floor := s.writeSeq
+
+	// Make the wipe DURABLE BEFORE it takes effect. An mmap shard rebuilds its index
+	// from page bytes at open, so the durable proof of a flush is the sidecar, not
+	// the in-memory swap. Writing (and fsyncing) the sidecar FIRST means a
+	// sidecar-write error returns here with the keyspace still intact and no swap
+	// performed — the flush op then fails and the client retries the idempotent
+	// flush — rather than ACKing an empty in-memory keyspace whose durable watermark
+	// never landed. That distinction matters because fsm.Apply advances the applied
+	// index even when the handler returns a (non-fatal) error, so a swap that
+	// preceded a failed sidecar write would leave the log unable to replay the flush
+	// on restart while the pages still framed the "wiped" entries: a resurrection on
+	// a single node, and a silent divergence from replicas whose sidecar write
+	// succeeded. Ordering the durable step first loses nothing on the success path —
+	// the swap below is infallible. And a crash BETWEEN this sidecar write and the
+	// swap is safe: the swap is RAM-only (lost on crash regardless) and, because the
+	// handler never returned, the applied index did not advance, so the log replays
+	// the flush — which the now-durable sidecar already makes the rebuild honor.
+	//
+	// Heap shards (!isMmap) have no rebuild path (their index is authoritative and
+	// never reconstructed from pages), so nothing a restart could resurrect and
+	// nothing to persist — skip the sidecar entirely.
+	if s.isMmap {
+		if err := s.writeFlushSidecar(floor); err != nil {
+			return err
+		}
+	}
+
+	// Durable now (or heap): perform the O(1) logical wipe. Swap in a fresh empty
+	// table — lock-free readers see it on their next load, and the old table (with
+	// its live/tomb counts) is dropped whole. The in-memory floor mirrors the
+	// sidecar for any same-process rebuild (none at runtime today; free and
+	// defensive).
+	s.flushedThroughSeq = floor
+	s.tab.Store(newIndexTable(0))
+	return nil
+}
+
+// Flush sidecar (dataDir/flushed.seq) — the per-shard durable watermark recording
+// the write-sequence floor a Cache.Flush() wiped through. Fixed 17-byte record,
+// CRC'd field-for-field the way cache/file.go guards its header fields.
+//
+//	0..3   magic uint32 (little-endian)
+//	4      version byte
+//	5..12  flushedThroughSeq uint64 (little-endian)
+//	13..16 CRC32-IEEE of bytes 0..12
+const (
+	flushSidecarName      = "flushed.seq"
+	flushSidecarTmpSuffix = ".tmp"
+	// flushSidecarMagic is "RSFL" in little-endian bytes — distinct from the pages
+	// file magic so a truncated/misnamed pages header can never be mistaken for a
+	// sidecar and vice versa.
+	flushSidecarMagic   uint32 = 0x4C465352
+	flushSidecarVersion byte   = 1
+	flushSidecarSize           = 17
+	flushSidecarCRCOff         = 13
+)
+
+// encodeFlushSidecar writes the fixed record into dst[:flushSidecarSize].
+func encodeFlushSidecar(dst []byte, floor uint64) {
+	binary.LittleEndian.PutUint32(dst[0:4], flushSidecarMagic)
+	dst[4] = flushSidecarVersion
+	binary.LittleEndian.PutUint64(dst[5:13], floor)
+	crc := crc32.ChecksumIEEE(dst[0:flushSidecarCRCOff])
+	binary.LittleEndian.PutUint32(dst[flushSidecarCRCOff:flushSidecarSize], crc)
+}
+
+// decodeFlushSidecar validates a sidecar record and returns its floor. ok=false on
+// any malformation — wrong length, bad magic/version, or CRC mismatch — so a torn
+// or foreign file collapses to "no watermark" (floor 0) rather than an over-report.
+func decodeFlushSidecar(b []byte) (floor uint64, ok bool) {
+	if len(b) != flushSidecarSize {
+		return 0, false
+	}
+	if binary.LittleEndian.Uint32(b[0:4]) != flushSidecarMagic {
+		return 0, false
+	}
+	if b[4] != flushSidecarVersion {
+		return 0, false
+	}
+	stored := binary.LittleEndian.Uint32(b[flushSidecarCRCOff:flushSidecarSize])
+	if stored != crc32.ChecksumIEEE(b[0:flushSidecarCRCOff]) {
+		return 0, false
+	}
+	return binary.LittleEndian.Uint64(b[5:13]), true
+}
+
+// writeFlushSidecar durably records `floor` into dataDir/flushed.seq using the same
+// atomic temp+fsync+rename+syncDir sequence cold compaction uses (compact.go): stage
+// into flushed.seq.tmp, fsync the temp so its bytes are on disk, rename over the real
+// path (atomic on POSIX), then fsync the directory so the rename survives a crash. A
+// crash-orphaned temp is harmless — it is never read and the next flush O_TRUNCs it.
+// Called with s.mu held.
+func (s *shard) writeFlushSidecar(floor uint64) error {
+	var rec [flushSidecarSize]byte
+	encodeFlushSidecar(rec[:], floor)
+
+	path := filepath.Join(s.dataDir, flushSidecarName)
+	tmp := path + flushSidecarTmpSuffix
+
+	f, err := os.OpenFile(tmp, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o640) //nolint:gosec // dataDir is caller-configured
+	if err != nil {
+		return fmt.Errorf("cache: create flush sidecar %s: %w", tmp, err)
+	}
+	if _, werr := f.Write(rec[:]); werr != nil {
+		_ = f.Close()
+		_ = os.Remove(tmp)
+		return fmt.Errorf("cache: write flush sidecar %s: %w", tmp, werr)
+	}
+	// fsync the bytes before anything points at them — this is the durability the
+	// flush's crash-safety rests on.
+	if serr := f.Sync(); serr != nil {
+		_ = f.Close()
+		_ = os.Remove(tmp)
+		return fmt.Errorf("cache: fsync flush sidecar %s: %w", tmp, serr)
+	}
+	if cerr := f.Close(); cerr != nil {
+		_ = os.Remove(tmp)
+		return fmt.Errorf("cache: close flush sidecar %s: %w", tmp, cerr)
+	}
+	if rerr := os.Rename(tmp, path); rerr != nil {
+		_ = os.Remove(tmp)
+		return fmt.Errorf("cache: publish flush sidecar %s: %w", path, rerr)
+	}
+	// Make the rename itself durable. Best-effort, exactly like cold compaction's
+	// step 5: the bytes and the rename's target are already synced, so losing the
+	// directory entry across a crash only reverts THIS shard's watermark to its
+	// previous value or absence. On a single node that costs just the flush (retry
+	// it). On a REPLICATED shard, a replica that loses its sidecar this way can
+	// resurrect keys its peers wiped and nothing re-sends the already-applied flush,
+	// so the operator's remedy is to re-issue the (idempotent) flush; the fsync loss
+	// itself is rare and the temp-file bytes are already on disk.
+	if derr := syncDir(s.dataDir); derr != nil {
+		slog.Warn("cache: flush sidecar directory fsync failed; the watermark may not survive a crash",
+			"component", "cache", "dir", s.dataDir, "err", derr)
+	}
+	return nil
+}
+
+// readFlushSidecar restores the flush watermark for a shard opening from dataDir.
+// A MISSING sidecar returns 0 — today's behaviour exactly, "nothing was ever
+// flushed". A present-but-invalid sidecar (torn write, CRC mismatch, foreign file)
+// ALSO returns 0 but is logged: the shard fails OPEN (pre-flush data may resurrect)
+// rather than refusing to start, mirroring readAppliedStamp/readPBFrontier, whose
+// 0-on-corruption is likewise the safe under-report.
+func readFlushSidecar(dataDir string) uint64 {
+	path := filepath.Join(dataDir, flushSidecarName)
+	b, err := os.ReadFile(path) //nolint:gosec // dataDir is caller-configured
+	if err != nil {
+		if !os.IsNotExist(err) {
+			slog.Warn("cache: cannot read flush sidecar; treating as no flush",
+				"component", "cache", "path", path, "err", err)
+		}
+		return 0
+	}
+	floor, ok := decodeFlushSidecar(b)
+	if !ok {
+		slog.Warn("cache: flush sidecar failed validation; treating as no flush (pre-flush data may resurrect)",
+			"component", "cache", "path", path)
+		return 0
+	}
+	return floor
+}

--- a/cache/flush.go
+++ b/cache/flush.go
@@ -200,17 +200,20 @@ func (s *shard) writeFlushSidecar(floor uint64) error {
 		_ = os.Remove(tmp)
 		return fmt.Errorf("cache: publish flush sidecar %s: %w", path, rerr)
 	}
-	// Make the rename itself durable. Best-effort, exactly like cold compaction's
-	// step 5: the bytes and the rename's target are already synced, so losing the
-	// directory entry across a crash only reverts THIS shard's watermark to its
-	// previous value or absence. On a single node that costs just the flush (retry
-	// it). On a REPLICATED shard, a replica that loses its sidecar this way can
-	// resurrect keys its peers wiped and nothing re-sends the already-applied flush,
-	// so the operator's remedy is to re-issue the (idempotent) flush; the fsync loss
-	// itself is rare and the temp-file bytes are already on disk.
+	// Make the rename itself durable. The bytes and the rename's TARGET inode are
+	// already fsynced; syncDir makes the rename's DIRECTORY ENTRY durable. If it
+	// fails we cannot know whether the rename survives a crash, so we must NOT
+	// acknowledge the flush as durable — return the error rather than warn-and-
+	// succeed. Because shard.flush writes this sidecar BEFORE it swaps the index, a
+	// failure here returns with the keyspace still live and the flush op fails, so
+	// the client retries. The residual is one-directional and NEVER resurrection: if
+	// the rename happened to survive, a crash before a successful retry applies the
+	// (already-durable) flush on restart — the "more flushed" direction — while the
+	// running node still held the keys and the errored flush told the caller the
+	// outcome was uncertain; a lost rename simply leaves nothing flushed, which the
+	// retry redoes.
 	if derr := syncDir(s.dataDir); derr != nil {
-		slog.Warn("cache: flush sidecar directory fsync failed; the watermark may not survive a crash",
-			"component", "cache", "dir", s.dataDir, "err", derr)
+		return fmt.Errorf("cache: fsync flush sidecar dir %s: %w", s.dataDir, derr)
 	}
 	return nil
 }

--- a/cache/flush.go
+++ b/cache/flush.go
@@ -79,6 +79,7 @@ func (c *Cache) Flush() error {
 //     the next COLD COMPACTION — which runs for an mmap shard at open (a restart), and
 //     NEVER online for a heap shard (heap has no cold-compaction path), so a full heap
 //     reject-writes shard does not regain capacity until the process restarts.
+//
 // Online reclaim under reject-writes is a separate, deeper change (it would have to
 // rendezvous with any lock-free reader still aliasing the pages) and is intentionally
 // NOT done here.

--- a/cache/flush_test.go
+++ b/cache/flush_test.go
@@ -1,0 +1,373 @@
+// SPDX-License-Identifier: Apache-2.0
+//go:build linux || windows
+
+package cache
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// Flush() tests — Stage 1 cache-layer core (global KV wipe by index swap + a
+// per-shard durability watermark). Mmap tests need the platform mmap build (hence
+// the build tag, matching warm_restart_test.go); the heap cases run there too.
+
+// flushCfg is a persistent (mmap when dir != "") reject-writes cache with a small
+// page budget so the handful of tiny keys these tests write keep occupancy well
+// below mmapCompactMinOccupancy — cold compaction never runs, so what keeps flushed
+// keys gone is the sidecar watermark, not the reclamation. A pinned NowFn keeps TTL
+// out of the picture entirely.
+func flushCfg(dir string, shards int) Config {
+	cfg := DefaultConfig()
+	cfg.NumShards = shards
+	cfg.PageSize = 1 << 20
+	cfg.MaxMemoryPerShard = 8 << 20 // 8 pages
+	cfg.AtCapPolicy = PolicyRejectWrites
+	cfg.TTLSweepIntervalMs = 0
+	cfg.DataDir = dir
+	cfg.NowFn = func() uint64 { return 5_000_000 }
+	return cfg
+}
+
+// liveCount returns the number of live entries visible through Iterate — the true
+// logical keyset size, which a flush must drive to 0.
+func liveCount(c *Cache) int {
+	n := 0
+	c.Iterate(func(_, _ []byte, _ uint64) bool { n++; return true })
+	return n
+}
+
+func flushKey(i int) []byte   { return []byte(fmt.Sprintf("key-%06d", i)) }
+func flushValue(i int) []byte { return []byte(fmt.Sprintf("val-%06d", i)) }
+
+// TestFlushEmptiesCache: N keys across many internal shards, Flush, every Get
+// misses and the live keyset (Iterate) is 0. Runs for both heap and mmap.
+func TestFlushEmptiesCache(t *testing.T) {
+	const n = 500
+	for _, tc := range []struct {
+		name string
+		dir  string
+	}{
+		{"heap", ""},
+		{"mmap", t.TempDir()},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := flushCfg(tc.dir, 16)
+			c, err := New(cfg)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer c.Close()
+			for i := 0; i < n; i++ {
+				if err := c.Put(flushKey(i), flushValue(i), 0); err != nil {
+					t.Fatalf("Put %d: %v", i, err)
+				}
+			}
+			if got := liveCount(c); got != n {
+				t.Fatalf("pre-flush live count = %d, want %d", got, n)
+			}
+			if err := c.Flush(); err != nil {
+				t.Fatalf("Flush: %v", err)
+			}
+			if got := liveCount(c); got != 0 {
+				t.Fatalf("post-flush live count = %d, want 0", got)
+			}
+			for i := 0; i < n; i++ {
+				if _, err := c.Get(flushKey(i)); err != ErrNotFound {
+					t.Fatalf("Get %d after flush: err=%v, want ErrNotFound", i, err)
+				}
+			}
+			// Cumulative counters are NOT reset by flush: Puts is a lifetime total.
+			if st := c.Stats(); st.Puts != n {
+				t.Fatalf("Stats.Puts = %d after flush, want %d (cumulative, not a live gauge)", st.Puts, n)
+			}
+		})
+	}
+}
+
+// TestFlushPostFlushWritesWork: writes after a flush store and read back, for both
+// modes.
+func TestFlushPostFlushWritesWork(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		dir  string
+	}{
+		{"heap", ""},
+		{"mmap", t.TempDir()},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			c, err := New(flushCfg(tc.dir, 4))
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer c.Close()
+			for i := 0; i < 50; i++ {
+				if err := c.Put(flushKey(i), flushValue(i), 0); err != nil {
+					t.Fatal(err)
+				}
+			}
+			if err := c.Flush(); err != nil {
+				t.Fatalf("Flush: %v", err)
+			}
+			for i := 100; i < 150; i++ {
+				if err := c.Put(flushKey(i), flushValue(i), 0); err != nil {
+					t.Fatalf("post-flush Put %d: %v", i, err)
+				}
+			}
+			for i := 100; i < 150; i++ {
+				v, err := c.Get(flushKey(i))
+				if err != nil || string(v) != string(flushValue(i)) {
+					t.Fatalf("post-flush Get %d: %q err=%v", i, v, err)
+				}
+			}
+			if got := liveCount(c); got != 50 {
+				t.Fatalf("live count = %d, want 50 (only post-flush keys)", got)
+			}
+		})
+	}
+}
+
+// TestFlushMmapRestartNoResurrection: put, Flush, Close, reopen → all pre-flush
+// keys are gone. This is the core durability property: the sidecar makes the wipe
+// survive the warm-restart rebuild.
+func TestFlushMmapRestartNoResurrection(t *testing.T) {
+	dir := t.TempDir()
+	cfg := flushCfg(dir, 1)
+	const n = 100
+
+	c, err := New(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for i := 0; i < n; i++ {
+		if err := c.Put(flushKey(i), flushValue(i), 0); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := c.Flush(); err != nil {
+		t.Fatalf("Flush: %v", err)
+	}
+	if err := c.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	c2, err := New(cfg)
+	if err != nil {
+		t.Fatalf("reopen: %v", err)
+	}
+	defer c2.Close()
+	if got := liveCount(c2); got != 0 {
+		t.Fatalf("after restart live count = %d, want 0 (flushed data resurrected)", got)
+	}
+	for i := 0; i < n; i++ {
+		if _, err := c2.Get(flushKey(i)); err != ErrNotFound {
+			t.Fatalf("restart Get %d: err=%v, want ErrNotFound — flushed key came back", i, err)
+		}
+	}
+}
+
+// TestFlushThenWriteSurvivesRestart: put A, Flush, put B, Close, reopen → A gone,
+// B present. Proves the watermark wipes only through the floor and post-flush
+// writes (seq > floor) survive.
+func TestFlushThenWriteSurvivesRestart(t *testing.T) {
+	dir := t.TempDir()
+	cfg := flushCfg(dir, 1)
+	keyA, valA := []byte("A-before-flush"), []byte("value-A")
+	keyB, valB := []byte("B-after-flush"), []byte("value-B")
+
+	c, err := New(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := c.Put(keyA, valA, 0); err != nil {
+		t.Fatal(err)
+	}
+	if err := c.Flush(); err != nil {
+		t.Fatalf("Flush: %v", err)
+	}
+	if err := c.Put(keyB, valB, 0); err != nil {
+		t.Fatal(err)
+	}
+	if err := c.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	c2, err := New(cfg)
+	if err != nil {
+		t.Fatalf("reopen: %v", err)
+	}
+	defer c2.Close()
+	if _, err := c2.Get(keyA); err != ErrNotFound {
+		t.Fatalf("restart: A (pre-flush) came back (err=%v), want ErrNotFound", err)
+	}
+	if v, err := c2.Get(keyB); err != nil || string(v) != string(valB) {
+		t.Fatalf("restart: B (post-flush) = %q err=%v, want %q", v, err, valB)
+	}
+}
+
+// TestFlushWriteSeqRestoreHazard is the most important durability test. Without the
+// writeSeq floor-restore in newShard, a post-flush write on an emptied shard would
+// get a low sequence (1..floor) that the NEXT restart's rebuild wrongly classifies
+// as flushed and skips — silently losing a committed write on the SECOND restart.
+//
+// put keys → Flush (shard now empty) → Close → reopen → put a NEW key → Close →
+// reopen again → the new key MUST still be present.
+func TestFlushWriteSeqRestoreHazard(t *testing.T) {
+	dir := t.TempDir()
+	cfg := flushCfg(dir, 1)
+	const n = 100
+
+	c, err := New(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for i := 0; i < n; i++ {
+		if err := c.Put(flushKey(i), flushValue(i), 0); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := c.Flush(); err != nil {
+		t.Fatalf("Flush: %v", err)
+	}
+	if err := c.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	// First restart: shard rebuilds EMPTY (every entry skipped). writeSeq must be
+	// lifted to the flush floor here, or the write below gets a flushed-range seq.
+	c2, err := New(cfg)
+	if err != nil {
+		t.Fatalf("reopen 1: %v", err)
+	}
+	newKey, newVal := []byte("post-flush-new-key"), []byte("must-survive")
+	if err := c2.Put(newKey, newVal, 0); err != nil {
+		t.Fatal(err)
+	}
+	if err := c2.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	// Second restart: the new key must NOT have been skipped as "flushed".
+	c3, err := New(cfg)
+	if err != nil {
+		t.Fatalf("reopen 2: %v", err)
+	}
+	defer c3.Close()
+	if v, err := c3.Get(newKey); err != nil || string(v) != string(newVal) {
+		t.Fatalf("second restart: new post-flush key = %q err=%v, want %q — "+
+			"writeSeq was not lifted to the flush floor, so the low-seq write was "+
+			"wrongly skipped as flushed", v, err, newVal)
+	}
+	if got := liveCount(c3); got != 1 {
+		t.Fatalf("second restart live count = %d, want 1 (only the new key)", got)
+	}
+}
+
+// TestFlushHeapNeedsNoSidecar: heap flush empties the cache and writes no sidecar
+// (heap has no rebuild path, so nothing to persist). No dir ⇒ nothing on disk.
+func TestFlushHeapNeedsNoSidecar(t *testing.T) {
+	c, err := New(flushCfg("", 4))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer c.Close()
+	for i := 0; i < 50; i++ {
+		if err := c.Put(flushKey(i), flushValue(i), 0); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := c.Flush(); err != nil {
+		t.Fatalf("Flush: %v", err)
+	}
+	if got := liveCount(c); got != 0 {
+		t.Fatalf("heap flush live count = %d, want 0", got)
+	}
+	// Heap shards keep no dataDir, so there is provably no sidecar to write.
+	for _, s := range c.shards {
+		if s.dataDir != "" {
+			t.Fatalf("heap shard has a dataDir %q; expected none", s.dataDir)
+		}
+	}
+}
+
+// TestFlushSidecarCorruptionTolerance: a corrupt sidecar falls back to floor 0 —
+// pre-flush data may resurrect, but the open must NOT crash or fail.
+func TestFlushSidecarCorruptionTolerance(t *testing.T) {
+	dir := t.TempDir()
+	cfg := flushCfg(dir, 1)
+
+	c, err := New(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := c.Put([]byte("k"), []byte("v"), 0); err != nil {
+		t.Fatal(err)
+	}
+	if err := c.Flush(); err != nil {
+		t.Fatalf("Flush: %v", err)
+	}
+	if err := c.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	sidecar := filepath.Join(dir, "shard-0000", flushSidecarName)
+	b, err := os.ReadFile(sidecar)
+	if err != nil {
+		t.Fatalf("sidecar should exist after a flush: %v", err)
+	}
+	if len(b) != flushSidecarSize {
+		t.Fatalf("sidecar size = %d, want %d", len(b), flushSidecarSize)
+	}
+	b[flushSidecarCRCOff] ^= 0xFF // corrupt the CRC
+	if err := os.WriteFile(sidecar, b, 0o640); err != nil {
+		t.Fatal(err)
+	}
+
+	// Must open cleanly (fail-open to floor 0), not panic or error.
+	c2, err := New(cfg)
+	if err != nil {
+		t.Fatalf("reopen with corrupt sidecar must not fail: %v", err)
+	}
+	defer c2.Close()
+	// floor 0 ⇒ the pre-flush key is re-indexed (resurrection is the documented,
+	// accepted cost of a corrupt watermark). We only require no crash.
+	if _, err := c2.Get([]byte("k")); err != nil && err != ErrNotFound {
+		t.Fatalf("unexpected Get error after corrupt-sidecar reopen: %v", err)
+	}
+}
+
+// TestFlushIdempotent: two flushes in a row are fine and leave the cache empty, for
+// both modes.
+func TestFlushIdempotent(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		dir  string
+	}{
+		{"heap", ""},
+		{"mmap", t.TempDir()},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			c, err := New(flushCfg(tc.dir, 2))
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer c.Close()
+			for i := 0; i < 30; i++ {
+				if err := c.Put(flushKey(i), flushValue(i), 0); err != nil {
+					t.Fatal(err)
+				}
+			}
+			if err := c.Flush(); err != nil {
+				t.Fatalf("Flush 1: %v", err)
+			}
+			if err := c.Flush(); err != nil {
+				t.Fatalf("Flush 2: %v", err)
+			}
+			if got := liveCount(c); got != 0 {
+				t.Fatalf("after double flush live count = %d, want 0", got)
+			}
+		})
+	}
+}

--- a/cache/flush_test.go
+++ b/cache/flush_test.go
@@ -4,6 +4,7 @@
 package cache
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -292,9 +293,12 @@ func TestFlushHeapNeedsNoSidecar(t *testing.T) {
 	}
 }
 
-// TestFlushSidecarCorruptionTolerance: a corrupt sidecar falls back to floor 0 —
-// pre-flush data may resurrect, but the open must NOT crash or fail.
-func TestFlushSidecarCorruptionTolerance(t *testing.T) {
+// TestFlushSidecarCorruptionFailsOpen: a PRESENT-but-corrupt sidecar must FAIL the
+// reopen, not silently fall back to floor 0. Falling back to 0 would re-index every
+// pre-flush entry permanently (the applied index is already past the flush op, so a
+// warm restart never replays it) and diverge this replica from peers whose sidecar is
+// intact — so a corrupt watermark is surfaced to the operator instead.
+func TestFlushSidecarCorruptionFailsOpen(t *testing.T) {
 	dir := t.TempDir()
 	cfg := flushCfg(dir, 1)
 
@@ -325,16 +329,42 @@ func TestFlushSidecarCorruptionTolerance(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// Must open cleanly (fail-open to floor 0), not panic or error.
+	// Reopen MUST fail: a present-but-invalid watermark is a durability fault, not a
+	// "never flushed" signal.
+	c2, err := New(cfg)
+	if err == nil {
+		_ = c2.Close()
+		t.Fatalf("reopen with a corrupt sidecar must FAIL, but succeeded")
+	}
+}
+
+// TestFlushSidecarAbsentOpensNormally: a genuinely ABSENT sidecar (never flushed, or
+// a shard predating the feature) opens normally at floor 0 — the backward-compatible
+// path that must survive the fail-closed change above.
+func TestFlushSidecarAbsentOpensNormally(t *testing.T) {
+	dir := t.TempDir()
+	cfg := flushCfg(dir, 1)
+
+	c, err := New(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := c.Put([]byte("k"), []byte("v"), 0); err != nil {
+		t.Fatal(err)
+	}
+	if err := c.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	// No flush ever happened, so no sidecar exists. Reopen must succeed and the key
+	// must survive (floor 0 wipes nothing).
 	c2, err := New(cfg)
 	if err != nil {
-		t.Fatalf("reopen with corrupt sidecar must not fail: %v", err)
+		t.Fatalf("reopen with no sidecar must succeed: %v", err)
 	}
 	defer c2.Close()
-	// floor 0 ⇒ the pre-flush key is re-indexed (resurrection is the documented,
-	// accepted cost of a corrupt watermark). We only require no crash.
-	if _, err := c2.Get([]byte("k")); err != nil && err != ErrNotFound {
-		t.Fatalf("unexpected Get error after corrupt-sidecar reopen: %v", err)
+	if v, err := c2.Get([]byte("k")); err != nil || string(v) != "v" {
+		t.Fatalf("key after no-sidecar reopen = %q err=%v, want v", v, err)
 	}
 }
 
@@ -369,5 +399,46 @@ func TestFlushIdempotent(t *testing.T) {
 				t.Fatalf("after double flush live count = %d, want 0", got)
 			}
 		})
+	}
+}
+
+// TestFlushSidecarWriteFailureIsNotDurable proves a sidecar I/O failure surfaces as
+// cache.ErrFlushNotDurable — the sentinel shard/apply_class.go classifies classFatal,
+// so a replicated follower that could not durably record the watermark HALTS rather
+// than advancing past a flush it did not durably apply. The failure is injected by
+// pre-creating the sidecar's temp path AS A DIRECTORY, so writeFlushSidecar's
+// O_CREATE|O_WRONLY open fails with EISDIR — a real I/O error that does not depend on
+// running as an unprivileged user.
+func TestFlushSidecarWriteFailureIsNotDurable(t *testing.T) {
+	dir := t.TempDir()
+	cfg := flushCfg(dir, 1)
+
+	c, err := New(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer c.Close()
+	if err := c.Put([]byte("k"), []byte("v"), 0); err != nil {
+		t.Fatal(err)
+	}
+
+	// Block the atomic sidecar write: its staging temp path already exists as a
+	// directory, so the O_CREATE|O_WRONLY|O_TRUNC open cannot succeed.
+	tmp := filepath.Join(dir, "shard-0000", flushSidecarName+flushSidecarTmpSuffix)
+	if err := os.Mkdir(tmp, 0o750); err != nil {
+		t.Fatalf("stage temp-as-directory: %v", err)
+	}
+
+	err = c.Flush()
+	if err == nil {
+		t.Fatalf("Flush must fail when the sidecar cannot be written")
+	}
+	if !errors.Is(err, ErrFlushNotDurable) {
+		t.Fatalf("Flush error = %v, want errors.Is(..., ErrFlushNotDurable)", err)
+	}
+	// The keyspace stays intact: the sidecar is written BEFORE the index swap, so a
+	// sidecar failure aborts with nothing wiped.
+	if v, gerr := c.Get([]byte("k")); gerr != nil || string(v) != "v" {
+		t.Fatalf("key after failed flush = %q err=%v, want v (keyspace must stay intact)", v, gerr)
 	}
 }

--- a/cache/shard.go
+++ b/cache/shard.go
@@ -33,6 +33,20 @@ var ErrFull = errors.New("cache: shard at capacity")
 // from the inline error it replaced.
 var ErrCannotEvict = errors.New("cache: nothing left to evict and still no room")
 
+// ErrFlushNotDurable marks a Cache.Flush() that could not make its per-shard
+// durability watermark (the flushed.seq sidecar) durable — a create/write/fsync/
+// rename/dir-fsync failure in writeFlushSidecar. It is NON-DETERMINISTIC across
+// replicas: a local disk fault on one node need not occur on its peers. On the
+// LEADER the sidecar is written BEFORE the index swap, so a failure returns with the
+// keyspace intact; but a replicated apply must additionally guarantee that a FOLLOWER
+// which hit this error does NOT advance its applied index past the flush, because
+// advancing over a flush it could not durably apply would resurrect every pre-flush
+// key on a later failover — silent divergence from peers whose sidecar landed. So
+// shard/apply_class.go classifies it classFatal (fail-closed), exactly like ErrFull
+// and ErrCannotEvict. Cache.Flush wraps every sidecar I/O failure so callers can
+// errors.Is it through the apply path's multi-%w wrapping.
+var ErrFlushNotDurable = errors.New("cache: flush watermark not durable")
+
 // shard is one independent slice of the cache: its own page list, lock,
 // and index. Shards do not share state and are safe to use concurrently
 // across goroutines.
@@ -297,7 +311,18 @@ func newShard(cfg Config, dataDir string) (*shard, error) {
 	// sidecar that outlived a rotated-aside pages file would otherwise let post-fresh
 	// low-seq writes be wrongly skipped on the next restart — the writeSeq floor-lift
 	// below closes that too.
-	s.flushedThroughSeq = readFlushSidecar(dataDir)
+	// A present-but-invalid sidecar FAILS the open (see readFlushSidecar): a corrupt
+	// flush watermark cannot be silently downgraded to floor 0, which would re-index
+	// pre-flush entries permanently and diverge this replica from peers with intact
+	// sidecars. A genuinely absent sidecar returns (0, nil) and opens normally.
+	flushedFloor, ferr := readFlushSidecar(dataDir)
+	if ferr != nil {
+		if s.file != nil {
+			_ = munmapAndClose(s.file, s.region)
+		}
+		return nil, ferr
+	}
+	s.flushedThroughSeq = flushedFloor
 	if !fresh {
 		// Restore the persisted LOGICAL clock (v3 header; 0 on a v2 file). This is
 		// what lets cold compaction judge TTL expiry deterministically on a

--- a/cache/shard.go
+++ b/cache/shard.go
@@ -105,6 +105,21 @@ type shard struct {
 	region       []byte
 	appliedIndex atomic.Uint64
 
+	// dataDir is the shard's on-disk directory (the parent of pages.dat), or "" in
+	// heap mode. Set once in newShard, immutable thereafter, so flush can locate the
+	// durability sidecar (dataDir/flushed.seq) without re-deriving it from s.file.
+	dataDir string
+
+	// flushedThroughSeq is the write-sequence FLOOR a prior Cache.Flush() recorded in
+	// this shard's sidecar (dataDir/flushed.seq): every entry whose metaSeq(meta) <=
+	// this value was logically wiped by that flush and MUST NOT be re-indexed by the
+	// warm-restart rebuild, nor resurrected across a restart. Restored from the
+	// sidecar at open BEFORE rebuildIndexFromPages runs; 0 when no sidecar exists
+	// (byte-identical to pre-flush behaviour) or it fails its CRC. Written under mu on
+	// flush; otherwise touched only at construction (single-threaded, pre-publish),
+	// and never read off-lock at runtime, so a plain field suffices.
+	flushedThroughSeq uint64
+
 	// stats — atomic counters; no shard lock needed. `hits` is NOT stored: every
 	// read bumps `gets` on entry and bumps `misses` on any non-returning path
 	// (absent, collision, corrupt, expired-on-read), so Hits = Gets - Misses is
@@ -208,6 +223,7 @@ type shard struct {
 func newShard(cfg Config, dataDir string) (*shard, error) {
 	s := &shard{
 		cfg:         cfg,
+		dataDir:     dataDir,
 		stopSweeper: make(chan struct{}),
 	}
 	if cfg.NowFn != nil {
@@ -275,6 +291,13 @@ func newShard(cfg Config, dataDir string) (*shard, error) {
 
 	s.attachMmapRegion(file, region)
 	s.appliedIndex.Store(appliedIdx)
+	// Restore the flush watermark BEFORE the index rebuild, so rebuildIndexFromPages
+	// can skip every entry a prior Cache.Flush() logically wiped (seq <= floor). Read
+	// unconditionally: on a fresh pages file it is normally absent (→ 0), but a
+	// sidecar that outlived a rotated-aside pages file would otherwise let post-fresh
+	// low-seq writes be wrongly skipped on the next restart — the writeSeq floor-lift
+	// below closes that too.
+	s.flushedThroughSeq = readFlushSidecar(dataDir)
 	if !fresh {
 		// Restore the persisted LOGICAL clock (v3 header; 0 on a v2 file). This is
 		// what lets cold compaction judge TTL expiry deterministically on a
@@ -318,6 +341,19 @@ func newShard(cfg Config, dataDir string) (*shard, error) {
 	// order is free to disagree with page order (it always did — see
 	// firstPageWithRoomLocked). This is now purely about packing density.
 	s.writeIdx = writeIdx
+
+	// writeSeq-restore — the flush durability payoff, and a genuine hazard without it.
+	// rebuildIndexFromPages recovers writeSeq as max(seq) over the SURVIVING entries;
+	// when a prior Flush() emptied this shard there are no survivors and the recovered
+	// max is ~0, while the flush floor may be large. Lift writeSeq to the floor so the
+	// NEXT writes get seq > floor and can never be re-classified as flushed (seq <=
+	// floor) — and therefore skipped — by a FUTURE restart's rebuild. Skipping this
+	// step would silently lose every post-flush write on the second restart. It only
+	// ever raises writeSeq (max is monotonic), so it is a no-op on a shard that was
+	// never flushed.
+	if s.flushedThroughSeq > s.writeSeq {
+		s.writeSeq = s.flushedThroughSeq
+	}
 
 	s.startSweeper()
 	return s, nil
@@ -993,6 +1029,15 @@ func (s *shard) rebuildIndexFromPages() {
 			}
 			esize := entrySize(len(key), len(value))
 			seq := metaSeq(meta)
+			if seq <= s.flushedThroughSeq {
+				// Wiped by a prior Cache.Flush(): this entry is below the durable flush
+				// floor, so it is neither indexed NOR allowed to contribute to the
+				// recovered max(seq) — letting it lift writeSeq back into the flushed
+				// range would re-open the very hazard the writeSeq-restore in newShard
+				// closes. Skip it entirely.
+				cursor += esize
+				continue
+			}
 			if seq > maxSeq {
 				maxSeq = seq
 			}

--- a/client/client.go
+++ b/client/client.go
@@ -277,6 +277,16 @@ func (c *Client) Exists(ctx context.Context, key []byte) (bool, error) {
 	return wire.DecodeCASResult(res)
 }
 
+// Flush wipes the ENTIRE KV keyspace. A single call fans out SERVER-SIDE: flush is
+// keyless, so it falls to a round-robin server in pickInitialTarget, and the
+// receiving node's Call intercept broadcasts it into every shard group's Raft log
+// (see cluster.broadcastFlush). It is idempotent, so it is deliberately NOT a
+// nonReplayableOp — a retry after an ambiguous transport failure simply re-wipes.
+func (c *Client) Flush(ctx context.Context) error {
+	_, err := c.Call(ctx, "flush", nil)
+	return err
+}
+
 // GetDel atomically returns key's value and deletes it. found is false (and value
 // nil) when the key was absent; a found empty value comes back as a non-nil
 // zero-length slice.

--- a/client/client.go
+++ b/client/client.go
@@ -280,8 +280,11 @@ func (c *Client) Exists(ctx context.Context, key []byte) (bool, error) {
 // Flush wipes the ENTIRE KV keyspace. A single call fans out SERVER-SIDE: flush is
 // keyless, so it falls to a round-robin server in pickInitialTarget, and the
 // receiving node's Call intercept broadcasts it into every shard group's Raft log
-// (see cluster.broadcastFlush). It is idempotent, so it is deliberately NOT a
-// nonReplayableOp — a retry after an ambiguous transport failure simply re-wipes.
+// (see cluster.broadcastFlush). flush IS a nonReplayableOp: it is idempotent only
+// while nothing else writes between attempts, so a blind replay after an AMBIGUOUS
+// (post-transmission) transport failure could re-wipe data another client wrote in
+// the interval. On an ambiguous failure Call therefore surfaces the error instead
+// of silently re-flushing; the caller decides whether re-issuing is safe.
 func (c *Client) Flush(ctx context.Context) error {
 	_, err := c.Call(ctx, "flush", nil)
 	return err
@@ -525,7 +528,7 @@ func (e *ambiguousError) Unwrap() error { return e.err }
 // ttl, mget) are deliberately absent: replaying them cannot corrupt a result.
 func nonReplayableOp(op string) bool {
 	switch op {
-	case "set_nx", "cas", "cad", "getdel", "getset", "incr_ex", "caex", "persist":
+	case "set_nx", "cas", "cad", "getdel", "getset", "incr_ex", "caex", "persist", "flush":
 		return true
 	}
 	return false

--- a/client/client.go
+++ b/client/client.go
@@ -526,9 +526,17 @@ func (e *ambiguousError) Unwrap() error { return e.err }
 // original, and persist/caex report the wrong bit or extend a lease the caller
 // can no longer be sure it still holds. Read-only / idempotent ops (get, exists,
 // ttl, mget) are deliberately absent: replaying them cannot corrupt a result.
+//
+// "flush" and its INTERNAL per-group wrapper "__flush_shard__" (cluster's
+// opFlushShardName, forwarded between nodes over a peer Client) are both here: a
+// flush is idempotent ONLY while nothing writes between attempts, so replaying one
+// whose commit succeeded but whose response was lost would silently re-wipe writes
+// made in the interval. The wrapper must carry the same guard as "flush" or the
+// double-apply hole reopens one layer down — cluster.proposeFlush relies on this to
+// surface an ambiguous per-group flush instead of the peer Client re-sending it.
 func nonReplayableOp(op string) bool {
 	switch op {
-	case "set_nx", "cas", "cad", "getdel", "getset", "incr_ex", "caex", "persist", "flush":
+	case "set_nx", "cas", "cad", "getdel", "getset", "incr_ex", "caex", "persist", "flush", "__flush_shard__":
 		return true
 	}
 	return false
@@ -541,6 +549,15 @@ func isAmbiguous(err error) bool {
 	var a *ambiguousError
 	return errors.As(err, &a)
 }
+
+// IsAmbiguous reports whether err (returned by Client.Call) is a post-transmission
+// transport failure: the request may have committed on the server before the failure,
+// so its outcome is UNKNOWN. Exposed for callers that forward a non-replayable op
+// across peers and must not try another target after an ambiguous send — notably
+// cluster.proposeFlush, whose per-group flush leg must surface such an error rather
+// than re-issue the wipe against the next owner. A PRE-transmission failure (dial
+// refused, no leader yet) is not ambiguous and is safe to retry elsewhere.
+func IsAmbiguous(err error) bool { return isAmbiguous(err) }
 
 // isTransportError reports whether err is a network-level transport
 // error (dial refused, connection reset, EOF, etc.) that is safe to

--- a/client_integration_test.go
+++ b/client_integration_test.go
@@ -84,6 +84,49 @@ func TestClientPutGet(t *testing.T) {
 	}
 }
 
+// TestClientFlushWipesStore exercises the typed client's Flush end-to-end against a
+// loopback server: it seeds keys, calls Flush once (which sends the keyless "flush"
+// op the server dispatches to handleFlush → cache.Flush), then asserts every key
+// misses and a post-flush write still reads back.
+func TestClientFlushWipesStore(t *testing.T) {
+	addr, stop := startTestStack(t)
+	defer stop()
+	c, err := client.New(client.Config{Servers: []string{addr}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = c.Close() }()
+
+	ctx := context.Background()
+	for _, k := range []string{"a", "b", "c"} {
+		if _, err := c.Call(ctx, "put", wire.EncodePutArgs([]byte(k), []byte("v"), 0)); err != nil {
+			t.Fatalf("put %q: %v", k, err)
+		}
+	}
+
+	if err := c.Flush(ctx); err != nil {
+		t.Fatalf("Flush: %v", err)
+	}
+
+	for _, k := range []string{"a", "b", "c"} {
+		_, err := c.Call(ctx, "get", wire.EncodeKeyArgs([]byte(k)))
+		if !errors.Is(err, client.ErrNotFound) {
+			t.Fatalf("get %q after flush: err = %v, want ErrNotFound", k, err)
+		}
+	}
+
+	if _, err := c.Call(ctx, "put", wire.EncodePutArgs([]byte("d"), []byte("w"), 0)); err != nil {
+		t.Fatalf("put after flush: %v", err)
+	}
+	res, err := c.Call(ctx, "get", wire.EncodeKeyArgs([]byte("d")))
+	if err != nil {
+		t.Fatalf("get after post-flush put: %v", err)
+	}
+	if !bytes.Equal(res, []byte("w")) {
+		t.Fatalf("post-flush get = %q, want w", res)
+	}
+}
+
 // Named to avoid colliding with the root Store-API test of the same intent
 // (client_test.go's TestClientGetMissingReturnsErrNotFound); this one exercises
 // the typed client's Call path directly.

--- a/cluster/admin_ops.go
+++ b/cluster/admin_ops.go
@@ -277,6 +277,9 @@ func (n *Node) registerAdminOps() {
 		// ONE group named in its payload and never re-broadcasts. See
 		// wasm_broadcast.go.
 		opRegisterWASMShardName: n.handleRegisterWASMShard,
+		// Shard-scoped leg of the KV flush broadcast: proposes a flush to the ONE
+		// group named in its payload and never re-broadcasts. See flush_broadcast.go.
+		opFlushShardName: n.handleFlushShard,
 		// WASM blob transport: how a node that lacks a module's bytes obtains
 		// them. Both are node-local leaves — the put verifies, compiles and
 		// stores; the get reads the content-addressed store and NOTHING ELSE (no

--- a/cluster/flush_broadcast.go
+++ b/cluster/flush_broadcast.go
@@ -1,0 +1,163 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package cluster
+
+import (
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/rostamlabs/rostam/shard"
+)
+
+// flushOpName is the KV op that wipes the ENTIRE keyspace. Node.Call intercepts it
+// and broadcasts, because a keyless op would otherwise route to shard 0 alone.
+const flushOpName = "flush"
+
+// opFlushShardName is the INTERNAL, node-local wrapper op used to drive a flush
+// into ONE named shard group on a peer. It dispatches off n.adminOps (Node.Call) —
+// before op-registry routing — so the receiving node proposes the flush to exactly
+// the requested group and does NOT re-broadcast.
+//
+// Sending flushOpName itself over the wire would re-enter Node.Call on the peer and
+// fan out to every group IT hosts, which in a cluster whose nodes host
+// overlapping-but-unequal shard subsets can bounce between nodes without
+// terminating. The wrapper makes the remote step a leaf — the exact shape
+// __register_wasm_shard__ gives the WASM-registration broadcast.
+//
+// It is not in authz's admin allowlist by NAME for its privilege to hold — an op
+// that matches no allowlist and is absent from the ops registry already falls
+// through to actionFor's deny-by-default "admin" bucket — but it IS enumerated in
+// authz.adminOps regardless, so a future refactor that registers the wrapper in the
+// ops registry cannot silently demote it from admin to write (the reasoning
+// __register_wasm_shard__ records). Inter-node hops carry the internal service
+// token, so peers pass; an external non-admin key does not.
+const opFlushShardName = "__flush_shard__"
+
+// encodeShardScopedFlush is the wire form of opFlushShardName: the target shard
+// index as 4 big-endian bytes. A flush carries no other payload.
+func encodeShardScopedFlush(shardIdx int) []byte {
+	out := make([]byte, 4)
+	binary.BigEndian.PutUint32(out, uint32(shardIdx)) //nolint:gosec // bounded by NumShards
+	return out
+}
+
+// decodeShardScopedFlush reads the target shard index written by
+// encodeShardScopedFlush.
+func decodeShardScopedFlush(args []byte) (int, error) {
+	if len(args) != 4 {
+		return 0, fmt.Errorf("cluster: %s: want a 4-byte shard index, got %d bytes", opFlushShardName, len(args))
+	}
+	return int(binary.BigEndian.Uint32(args)), nil
+}
+
+// flushBroadcastGroupTimeout bounds ONE group's leg of the flush broadcast,
+// mirroring wasmBroadcastGroupTimeout: without it a single
+// unreachable-but-not-erroring peer stalls the whole flush — and the client
+// connection behind it — indefinitely, because the loop is sequential over up to
+// NumShards groups and forward() used an unbounded context. A group that times out
+// is reported as a failure like any other, and the client retries.
+const flushBroadcastGroupTimeout = 10 * time.Second
+
+// broadcastFlush proposes a flush op into EVERY shard Raft group instead of only
+// shard 0's, so one client-visible flush wipes the WHOLE keyspace rather than only
+// the keys that happen to hash to group 0.
+//
+// WHY (a keyless op otherwise routes to shard 0 alone). flush has no routing key,
+// so Node.shardIndexFor returns 0 for it and Call would propose it into group 0's
+// log only, leaving groups 1..N intact. Each shard group is an INDEPENDENT Raft
+// group with its OWN cache.Cache, so wiping the whole keyspace means landing a flush
+// in every group's log. This is the same "replicate a mutation to every group"
+// precedent broadcastWASMRegistration establishes; flush is simpler because it
+// carries no payload and needs no propose-time refusals, size cap, or update gate.
+//
+// Each group applies the flush through its own FSM/Raft (and PB) path →
+// ops.handleFlush → that group's cache.Flush(). No leader-stamping is needed: the
+// cache layer captures each replica's LOCAL writeSeq floor at apply, so replicas
+// converge on an empty keyspace without a coordinated clock (see cache.Cache.Flush's
+// durability-ordering contract).
+//
+// IDEMPOTENT. A flush is idempotent — re-applying it to an already-empty (or
+// since-rewritten) group simply re-wipes — so a Raft replay or a retry after a
+// partial failure is safe and needs no dedup.
+//
+// PARTIAL FAILURE. Every group is attempted even after one fails (a transient
+// election on group 3 must not deny groups 4..N the flush), and a non-empty failure
+// set is returned as an error so the caller can retry. Retrying re-flushes the
+// groups that already succeeded to no ill effect, and is how a group that missed the
+// first attempt is eventually wiped.
+func (n *Node) broadcastFlush() ([]byte, error) {
+	var failures []string
+	for i := 0; i < n.cfg.NumShards; i++ {
+		if err := n.proposeFlush(i); err != nil {
+			failures = append(failures, fmt.Sprintf("shard %d: %v", i, err))
+		}
+	}
+	if len(failures) > 0 {
+		return nil, fmt.Errorf("cluster: flush: %d of %d shard groups failed (safe to retry, flush is idempotent): %s",
+			len(failures), n.cfg.NumShards, strings.Join(failures, "; "))
+	}
+	return nil, nil
+}
+
+// proposeFlush lands a flush in shard idx's Raft log, wherever this node sits
+// relative to that group (mirrors proposeWASMRegistration):
+//
+//   - hosted and led here: propose straight into the local store;
+//   - hosted but led elsewhere (the normal case for all but one group in a
+//     multi-shard cluster): shard.Store.Call answers NotLeaderError, so hop;
+//   - not hosted at all (partitioned cluster): hop.
+//
+// The hop reuses forwardTimeout, whose per-owner client follows NotLeader to the
+// group's leader — but carries the shard-scoped wrapper op so the peer handles this
+// ONE group and does not re-broadcast (see opFlushShardName).
+//
+// A NotLeaderError must not escape to the client here: a broadcast spans groups with
+// DIFFERENT leaders, so "retry at node X" is not a hint any single node can satisfy,
+// and following it would bounce the client between nodes that each lead a different
+// subset. The text is preserved for diagnostics; the type is not.
+func (n *Node) proposeFlush(idx int) error {
+	var hostedErr error
+	if s := n.getShard(idx); s != nil {
+		_, err := n.callHostedShard(s, flushOpName, nil)
+		if err == nil {
+			return nil
+		}
+		var nle *shard.NotLeaderError
+		if !errors.As(err, &nle) {
+			// A genuine propose/apply failure for this group (not a routing miss);
+			// another owner would fail the same way.
+			return err
+		}
+		hostedErr = err
+	}
+	if _, err := n.forwardTimeout(idx, opFlushShardName, encodeShardScopedFlush(idx), flushBroadcastGroupTimeout); err != nil {
+		if hostedErr != nil {
+			return fmt.Errorf("%v; leader hop: %v", hostedErr, err)
+		}
+		return err
+	}
+	return nil
+}
+
+// handleFlushShard is the node-local handler for opFlushShardName. It proposes the
+// flush to the ONE group named in the payload — never to any other group, and never
+// onward to another node — so the broadcast fan-out stays flat. Returning
+// ErrNoShardOwner when this node does not host the group lets the sender's forward()
+// loop move on to the next owner.
+func (n *Node) handleFlushShard(args []byte) ([]byte, error) {
+	idx, err := decodeShardScopedFlush(args)
+	if err != nil {
+		return nil, err
+	}
+	if idx < 0 || idx >= n.cfg.NumShards {
+		return nil, fmt.Errorf("cluster: %s: shard %d out of range [0,%d)", opFlushShardName, idx, n.cfg.NumShards)
+	}
+	s := n.getShard(idx)
+	if s == nil {
+		return nil, ErrNoShardOwner
+	}
+	return n.callHostedShard(s, flushOpName, nil)
+}

--- a/cluster/flush_broadcast.go
+++ b/cluster/flush_broadcast.go
@@ -88,6 +88,17 @@ const flushBroadcastGroupTimeout = 10 * time.Second
 // client op is nonReplayableOp, so Client.Call never blindly replays an ambiguous
 // flush; a caller re-issues only when re-wiping intervening writes is acceptable.
 //
+// THE INTERNAL LEG IS ITSELF AMBIGUOUS-SAFE — no post-send owner retry. proposeFlush
+// forwards __flush_shard__ via forwardTimeoutNoReplay, which surfaces an ambiguous
+// (post-transmission) per-owner failure instead of re-sending the wrapper to the next
+// owner, and __flush_shard__ is a nonReplayableOp so the peer Client does not auto-
+// retry it after an ambiguous send either. Both together mean a group whose flush
+// COMMITTED but whose response was lost is reported as a partial failure and bubbles
+// up as the broadcast error — never a silent SECOND flush of that group. That closes
+// the "flush is not blindly replayable under concurrency" contract end to end: the
+// external op guard (nonReplayableOp "flush") stops the client re-issuing, and this
+// stops the internal fan-out re-issuing one layer down.
+//
 // PARTIAL FAILURE. Every group is attempted even after one fails (a transient
 // election on group 3 must not deny groups 4..N the flush); a non-empty failure set
 // leaves the keyspace PARTIALLY wiped and is returned as an error so the caller can
@@ -114,9 +125,14 @@ func (n *Node) broadcastFlush() ([]byte, error) {
 //     multi-shard cluster): shard.Store.Call answers NotLeaderError, so hop;
 //   - not hosted at all (partitioned cluster): hop.
 //
-// The hop reuses forwardTimeout, whose per-owner client follows NotLeader to the
-// group's leader — but carries the shard-scoped wrapper op so the peer handles this
-// ONE group and does not re-broadcast (see opFlushShardName).
+// The hop reuses forwardTimeoutNoReplay, whose per-owner client follows NotLeader to
+// the group's leader — but carries the shard-scoped wrapper op so the peer handles
+// this ONE group and does not re-broadcast (see opFlushShardName). NoReplay because a
+// flush is not blindly replayable: on an AMBIGUOUS (post-transmission) per-owner
+// error the wrapper's commit may already have landed, so we must NOT re-send it to
+// the next owner (that would double-apply and re-wipe intervening writes). An
+// ambiguous error therefore propagates up as a partial failure; a PRE-transmission
+// error (dial/NotLeader/no-leader-yet) is safe and still rotates to the next owner.
 //
 // A NotLeaderError must not escape to the client here: a broadcast spans groups with
 // DIFFERENT leaders, so "retry at node X" is not a hint any single node can satisfy,
@@ -137,7 +153,7 @@ func (n *Node) proposeFlush(idx int) error {
 		}
 		hostedErr = err
 	}
-	if _, err := n.forwardTimeout(idx, opFlushShardName, encodeShardScopedFlush(idx), flushBroadcastGroupTimeout); err != nil {
+	if _, err := n.forwardTimeoutNoReplay(idx, opFlushShardName, encodeShardScopedFlush(idx), flushBroadcastGroupTimeout); err != nil {
 		if hostedErr != nil {
 			return fmt.Errorf("%v; leader hop: %v", hostedErr, err)
 		}

--- a/cluster/flush_broadcast.go
+++ b/cluster/flush_broadcast.go
@@ -79,15 +79,19 @@ const flushBroadcastGroupTimeout = 10 * time.Second
 // converge on an empty keyspace without a coordinated clock (see cache.Cache.Flush's
 // durability-ordering contract).
 //
-// IDEMPOTENT. A flush is idempotent — re-applying it to an already-empty (or
-// since-rewritten) group simply re-wipes — so a Raft replay or a retry after a
-// partial failure is safe and needs no dedup.
+// REPLAY / RETRY. A single flush entry is idempotent WITHIN its own group — a Raft
+// replay re-wipes to the same empty state and needs no dedup. Retrying the whole
+// broadcast after a partial failure is how the groups that missed the first attempt
+// are eventually wiped, but it is NOT a no-op on the groups that already succeeded:
+// a write that landed in one of them since the first attempt is re-wiped by the
+// retry. That is inherent to "wipe everything now" — not a bug — and is why the
+// client op is nonReplayableOp, so Client.Call never blindly replays an ambiguous
+// flush; a caller re-issues only when re-wiping intervening writes is acceptable.
 //
 // PARTIAL FAILURE. Every group is attempted even after one fails (a transient
-// election on group 3 must not deny groups 4..N the flush), and a non-empty failure
-// set is returned as an error so the caller can retry. Retrying re-flushes the
-// groups that already succeeded to no ill effect, and is how a group that missed the
-// first attempt is eventually wiped.
+// election on group 3 must not deny groups 4..N the flush); a non-empty failure set
+// leaves the keyspace PARTIALLY wiped and is returned as an error so the caller can
+// decide whether to complete it.
 func (n *Node) broadcastFlush() ([]byte, error) {
 	var failures []string
 	for i := 0; i < n.cfg.NumShards; i++ {
@@ -96,7 +100,7 @@ func (n *Node) broadcastFlush() ([]byte, error) {
 		}
 	}
 	if len(failures) > 0 {
-		return nil, fmt.Errorf("cluster: flush: %d of %d shard groups failed (safe to retry, flush is idempotent): %s",
+		return nil, fmt.Errorf("cluster: flush: %d of %d shard groups failed — keyspace is now PARTIALLY wiped; re-issuing completes it but also re-wipes any writes made since to the groups that already succeeded: %s",
 			len(failures), n.cfg.NumShards, strings.Join(failures, "; "))
 	}
 	return nil, nil

--- a/cluster/flush_broadcast_test.go
+++ b/cluster/flush_broadcast_test.go
@@ -1,0 +1,232 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package cluster
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/rostamlabs/rostam/ops"
+	"github.com/rostamlabs/rostam/shard"
+)
+
+// keysCoveringEveryShard returns one key per shard group [0,numShards), each key
+// hashing (via shardOf, the SAME router Node.Call uses) to its index. It is the
+// fixture the flush-broadcast test needs: a keyspace spread across EVERY group, so
+// that a flush wiping all of them can only be explained by the broadcast reaching
+// every group — not just group 0, where a keyless op would otherwise route.
+func keysCoveringEveryShard(t *testing.T, numShards int) [][]byte {
+	t.Helper()
+	keys := make([][]byte, numShards)
+	filled := 0
+	for i := 0; filled < numShards; i++ {
+		k := []byte(fmt.Sprintf("flush-key-%d", i))
+		g := shardOf(k, numShards)
+		if keys[g] == nil {
+			keys[g] = k
+			filled++
+		}
+		if i > 100000 {
+			t.Fatalf("could not cover all %d shards after 100k candidates (filled %d)", numShards, filled)
+		}
+	}
+	return keys
+}
+
+// TestNodeFlushBroadcastWipesEveryShardGroup is the core proof of Stage 2: a single
+// flush call, dispatched to a node hosting many independent shard groups, must empty
+// EVERY group's keyspace — not only group 0, where a keyless op routes by default.
+//
+// It seeds one key per group (each hashing to a distinct group), confirms every key
+// reads back, calls flush once, then asserts every key now misses. Because the keys
+// live in different Raft groups with independent caches, an all-miss result can only
+// come from the broadcast landing a flush in each group's log (broadcastFlush).
+func TestNodeFlushBroadcastWipesEveryShardGroup(t *testing.T) {
+	const numShards = 8
+	n := newTestNode(t, numShards)
+
+	keys := keysCoveringEveryShard(t, numShards)
+
+	// Seed and confirm each key is stored in its group.
+	for _, k := range keys {
+		if _, err := n.Call("put", ops.EncodePutArgs(k, []byte("v"), 0)); err != nil {
+			t.Fatalf("put %q: %v", k, err)
+		}
+	}
+	for i, k := range keys {
+		res, err := n.Call("get", ops.EncodeKeyArgs(k))
+		if err != nil {
+			t.Fatalf("get %q (shard %d) before flush: %v", k, i, err)
+		}
+		if string(res) != "v" {
+			t.Fatalf("get %q (shard %d) before flush = %q, want v", k, i, res)
+		}
+	}
+
+	// One flush call — the node must fan it out to every group.
+	if _, err := n.Call("flush", nil); err != nil {
+		t.Fatalf("flush: %v", err)
+	}
+
+	// Every group must now be empty. A single group left non-empty means the
+	// broadcast missed it.
+	for i, k := range keys {
+		_, err := n.Call("get", ops.EncodeKeyArgs(k))
+		if err == nil {
+			t.Fatalf("key %q (shard %d) still present after flush — broadcast missed its group", k, i)
+		}
+		if !isNotFoundErr(err) {
+			t.Fatalf("get %q (shard %d) after flush: unexpected err %v, want not-found", k, i, err)
+		}
+	}
+
+	// The store is live, not poisoned: a post-flush write reads back.
+	postKey := keys[numShards-1]
+	if _, err := n.Call("put", ops.EncodePutArgs(postKey, []byte("w"), 0)); err != nil {
+		t.Fatalf("put after flush: %v", err)
+	}
+	res, err := n.Call("get", ops.EncodeKeyArgs(postKey))
+	if err != nil {
+		t.Fatalf("get after post-flush put: %v", err)
+	}
+	if string(res) != "w" {
+		t.Fatalf("post-flush get = %q, want w", res)
+	}
+}
+
+// TestNodeFlushBroadcastAcrossPartitionedCluster proves the flush fan-out crosses
+// NODE boundaries, not just group boundaries. With ReplicationFactor=1 over 3 nodes
+// and 6 shard groups, each group lives on exactly ONE node, so a flush issued to a
+// single node MUST forward a per-group leg (opFlushShardName) to the owner of every
+// group it does not host — the proposeFlush leader-hop path. It seeds keys across
+// all groups, flushes via one node, then asserts every key misses cluster-wide: a
+// group whose remote owner never received the forwarded flush would still hold its
+// keys.
+func TestNodeFlushBroadcastAcrossPartitionedCluster(t *testing.T) {
+	const nodes, numShards, rf = 3, 6, 1
+	tc := newTestCluster(t, nodes, numShards, rf)
+	ctx := context.Background()
+
+	keys := keysCoveringEveryShard(t, numShards)
+
+	// Seed via the routing client (each key reaches its group's owner) and wait for
+	// every node to apply.
+	for _, k := range keys {
+		if _, err := tc.client.Call(ctx, "put", ops.EncodePutArgs(k, []byte("v"), 0)); err != nil {
+			t.Fatalf("put %q: %v", k, err)
+		}
+	}
+	for _, n := range tc.nodes {
+		waitAllApplied(t, n)
+	}
+	for i, k := range keys {
+		got, err := tc.client.Call(ctx, "get", ops.EncodeKeyArgs(k))
+		if err != nil {
+			t.Fatalf("get %q (shard %d) before flush: %v", k, i, err)
+		}
+		if string(got) != "v" {
+			t.Fatalf("get %q (shard %d) before flush = %q, want v", k, i, got)
+		}
+	}
+
+	// One flush issued to a SINGLE node — it must fan out to every group's owner,
+	// hopping across nodes for the groups it does not host itself.
+	if _, err := tc.nodes[0].Call("flush", nil); err != nil {
+		t.Fatalf("flush via node 0: %v", err)
+	}
+
+	// Every key must now miss cluster-wide.
+	for i, k := range keys {
+		_, err := tc.client.Call(ctx, "get", ops.EncodeKeyArgs(k))
+		if err == nil {
+			t.Fatalf("key %q (shard %d) still present after flush — a remote group's owner was not reached", k, i)
+		}
+		if !isNotFoundErr(err) {
+			t.Fatalf("get %q (shard %d) after flush: unexpected err %v, want not-found", k, i, err)
+		}
+	}
+}
+
+// TestNodeFlushBroadcastWipesBackupReplica proves the flush is applied on BACKUP
+// replicas, not only on each group's leader. The two other broadcast tests run
+// RF=1 (one owner per group), so they show fan-out reaches every group/node but do
+// NOT prove a follower applies the wipe. Here RF=3 over 3 nodes puts every group on
+// all three nodes; after a single flush, this reads each key from a FOLLOWER's LOCAL
+// cache (getShard(idx).Get bypasses leader routing), so an all-miss result can only
+// mean the backup applied the flush through its own Raft log — the property RF=1
+// asserts only by construction. (Correctness rests on flush using the identical
+// propose path as a normal write; this closes it by execution.)
+func TestNodeFlushBroadcastWipesBackupReplica(t *testing.T) {
+	const nodes, numShards, rf = 3, 6, 3
+	tc := newTestCluster(t, nodes, numShards, rf)
+	ctx := context.Background()
+
+	keys := keysCoveringEveryShard(t, numShards)
+
+	// Seed via the routing client, then wait for every replica to apply.
+	for _, k := range keys {
+		if _, err := tc.client.Call(ctx, "put", ops.EncodePutArgs(k, []byte("v"), 0)); err != nil {
+			t.Fatalf("put %q: %v", k, err)
+		}
+	}
+	for _, n := range tc.nodes {
+		waitAllApplied(t, n)
+	}
+
+	// For each key, pin a FOLLOWER store hosting its group and confirm the key is
+	// present there BEFORE the flush — reading a follower's local cache (not routing
+	// to the leader) is what makes the post-flush miss prove the backup was wiped.
+	type followerRead struct {
+		key   []byte
+		store *shard.Store
+		node  string
+	}
+	var reads []followerRead
+	for _, k := range keys {
+		idx := shardOf(k, numShards)
+		var fs *shard.Store
+		var fnode string
+		for _, n := range tc.nodes {
+			if s := n.getShard(idx); s != nil && !s.IsLeader() {
+				fs, fnode = s, n.cfg.NodeID
+				break
+			}
+		}
+		if fs == nil {
+			t.Fatalf("shard %d (key %q): no follower store found; RF=%d over %d nodes should give one", idx, k, rf, nodes)
+		}
+		if got, err := fs.Get(k); err != nil || string(got) != "v" {
+			t.Fatalf("key %q not present on follower %s (shard %d) before flush: v=%q err=%v", k, fnode, idx, got, err)
+		}
+		reads = append(reads, followerRead{key: k, store: fs, node: fnode})
+	}
+
+	// One flush via a single node → replicates through EVERY group's Raft log so
+	// every replica (leader AND backups) applies it.
+	if _, err := tc.nodes[0].Call("flush", nil); err != nil {
+		t.Fatalf("flush via node 0: %v", err)
+	}
+	for _, n := range tc.nodes {
+		waitAllApplied(t, n)
+	}
+
+	// The BACKUP replica's LOCAL cache must now miss.
+	for _, r := range reads {
+		_, err := r.store.Get(r.key)
+		if err == nil {
+			t.Fatalf("key %q still present on follower %s after flush — the backup replica did not apply the flush", r.key, r.node)
+		}
+		if !isNotFoundErr(err) {
+			t.Fatalf("follower %s get %q after flush: unexpected err %v, want not-found", r.node, r.key, err)
+		}
+	}
+}
+
+// isNotFoundErr reports whether err is the cache key-miss, matched by message so it
+// covers both the in-process sentinel and its stringified form across the Raft/apply
+// boundary (the same approach httpapi.isKVNotFound uses).
+func isNotFoundErr(err error) bool {
+	return err != nil && strings.Contains(err.Error(), "not found")
+}

--- a/cluster/flush_pb_test.go
+++ b/cluster/flush_pb_test.go
@@ -1,0 +1,88 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package cluster
+
+import (
+	"fmt"
+	"testing"
+	"time"
+)
+
+// TestPBFlushBroadcastWipesBackupReplica proves the flush replicates through the
+// PRIMARY-BACKUP apply path, not only Raft. The other flush tests use newTestCluster
+// (the Raft harness); this uses newPBTestCluster (ReplicationMode="pb"), seeds keys
+// via the primary, flushes, waits for apply, then reads a BACKUP's LOCAL cache
+// (node.getShard(idx).Get) and asserts it misses — which can only mean the flush
+// reached the backup through PB replication and its apply path wiped it.
+//
+// One shard keeps the topology unambiguous: a single primary and two backups, so the
+// flush issued at the primary proposes locally and replicates to both backups.
+func TestPBFlushBroadcastWipesBackupReplica(t *testing.T) {
+	const nodes, numShards, minISR = 3, 1, 2
+	tc := newPBTestCluster(t, nodes, numShards, minISR)
+
+	// Seed a spread of keys (all route to shard 0's primary here).
+	keys := make([][]byte, 0, 12)
+	for i := 0; i < 12; i++ {
+		k := []byte(fmt.Sprintf("pbflush-%03d", i))
+		pbPutKey(t, tc, numShards, k, []byte("v"))
+		keys = append(keys, k)
+	}
+
+	primaryIdx := pbPrimaryIdx(t, tc, 0)
+
+	// Confirm every key is present on a BACKUP's local cache before the flush —
+	// reading the backup directly (not routing to the primary) is what makes the
+	// post-flush miss prove the backup itself applied the wipe.
+	backupIdx := -1
+	for i := range tc.nodes {
+		if i != primaryIdx {
+			backupIdx = i
+			break
+		}
+	}
+	if backupIdx < 0 {
+		t.Fatalf("no backup node found (primary=%d of %d nodes)", primaryIdx, nodes)
+	}
+	backup := tc.nodes[backupIdx].getShard(0)
+	if backup == nil {
+		t.Fatalf("backup node %d does not host shard 0", backupIdx)
+	}
+	for _, k := range keys {
+		if v, err := backup.Get(k); err != nil || string(v) != "v" {
+			t.Fatalf("key %q not present on backup n%d before flush: v=%q err=%v", k, backupIdx+1, v, err)
+		}
+	}
+
+	// One flush issued at the primary → proposes into shard 0 and replicates to the
+	// PB backups.
+	if _, err := tc.nodes[primaryIdx].Call("flush", nil); err != nil {
+		t.Fatalf("flush via primary n%d: %v", primaryIdx+1, err)
+	}
+
+	// The BACKUP's LOCAL cache must now miss every key. Poll: PB apply on the backup
+	// is asynchronous to the primary's flush return.
+	deadline := time.Now().Add(10 * time.Second)
+	for _, k := range keys {
+		var missErr error
+		gone := false
+		for time.Now().Before(deadline) {
+			_, err := backup.Get(k)
+			if err != nil {
+				missErr, gone = err, true
+				break
+			}
+			// Still present: the backup has not applied the flush yet.
+			time.Sleep(25 * time.Millisecond)
+		}
+		if !gone {
+			t.Fatalf("key %q still present on backup n%d after flush — the PB backup did not apply the flush", k, backupIdx+1)
+		}
+		if !isNotFoundErr(missErr) {
+			t.Fatalf("backup n%d get %q after flush: unexpected err %v, want not-found", backupIdx+1, k, missErr)
+		}
+	}
+
+	// Post-flush write still works through the primary (store is live, not poisoned).
+	pbPutKey(t, tc, numShards, []byte("pbflush-post"), []byte("w"))
+}

--- a/cluster/node.go
+++ b/cluster/node.go
@@ -1143,6 +1143,12 @@ func (n *Node) Call(name string, args []byte) ([]byte, error) {
 		}
 		return []byte(report), nil
 	}
+	// A flush is the other op that must land in EVERY shard group's log, not just
+	// shard 0's: it is keyless (so shardIndexFor returns 0 for it) but wipes the
+	// WHOLE keyspace, and each group owns an independent cache. See broadcastFlush.
+	if name == flushOpName {
+		return n.broadcastFlush()
+	}
 	idx, err := n.shardIndexFor(ke, layout, args)
 	if err != nil {
 		return nil, err

--- a/cluster/node.go
+++ b/cluster/node.go
@@ -1514,6 +1514,32 @@ func (n *Node) forward(shardIdx int, name string, args []byte) ([]byte, error) {
 // the whole owner-rotation loop, which is what makes it a bound on the CALL
 // rather than on one attempt.
 func (n *Node) forwardTimeout(shardIdx int, name string, args []byte, timeout time.Duration) ([]byte, error) {
+	return n.forwardTimeoutOpt(shardIdx, name, args, timeout, false)
+}
+
+// forwardTimeoutNoReplay is forwardTimeout for a NON-REPLAYABLE op. It differs in
+// exactly one respect: when a per-owner cl.Call returns an AMBIGUOUS error (a
+// post-transmission failure — the entry may already be committed, client.IsAmbiguous),
+// it returns that error IMMEDIATELY instead of trying the next owner. Trying another
+// owner after an ambiguous send is precisely a blind replay: it could apply the op a
+// SECOND time. A PRE-transmission error (dial refused, NotLeader, no-leader-yet) is
+// still safe to retry against the next owner, so those keep rotating.
+//
+// This exists for the flush per-group leg (cluster.proposeFlush): re-forwarding a
+// committed-but-ambiguous __flush_shard__ to another owner would append a second
+// flush and wipe any writes made in between — the double-apply the client-side
+// nonReplayableOp guard already closes for the external "flush" op. The plain
+// forwardTimeout is deliberately left untouched so WASM registration (which IS
+// idempotent under replay) keeps its rotate-on-any-error behavior.
+func (n *Node) forwardTimeoutNoReplay(shardIdx int, name string, args []byte, timeout time.Duration) ([]byte, error) {
+	return n.forwardTimeoutOpt(shardIdx, name, args, timeout, true)
+}
+
+// forwardTimeoutOpt is the shared owner-rotation loop behind forwardTimeout and
+// forwardTimeoutNoReplay. When noReplayOnAmbiguous is set, an ambiguous per-owner
+// error short-circuits the loop (see forwardTimeoutNoReplay); otherwise every error
+// rotates to the next owner (forwardTimeout's historical behavior).
+func (n *Node) forwardTimeoutOpt(shardIdx int, name string, args []byte, timeout time.Duration, noReplayOnAmbiguous bool) ([]byte, error) {
 	owners := n.ownersFor(shardIdx)
 	if len(owners) == 0 {
 		return nil, ErrNoShardOwner
@@ -1541,6 +1567,13 @@ func (n *Node) forwardTimeout(shardIdx int, name string, args []byte, timeout ti
 		res, err := cl.Call(ctx, name, args)
 		if err == nil {
 			return res, nil
+		}
+		// For a non-replayable op, an AMBIGUOUS (post-transmission) failure must NOT
+		// fall through to the next owner: the entry may already be committed, so a
+		// retry elsewhere would double-apply. Surface it now. Pre-transmission errors
+		// are not ambiguous and stay safe to retry, so they keep rotating below.
+		if noReplayOnAmbiguous && client.IsAmbiguous(err) {
+			return nil, err
 		}
 		lastErr = err // try the next owner (transport error / no leader yet)
 	}

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -16,7 +16,11 @@ Notable user-visible changes. Entries that alter existing behaviour are marked
   `Flush(ctx)` and over REST as `POST /v1/kv/flush`. This removes the need for
   the generation-counter workaround a cache driver otherwise needs for
   `Cache::flush()`-style clears (which is not correct on the client side, because
-  the counter is itself an evictable cache entry).
+  the counter is itself an evictable cache entry). Caveat: flush empties the
+  keyspace but leaves the page allocation intact, so under the non-default
+  `PolicyRejectWrites` a shard that was full can still reject the next write with
+  "at capacity" until its space is reclaimed by a later cold compaction (at
+  restart) — under the default ring-buffer eviction policy this is invisible.
 
 - **Embedded web dashboard.** The server now ships a browser UI at
   `/dashboard/` for inspecting and operating on a running instance — vector

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -5,6 +5,19 @@ Notable user-visible changes. Entries that alter existing behaviour are marked
 
 ## Unreleased
 
+- **New key-value op: `flush`.** Wipes the entire KV keyspace in one call,
+  in O(shards) rather than O(keys) — it swaps each shard's in-memory index for
+  an empty one and records a small per-shard durability watermark, so pages are
+  reclaimed lazily by later compaction instead of scanned and deleted up front.
+  It replicates like any other write (applied through each shard group's log, so
+  every replica converges on an empty keyspace) and, in a cluster, one call fans
+  out to every shard group. Requires a global write scope (`write:*`); a
+  read-only or single-collection key cannot flush. Available on the Go client as
+  `Flush(ctx)` and over REST as `POST /v1/kv/flush`. This removes the need for
+  the generation-counter workaround a cache driver otherwise needs for
+  `Cache::flush()`-style clears (which is not correct on the client side, because
+  the counter is itself an evictable cache entry).
+
 - **Embedded web dashboard.** The server now ships a browser UI at
   `/dashboard/` for inspecting and operating on a running instance — vector
   collections, cluster topology, and KV keys — with no separate install. It

--- a/httpapi/httpapi.go
+++ b/httpapi/httpapi.go
@@ -149,6 +149,9 @@ func Handler(disp Dispatcher, opts Options) http.Handler {
 	mux.HandleFunc("GET /v1/kv/{key}", a.kvGet)
 	mux.HandleFunc("PUT /v1/kv/{key}", a.kvPut)
 	mux.HandleFunc("DELETE /v1/kv/{key}", a.kvDelete)
+	// Wipe the whole KV keyspace. A fixed, keyless route — no {key} — so it never
+	// collides with the /v1/kv/{key} patterns above (those are GET/PUT/DELETE only).
+	mux.HandleFunc("POST /v1/kv/flush", a.kvFlush)
 	mux.HandleFunc("POST /v1/collections", a.createCollection)
 	mux.HandleFunc("DELETE /v1/collections/{name}", a.dropCollection)
 	mux.HandleFunc("POST /v1/collections/{name}/points", a.putPoint)

--- a/httpapi/kv.go
+++ b/httpapi/kv.go
@@ -182,3 +182,16 @@ func (a *api) kvDelete(w http.ResponseWriter, r *http.Request) {
 	deleted := len(body) > 0 && body[0] == 1
 	writeJSON(w, http.StatusOK, map[string]bool{"deleted": deleted})
 }
+
+// kvFlush wipes the ENTIRE KV keyspace → {"flushed":true}. Dispatched via callWrite
+// with the default (no write-consistency) path and empty args; the flush op is
+// keyless and takes no body, and in cluster mode the node fans it out to every shard
+// group (cluster.broadcastFlush). It requires GLOBAL write authority (a read-only
+// key gets 401), exactly like kvDelete's classification but against the empty
+// (cluster) resource — see the flush routing row in sdk/wire.
+func (a *api) kvFlush(w http.ResponseWriter, r *http.Request) {
+	if _, ok := a.callWrite(w, r, "flush", nil, 0, true); !ok {
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]bool{"flushed": true})
+}

--- a/httpapi/kv_flush_test.go
+++ b/httpapi/kv_flush_test.go
@@ -1,0 +1,81 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package httpapi
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"testing"
+
+	"github.com/rostamlabs/rostam/authz"
+	"github.com/rostamlabs/rostam/ops"
+	"github.com/rostamlabs/rostam/vector"
+)
+
+// TestHTTPKVFlush covers POST /v1/kv/flush: it returns 200 {"flushed":true} and
+// wipes the keyspace — a key written before the flush reads back found=false after.
+func TestHTTPKVFlush(t *testing.T) {
+	h, cleanup := newTestAPI(t)
+	defer cleanup()
+
+	if rec := do(t, h, "PUT", "/v1/kv/gone", `{"value":"x"}`, nil); rec.Code != http.StatusOK {
+		t.Fatalf("put = %d, want 200 (%s)", rec.Code, rec.Body)
+	}
+
+	var flushed struct {
+		Flushed bool `json:"flushed"`
+	}
+	rec := do(t, h, "POST", "/v1/kv/flush", "", &flushed)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("flush = %d, want 200 (%s)", rec.Code, rec.Body)
+	}
+	if !flushed.Flushed {
+		t.Fatalf("flush body = %s, want flushed:true", rec.Body)
+	}
+
+	var out kvGetResponse
+	do(t, h, "GET", "/v1/kv/gone", "", &out)
+	if out.Found {
+		t.Fatalf("key still present after flush; want found=false")
+	}
+}
+
+// TestHTTPKVFlushRBAC pins the authz bar on the REST surface: flush is a
+// global-WRITE op, so a read-only key is denied 401 while a cluster-wide write:* key
+// succeeds 200. This mirrors the del classification against the empty resource.
+func TestHTTPKVFlushRBAC(t *testing.T) {
+	keyReg, err := vector.OpenKeyRegistry(filepath.Join(t.TempDir(), "keys.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	mustAddKey(t, keyReg, vector.APIKey{Token: "k_read", Tenant: "acme", Scopes: []string{"read:*"}})
+	mustAddKey(t, keyReg, vector.APIKey{Token: "k_write", Tenant: "acme", Scopes: []string{"write:*"}})
+
+	opsReg := ops.NewRegistry()
+	if err := ops.RegisterBuiltins(opsReg); err != nil {
+		t.Fatal(err)
+	}
+	h, cleanup := newTestAPIOpts(t, Options{Authenticator: authz.NewRBACAuthenticator(keyReg, opsReg, "")})
+	defer cleanup()
+
+	flushReq := func(token string) int {
+		r := httptest.NewRequest("POST", "/v1/kv/flush", nil)
+		if token != "" {
+			r.Header.Set("Authorization", "Bearer "+token)
+		}
+		rec := httptest.NewRecorder()
+		h.ServeHTTP(rec, r)
+		return rec.Code
+	}
+
+	if code := flushReq("k_read"); code != http.StatusUnauthorized {
+		t.Fatalf("flush by read-only key = %d, want 401", code)
+	}
+	if code := flushReq(""); code != http.StatusUnauthorized {
+		t.Fatalf("flush by anonymous caller = %d, want 401", code)
+	}
+	if code := flushReq("k_write"); code != http.StatusOK {
+		t.Fatalf("flush by write:* key = %d, want 200", code)
+	}
+}

--- a/ops/builtin.go
+++ b/ops/builtin.go
@@ -71,6 +71,10 @@ var builtinHandlers = map[string]Handler{
 	"incr_ex": handleIncrEx,
 	"caex":    handleCAEX,
 	"mget":    handleMGet,
+	// flush wipes the ENTIRE KV keyspace (keyless, no args). The cluster path
+	// broadcasts it to every shard group; each group applies it here against its own
+	// cache. See handleFlush.
+	"flush": handleFlush,
 	// put_batch packs N puts into one Raft log entry (one fsync / round-trip /
 	// apply for the whole batch). It routes by its FIRST key, so every key in a
 	// batch must hash to the same shard — the cluster fan-out (Node.PutBatch)
@@ -194,6 +198,7 @@ var builtinHandlers = map[string]Handler{
 //   - "incr_ex" (read-write) args: [keyLen u16][key][delta i64][ttlMs u64] → new value as i64 BE (TTL set on create only)
 //   - "caex"    (read-write) args: [keyLen u16][key][expLen u32][expected][ttlMs u64] → 1-byte 1=TTL refreshed/0=mismatch|absent
 //   - "mget"    (read-only)  args: [count u16]([keyLen u16][key])*         → [count u16]([found u8](+[valLen u32][val] if found))*
+//   - "flush"   (read-write) args: (ignored)                               → empty (wipes the ENTIRE keyspace; broadcast to every shard group in cluster mode)
 //   - "__ping__" (read-only) args: (ignored)                             → empty
 //
 // Routing metadata (kind/wire.KeyExtractor/wire.RouteLayout) comes from wire.BuiltinOps,
@@ -245,6 +250,18 @@ func handleDel(tx *TxContext, args []byte) ([]byte, error) {
 		return []byte{1}, nil
 	}
 	return []byte{0}, nil
+}
+
+// handleFlush wipes the ENTIRE KV keyspace of the cache this op is applied against
+// in O(shards), not O(keys) — see cache.Cache.Flush. It is keyless and ignores its
+// args (the client sends nil); it returns (nil, err), the empty ack del returns on
+// success. In the cluster it applies once per shard group (cluster.broadcastFlush
+// lands it in every group's log), so the union of every group's Flush wipes the
+// whole keyspace. Flush is idempotent, so a Raft replay or a broadcast retry is
+// safe. No apply-stamping: cache.Flush captures each replica's local writeSeq floor,
+// so replicas converge on an empty keyspace with no coordinated clock.
+func handleFlush(tx *TxContext, _ []byte) ([]byte, error) {
+	return nil, tx.Cache().Flush()
 }
 
 func handleExpire(tx *TxContext, args []byte) ([]byte, error) {

--- a/ops/flush_test.go
+++ b/ops/flush_test.go
@@ -1,0 +1,62 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package ops
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/rostamlabs/rostam/cache"
+)
+
+// TestBuiltinFlushWipesKeyspace dispatches the flush op through a TxContext-backed
+// store and asserts every prior key misses afterward while a post-flush write reads
+// back — the single-cache contract every shard group's FSM relies on.
+func TestBuiltinFlushWipesKeyspace(t *testing.T) {
+	r, tx := newTestSetup(t)
+
+	putH, _, _, _ := r.Lookup("put")
+	getH, _, _, _ := r.Lookup("get")
+
+	// Seed several keys.
+	for _, k := range [][]byte{[]byte("a"), []byte("b"), []byte("c")} {
+		if _, err := putH(tx, EncodePutArgs(k, []byte("v"), 0)); err != nil {
+			t.Fatalf("put %q: %v", k, err)
+		}
+	}
+
+	flushH, kind, _, ok := r.Lookup("flush")
+	if !ok {
+		t.Fatal("flush not registered")
+	}
+	if kind != OpReadWrite {
+		t.Fatalf("flush kind = %v, want OpReadWrite", kind)
+	}
+	// Flush ignores its args (nil here) and returns an empty ack.
+	res, err := flushH(tx, nil)
+	if err != nil {
+		t.Fatalf("flush handler: %v", err)
+	}
+	if len(res) != 0 {
+		t.Fatalf("flush result = %q, want empty", res)
+	}
+
+	// Every seeded key must now miss.
+	for _, k := range [][]byte{[]byte("a"), []byte("b"), []byte("c")} {
+		if _, err := getH(tx, EncodeKeyArgs(k)); err != cache.ErrNotFound {
+			t.Fatalf("get %q after flush: err = %v, want ErrNotFound", k, err)
+		}
+	}
+
+	// A post-flush write reads back — the store is live, not poisoned.
+	if _, err := putH(tx, EncodePutArgs([]byte("d"), []byte("w"), 0)); err != nil {
+		t.Fatalf("put after flush: %v", err)
+	}
+	got, err := getH(tx, EncodeKeyArgs([]byte("d")))
+	if err != nil {
+		t.Fatalf("get after post-flush put: %v", err)
+	}
+	if !bytes.Equal(got, []byte("w")) {
+		t.Fatalf("post-flush get = %q, want w", got)
+	}
+}

--- a/sdk/wire/builtin_routing.go
+++ b/sdk/wire/builtin_routing.go
@@ -53,6 +53,21 @@ var BuiltinOps = []BuiltinOp{
 	// the read counterpart of put_batch. The client groups keys by owning shard
 	// before it calls, so every key in one mget hashes to the same shard.
 	{"mget", OpReadOnly, mgetKeyExtractor, RouteLayoutNone, false},
+	// flush wipes the ENTIRE KV keyspace. It is KEYLESS (nil KeyExtractor,
+	// RouteLayoutNone), takes no args, and returns an empty ack. A keyless op would
+	// otherwise route to shard 0 alone, so the cluster path (cluster.Node.Call)
+	// intercepts flush and fans it out to EVERY shard group's Raft log — see
+	// cluster.broadcastFlush; Direct/embedded dispatches it once against its single
+	// cache.Cache.
+	//
+	// AUTHZ: registered OpReadWrite, so authz classifies it ActionWrite against the
+	// EMPTY (cluster) resource — exactly like del. It therefore requires GLOBAL write
+	// authority (write:*/*:*): a read-only key is rejected by ActionWrite, and a
+	// collection-scoped write:docs never matches the empty resource. That is the
+	// intended bar — write authority already implies deleting any key, and flush is
+	// merely the O(1) form of "delete every key" — so it is deliberately NOT added to
+	// the admin allowlist.
+	{"flush", OpReadWrite, nil, RouteLayoutNone, false},
 	// __ping__/__ready__/__metrics__/__repl_metrics__/__collections__ are shardless (nil KeyExtractor).
 	{"__ping__", OpReadOnly, nil, RouteLayoutNone, false},
 	{ReadyOp, OpReadOnly, nil, RouteLayoutNone, false},

--- a/shard/apply_class.go
+++ b/shard/apply_class.go
@@ -341,5 +341,17 @@ func classifyApplyErr(err error) applyClass {
 	if errors.Is(err, cache.ErrFull) || errors.Is(err, cache.ErrCannotEvict) {
 		return classFatal
 	}
+	// cache.ErrFlushNotDurable: this replica could not make the flush watermark
+	// (flushed.seq sidecar) durable — a LOCAL disk fault that a peer need not share.
+	// It is fatal for the same reason ErrFull is: advancing the applied index past a
+	// flush this node could not durably record would, on a later failover, resurrect
+	// every pre-flush key while peers whose sidecar landed hold an empty keyspace —
+	// silent, permanent divergence. Fail-closed instead (halt in Raft mode; NACK in
+	// PB mode). On a single-node (non-replicated) shard classFatal does not halt (see
+	// fsm.go), which is correct: there is no peer to diverge from, and shard.flush
+	// writes the sidecar BEFORE the index swap, so the keyspace stays intact anyway.
+	if errors.Is(err, cache.ErrFlushNotDurable) {
+		return classFatal
+	}
 	return classAdvance
 }

--- a/shard/fail_closed_test.go
+++ b/shard/fail_closed_test.go
@@ -110,6 +110,12 @@ func TestClassifyApplyErr(t *testing.T) {
 		// divergence as ErrOpNotRegistered.
 		{"ops.ErrWASMNoGroupBinding", ops.ErrWASMNoGroupBinding},
 		{"wrapped ops.ErrWASMNoGroupBinding (as the resolver wraps it)", fmt.Errorf("%w: op %q shard group %d", ops.ErrWASMNoGroupBinding, "udf", 3)},
+		// A flush whose durability watermark (sidecar) could not be persisted on THIS
+		// node. A local disk fault a peer need not share, so advancing over it would
+		// resurrect pre-flush keys on a later failover — fatal, like ErrFull. The
+		// wrapped case mirrors how cache.shard.flush wraps the sidecar I/O cause.
+		{"cache.ErrFlushNotDurable", cache.ErrFlushNotDurable},
+		{"wrapped cache.ErrFlushNotDurable (as cache.flush wraps the I/O cause)", fmt.Errorf("%w: %w", cache.ErrFlushNotDurable, errors.New("fsync flush sidecar dir: read-only file system"))},
 	}
 	for _, tc := range fatal {
 		if got := classifyApplyErr(tc.err); got != classFatal {


### PR DESCRIPTION
Implements the global KV `flush` op proposed in #64 — an O(shards) keyspace wipe, replicated to every shard group. Closes #64.

## Why
A cache driver on the binary protocol (e.g. Laravel's `Cache`) maps every verb to a native op **except** `Cache::flush()`. As #64 argues, the client-side generation-counter workaround is not correct: the counter is itself an ordinary cache entry under `PolicyRingbufEvict` (write-ordered eviction), so it ages out and is evicted — silently resurrecting flushed data and letting processes disagree on the current generation. A server-side flush removes the counter, the key-mangling, and that whole failure mode.

## Design (per the #64 proposal, verified against the code)
- **Runtime — swap the index, keep the pages.** Each cache-internal shard's `tab` (`atomic.Pointer[indexTable]`) is swapped for a fresh empty table — the same O(1) atomic idiom resize/compaction already use. Lock-free readers pick up the empty table on their next load; page bytes are reclaimed lazily by eviction / the next cold compaction, not scanned and deleted up front.
- **Durability — a sidecar watermark, not a header field.** A per-shard `flushed.seq` sidecar records the write-sequence floor the flush wiped through, written + fsynced **before** the swap (so a sidecar-write failure aborts the flush with the keyspace intact, never an acked-but-non-durable wipe). `rebuildIndexFromPages` skips entries at/below the floor on open, and `writeSeq` is lifted to the floor so post-flush writes are never wrongly skipped after a restart. The 64-byte header is full and version-locked (`minReadableCacheVersion == cacheVersion`), so a sidecar is the right call. Heap shards need none.
- **Replication — an ordinary op.** Registered in the op registry and applied through each shard group's log (Raft **and** primary-backup), so every replica converges on an empty keyspace. The floor is captured **locally per replica** (never leader-stamped), since `writeSeq` is node-local physical state.
- **Cluster fan-out.** A keyless op would route to shard 0 alone, so `Node.Call` intercepts `flush` and broadcasts a per-group flush into **every** shard group's log — mirroring the `__register_wasm__` broadcast, with a `__flush_shard__` leaf wrapper so remote hops don't re-broadcast. Partial failure is reported and safe to retry (flush is idempotent).
- **Scope — global only.** A prefix/namespace-scoped flush would need a scan (the O(n) pause this avoids); global-only keeps it O(shards).

## Decisions on the open questions in #64
1. **Log-order** semantic (applied where it sits in the log), not a wall-clock barrier — the only deterministic reading, and the same ordering every other mutation uses.
2. **Sidecar**, not a header field (header is full + version-locked).
3. **Lazy** page reclaim (eviction + next cold compaction), not eager — the lower-risk default.
4. **PB path** needs nothing beyond the Raft path (same apply entrypoint) and is covered by tests.

## Auth
`flush` is an ordinary **write** on the cluster resource, so it requires a global write scope (`write:*`/`*:*`); a read-only key and a collection-scoped `write:docs` are both denied. A `write:*` key can already `del` every key one at a time — this is the O(1) form — so it needs no separate admin gate (which would break the app-key use case). The internal `__flush_shard__` wrapper is admin-only and carries the inter-node token, so no external non-admin caller can invoke it.

## Surfaces
- Go client: `Flush(ctx) error` (one call fans out server-side; idempotent, so not marked non-replayable).
- REST: `POST /v1/kv/flush` → `{"flushed":true}` (usable from the dashboard KV console and curl).

## Testing
- **Cache durability matrix:** flush empties (heap + mmap); restart → no resurrection; flush-then-write survives restart; the empty-then-write **double-restart** hazard (proves the `writeSeq` floor-restore); sidecar-corruption tolerance (fails safe to floor 0); idempotent; all also under `-race`.
- **Op / authz / HTTP:** dispatch wipes and stays live; read-only and collection-scoped keys denied, global-write allowed; `POST /v1/kv/flush` RBAC.
- **Cluster:** one flush wipes every group on a single node (8 groups) and across a 3-node partitioned cluster (forwards to every owner); and an **RF=3 test reading a follower's local cache** proves a **backup** replica is wiped by replication, not just hidden behind leader routing.

A separate review pass (0 Critical/High) flagged two things now fixed: the sidecar is written **before** the swap (so a sidecar I/O error can't ack a non-durable wipe), and the RF=3 backup test was added to prove replica-wipe by execution rather than only by construction.

Thanks to @Keivan-S for the detailed, code-anchored proposal in #64.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## New Features
- Added a `flush` operation to clear the entire key-value store.
- Added Go client support via `Client.Flush(ctx)`.
- Added REST support through `POST /v1/kv/flush`.
- Cluster-wide flushes now clear data across all shards and replicas.
- Flushes remain durable across restarts, with writes available immediately afterward.

## Authorization
- Restricted flushing to callers with global write permission.

## Bug Fixes
- Prevented ambiguous flush requests from being automatically replayed.
- Invalid durability metadata now prevents unsafe recovery.
- Flush failures are reported when durability cannot be confirmed.

## Documentation
- Documented that flushing clears keys but preserves page allocation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->