### PR TITLE
docs: add 'Migrating from Pinecone' guide

### DIFF
--- a/docs/migrate/from-pinecone.md
+++ b/docs/migrate/from-pinecone.md
@@ -4,15 +4,21 @@ This guide maps Pinecone concepts and API calls to Rostam so you can move an
 existing workload over. Rostam is open source (Apache-2.0) and **self-hosted** —
 one Go binary you run in your own environment — so the main reasons teams make
 this move are cost control and keeping vector data inside a boundary you own
-(data residency, on-prem, air-gapped). There is no per-project minimum, and the
-database itself makes no outbound calls: nothing Rostam stores leaves your
-network.
+(data residency, on-prem, air-gapped). There is no per-project minimum, and
+Rostam makes no outbound calls on its own — data leaves only through egress you
+explicitly configure, which you control.
 
-!!! note "One caveat about egress"
-    Rostam has no egress, but *embedding* is a separate step. If you generate
-    embeddings with a hosted API (OpenAI, Cohere, …), your text leaves your
-    network at that step regardless of where the vectors are stored. For a fully
-    in-boundary pipeline, embed with a local/self-hosted model.
+!!! note "The two places data can leave — both under your control"
+    1. **Backups / cold tier.** If you configure S3 backups or a cold tier
+       ([Backups](../server/backups.md)), Rostam writes snapshots to that object
+       store. Point it at an in-boundary store (e.g. MinIO) to keep everything
+       inside your network, or leave it unconfigured.
+    2. **Embedding.** Embedding is a separate step from storage. If you generate
+       embeddings with a hosted API (OpenAI, Cohere, …), your text leaves your
+       network there regardless of where the vectors live. Embed with a
+       local/self-hosted model for a fully in-boundary pipeline.
+
+    Neither happens unless you set it up — Rostam initiates no egress by default.
 
 If you just want the API side by side, jump to [Code, side by side](#code-side-by-side).
 

--- a/docs/migrate/from-pinecone.md
+++ b/docs/migrate/from-pinecone.md
@@ -1,0 +1,185 @@
+# Migrating from Pinecone to Rostam
+
+This guide maps Pinecone concepts and API calls to Rostam so you can move an
+existing workload over. Rostam is open source (Apache-2.0) and **self-hosted** —
+one Go binary you run in your own environment — so the main reasons teams make
+this move are cost control, and keeping vector data inside a boundary you own
+(data residency, on-prem, air-gapped). Nothing leaves your network, and there is
+no per-project minimum.
+
+If you just want to see the API side by side, jump to
+[Code, side by side](#code-side-by-side).
+
+## Concept mapping
+
+| Pinecone | Rostam | Notes |
+|---|---|---|
+| Account / project | Your Rostam server (or cluster) | You run it; no hosted control plane. |
+| Index | **Collection** | `create_collection(name, dim, metric)`. |
+| Metric `cosine` / `euclidean` / `dotproduct` | `metric="cosine"` / `"l2"` / `"dot"` | Set per collection at creation. |
+| Vector (`id`, `values`, `metadata`) | Point (`id`, embedding, `metadata`, optional `content`) | Rostam ids are integers; see [IDs](#ids-string-vs-integer). |
+| Namespace | A metadata field you filter on, or a separate collection | Rostam has no namespace primitive; both patterns work — see [Namespaces](#namespaces). |
+| Metadata filter (`$eq`, `$in`, …) | `filters` helpers (`f.eq`, `f.in_`, …) | Full translation table [below](#translating-metadata-filters). |
+| Serverless / pods | The single binary, or a Raft cluster | Scale by running more shards/nodes; see [Clustering](../server/clustering.md). |
+| Managed, multi-tenant SaaS | You operate it | See [Security](../server/security.md) and [Backups](../server/backups.md). |
+
+## Run Rostam
+
+```bash
+# one static binary; data stays on disk you control
+rostam-server -http :8080 -data ./data -api-key "$ROSTAM_TOKEN"
+```
+
+The server refuses to bind a reachable address without auth. See
+[Running the server](../server/running.md) for TLS, clustering, and Docker.
+
+Install the Python client:
+
+```bash
+pip install rostam-client
+```
+
+## Code, side by side
+
+### Connect
+
+```python
+# Pinecone
+from pinecone import Pinecone
+pc = Pinecone(api_key="...")
+index = pc.Index("docs")
+
+# Rostam
+from rostam import Rostam, filters as f
+c = Rostam("http://localhost:8080", api_key="optional-bearer-token")
+```
+
+### Create the index / collection
+
+```python
+# Pinecone
+pc.create_index(name="docs", dimension=384, metric="cosine", spec=...)
+
+# Rostam
+c.create_collection("docs", dim=384, metric="cosine")   # metric: cosine | l2 | dot
+```
+
+### Upsert
+
+```python
+# Pinecone
+index.upsert(vectors=[
+    {"id": "1", "values": embedding, "metadata": {"doc_id": 7, "lang": "en"}},
+])
+
+# Rostam  (content is an optional stored text payload returned with hits)
+c.upsert("docs", 1, embedding, content="the chunk text",
+         metadata={"doc_id": 7, "lang": "en"})
+```
+
+### Query
+
+```python
+# Pinecone
+res = index.query(vector=embedding, top_k=5,
+                  filter={"doc_id": {"$eq": 7}}, include_metadata=True)
+for m in res["matches"]:
+    print(m["id"], m["score"], m["metadata"])
+
+# Rostam  (hits carry .id / .content / .metadata / .distance)
+hits = c.search_docs("docs", embedding, k=5, filter=f.eq("doc_id", 7))
+for h in hits:
+    print(h.id, h.distance, h.metadata)
+```
+
+### Fetch and delete
+
+```python
+# Pinecone
+index.fetch(ids=["1"])
+index.delete(ids=["1"])
+
+# Rostam
+c.get("docs", 1)      # -> Point | None
+c.delete("docs", 1)
+```
+
+## Translating metadata filters
+
+Pinecone filters are dicts of operators; Rostam uses the `filters` helpers
+(`from rostam import filters as f`). They compose the same way.
+
+| Pinecone | Rostam |
+|---|---|
+| `{"g": {"$eq": "x"}}` | `f.eq("g", "x")` |
+| `{"g": {"$ne": "x"}}` | `f.ne("g", "x")` |
+| `{"n": {"$gt": 3}}` | `f.gt("n", 3)` |
+| `{"n": {"$gte": 3}}` | `f.gte("n", 3)` |
+| `{"n": {"$lt": 3}}` | `f.lt("n", 3)` |
+| `{"n": {"$lte": 3}}` | `f.lte("n", 3)` |
+| `{"g": {"$in": ["a","b"]}}` | `f.in_("g", ["a", "b"])` |
+| `{"$and": [A, B]}` | `f.and_(A, B)` |
+| `{"$or": [A, B]}` | `f.or_(A, B)` |
+| implicit `{"a": 1, "b": 2}` (AND) | `f.and_(f.eq("a", 1), f.eq("b", 2))` |
+
+Rostam runs filters through an **exact, filter-first path** — a selective filter
+does not degrade recall. See [Filtering](../vector/filtering.md).
+
+## Namespaces
+
+Pinecone namespaces partition a single index. Rostam has no namespace primitive;
+two patterns cover the same need:
+
+1. **A metadata field.** Store the namespace as metadata (`metadata={"ns": "user-42"}`)
+   and add `f.eq("ns", "user-42")` to every query. Simplest; one collection.
+2. **A collection per namespace.** `create_collection("docs__user-42", ...)`. Use
+   this when namespaces need independent lifecycles (drop one without touching others).
+
+For true multi-tenant isolation with quotas, see
+[Collections, tenants & aliases](../concepts/collections.md).
+
+## IDs: string vs. integer
+
+Pinecone ids are strings; Rostam point ids are integers. If your ids are already
+numeric, use them directly. If they are strings, keep the original in metadata and
+map to an integer id — the Python client's `TextStore`/framework adapters do this
+for you (hash the string to a `uint64`, store the original under a reserved key,
+strip it on return). For a hand-rolled migration, keep a `{"ext_id": "abc"}`
+metadata field so you can look the original back up.
+
+## Migrating your data
+
+There is no import tool — you re-upsert. If you still have the source embeddings,
+upsert them straight into Rostam. If not, read them out of Pinecone in pages and
+write them across:
+
+```python
+# pull from Pinecone (list + fetch), push into Rostam
+for ids in paginate_pinecone_ids(index):          # your paging over index.list()
+    fetched = index.fetch(ids=ids)["vectors"]
+    for pid, v in fetched.items():
+        c.upsert("docs", int_id(pid), v["values"],
+                 metadata={**v.get("metadata", {}), "ext_id": pid})
+```
+
+Re-embedding from source documents is often cleaner than exporting vectors, and it
+lets you switch embedding models at the same time. Rostam can also do the embedding
+for you — see `TextStore` and the built-in embedders in the
+[Python client](../api/python.md).
+
+## What is different (read before you commit)
+
+- **You operate it.** No managed control plane — you run the server, back it up
+  ([Backups](../server/backups.md)), and secure it ([Security](../server/security.md)).
+  That is the point (your data, your boundary), but it is real work.
+- **Integer ids** (see above).
+- **No namespace primitive** (see above).
+- Rostam returns **`distance`**, not a similarity `score`; smaller is closer. Convert
+  if your app expects Pinecone-style scores.
+
+## Next steps
+
+- [Quickstart](../quickstart.md)
+- [Search](../vector/search.md) · [Filtering](../vector/filtering.md) · [Hybrid & full-text](../vector/hybrid-search.md)
+- [Clustering](../server/clustering.md) for HA, [Security](../server/security.md) for auth/TLS/RBAC
+- Benchmarks vs. Pinecone and others: <https://rostamlabs.com/compare>

--- a/docs/migrate/from-pinecone.md
+++ b/docs/migrate/from-pinecone.md
@@ -3,12 +3,18 @@
 This guide maps Pinecone concepts and API calls to Rostam so you can move an
 existing workload over. Rostam is open source (Apache-2.0) and **self-hosted** —
 one Go binary you run in your own environment — so the main reasons teams make
-this move are cost control, and keeping vector data inside a boundary you own
-(data residency, on-prem, air-gapped). Nothing leaves your network, and there is
-no per-project minimum.
+this move are cost control and keeping vector data inside a boundary you own
+(data residency, on-prem, air-gapped). There is no per-project minimum, and the
+database itself makes no outbound calls: nothing Rostam stores leaves your
+network.
 
-If you just want to see the API side by side, jump to
-[Code, side by side](#code-side-by-side).
+!!! note "One caveat about egress"
+    Rostam has no egress, but *embedding* is a separate step. If you generate
+    embeddings with a hosted API (OpenAI, Cohere, …), your text leaves your
+    network at that step regardless of where the vectors are stored. For a fully
+    in-boundary pipeline, embed with a local/self-hosted model.
+
+If you just want the API side by side, jump to [Code, side by side](#code-side-by-side).
 
 ## Concept mapping
 
@@ -18,7 +24,7 @@ If you just want to see the API side by side, jump to
 | Index | **Collection** | `create_collection(name, dim, metric)`. |
 | Metric `cosine` / `euclidean` / `dotproduct` | `metric="cosine"` / `"l2"` / `"dot"` | Set per collection at creation. |
 | Vector (`id`, `values`, `metadata`) | Point (`id`, embedding, `metadata`, optional `content`) | Rostam ids are integers; see [IDs](#ids-string-vs-integer). |
-| Namespace | A metadata field you filter on, or a separate collection | Rostam has no namespace primitive; both patterns work — see [Namespaces](#namespaces). |
+| Namespace | **Tenant** (`<tenant>/<collection>`) | A real primitive — and an optional security boundary. See [Namespaces](#namespaces-tenants). |
 | Metadata filter (`$eq`, `$in`, …) | `filters` helpers (`f.eq`, `f.in_`, …) | Full translation table [below](#translating-metadata-filters). |
 | Serverless / pods | The single binary, or a Raft cluster | Scale by running more shards/nodes; see [Clustering](../server/clustering.md). |
 | Managed, multi-tenant SaaS | You operate it | See [Security](../server/security.md) and [Backups](../server/backups.md). |
@@ -26,8 +32,10 @@ If you just want to see the API side by side, jump to
 ## Run Rostam
 
 ```bash
-# one static binary; data stays on disk you control
-rostam-server -http :8080 -data ./data -api-key "$ROSTAM_TOKEN"
+# one static binary; data stays on disk you control.
+# pass the token via the environment, NOT -api-key (a flag secret leaks via /proc and shell history):
+export ROSTAM_API_KEY="a-strong-token"
+rostam-server -http :8080 -data ./data
 ```
 
 The server refuses to bind a reachable address without auth. See
@@ -51,7 +59,7 @@ index = pc.Index("docs")
 
 # Rostam
 from rostam import Rostam, filters as f
-c = Rostam("http://localhost:8080", api_key="optional-bearer-token")
+c = Rostam("http://localhost:8080", api_key="a-strong-token")
 ```
 
 ### Create the index / collection
@@ -86,7 +94,7 @@ res = index.query(vector=embedding, top_k=5,
 for m in res["matches"]:
     print(m["id"], m["score"], m["metadata"])
 
-# Rostam  (hits carry .id / .content / .metadata / .distance)
+# Rostam  (hits carry .id / .content / .metadata / .distance — smaller distance = closer)
 hits = c.search_docs("docs", embedding, k=5, filter=f.eq("doc_id", 7))
 for h in hits:
     print(h.id, h.distance, h.metadata)
@@ -118,64 +126,84 @@ Pinecone filters are dicts of operators; Rostam uses the `filters` helpers
 | `{"n": {"$lt": 3}}` | `f.lt("n", 3)` |
 | `{"n": {"$lte": 3}}` | `f.lte("n", 3)` |
 | `{"g": {"$in": ["a","b"]}}` | `f.in_("g", ["a", "b"])` |
+| `{"g": {"$nin": ["a","b"]}}` | `f.not_(f.in_("g", ["a", "b"]))` |
 | `{"$and": [A, B]}` | `f.and_(A, B)` |
 | `{"$or": [A, B]}` | `f.or_(A, B)` |
 | implicit `{"a": 1, "b": 2}` (AND) | `f.and_(f.eq("a", 1), f.eq("b", 2))` |
 
+Pinecone's **`$exists`** has no direct equivalent — Rostam filters match on values,
+not key presence. Emulate it by storing an explicit sentinel (e.g. a boolean
+`has_x` field) at write time and filtering on that.
+
 Rostam runs filters through an **exact, filter-first path** — a selective filter
 does not degrade recall. See [Filtering](../vector/filtering.md).
 
-## Namespaces
+## Namespaces → tenants
 
-Pinecone namespaces partition a single index. Rostam has no namespace primitive;
-two patterns cover the same need:
+Pinecone namespaces partition one index. Rostam's equivalent is a **tenant**:
+collection names can be written `<tenant>/<collection>` (a bare name lands in the
+default tenant). Unlike a Pinecone namespace — which is only a partition — a Rostam
+tenant can also be an **authoritative security boundary**: bind an API key to a
+tenant and run the server with `-tenant-isolation`, and that key can only see its
+own tenant's collections.
 
-1. **A metadata field.** Store the namespace as metadata (`metadata={"ns": "user-42"}`)
-   and add `f.eq("ns", "user-42")` to every query. Simplest; one collection.
-2. **A collection per namespace.** `create_collection("docs__user-42", ...)`. Use
-   this when namespaces need independent lifecycles (drop one without touching others).
+```python
+# Pinecone: index.query(vector=v, top_k=5, namespace="user-42")
+# Rostam:   the namespace becomes the tenant prefix
+c.search_docs("user-42/docs", v, k=5)
+```
 
-For true multi-tenant isolation with quotas, see
-[Collections, tenants & aliases](../concepts/collections.md).
+Alternatives when you do **not** need isolation: store the namespace as a metadata
+field and add `f.eq("ns", "user-42")` to every query, or use a separate collection
+per namespace. See [Collections, tenants & aliases](../concepts/collections.md).
 
 ## IDs: string vs. integer
 
-Pinecone ids are strings; Rostam point ids are integers. If your ids are already
-numeric, use them directly. If they are strings, keep the original in metadata and
-map to an integer id — the Python client's `TextStore`/framework adapters do this
-for you (hash the string to a `uint64`, store the original under a reserved key,
-strip it on return). For a hand-rolled migration, keep a `{"ext_id": "abc"}`
-metadata field so you can look the original back up.
+Pinecone ids are strings; Rostam point ids are integers (`uint64`). Map strings
+deterministically with the client's helper:
+
+```python
+from rostam._ids import to_uint64   # stable str -> uint64; used by all the framework adapters
+c.upsert("docs", to_uint64("abc-123"), embedding, metadata={"pinecone_id": "abc-123"})
+```
+
+`to_uint64` is **one-way**. Neither the raw client nor `TextStore` preserves the
+original string for you — if you need it back on read, store it in metadata
+yourself (as above) and read it from `hit.metadata["pinecone_id"]`. Pick a key
+your own metadata doesn't already use.
 
 ## Migrating your data
 
 There is no import tool — you re-upsert. If you still have the source embeddings,
 upsert them straight into Rostam. If not, read them out of Pinecone in pages and
-write them across:
+write them across, keeping the original id in metadata:
 
 ```python
-# pull from Pinecone (list + fetch), push into Rostam
+from rostam._ids import to_uint64
+
 for ids in paginate_pinecone_ids(index):          # your paging over index.list()
     fetched = index.fetch(ids=ids)["vectors"]
     for pid, v in fetched.items():
-        c.upsert("docs", int_id(pid), v["values"],
-                 metadata={**v.get("metadata", {}), "ext_id": pid})
+        meta = dict(v.get("metadata") or {})
+        meta["pinecone_id"] = pid                  # preserve the original id for lookup
+        c.upsert("docs", to_uint64(pid), v["values"], metadata=meta)
 ```
 
 Re-embedding from source documents is often cleaner than exporting vectors, and it
-lets you switch embedding models at the same time. Rostam can also do the embedding
-for you — see `TextStore` and the built-in embedders in the
-[Python client](../api/python.md).
+lets you switch embedding models at the same time. Rostam can also embed for you —
+see `TextStore` and the built-in embedders in the [Python client](../api/python.md)
+(note that a hosted embedder sends text out at the embedding step; see the egress
+caveat above).
 
 ## What is different (read before you commit)
 
 - **You operate it.** No managed control plane — you run the server, back it up
   ([Backups](../server/backups.md)), and secure it ([Security](../server/security.md)).
   That is the point (your data, your boundary), but it is real work.
-- **Integer ids** (see above).
-- **No namespace primitive** (see above).
-- Rostam returns **`distance`**, not a similarity `score`; smaller is closer. Convert
-  if your app expects Pinecone-style scores.
+- **Integer ids** — map strings with `to_uint64`, keep the original in metadata (see above).
+- **Distance, not score** — hits carry `distance` (smaller = closer), not a Pinecone-style
+  similarity `score`. Convert if your app expects scores.
+- **No `$exists` filter** and no server-side embedding — see the sections above.
 
 ## Next steps
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -84,6 +84,8 @@ markdown_extensions:
 nav:
   - Home: index.md
   - Quickstart: quickstart.md
+  - Migrating:
+      - From Pinecone: migrate/from-pinecone.md
   - Concepts:
       - Architecture: concepts/architecture.md
       - Deployment modes: concepts/deployment-modes.md


### PR DESCRIPTION
## Why
The `/compare` page attracts "Pinecone alternative" searchers; there was no landing spot to convert them. This is the first migration guide — a durable, high-intent SEO/onboarding page.

## What
`docs/migrate/from-pinecone.md` (new "Migrating" nav section):
- Concept mapping (index→collection, metric names, namespaces→metadata/collection, vectors→points).
- Side-by-side Python for connect / create / upsert / query / fetch / delete — every call verified against `docs/api/python.md` (`Rostam`, `create_collection`, `upsert`, `search_docs`, `get`, `delete`, `filters as f`).
- Full metadata-filter translation table (`$eq`→`f.eq`, `$in`→`f.in_`, `$and`→`f.and_`, …).
- Data-migration snippet (read-from-Pinecone → upsert-to-Rostam) and the re-embed alternative.
- Honest "what's different" section: you operate it, integer ids, no namespace primitive, `distance` (not `score`).
- Leads with the self-hosted / residency / no-per-project-minimum angle (the wedge).

## Checks
- `mkdocs build --strict` passes (strict fails on any broken nav ref or dead internal link).
- All 10 internal doc links verified to resolve.

Part of the "reduce adoption friction" push. A "From Qdrant" guide is the natural follow-up.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a 'Migrating from Pinecone' guide so the /compare page's "Pinecone alternative" traffic has a landing spot, with a full concept and API mapping plus a data migration walkthrough.

**Guide contents**
- Maps Pinecone concepts to Rostam (namespaces map to tenants) and provides side-by-side Python for connect, create, upsert, query, fetch, and delete.
- Includes a metadata filter translation table, integer-ID handling with `to_uint64`, and a data migration snippet that preserves original IDs.
- Documents honest differences (self-hosted ops, integer ids, distance vs score, no `$exists` filter), qualifies egress (only backups/cold-tier and a hosted embedder, both operator-configured), and adds the guide to the nav under a new 'Migrating' section.

<sup>Written for commit 83d04191772bc3cd2ede0242533ddc9a950a3a41. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rostamlabs/rostam/pull/80?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a migration guide for moving from Pinecone to Rostam.
  * Included setup instructions, conceptual mappings, CRUD examples, metadata filter translations, namespace and ID differences, manual data migration steps, and operational guidance.
  * Added the guide to the documentation navigation under a new “Migrating” section.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->