### PR TITLE
fix(vector): clear a reservation's state only after the unmap succeeds

### DIFF
--- a/vector/reserve_linux.go
+++ b/vector/reserve_linux.go
@@ -180,11 +180,21 @@ func (r *slabReservation) release() error {
 	if r == nil || r.base == nil {
 		return nil
 	}
-	base, n := r.base, r.resLen
-	r.base, r.commit, r.resLen = nil, 0, 0
-	liveSlabReservations.Add(-1)
-	if err := unix.MunmapPtr(base, n); err != nil {
+	// The bookkeeping is cleared only AFTER the unmap succeeds. Doing it
+	// first would say "released" about a range that is still mapped:
+	// mapped() would report false, liveSlabReservations would under-count
+	// the very leak it exists to detect - so reserve_leak_test.go would
+	// pass while the range leaked - and a second release would return
+	// early instead of trying again.
+	//
+	// munmap of a range this package mapped itself is close to
+	// unfailable, which is why the order went unnoticed; that makes it
+	// cheap to get right rather than a reason to leave it.
+	if err := unix.MunmapPtr(r.base, r.resLen); err != nil {
 		return fmt.Errorf("vector: munmap reservation: %w", err)
 	}
+
+	r.base, r.commit, r.resLen = nil, 0, 0
+	liveSlabReservations.Add(-1)
 	return nil
 }


### PR DESCRIPTION
## What this fixes

`slabReservation.release()` clears its bookkeeping before calling `munmap`:

```go
base, n := r.base, r.resLen
r.base, r.commit, r.resLen = nil, 0, 0
liveSlabReservations.Add(-1)
if err := unix.MunmapPtr(base, n); err != nil {
    return fmt.Errorf("vector: munmap reservation: %w", err)
}
```

If that `munmap` fails, the range is still mapped and every observer says it is not:

- `mapped()` reports false, so the slab looks unreserved to anything that asks.
- A second `release()` returns early at the `r.base == nil` guard instead of trying again.
- `liveSlabReservations` has already been decremented, so the counter under-reports the leak — and that counter is what `reserve_leak_test.go` asserts on. The one mechanism built to catch a leaked reservation would report balance while the reservation leaked.

Swapping the order costs nothing on the success path and stops the failure path lying about what it did.

## Why it has not bitten

`munmap` of a range this package mapped itself, at the length it mapped it, is close to unfailable — which is exactly why the order went unnoticed. That makes it cheap to get right rather than a reason to leave it: an invariant that only holds because its violation is rare is still worth stating correctly, particularly when the thing it misleads is a leak detector.

## How it was found

Reviewing a Windows implementation that had copied the pattern (#65). That one is fixed there; this is kept separate so a Windows branch does not carry a change to Linux behaviour.

## Testing

`gofmt` clean, `go vet ./vector/...` clean for linux/amd64 including tests, `go build ./...` for linux/amd64. The file is `//go:build linux && (amd64 || arm64)`, so the parts of the suite reachable from this machine were exercised on windows/amd64 and are unaffected; the Linux lanes cover the changed line itself.