### PR TITLE
fix(meta_fsm): improve concurrency handling for metaApplyCatalogGate

### DIFF
--- a/cluster/meta_fsm.go
+++ b/cluster/meta_fsm.go
@@ -107,15 +107,21 @@ func newMetaFSMForNode(nodeID string) *MetaFSM {
 // nil in production ⇒ zero overhead, behaviour byte-identical. It fires BEFORE the
 // FSM write lock is taken, so a blocking gate stalls only THIS node's apply of the
 // cutover entry while its prior catalog state stays readable (it keeps reporting
-// the old gen) — the intended lag, not a hang. Set/reset under no concurrency.
-var metaApplyCatalogGate func(nodeID, collection string, partitions, generation uint32)
+// the old gen) — the intended lag, not a hang.
+// Protected by atomic.Pointer so concurrent Apply reads and test-goroutine writes
+// do not race under -race.
+var metaApplyCatalogGate atomic.Pointer[func(nodeID, collection string, partitions, generation uint32)]
 
 // SetMetaApplyCatalogGate installs (or clears with nil) the test-only catalog-gen
 // apply observer (metaApplyCatalogGate). Exported so the root-package integration
 // tests (different package) can deterministically lag ONE node's cutover apply.
-// Test-only; nil in production. Set/reset under no concurrency.
+// Test-only; nil in production.
 func SetMetaApplyCatalogGate(fn func(nodeID, collection string, partitions, generation uint32)) {
-	metaApplyCatalogGate = fn
+	if fn == nil {
+		metaApplyCatalogGate.Store(nil)
+	} else {
+		metaApplyCatalogGate.Store(&fn)
+	}
 }
 
 // State returns a deep copy of the current FSM state.
@@ -305,8 +311,8 @@ func (m *MetaFSM) Apply(log *raft.Log) any {
 	// gen) while this node's apply of the cutover is deferred. That is precisely the
 	// lagging-follower window: the node routes reads to the still-fresh old gen until
 	// the test releases the gate. nil ⇒ no-op, no lock-ordering effect.
-	if entry.Op == OpSetCatalogEntry && metaApplyCatalogGate != nil {
-		metaApplyCatalogGate(m.nodeID, entry.Collection, entry.Partitions, entry.Generation)
+	if gate := metaApplyCatalogGate.Load(); gate != nil && entry.Op == OpSetCatalogEntry {
+		(*gate)(m.nodeID, entry.Collection, entry.Partitions, entry.Generation)
 	}
 	m.mu.Lock()
 	defer m.mu.Unlock()

--- a/cluster/meta_fsm.go
+++ b/cluster/meta_fsm.go
@@ -311,8 +311,10 @@ func (m *MetaFSM) Apply(log *raft.Log) any {
 	// gen) while this node's apply of the cutover is deferred. That is precisely the
 	// lagging-follower window: the node routes reads to the still-fresh old gen until
 	// the test releases the gate. nil ⇒ no-op, no lock-ordering effect.
-	if gate := metaApplyCatalogGate.Load(); gate != nil && entry.Op == OpSetCatalogEntry {
-		(*gate)(m.nodeID, entry.Collection, entry.Partitions, entry.Generation)
+	if entry.Op == OpSetCatalogEntry {
+		if gate := metaApplyCatalogGate.Load(); gate != nil {
+			(*gate)(m.nodeID, entry.Collection, entry.Partitions, entry.Generation)
+		}
 	}
 	m.mu.Lock()
 	defer m.mu.Unlock()


### PR DESCRIPTION
This pull request refactors the test-only `metaApplyCatalogGate` hook in `meta_fsm.go` to make it safe for concurrent access, addressing potential data races during testing. The most important changes are:

**Thread safety improvements:**

* Changed `metaApplyCatalogGate` from a plain function variable to an `atomic.Pointer` to a function, ensuring safe concurrent reads and writes between the FSM apply path and test goroutines.
* Updated the `SetMetaApplyCatalogGate` function to use atomic operations for installing or clearing the gate function, instead of direct assignment.
* Modified the `Apply` method to safely load and invoke the gate function using atomic operations, preventing race conditions during concurrent access.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Converts the test-only `metaApplyCatalogGate` hook from a plain function variable to an `atomic.Pointer`, so setting and resetting the gate in tests no longer races with the FSM apply path under `-race`. The hook is loaded only for `OpSetCatalogEntry`, and it stays nil in production, so production behavior is unchanged.

<sup>Written for commit a6ab4070cb2374783a1c1b25dbebc28fea8e7519. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rostamlabs/rostam/pull/79?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the reliability of test-only catalog application checks by making gate updates and reads safe for concurrent use.
  * Preserved catalog entry application behavior while preventing race conditions when the test observer is configured or cleared.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->