### PR TITLE
docs(migrate/pinecone): correct $exists mapping to is_empty/is_null

### DIFF
--- a/docs/migrate/from-pinecone.md
+++ b/docs/migrate/from-pinecone.md
@@ -216,8 +216,9 @@ caveat above).
 - **Integer ids** — map strings with `to_uint64`, keep the original in metadata (see above).
 - **Distance, not score** — hits carry `distance` (smaller = closer), not a Pinecone-style
   similarity `score`. Convert if your app expects scores.
-- **No server-side embedding** — see the sections above (`$exists` maps to the
-  `is_empty`/`is_null` predicates, with the presence-semantics caveat noted there).
+- **No server-side embedding** — generate embeddings before you upsert (see above).
+  (`$exists` is covered — it maps to the `is_empty`/`is_null` predicates in
+  [Translating metadata filters](#translating-metadata-filters).)
 
 ## Next steps
 

--- a/docs/migrate/from-pinecone.md
+++ b/docs/migrate/from-pinecone.md
@@ -135,11 +135,18 @@ Pinecone filters are dicts of operators; Rostam uses the `filters` helpers
 | `{"g": {"$nin": ["a","b"]}}` | `f.not_(f.in_("g", ["a", "b"]))` |
 | `{"$and": [A, B]}` | `f.and_(A, B)` |
 | `{"$or": [A, B]}` | `f.or_(A, B)` |
+| `{"g": {"$exists": false}}` | `{"op": "is_empty", "field": "g"}` (raw dict) |
+| `{"g": {"$exists": true}}` | `f.not_({"op": "is_empty", "field": "g"})` |
 | implicit `{"a": 1, "b": 2}` (AND) | `f.and_(f.eq("a", 1), f.eq("b", 2))` |
 
-Pinecone's **`$exists`** has no direct equivalent — Rostam filters match on values,
-not key presence. Emulate it by storing an explicit sentinel (e.g. a boolean
-`has_x` field) at write time and filtering on that.
+Rostam has **`is_empty`** and **`is_null`** predicates for this — the Python
+`filters` helpers just don't expose builders for them, so pass the raw predicate
+dict (a filter is a plain dict). `is_empty` matches a field that is absent, null,
+`""`, or an empty array; `is_null` matches a field that is present and explicitly
+null. Note the semantic gap from Pinecone's `$exists`, which tests key presence
+alone: `is_empty` treats a present-but-empty value as "empty" too. If you need
+exact key-presence semantics, a boolean sentinel field (`has_x`) written at upsert
+time is still the precise option.
 
 Rostam runs filters through an **exact, filter-first path** — a selective filter
 does not degrade recall. See [Filtering](../vector/filtering.md).
@@ -209,7 +216,8 @@ caveat above).
 - **Integer ids** — map strings with `to_uint64`, keep the original in metadata (see above).
 - **Distance, not score** — hits carry `distance` (smaller = closer), not a Pinecone-style
   similarity `score`. Convert if your app expects scores.
-- **No `$exists` filter** and no server-side embedding — see the sections above.
+- **No server-side embedding** — see the sections above (`$exists` maps to the
+  `is_empty`/`is_null` predicates, with the presence-semantics caveat noted there).
 
 ## Next steps
 


### PR DESCRIPTION
The merged Pinecone guide wrongly claimed `$exists` has no Rostam equivalent and steered users to a boolean sentinel field. The engine actually exposes `is_empty` and `is_null` filter predicates (`sdk/vtypes/filter.go`), decoded by op-name from a plain filter dict — only the Python `filters as f` helpers lack builders for them.

This is the same correction made for the Qdrant guide in #81.

- Add `$exists` rows to the filter table mapping to the raw `{"op": "is_empty", ...}` / `f.not_(...)` forms.
- Rewrite the prose to document the predicates and honestly note the semantic gap: Pinecone's `$exists` tests key presence alone, while `is_empty` also matches present-but-empty values — so the boolean sentinel remains the option for exact key-presence semantics.
- Fix the stale "No `$exists` filter" bullet.

`mkdocs build --strict` clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Pinecone migration guide so `$exists` filters no longer appear to have no Rostam equivalent.

- Maps `$exists` to the raw `is_empty`/`is_null` predicate dicts and documents the semantic gap versus Pinecone's key-presence check.
- Keeps the boolean sentinel as the exact key-presence option.
- Fixes the "what is different" bullet so its heading matches its content and the `$exists` note points to the filter section.

<sup>Written for commit c53a469278c430939ca0a67313380112b176f29e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rostamlabs/rostam/pull/82?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the Pinecone migration guide to instruct users to generate embeddings before upserting data.
  * Consolidated `$exists` filter guidance by linking to the Translating metadata filters section.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->