### PR TITLE
chore(release): cut v0.6.0

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -5,6 +5,8 @@ Notable user-visible changes. Entries that alter existing behaviour are marked
 
 ## Unreleased
 
+## v0.6.0 — 2026-09-02
+
 - **Online compaction for replicated shards (opt-in, off by default).** A
   persistent (mmap) cluster-replicated shard is append-only under reject-writes:
   an overwrite writes a new copy and leaves the old one as dead "ghost" bytes, so
@@ -70,6 +72,16 @@ Notable user-visible changes. Entries that alter existing behaviour are marked
   existing reservation needs the Windows 10 1803 placeholder API, which is not
   wired up. Nothing changes for Linux, and a reservation remains an optimization
   — where it cannot be made, growth simply falls back.
+
+- **Cluster metadata stability fixes.** Three correctness fixes in the
+  Raft-replicated metadata plane: `Node.Close()` now waits for its background
+  cluster-management goroutines (the PB control-plane seeder and the
+  shard-formation seeder/driver) to exit before tearing down shared resources,
+  removing a shutdown use-after-free; `MetaFSM.State()` returns a deep copy of
+  `ShardFormer` so a caller can no longer mutate the internal map or race a
+  concurrent `Apply`; and the `ApplySetMembersIfLeader` idempotency check now
+  accounts for `ReplicationFactor`, so an RF change is no longer silently skipped
+  when members, shard count, and MinISR are unchanged.
 
 ## v0.5.0 — 2026-08-30
 


### PR DESCRIPTION
Cuts **v0.6.0**. Retitles the `Unreleased` changelog section and dates it 2026-09-02.

## Highlights since v0.5.0
- **Online compaction for replicated shards** (opt-in, off by default) — reclaims dead ghost-byte space in mmap reject-writes shards while the process runs, keeping the lock-free zero-copy read path (#76).
- **`ServerConfig.WriteTimeout`** — bounds a stalled response write; source of truth for the online-compaction alias fence (#76).
- **KV `flush` op** — O(shards) keyspace wipe, replicated (#67).
- **Embedded web dashboard** at `/dashboard/` + KV/topology/collections REST endpoints (#66).
- **In-place slab growth on Windows** (heap-backed) (#65).
- **Cluster-metadata stability fixes** — shutdown use-after-free in `Node.Close()` (#69/#74), `MetaFSM.State()` ShardFormer deep copy (#70/#73), and `ApplySetMembersIfLeader` replication-factor idempotency (#71/#75).

## Release steps
1. Merge this PR to `main`.
2. Tag the merge commit `v0.6.0` and push it — `release.yml` publishes the binaries and container image on the `v*` tag.

The Python client versions independently (`py-v*`) and is not bumped here.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cuts v0.6.0 by renaming the `Unreleased` changelog section and dating it 2026-09-02. No code changes.

**Release steps**
- Merge this PR to `main`.
- Tag the merge commit `v0.6.0` and push it so `release.yml` publishes binaries and the container image.
- The Python client versions independently (`py-v*`) and is not bumped here.

<sup>Written for commit 17d91a1f2cd972ca26e4d59f85b43203c3189023. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rostamlabs/rostam/pull/77?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added the v0.6.0 release notes dated September 2, 2026.
  * Documented improvements to cluster metadata stability, shutdown handling, state isolation, and replication-aware member-set checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->