### PR TITLE
docs: add 'Migrating from Qdrant' guide

### DIFF
--- a/docs/migrate/from-qdrant.md
+++ b/docs/migrate/from-qdrant.md
@@ -1,0 +1,232 @@
+# Migrating from Qdrant to Rostam
+
+This guide maps Qdrant concepts and API calls to Rostam so you can move an
+existing workload over. Both are self-hostable, so the usual reasons for the
+switch are operational: one Go binary with **no external dependencies** and a
+second built-in engine (a sub-µs key-value store) in the same process, plus
+throughput ahead of Qdrant at matched recall
+([benchmarks](https://rostamlabs.com/compare)).
+
+!!! note "Egress — both paths are under your control"
+    Rostam makes no outbound calls on its own. Data leaves only through egress you
+    configure: S3 backups / a cold tier ([Backups](../server/backups.md)) — point
+    it at an in-boundary object store to stay fully local — and, separately, a
+    **hosted embedder** (OpenAI, Cohere, …), which sends your text out at the
+    embedding step regardless of where vectors live. Embed with a local model for a
+    fully in-boundary pipeline.
+
+Jump to [Code, side by side](#code-side-by-side).
+
+## Concept mapping
+
+| Qdrant | Rostam | Notes |
+|---|---|---|
+| `QdrantClient(url=…)` | `Rostam(url, api_key=…)` | REST on `:8080`, native TCP on `:7000`. |
+| Collection | **Collection** | `create_collection(name, dim, metric)`. |
+| `VectorParams(size, distance)` | `dim=…, metric=…` | Distance mapping [below](#distance-metrics). |
+| `PointStruct(id, vector, payload)` | Point (`id`, embedding, `metadata`, optional `content`) | `payload` → `metadata`; ids are integers, see [IDs](#ids). |
+| `Filter` / `FieldCondition` | `filters` helpers (`f.eq`, …) | Full table [below](#translating-filters). |
+| Multitenancy via a payload field | **Tenant** (`<tenant>/<collection>`) | A real primitive + optional auth boundary; see [Multitenancy](#multitenancy-tenants). |
+| `ScoredPoint.score` | `hit.distance` (and `hit.score`) | Rostam's `distance` is unambiguous (smaller = closer); see [Scores](#scores-vs-distances). |
+| Cluster / sharding | Raft cluster, online resharding | [Clustering](../server/clustering.md). |
+
+## Run Rostam
+
+```bash
+# one static binary; no separate services to run. Pass the token via env, not a
+# flag (a -api-key flag secret leaks via /proc and shell history):
+export ROSTAM_API_KEY="a-strong-token"
+rostam-server -http :8080 -data ./data
+```
+
+The server refuses to bind a reachable address without auth. See
+[Running the server](../server/running.md) for TLS, clustering, and Docker.
+
+```bash
+pip install rostam-client
+```
+
+## Code, side by side
+
+### Connect
+
+```python
+# Qdrant
+from qdrant_client import QdrantClient, models
+client = QdrantClient(url="http://localhost:6333")
+
+# Rostam
+from rostam import Rostam, filters as f
+c = Rostam("http://localhost:8080", api_key="a-strong-token")
+```
+
+### Create the collection
+
+```python
+# Qdrant
+client.create_collection(
+    "docs",
+    vectors_config=models.VectorParams(size=384, distance=models.Distance.COSINE),
+)
+
+# Rostam
+c.create_collection("docs", dim=384, metric="cosine")   # metric: cosine | l2 | dot
+```
+
+### Upsert
+
+```python
+# Qdrant  (payload holds your metadata)
+client.upsert("docs", points=[
+    models.PointStruct(id=1, vector=embedding, payload={"doc_id": 7, "lang": "en"}),
+])
+
+# Rostam  (payload -> metadata; content is an optional stored text payload)
+c.upsert("docs", 1, embedding, content="the chunk text",
+         metadata={"doc_id": 7, "lang": "en"})
+```
+
+### Query
+
+```python
+# Qdrant  (query_points; older clients use .search)
+res = client.query_points(
+    "docs", query=embedding, limit=5,
+    query_filter=models.Filter(
+        must=[models.FieldCondition(key="doc_id", match=models.MatchValue(value=7))]),
+).points
+for p in res:
+    print(p.id, p.score, p.payload)
+
+# Rostam  (hits carry .id / .content / .metadata / .distance)
+hits = c.search_docs("docs", embedding, k=5, filter=f.eq("doc_id", 7))
+for h in hits:
+    print(h.id, h.distance, h.metadata)
+```
+
+### Retrieve and delete
+
+```python
+# Qdrant
+client.retrieve("docs", ids=[1])
+client.delete("docs", points_selector=[1])
+
+# Rostam
+c.get("docs", 1)      # -> Point | None
+c.delete("docs", 1)
+```
+
+## Distance metrics
+
+| Qdrant | Rostam |
+|---|---|
+| `Distance.COSINE` | `metric="cosine"` |
+| `Distance.EUCLID` | `metric="l2"` |
+| `Distance.DOT` | `metric="dot"` |
+| `Distance.MANHATTAN` | no direct equivalent — use `l2`, or file an issue if you need L1 |
+
+## Translating filters
+
+Qdrant builds filters from `Filter` / `FieldCondition`; Rostam uses the `filters`
+helpers (`from rostam import filters as f`).
+
+| Qdrant | Rostam |
+|---|---|
+| `FieldCondition(key="g", match=MatchValue(value="x"))` | `f.eq("g", "x")` |
+| `FieldCondition(key="g", match=MatchAny(any=["a","b"]))` | `f.in_("g", ["a", "b"])` |
+| `FieldCondition(key="g", match=MatchExcept(**{"except": ["a"]}))` | `f.not_(f.in_("g", ["a"]))` |
+| `FieldCondition(key="n", range=Range(gte=3, lte=9))` | `f.and_(f.gte("n", 3), f.lte("n", 9))` |
+| `Filter(must=[A, B])` | `f.and_(A, B)` |
+| `Filter(should=[A, B])` | `f.or_(A, B)` |
+| `Filter(must_not=[A])` | `f.not_(A)` |
+
+Qdrant's `IsEmptyCondition` / `IsNullCondition` (matching on key presence) have no
+direct Rostam equivalent — Rostam filters match on values. Emulate by writing an
+explicit sentinel field (e.g. a boolean `has_x`) and filtering on it.
+
+Rostam runs filters through an **exact, filter-first path**, so a selective filter
+does not degrade recall. See [Filtering](../vector/filtering.md).
+
+## Multitenancy → tenants
+
+Qdrant's recommended multitenancy is a single collection with a tenant payload
+field and a payload index. Rostam offers that pattern too (store the tenant in
+`metadata` and add `f.eq("tenant", "user-42")` to every query), but it also has a
+first-class **tenant** primitive: collection names can be written
+`<tenant>/<collection>`, and with `-tenant-isolation` a tenant becomes an
+**authoritative security boundary** — an API key bound to a tenant can only see
+that tenant's collections.
+
+```python
+c.create_collection("user-42/docs", dim=384, metric="cosine")
+c.search_docs("user-42/docs", v, k=5)
+```
+
+See [Collections, tenants & aliases](../concepts/collections.md).
+
+## Scores vs. distances
+
+Qdrant returns a similarity `score` (for cosine, higher is closer). Rostam hits
+carry `distance` (smaller is closer) — the unambiguous field to sort or threshold
+on — and also expose a `score` field. Because score scaling can differ, prefer
+`distance` when porting ranking/threshold logic, or re-tune thresholds against
+Rostam's values.
+
+## IDs
+
+Qdrant point ids are unsigned integers or UUIDs; Rostam ids are integers
+(`uint64`). Integer ids carry over directly. Map UUID/string ids deterministically
+with the client helper and keep the original in metadata so you can read it back:
+
+```python
+from rostam._ids import to_uint64   # stable str -> uint64; the framework adapters use it
+c.upsert("docs", to_uint64("2f1c…"), embedding, metadata={"qdrant_id": "2f1c…"})
+```
+
+`to_uint64` is one-way; neither the client nor `TextStore` preserves the original
+string for you, so store it yourself (pick a metadata key your data doesn't use).
+
+## Migrating your data
+
+There is no import tool — you re-upsert. Page through the source with Qdrant's
+`scroll` and write each point across, preserving the id:
+
+```python
+from rostam._ids import to_uint64
+
+next_page = None
+while True:
+    points, next_page = client.scroll("docs", limit=256, offset=next_page,
+                                       with_vectors=True, with_payload=True)
+    for p in points:
+        meta = dict(p.payload or {})
+        pid = p.id if isinstance(p.id, int) else to_uint64(str(p.id))
+        if not isinstance(p.id, int):
+            meta["qdrant_id"] = str(p.id)
+        c.upsert("docs", pid, p.vector, metadata=meta)
+    if next_page is None:
+        break
+```
+
+Re-embedding from source documents is often cleaner than exporting vectors, and it
+lets you change embedding models at the same time — Rostam can embed for you via
+`TextStore` (see the [Python client](../api/python.md); note the egress caveat for
+hosted embedders).
+
+## What is different (read before you commit)
+
+- **You operate it** — same as self-hosted Qdrant: run it, back it up
+  ([Backups](../server/backups.md)), secure it ([Security](../server/security.md)).
+- **`distance`, not `score`**, as the primary ranking field (see above).
+- **Integer ids** — map UUIDs with `to_uint64`, keep the original in metadata.
+- **No `is-empty`/`is-null` filter** and no server-side embedding (see above).
+- **Named/sparse vectors:** Rostam does hybrid dense+sparse and full-text (BM25) —
+  see [Hybrid & full-text](../vector/hybrid-search.md) — but the API shape differs
+  from Qdrant's named vectors; check that doc before porting a multi-vector schema.
+
+## Next steps
+
+- [Quickstart](../quickstart.md)
+- [Search](../vector/search.md) · [Filtering](../vector/filtering.md) · [Hybrid & full-text](../vector/hybrid-search.md) · [Quantization](../vector/quantization.md)
+- [Clustering](../server/clustering.md) · [Security](../server/security.md)
+- Benchmarks vs. Qdrant and others: <https://rostamlabs.com/compare>

--- a/docs/migrate/from-qdrant.md
+++ b/docs/migrate/from-qdrant.md
@@ -24,7 +24,7 @@ Jump to [Code, side by side](#code-side-by-side).
 | `QdrantClient(url=…)` | `Rostam(url, api_key=…)` | REST on `:8080`; native TCP on `:7000` is opt-in (start with `-tcp :7000`). |
 | Collection | **Collection** | `create_collection(name, dim, metric)`. |
 | `VectorParams(size, distance)` | `dim=…, metric=…` | Distance mapping [below](#distance-metrics). |
-| `PointStruct(id, vector, payload)` | Point (`id`, embedding, `metadata`, optional `content`) | `payload` → `metadata` (scalar values only); ids are integers, see [IDs](#ids). |
+| `PointStruct(id, vector, payload)` | Point (`id`, embedding, `metadata`, optional `content`) | `payload` → `metadata` (scalars + homogeneous scalar lists); ids are integers, see [IDs](#ids). |
 | `Filter` / `FieldCondition` | `filters` helpers (`f.eq`, …) | Full table [below](#translating-filters). |
 | Multitenancy via a payload field | **Tenant** (`<tenant>/<collection>`) | A real primitive + optional auth boundary; see [Multitenancy](#multitenancy). |
 | `ScoredPoint.score` | `hit.distance` (and `hit.score`) | Rostam's `distance` is unambiguous (smaller = closer); see [Scores](#scores-vs-distances). |
@@ -81,7 +81,7 @@ client.upsert("docs", points=[
     models.PointStruct(id=1, vector=embedding, payload={"doc_id": 7, "lang": "en"}),
 ])
 
-# Rostam  (payload -> metadata, scalar values only; content is an optional stored text payload)
+# Rostam  (payload -> metadata: scalars or homogeneous scalar lists; content is an optional stored text payload)
 c.upsert("docs", 1, embedding, content="the chunk text",
          metadata={"doc_id": 7, "lang": "en"})
 ```
@@ -147,9 +147,12 @@ Two mapping caveats worth checking against your data:
   one of these" → `f.in_`. On an **array** payload field it means "the array contains
   any of these" → use `f.contains` (which tests array membership), OR'd across the
   values. Rostam's `f.in_` is for scalar fields.
-- **`is-empty` / `is-null`** have no Rostam equivalent — Rostam filters match on
-  values, not key presence. Emulate by writing an explicit sentinel field (e.g. a
-  boolean `has_x`) at upsert time and filtering on it.
+- **`is-empty` / `is-null`** *are* supported by the engine — the Python `filters`
+  helpers just don't have a dedicated builder for them. A filter is a plain dict, so
+  pass the raw predicate: Qdrant's `IsEmpty(key="x")` → `{"op": "is_empty", "field": "x"}`
+  (field absent, null, `""`, or empty array) and `IsNull(key="x")` →
+  `{"op": "is_null", "field": "x"}` (present and explicitly null). These compose with
+  the `f.*` helpers (`f.and_`, `f.not_`, …) like any other predicate.
 
 Rostam runs filters through an **exact, filter-first path**, so a selective filter
 does not degrade recall. See [Filtering](../vector/filtering.md).
@@ -208,21 +211,34 @@ string for you, so store it yourself (pick a metadata key your data doesn't use)
 ## Migrating your data
 
 There is no import tool — you re-upsert. Page through the source with Qdrant's
-`scroll` and write each point across. Rostam metadata values must be **scalars**
-(str / int / float / bool), so coerce anything nested, null, or list-valued in the
-payload before upserting:
+`scroll` and write each point across. Rostam metadata values are scalars
+(str / int / float / bool) **or homogeneous scalar lists** (all-int, all-float, or
+all-str — these stay filterable with `f.contains`). What it can't store is a nested
+object, a mixed-type or empty list, or an explicit null, so coerce only those before
+upserting:
 
 ```python
 import json
 from rostam._ids import to_uint64
 
+def _scalar_list(v):
+    """True if v is a non-empty, homogeneous int/float/str list Rostam can store."""
+    v = list(v)
+    if not v or all(isinstance(x, bool) for x in v):   # no bool-list kind
+        return False
+    return (all(isinstance(x, int) and not isinstance(x, bool) for x in v)
+            or all(isinstance(x, float) for x in v)
+            or all(isinstance(x, str) for x in v))
+
 def scalarize(payload):
     out = {}
     for k, v in (payload or {}).items():
-        if v is None or isinstance(v, (dict, list)):
-            out[k] = json.dumps(v)          # keep it, but as a scalar string
+        if isinstance(v, (bool, int, float, str)):
+            out[k] = v                                 # scalar -> as-is
+        elif isinstance(v, (list, tuple)) and _scalar_list(v):
+            out[k] = list(v)                           # keep the array; f.contains still works
         else:
-            out[k] = v
+            out[k] = json.dumps(v)                     # nested / mixed / empty / null -> string
     return out
 
 next_page = None
@@ -248,8 +264,9 @@ hosted embedders).
   ([Backups](../server/backups.md)), secure it ([Security](../server/security.md)).
 - **`distance`, not `score`**, as the primary ranking field (see above).
 - **Integer ids** — map UUIDs with `to_uint64`, keep the original in metadata.
-- **Scalar-only metadata** — coerce nested/list/null payload values (see above).
-- **No `is-empty`/`is-null` filter**, and no server-side embedding.
+- **Scalar or homogeneous-scalar-list metadata** — coerce only nested/mixed/null
+  payload values (see above).
+- **No server-side embedding** (`is-empty`/`is-null` *are* supported — see Filters).
 - **Named/sparse vectors:** Rostam does hybrid dense+sparse and full-text (BM25) —
   see [Hybrid & full-text](../vector/hybrid-search.md) — but the API shape differs
   from Qdrant's named vectors; check that doc before porting a multi-vector schema.

--- a/docs/migrate/from-qdrant.md
+++ b/docs/migrate/from-qdrant.md
@@ -21,12 +21,12 @@ Jump to [Code, side by side](#code-side-by-side).
 
 | Qdrant | Rostam | Notes |
 |---|---|---|
-| `QdrantClient(url=…)` | `Rostam(url, api_key=…)` | REST on `:8080`, native TCP on `:7000`. |
+| `QdrantClient(url=…)` | `Rostam(url, api_key=…)` | REST on `:8080`; native TCP on `:7000` is opt-in (start with `-tcp :7000`). |
 | Collection | **Collection** | `create_collection(name, dim, metric)`. |
 | `VectorParams(size, distance)` | `dim=…, metric=…` | Distance mapping [below](#distance-metrics). |
-| `PointStruct(id, vector, payload)` | Point (`id`, embedding, `metadata`, optional `content`) | `payload` → `metadata`; ids are integers, see [IDs](#ids). |
+| `PointStruct(id, vector, payload)` | Point (`id`, embedding, `metadata`, optional `content`) | `payload` → `metadata` (scalar values only); ids are integers, see [IDs](#ids). |
 | `Filter` / `FieldCondition` | `filters` helpers (`f.eq`, …) | Full table [below](#translating-filters). |
-| Multitenancy via a payload field | **Tenant** (`<tenant>/<collection>`) | A real primitive + optional auth boundary; see [Multitenancy](#multitenancy-tenants). |
+| Multitenancy via a payload field | **Tenant** (`<tenant>/<collection>`) | A real primitive + optional auth boundary; see [Multitenancy](#multitenancy). |
 | `ScoredPoint.score` | `hit.distance` (and `hit.score`) | Rostam's `distance` is unambiguous (smaller = closer); see [Scores](#scores-vs-distances). |
 | Cluster / sharding | Raft cluster, online resharding | [Clustering](../server/clustering.md). |
 
@@ -36,7 +36,7 @@ Jump to [Code, side by side](#code-side-by-side).
 # one static binary; no separate services to run. Pass the token via env, not a
 # flag (a -api-key flag secret leaks via /proc and shell history):
 export ROSTAM_API_KEY="a-strong-token"
-rostam-server -http :8080 -data ./data
+rostam-server -http :8080 -data ./data          # add -tcp :7000 to also serve the native TCP protocol
 ```
 
 The server refuses to bind a reachable address without auth. See
@@ -81,7 +81,7 @@ client.upsert("docs", points=[
     models.PointStruct(id=1, vector=embedding, payload={"doc_id": 7, "lang": "en"}),
 ])
 
-# Rostam  (payload -> metadata; content is an optional stored text payload)
+# Rostam  (payload -> metadata, scalar values only; content is an optional stored text payload)
 c.upsert("docs", 1, embedding, content="the chunk text",
          metadata={"doc_id": 7, "lang": "en"})
 ```
@@ -133,36 +133,48 @@ helpers (`from rostam import filters as f`).
 | Qdrant | Rostam |
 |---|---|
 | `FieldCondition(key="g", match=MatchValue(value="x"))` | `f.eq("g", "x")` |
-| `FieldCondition(key="g", match=MatchAny(any=["a","b"]))` | `f.in_("g", ["a", "b"])` |
-| `FieldCondition(key="g", match=MatchExcept(**{"except": ["a"]}))` | `f.not_(f.in_("g", ["a"]))` |
-| `FieldCondition(key="n", range=Range(gte=3, lte=9))` | `f.and_(f.gte("n", 3), f.lte("n", 9))` |
+| `MatchAny(any=[…])` on a **scalar** field | `f.in_("g", [...])` |
+| `MatchAny(any=[…])` on an **array** field | `f.or_(f.contains("g", a), f.contains("g", b), …)` |
+| `MatchExcept(except=[…])` (scalar field) | `f.not_(f.in_("g", [...]))` |
+| `range=Range(gte=3, lte=9)` | `f.and_(f.gte("n", 3), f.lte("n", 9))` |
 | `Filter(must=[A, B])` | `f.and_(A, B)` |
 | `Filter(should=[A, B])` | `f.or_(A, B)` |
 | `Filter(must_not=[A])` | `f.not_(A)` |
 
-Qdrant's `IsEmptyCondition` / `IsNullCondition` (matching on key presence) have no
-direct Rostam equivalent — Rostam filters match on values. Emulate by writing an
-explicit sentinel field (e.g. a boolean `has_x`) and filtering on it.
+Two mapping caveats worth checking against your data:
+
+- **`MatchAny` semantics depend on the field.** On a scalar field it means "value is
+  one of these" → `f.in_`. On an **array** payload field it means "the array contains
+  any of these" → use `f.contains` (which tests array membership), OR'd across the
+  values. Rostam's `f.in_` is for scalar fields.
+- **`is-empty` / `is-null`** have no Rostam equivalent — Rostam filters match on
+  values, not key presence. Emulate by writing an explicit sentinel field (e.g. a
+  boolean `has_x`) at upsert time and filtering on it.
 
 Rostam runs filters through an **exact, filter-first path**, so a selective filter
 does not degrade recall. See [Filtering](../vector/filtering.md).
 
-## Multitenancy → tenants
+## Multitenancy
 
 Qdrant's recommended multitenancy is a single collection with a tenant payload
-field and a payload index. Rostam offers that pattern too (store the tenant in
-`metadata` and add `f.eq("tenant", "user-42")` to every query), but it also has a
+field and a payload index. Rostam supports that pattern (store the tenant in
+`metadata` and add `f.eq("tenant", "user-42")` to every query), and it also has a
 first-class **tenant** primitive: collection names can be written
-`<tenant>/<collection>`, and with `-tenant-isolation` a tenant becomes an
-**authoritative security boundary** — an API key bound to a tenant can only see
-that tenant's collections.
+`<tenant>/<collection>`.
 
 ```python
 c.create_collection("user-42/docs", dim=384, metric="cosine")
 c.search_docs("user-42/docs", v, k=5)
 ```
 
-See [Collections, tenants & aliases](../concepts/collections.md).
+For an **enforced** isolation boundary (a key that can only see its own tenant),
+the `<tenant>/<collection>` naming alone is not enough — you need **tenant-bound
+keys**. Issue keys via `-keys-file` (per-key RBAC, each key carrying a tenant) and
+run with `-tenant-isolation`; then that boundary is enforced after scope checks.
+The single static `-api-key`/`ROSTAM_API_KEY` used elsewhere in this guide is a
+**superuser** and sees every tenant, so use it for setup, not for tenant isolation.
+See [Security](../server/security.md#tenant-isolation) and
+[Collections, tenants & aliases](../concepts/collections.md).
 
 ## Scores vs. distances
 
@@ -186,24 +198,41 @@ c.upsert("docs", to_uint64("2f1c…"), embedding, metadata={"qdrant_id": "2f1c�
 `to_uint64` is one-way; neither the client nor `TextStore` preserves the original
 string for you, so store it yourself (pick a metadata key your data doesn't use).
 
+!!! warning "Mixed integer and UUID ids in one collection"
+    If a source collection mixes plain integer ids with UUIDs, writing ints verbatim
+    while hashing UUIDs puts both in the same `uint64` space, where a hashed UUID
+    could collide with a verbatim int. For a mixed collection, hash **every** id
+    (`to_uint64(str(p.id))`) so they share one consistent mapping, and keep the
+    original in metadata.
+
 ## Migrating your data
 
 There is no import tool — you re-upsert. Page through the source with Qdrant's
-`scroll` and write each point across, preserving the id:
+`scroll` and write each point across. Rostam metadata values must be **scalars**
+(str / int / float / bool), so coerce anything nested, null, or list-valued in the
+payload before upserting:
 
 ```python
+import json
 from rostam._ids import to_uint64
+
+def scalarize(payload):
+    out = {}
+    for k, v in (payload or {}).items():
+        if v is None or isinstance(v, (dict, list)):
+            out[k] = json.dumps(v)          # keep it, but as a scalar string
+        else:
+            out[k] = v
+    return out
 
 next_page = None
 while True:
     points, next_page = client.scroll("docs", limit=256, offset=next_page,
                                        with_vectors=True, with_payload=True)
     for p in points:
-        meta = dict(p.payload or {})
-        pid = p.id if isinstance(p.id, int) else to_uint64(str(p.id))
-        if not isinstance(p.id, int):
-            meta["qdrant_id"] = str(p.id)
-        c.upsert("docs", pid, p.vector, metadata=meta)
+        meta = scalarize(p.payload)
+        meta["qdrant_id"] = str(p.id)       # preserve the original id
+        c.upsert("docs", to_uint64(str(p.id)), p.vector, metadata=meta)
     if next_page is None:
         break
 ```
@@ -219,7 +248,8 @@ hosted embedders).
   ([Backups](../server/backups.md)), secure it ([Security](../server/security.md)).
 - **`distance`, not `score`**, as the primary ranking field (see above).
 - **Integer ids** — map UUIDs with `to_uint64`, keep the original in metadata.
-- **No `is-empty`/`is-null` filter** and no server-side embedding (see above).
+- **Scalar-only metadata** — coerce nested/list/null payload values (see above).
+- **No `is-empty`/`is-null` filter**, and no server-side embedding.
 - **Named/sparse vectors:** Rostam does hybrid dense+sparse and full-text (BM25) —
   see [Hybrid & full-text](../vector/hybrid-search.md) — but the API shape differs
   from Qdrant's named vectors; check that doc before porting a multi-vector schema.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -86,6 +86,7 @@ nav:
   - Quickstart: quickstart.md
   - Migrating:
       - From Pinecone: migrate/from-pinecone.md
+      - From Qdrant: migrate/from-qdrant.md
   - Concepts:
       - Architecture: concepts/architecture.md
       - Deployment modes: concepts/deployment-modes.md


### PR DESCRIPTION
## Why
Completes the migration pair — converts the "Qdrant alternative" searchers the `/compare` page attracts. Companion to #80 (Pinecone).

## What
`docs/migrate/from-qdrant.md` (added to the "Migrating" nav):
- Concept mapping (collection, `VectorParams`/`Distance`→`dim`/`metric`, `PointStruct` payload→metadata, multitenancy→tenant).
- Side-by-side Python for connect / create / upsert / query (`query_points`) / retrieve / delete.
- Distance-metric table (COSINE/EUCLID/DOT→cosine/l2/dot; Manhattan noted as unsupported).
- Filter translation (`FieldCondition`/`MatchValue`/`MatchAny`/`MatchExcept`/`Range` and `must`/`should`/`must_not` → `filters` helpers).
- `scroll`-based data-migration snippet preserving the original id.
- Honest "what's different": operate it, `distance` vs `score`, integer ids (`to_uint64`), no is-empty/is-null filter, named/sparse-vector API differs (points to the hybrid doc).

## Accuracy (applying the #80 lesson — verify, don't write from memory)
- Rostam-side reuses the patterns verified during #80; re-confirmed `filters` helpers, `create_collection` metric names, `to_uint64`, tenant naming, and that results carry `distance` (+ a `score` whose scale I did **not** over-claim).
- `mkdocs build --strict` passes; all internal links verified to resolve.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a "Migrating from Qdrant" guide that maps Qdrant concepts and API calls to Rostam, completing the migration docs pair with the existing Pinecone guide. It includes side-by-side Python examples, filter translations, distance-metric mapping, multitenancy, and a `scroll`-based data migration, plus an honest list of differences like integer-only ids and no Manhattan metric.

- Adds the guide to the "Migrating" navigation in `mkdocs.yml`.
- Documents the native TCP protocol as opt-in and tenant isolation as requiring tenant-bound keys with `-keys-file` and `-tenant-isolation`.
- Covers `is-empty`/`is-null` filters passed as raw predicate dicts (the Python `f.*` helpers lack builders) and preserves homogeneous scalar-list metadata during migration; only nested, mixed, empty, or null values get coerced.

<sup>Written for commit 028faaee04796f77027571cb9606e6635a198ecd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rostamlabs/rostam/pull/81?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a migration guide for moving from Qdrant to Rostam.
  * Documented concept mappings, API equivalents, filtering, multitenancy, distance metrics, identifier handling, and data migration workflows.
  * Added the guide to the documentation’s “Migrating” navigation section.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->