### PR TITLE
fix(release): stop image-manifest silently skipping on tag push

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -156,6 +156,14 @@ jobs:
   image-manifest:
     name: image manifest
     needs: image
+    # Explicit condition, not the implicit success(): the `image` job carries an
+    # always()-guarded `if`, and on a tag push the upstream validate-tag job is
+    # skipped — that combination poisons a downstream default success() check and
+    # silently SKIPS this job, so the per-arch digests never get combined into the
+    # tagged `:vX.Y.Z` / `:latest` manifest (the binaries still publish, so the gap
+    # is easy to miss). Gate on image succeeding regardless of how validate-tag
+    # resolved, matching the always() pattern the binaries/image jobs already use.
+    if: ${{ always() && needs.image.result == 'success' }}
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
## Problem

The v0.6.0 tag-push release published the binaries and the GitHub release, but the **container image tag was never created** — `ghcr.io/rostamlabs/rostam:v0.6.0` 404s, and `:latest` still points at v0.5.0.

Root cause is a GitHub Actions evaluation gotcha:
- The per-arch `image` jobs push **digest-only, untagged** (`push-by-digest=true`); the `image-manifest` job is the *only* place the `:vX.Y.Z` / `:latest` tags are created.
- `image-manifest` used the implicit `success()` condition. Its upstream `image` job carries an `if: always() && …`, and on a **tag push** the `validate-tag` job (dispatch-only) is **skipped**. That skipped transitive dependency poisons the downstream `success()` check, so `image-manifest` is silently skipped.
- v0.5.0 released fine because it predated the `validate-tag` job.

Because the binaries still publish, the missing image is easy to miss.

## Fix

Give `image-manifest` the same explicit guard the `binaries`/`image` jobs already use:

```yaml
if: ${{ always() && needs.image.result == 'success' }}
```

so it runs whenever the per-arch build succeeded, regardless of how `validate-tag` resolved.

## v0.6.0 remediation (already done, out of band)

Re-ran the release via `workflow_dispatch` for `v0.6.0` — on a dispatch `validate-tag` *runs and succeeds*, so the manifest job executes and publishes the missing `:v0.6.0` / `:latest` tags. This PR makes the normal tag-push path correct so no future release needs the manual re-run.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the release workflow so tag-push releases now create the container image manifest. Previously `image-manifest` was silently skipped on tag pushes, leaving `ghcr.io/rostamlabs/rostam` without the `:vX.Y.Z` / `:latest` tags (as happened for v0.6.0, where binaries published but the image tag 404'd). Now it runs whenever the per-arch `image` jobs succeed, regardless of how the `validate-tag` job resolves.

- The per-arch `image` jobs push digest-only untagged images; only `image-manifest` combines them into the tagged manifest.
- `image-manifest` used the implicit `success()` condition, which is poisoned on tag pushes because the upstream `image` job has an `always()` guard and `validate-tag` is skipped.
- Added the explicit guard `if: ${{ always() && needs.image.result == 'success' }}`, matching the `binaries`/`image` jobs.
- v0.6.0 was already republished via `workflow_dispatch` (where `validate-tag` runs and succeeds); this change fixes the normal tag-push path for future releases.

<sup>Written for commit ada2b78567641b6f1a0ebb4e42f497deed7a82f0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rostamlabs/rostam/pull/78?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed release builds triggered by tags so architecture-specific container images are consistently combined into a single tagged image manifest.
  - Ensured tagged releases complete the image publishing process instead of silently skipping manifest creation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->