### PR TITLE
fix(meta): enhance idempotency check for replication factor changes

### DIFF
--- a/cluster/meta.go
+++ b/cluster/meta.go
@@ -127,7 +127,7 @@ func (m *MetaRaft) ApplySetMembersIfLeader(peers []Peer, numShards, replicationF
 	st := m.FSM.State()
 	if st.NumShards == numShards &&
 		st.MinISR == minISR &&
-		st.ReplicationFactor == replicationFactor &&
+		st.ReplicationFactorSet && st.ReplicationFactor == replicationFactor &&
 		peerSlicesEqual(st.Members, sortedPeers) {
 		return nil
 	}

--- a/cluster/meta.go
+++ b/cluster/meta.go
@@ -119,15 +119,16 @@ func (m *MetaRaft) ApplySetMembersIfLeader(peers []Peer, numShards, replicationF
 	})
 	// Idempotency: skip if state already matches (INCLUDING the seeded ISR floor,
 	// so a first bootstrap that must raise MinISR from 0 is not skipped).
-	// ReplicationFactor is not stored in State directly; compare the computed
-	// target placement against the current one so an RF-only change is not
-	// silently dropped.
+	// ReplicationFactor is stored in State since it is not derivable from
+	// Placement after an online rebalance (Placement diverges from the computed
+	// layout); comparing st.ReplicationFactor avoids reverting rebalanced shards.
+	// st.ReplicationFactor == 0 means an old snapshot predating this field: fall
+	// through and let Apply record it.
 	st := m.FSM.State()
-	targetPlacement := computePlacement(sortedPeers, numShards, replicationFactor)
 	if st.NumShards == numShards &&
 		st.MinISR == minISR &&
