### PR TITLE
Add ShardFormer handling in State method

### DIFF
--- a/cluster/meta_fsm.go
+++ b/cluster/meta_fsm.go
@@ -170,6 +170,12 @@ func (m *MetaFSM) State() State {
 			cp.ShardISR[k] = append([]string(nil), v...)
 		}
 	}
+	if m.state.ShardFormer != nil {
+		cp.ShardFormer = make(map[int]string, len(m.state.ShardFormer))
+		for k, v := range m.state.ShardFormer {
+			cp.ShardFormer[k] = v
+		}
+	}
 	return cp
 }
 

--- a/cluster/meta_fsm_test.go
+++ b/cluster/meta_fsm_test.go
@@ -116,6 +116,22 @@ func TestMetaFSMStateIsDeepCopy(t *testing.T) {
 	}
 }
 
+func TestMetaFSMStateShardFormerIsDeepCopy(t *testing.T) {
+	f := NewMetaFSM()
+	data, _ := encodeLogEntry(LogEntry{Op: OpSetShardFormer, ShardID: 0, Node: "n1"})
+	// OpSetShardFormer returns true on first write (write-once designation), not nil.
+	resp := f.Apply(&raft.Log{Data: data})
+	if installed, ok := resp.(bool); !ok || !installed {
+		t.Fatalf("Apply: expected true, got %v", resp)
+	}
+	st1 := f.State()
+	st1.ShardFormer[0] = "MUTATED"
+	st2 := f.State()
+	if st2.ShardFormer[0] != "n1" {
+		t.Errorf("ShardFormer not deep-copied: got %q, want %q", st2.ShardFormer[0], "n1")
+	}
+}
+
 func TestMetaFSMApplySortsMembersByNodeID(t *testing.T) {
 	f := NewMetaFSM()
 	// Pass members in reverse alphabetical order.


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `MetaFSM.State` so the returned state includes a deep copy of `ShardFormer`, preventing callers from mutating the internal map.

<sup>Written for commit 6dc3e86b979a3f40fa41064c85d50c28b1a1cba4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rostamlabs/rostam/pull/73?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved state isolation by ensuring shard transition information is safely copied when retrieving cluster metadata.
  - Prevented unintended changes to internal state when modifying returned metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->