-		peerSlicesEqual(st.Members, sortedPeers) &&
-		placementEqual(st.Placement, targetPlacement) {
+		st.ReplicationFactor == replicationFactor &&
+		peerSlicesEqual(st.Members, sortedPeers) {
 		return nil
 	}
 	entry, err := encodeLogEntry(LogEntry{

--- a/cluster/meta.go
+++ b/cluster/meta.go
@@ -119,8 +119,15 @@ func (m *MetaRaft) ApplySetMembersIfLeader(peers []Peer, numShards, replicationF
 	})
 	// Idempotency: skip if state already matches (INCLUDING the seeded ISR floor,
 	// so a first bootstrap that must raise MinISR from 0 is not skipped).
+	// ReplicationFactor is not stored in State directly; compare the computed
+	// target placement against the current one so an RF-only change is not
+	// silently dropped.
 	st := m.FSM.State()
-	if st.NumShards == numShards && st.MinISR == minISR && peerSlicesEqual(st.Members, sortedPeers) {
+	targetPlacement := computePlacement(sortedPeers, numShards, replicationFactor)
+	if st.NumShards == numShards &&
+		st.MinISR == minISR &&
+		peerSlicesEqual(st.Members, sortedPeers) &&
+		placementEqual(st.Placement, targetPlacement) {
 		return nil
 	}
 	entry, err := encodeLogEntry(LogEntry{

--- a/cluster/meta.go
+++ b/cluster/meta.go
@@ -122,8 +122,8 @@ func (m *MetaRaft) ApplySetMembersIfLeader(peers []Peer, numShards, replicationF
 	// ReplicationFactor is stored in State since it is not derivable from
 	// Placement after an online rebalance (Placement diverges from the computed
 	// layout); comparing st.ReplicationFactor avoids reverting rebalanced shards.
-	// st.ReplicationFactor == 0 means an old snapshot predating this field: fall
-	// through and let Apply record it.
+	// !st.ReplicationFactorSet means a snapshot predating this field: fall
+	// through and let Apply record it without resetting Placement.
 	st := m.FSM.State()
 	if st.NumShards == numShards &&
 		st.MinISR == minISR &&

--- a/cluster/meta_fsm.go
+++ b/cluster/meta_fsm.go
@@ -319,13 +319,22 @@ func (m *MetaFSM) Apply(log *raft.Log) any {
 		sort.Slice(sorted, func(i, j int) bool {
 			return sorted[i].NodeID < sorted[j].NodeID
 		})
+		// Backfill: if this is the first OpSetMembers to carry ReplicationFactor
+		// (ReplicationFactorSet was false on a legacy snapshot) and members/shard
+		// count are unchanged, only record the RF — do NOT recompute Placement,
+		// which would clobber any per-shard rebalance work stored in the snapshot.
+		backfill := !m.state.ReplicationFactorSet &&
+			m.state.NumShards == entry.NumShards &&
+			peerSlicesEqual(m.state.Members, sorted)
 		m.state.Members = sorted
 		m.state.NumShards = entry.NumShards
 		m.state.ReplicationFactor = entry.ReplicationFactor
 		m.state.ReplicationFactorSet = true
-		// Placement distributes shards across members in replica sets of
-		// ReplicationFactor nodes; rf 0 / >= len(members) = full replication.
-		m.state.Placement = computePlacement(sorted, entry.NumShards, entry.ReplicationFactor)
+		if !backfill {
+			// Placement distributes shards across members in replica sets of
+			// ReplicationFactor nodes; rf 0 / >= len(members) = full replication.
+			m.state.Placement = computePlacement(sorted, entry.NumShards, entry.ReplicationFactor)
+		}
 		// Seed the structural ISR floor (ISR hardening). Only RAISE it from a
 		// real seed (>0); a stray/old OpSetMembers carrying MinISR==0 (raft mode, or
 		// a pre-floor snapshot re-commit) must never clobber an established floor.

--- a/cluster/meta_fsm.go
+++ b/cluster/meta_fsm.go
@@ -322,6 +322,7 @@ func (m *MetaFSM) Apply(log *raft.Log) any {
 		m.state.Members = sorted
 		m.state.NumShards = entry.NumShards
 		m.state.ReplicationFactor = entry.ReplicationFactor
+		m.state.ReplicationFactorSet = true
 		// Placement distributes shards across members in replica sets of
 		// ReplicationFactor nodes; rf 0 / >= len(members) = full replication.
 		m.state.Placement = computePlacement(sorted, entry.NumShards, entry.ReplicationFactor)

--- a/cluster/meta_fsm.go
+++ b/cluster/meta_fsm.go
@@ -321,6 +321,7 @@ func (m *MetaFSM) Apply(log *raft.Log) any {
 		})
 		m.state.Members = sorted
 		m.state.NumShards = entry.NumShards
+		m.state.ReplicationFactor = entry.ReplicationFactor
 		// Placement distributes shards across members in replica sets of
 		// ReplicationFactor nodes; rf 0 / >= len(members) = full replication.
 		m.state.Placement = computePlacement(sorted, entry.NumShards, entry.ReplicationFactor)

--- a/cluster/meta_fsm_test.go
+++ b/cluster/meta_fsm_test.go
@@ -116,6 +116,39 @@ func TestMetaFSMStateIsDeepCopy(t *testing.T) {
 	}
 }
 
+// TestApplySetMembersRFChangeIsNotIdempotent is the regression test for #71:
+// when only ReplicationFactor changes (same members, shard count, MinISR),
+// ApplySetMembersIfLeader must NOT short-circuit — Placement must be recomputed.
+func TestApplySetMembersRFChangeIsNotIdempotent(t *testing.T) {
+	f := NewMetaFSM()
+	peers := []Peer{
+		{NodeID: "n1", RaftAddr: "a:1", ServerAddr: "a:2"},
+		{NodeID: "n2", RaftAddr: "b:1", ServerAddr: "b:2"},
+		{NodeID: "n3", RaftAddr: "c:1", ServerAddr: "c:2"},
+	}
+	apply := func(rf int) {
+		data, _ := encodeLogEntry(LogEntry{Op: OpSetMembers, Members: peers, NumShards: 2, ReplicationFactor: rf})
+		if resp := f.Apply(&raft.Log{Data: data}); resp != nil {
+			t.Fatalf("Apply(RF=%d): %v", rf, resp)
+		}
+	}
+	// Bootstrap with RF=3 (full replication on 3 nodes).
+	apply(3)
+	st := f.State()
+	if len(st.Placement[0]) != 3 {
+		t.Fatalf("after RF=3: Placement[0] len = %d, want 3", len(st.Placement[0]))
+	}
+	// Change only RF to 2. Placement must reflect the new RF.
+	apply(2)
+	st = f.State()
+	if len(st.Placement[0]) != 2 {
+		t.Fatalf("after RF=2: Placement[0] len = %d, want 2 (RF change was dropped)", len(st.Placement[0]))
+	}
+	if st.ReplicationFactor != 2 || !st.ReplicationFactorSet {
+		t.Fatalf("ReplicationFactor not recorded: got %d set=%v", st.ReplicationFactor, st.ReplicationFactorSet)
+	}
+}
+
 func TestMetaFSMApplySortsMembersByNodeID(t *testing.T) {
 	f := NewMetaFSM()
 	// Pass members in reverse alphabetical order.

--- a/cluster/meta_fsm_test.go
+++ b/cluster/meta_fsm_test.go
@@ -116,9 +116,7 @@ func TestMetaFSMStateIsDeepCopy(t *testing.T) {
 	}
 }
 
-// TestApplySetMembersRFChangeIsNotIdempotent is the regression test for #71:
-// when only ReplicationFactor changes (same members, shard count, MinISR),
-// ApplySetMembersIfLeader must NOT short-circuit — Placement must be recomputed.
+
 func TestApplySetMembersRFChangeIsNotIdempotent(t *testing.T) {
 	f := NewMetaFSM()
 	peers := []Peer{

--- a/cluster/meta_fsm_test.go
+++ b/cluster/meta_fsm_test.go
@@ -116,7 +116,6 @@ func TestMetaFSMStateIsDeepCopy(t *testing.T) {
 	}
 }
 
-
 func TestApplySetMembersRFChangeIsNotIdempotent(t *testing.T) {
 	f := NewMetaFSM()
 	peers := []Peer{

--- a/cluster/meta_fsm_test.go
+++ b/cluster/meta_fsm_test.go
@@ -534,6 +534,9 @@ func equalState(a, b State) bool {
 	if a.NumShards != b.NumShards || len(a.Members) != len(b.Members) || len(a.Placement) != len(b.Placement) {
 		return false
 	}
+	if a.ReplicationFactor != b.ReplicationFactor || a.ReplicationFactorSet != b.ReplicationFactorSet {
+		return false
+	}
 	for i := range a.Members {
 		if a.Members[i] != b.Members[i] {
 			return false

--- a/cluster/meta_state.go
+++ b/cluster/meta_state.go
@@ -131,12 +131,8 @@ type State struct {
 	// rest of State. NEVER blocks the election reset (that is OpSetShardEpoch, which
 	// deliberately resets the ISR to {primary} — a different op, not floor-checked).
 	MinISR int
-	// ReplicationFactor is the RF committed by the last OpSetMembers entry. A zero
-	// value (old gob snapshot, or raft mode before this field existed) means "not
-	// yet recorded" — the idempotency guard in ApplySetMembersIfLeader treats 0 as
-	// unset and will not short-circuit on an RF mismatch, matching the pre-fix
-	// behavior. gob matches by field name so old snapshots decode it as 0 safely.
-	ReplicationFactor int
+	ReplicationFactor    int
+	ReplicationFactorSet bool
 	// LastIndex carries the MetaFSM command frontier (its applied-command index)
 	// INTO a snapshot so a snapshot-restored follower does not under-report 0 and
 	// wait forever for the readIndex barrier. It is FSM-applied metadata, NOT

--- a/cluster/meta_state.go
+++ b/cluster/meta_state.go
@@ -130,7 +130,7 @@ type State struct {
 	// a per-shard floor is a later refinement. Guarded by the FSM lock like the
 	// rest of State. NEVER blocks the election reset (that is OpSetShardEpoch, which
 	// deliberately resets the ISR to {primary} — a different op, not floor-checked).
-	MinISR int
+	MinISR               int
 	ReplicationFactor    int
 	ReplicationFactorSet bool
 	// LastIndex carries the MetaFSM command frontier (its applied-command index)

--- a/cluster/meta_state.go
+++ b/cluster/meta_state.go
@@ -131,6 +131,12 @@ type State struct {
 	// rest of State. NEVER blocks the election reset (that is OpSetShardEpoch, which
 	// deliberately resets the ISR to {primary} — a different op, not floor-checked).
 	MinISR int
+	// ReplicationFactor is the RF committed by the last OpSetMembers entry. A zero
+	// value (old gob snapshot, or raft mode before this field existed) means "not
+	// yet recorded" — the idempotency guard in ApplySetMembersIfLeader treats 0 as
+	// unset and will not short-circuit on an RF mismatch, matching the pre-fix
+	// behavior. gob matches by field name so old snapshots decode it as 0 safely.
+	ReplicationFactor int
 	// LastIndex carries the MetaFSM command frontier (its applied-command index)
 	// INTO a snapshot so a snapshot-restored follower does not under-report 0 and
 	// wait forever for the readIndex barrier. It is FSM-applied metadata, NOT

--- a/cluster/meta_test.go
+++ b/cluster/meta_test.go
@@ -20,7 +20,11 @@ func metaTransport(sl *mux.StreamLayer) hraft.Transport {
 	return hraft.NewNetworkTransport(sl.For(metaGroupID), 3, 10*time.Second, os.Stderr)
 }
 
-func TestMetaRaftStartsAndElectsLeader(t *testing.T) {
+// newTestMetaRaft starts a single-node MetaRaft instance, waits for it to elect
+// a leader, registers cleanups, and returns the instance and the Config used to
+// create it. Fatal on any setup error.
+func newTestMetaRaft(t *testing.T) (*MetaRaft, Config) {
+	t.Helper()
 	sl, err := mux.New("127.0.0.1:0", []uint32{metaGroupID}, nil, nil, nil)
 	if err != nil {
 		t.Fatal(err)
@@ -56,6 +60,12 @@ func TestMetaRaftStartsAndElectsLeader(t *testing.T) {
 	if err := waitForAnyLeader(mr.Raft, 5*time.Second); err != nil {
 		t.Fatal(err)
 	}
+	return mr, cfg
+}
+
+func TestMetaRaftStartsAndElectsLeader(t *testing.T) {
+	mr, cfg := newTestMetaRaft(t)
+
 	if err := mr.ApplySetMembersIfLeader(cfg.Peers, cfg.NumShards, 0, 0, 5*time.Second); err != nil {
 		t.Fatal(err)
 	}
@@ -77,41 +87,7 @@ func TestMetaRaftStartsAndElectsLeader(t *testing.T) {
 }
 
 func TestMetaRaftApplySetCatalogEntry(t *testing.T) {
-	sl, err := mux.New("127.0.0.1:0", []uint32{metaGroupID}, nil, nil, nil)
-	if err != nil {
-		t.Fatal(err)
-	}
-	t.Cleanup(func() { _ = sl.Close() })
-
-	reg := ops.NewRegistry()
-	if err := ops.RegisterBuiltins(reg); err != nil {
-		t.Fatal(err)
-	}
-	self := Peer{NodeID: "node1", RaftAddr: sl.Addr().String(), ServerAddr: "127.0.0.1:0"}
-	cfg := Config{
-		NodeID:    "node1",
-		DataDir:   t.TempDir(),
-		NumShards: 4,
-		Bootstrap: true,
-		ShardCfg: shard.Config{
-			RaftHeartbeatMs: 50,
-			RaftElectionMs:  100,
-			NoSync:          true,
-		},
-		Ops:      reg,
-		Peers:    []Peer{self},
-		RaftAddr: sl.Addr().String(),
-	}
-
-	mr, err := startMetaRaft(cfg, metaTransport(sl))
-	if err != nil {
-		t.Fatal(err)
-	}
-	t.Cleanup(func() { _ = mr.Close() })
-
-	if err := waitForAnyLeader(mr.Raft, 5*time.Second); err != nil {
-		t.Fatal(err)
-	}
+	mr, _ := newTestMetaRaft(t)
 
 	if err := mr.ApplySetCatalogEntry("default/docs", 8, 0, 5*time.Second); err != nil {
 		t.Fatalf("ApplySetCatalogEntry: %v", err)
@@ -130,41 +106,7 @@ func TestMetaRaftApplySetCatalogEntry(t *testing.T) {
 
 
 func TestApplySetMembersIfLeaderRFChangeIsNotIdempotent(t *testing.T) {
-	sl, err := mux.New("127.0.0.1:0", []uint32{metaGroupID}, nil, nil, nil)
-	if err != nil {
-		t.Fatal(err)
-	}
-	t.Cleanup(func() { _ = sl.Close() })
-
-	reg := ops.NewRegistry()
-	if err := ops.RegisterBuiltins(reg); err != nil {
-		t.Fatal(err)
-	}
-	self := Peer{NodeID: "node1", RaftAddr: sl.Addr().String(), ServerAddr: "127.0.0.1:0"}
-	cfg := Config{
-		NodeID:    "node1",
-		DataDir:   t.TempDir(),
-		NumShards: 4,
-		Bootstrap: true,
-		ShardCfg: shard.Config{
-			RaftHeartbeatMs: 50,
-			RaftElectionMs:  100,
-			NoSync:          true,
-		},
-		Ops:      reg,
-		Peers:    []Peer{self},
-		RaftAddr: sl.Addr().String(),
-	}
-
-	mr, err := startMetaRaft(cfg, metaTransport(sl))
-	if err != nil {
-		t.Fatal(err)
-	}
-	t.Cleanup(func() { _ = mr.Close() })
-
-	if err := waitForAnyLeader(mr.Raft, 5*time.Second); err != nil {
-		t.Fatal(err)
-	}
+	mr, cfg := newTestMetaRaft(t)
 
 	// First apply: RF=0 (full replication).
 	if err := mr.ApplySetMembersIfLeader(cfg.Peers, cfg.NumShards, 0, 0, 5*time.Second); err != nil {
@@ -185,11 +127,14 @@ func TestApplySetMembersIfLeaderRFChangeIsNotIdempotent(t *testing.T) {
 		t.Fatalf("after RF=1: got RF=%d set=%v, want RF=1 set=true — guard may have short-circuited", st.ReplicationFactor, st.ReplicationFactorSet)
 	}
 
-	// Third apply with same RF=1: must be idempotent (no-op).
+	// Idempotency: re-applying the same RF=1 must short-circuit — no new log
+	// entry committed. Capture LastIndex before the call; if the guard fires,
+	// Raft.Apply is never invoked and LastIndex stays unchanged.
+	idxBefore := mr.Raft.LastIndex()
 	if err := mr.ApplySetMembersIfLeader(cfg.Peers, cfg.NumShards, 1, 0, 5*time.Second); err != nil {
 		t.Fatalf("idempotent re-apply (RF=1): %v", err)
 	}
-	if st2 := mr.FSM.State(); st2.ReplicationFactor != 1 {
-		t.Fatalf("after idempotent re-apply: RF=%d, want 1", st2.ReplicationFactor)
+	if got := mr.Raft.LastIndex(); got != idxBefore {
+		t.Fatalf("idempotent re-apply advanced LastIndex %d → %d; guard did not short-circuit", idxBefore, got)
 	}
 }

--- a/cluster/meta_test.go
+++ b/cluster/meta_test.go
@@ -104,7 +104,6 @@ func TestMetaRaftApplySetCatalogEntry(t *testing.T) {
 	}
 }
 
-
 func TestApplySetMembersIfLeaderRFChangeIsNotIdempotent(t *testing.T) {
 	mr, cfg := newTestMetaRaft(t)
 

--- a/cluster/meta_test.go
+++ b/cluster/meta_test.go
@@ -127,3 +127,69 @@ func TestMetaRaftApplySetCatalogEntry(t *testing.T) {
 		t.Fatal("p=0 must not be committed to the catalog")
 	}
 }
+
+
+func TestApplySetMembersIfLeaderRFChangeIsNotIdempotent(t *testing.T) {
+	sl, err := mux.New("127.0.0.1:0", []uint32{metaGroupID}, nil, nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = sl.Close() })
+
+	reg := ops.NewRegistry()
+	if err := ops.RegisterBuiltins(reg); err != nil {
+		t.Fatal(err)
+	}
+	self := Peer{NodeID: "node1", RaftAddr: sl.Addr().String(), ServerAddr: "127.0.0.1:0"}
+	cfg := Config{
+		NodeID:    "node1",
+		DataDir:   t.TempDir(),
+		NumShards: 4,
+		Bootstrap: true,
+		ShardCfg: shard.Config{
+			RaftHeartbeatMs: 50,
+			RaftElectionMs:  100,
+			NoSync:          true,
+		},
+		Ops:      reg,
+		Peers:    []Peer{self},
+		RaftAddr: sl.Addr().String(),
+	}
+
+	mr, err := startMetaRaft(cfg, metaTransport(sl))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = mr.Close() })
+
+	if err := waitForAnyLeader(mr.Raft, 5*time.Second); err != nil {
+		t.Fatal(err)
+	}
+
+	// First apply: RF=0 (full replication).
+	if err := mr.ApplySetMembersIfLeader(cfg.Peers, cfg.NumShards, 0, 0, 5*time.Second); err != nil {
+		t.Fatalf("first apply (RF=0): %v", err)
+	}
+	st := mr.FSM.State()
+	if !st.ReplicationFactorSet || st.ReplicationFactor != 0 {
+		t.Fatalf("after RF=0: got RF=%d set=%v, want RF=0 set=true", st.ReplicationFactor, st.ReplicationFactorSet)
+	}
+
+	// Same members + same NumShards, only RF changes: the guard must fall through
+	// and commit the new entry (regression for #71 — the old guard ignored RF).
+	if err := mr.ApplySetMembersIfLeader(cfg.Peers, cfg.NumShards, 1, 0, 5*time.Second); err != nil {
+		t.Fatalf("second apply (RF=1): %v", err)
+	}
+	st = mr.FSM.State()
+	if st.ReplicationFactor != 1 || !st.ReplicationFactorSet {
+		t.Fatalf("after RF=1: got RF=%d set=%v, want RF=1 set=true — guard may have short-circuited", st.ReplicationFactor, st.ReplicationFactorSet)
+	}
+
+	// Third apply with same RF=1: must be idempotent (no-op).
+	if err := mr.ApplySetMembersIfLeader(cfg.Peers, cfg.NumShards, 1, 0, 5*time.Second); err != nil {
+		t.Fatalf("idempotent re-apply (RF=1): %v", err)
+	}
+	if st2 := mr.FSM.State(); st2.ReplicationFactor != 1 {
+		t.Fatalf("after idempotent re-apply: RF=%d, want 1", st2.ReplicationFactor)
+	}
+}

--- a/cluster/placement.go
+++ b/cluster/placement.go
@@ -41,6 +41,27 @@ func computePlacement(members []Peer, numShards, rf int) [][]string {
 	return out
 }
 
+// placementEqual reports whether two placement slices are identical (same shard
+// count, same owner sets in the same order). Used by the idempotency guard in
+// ApplySetMembersIfLeader to detect RF-only changes that alter Placement without
+// changing Members, NumShards, or MinISR.
+func placementEqual(a, b [][]string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if len(a[i]) != len(b[i]) {
+			return false
+		}
+		for j := range a[i] {
+			if a[i][j] != b[i][j] {
+				return false
+			}
+		}
+	}
+	return true
+}
+
 // placementContains reports whether nodeID is in the owner set.
 func placementContains(owners []string, nodeID string) bool {
 	for _, o := range owners {

--- a/cluster/placement.go
+++ b/cluster/placement.go
@@ -41,27 +41,6 @@ func computePlacement(members []Peer, numShards, rf int) [][]string {
 	return out
 }
 
-// placementEqual reports whether two placement slices are identical (same shard
-// count, same owner sets in the same order). Used by the idempotency guard in
-// ApplySetMembersIfLeader to detect RF-only changes that alter Placement without
-// changing Members, NumShards, or MinISR.
-func placementEqual(a, b [][]string) bool {
-	if len(a) != len(b) {
-		return false
-	}
-	for i := range a {
-		if len(a[i]) != len(b[i]) {
-			return false
-		}
-		for j := range a[i] {
-			if a[i][j] != b[i][j] {
-				return false
-			}
-		}
-	}
-	return true
-}
-
 // placementContains reports whether nodeID is in the owner set.
 func placementContains(owners []string, nodeID string) bool {
 	for _, o := range owners {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the idempotency check in `ApplySetMembersIfLeader` so replication factor changes are no longer silently skipped when members, shard count, and MinISR are unchanged.

**Bug Fixes**
- Stores the committed `ReplicationFactor` in `State` and sets it from `MetaFSM.Apply`.
- Adds `ReplicationFactorSet` so old snapshots (unset) fall through and get recorded, while a legitimate zero replication factor is still compared.
- Adds regression tests covering a replication factor change with unchanged members, shard count, and MinISR, and refactors test setup into a shared helper.

<sup>Written for commit 649b037337d8cee62fa014f3c1a83d800b5de269. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rostamlabs/rostam/pull/75?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Changing the cluster replication factor now reliably applies updated shard placement.
  * Repeated member updates no longer reset completed shard rebalancing.
  * Improved compatibility with older cluster state while preserving existing placement information.

* **Tests**
  * Added coverage for replication-factor changes, idempotent updates, and placement preservation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->