### PR TITLE
docs(quickstart): lead with a 5-minute try-it path

### DIFF
--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -11,8 +11,10 @@ modes, and the Go embedding paths.
 Zero to a filtered vector search — one container, the Python client, no build.
 
 ```sh
-# 1. Start the server (Docker). The image binds 0.0.0.0, so it needs a token.
-docker run -p 8080:8080 -e ROSTAM_API_KEY=secret ghcr.io/rostamlabs/rostam
+# 1. Start the server (Docker), published on loopback only for local use. The
+#    image binds 0.0.0.0 inside the container so it needs a token; 'secret' is a
+#    demo placeholder — use a generated token + TLS for anything remote.
+docker run -p 127.0.0.1:8080:8080 -e ROSTAM_API_KEY=secret ghcr.io/rostamlabs/rostam
 ```
 
 ```sh

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -2,8 +2,48 @@
 
 Rostam can run three ways: as a **single-node server** speaking HTTP/gRPC/TCP,
 as a **replicated Raft cluster**, or as a **Go library** embedded in your binary
-(no server at all). This page gets you from zero to a working search in each
-mode — the server and Python paths first, the Go embedding paths after.
+(no server at all). If you just want to see it work, start with the five-minute
+path below; the rest of the page covers every install method, the three run
+modes, and the Go embedding paths.
+
+## Try it in 5 minutes
+
+Zero to a filtered vector search — one container, the Python client, no build.
+
+```sh
+# 1. Start the server (Docker). The image binds 0.0.0.0, so it needs a token.
+docker run -p 8080:8080 -e ROSTAM_API_KEY=secret ghcr.io/rostamlabs/rostam
+```
+
+```sh
+# 2. In another terminal, install the client:
+pip install rostam-client
+```
+
+```python
+# 3. Create a collection, add a point, search it:
+from rostam import Rostam, filters as f
+
+c = Rostam("http://localhost:8080", api_key="secret")
+
+c.create_collection("docs", dim=4, metric="cosine")
+c.upsert("docs", 1, [0.1, 0.2, 0.3, 0.4],
+         content="hello rostam", metadata={"tenant": "acme"})
+
+hits = c.search_docs("docs", [0.1, 0.2, 0.3, 0.4], k=3,
+                     filter=f.eq("tenant", "acme"))
+print([(h.id, h.content) for h in hits])   # -> [(1, 'hello rostam')]
+```
+
+That's a running server and an exact, filter-first vector search. Real data uses
+a real embedding model — swap the 4-number vectors for your model's output and
+set `dim` to match. From here:
+
+- **No Docker?** Install the binary directly — [Install the server](#install-the-server).
+- **Embed it in Go** instead of running a server — [Embedded vector search](#embedded-vector-search-go-library).
+- **Bulk-load** a large dataset fast — [Large initial loads](#large-initial-loads).
+
+The sections below go deeper on each.
 
 ## Requirements
 


### PR DESCRIPTION
## What

Adds a **Try it in 5 minutes** section at the top of the quickstart: one `docker run`, `pip install rostam-client`, and a Python snippet that creates a collection, upserts a point, and runs a filtered vector search — ending in a printed result. Deeper sections (all install methods, run modes, Go embedding, bulk load) are unchanged and linked from the new section.

## Why

The page front-loaded requirements, four install tabs, and auth caveats before the reader saw anything work — the biggest drop-off point in the funnel, and the shared landing spot for both migration guides (#80, #81) and the comparison pages.

## Verification

Every command was run against a locally-built `rostam-server`, not written from memory:
- `/v1/health` → 200; `/v1/collections`, `/points`, `/points/search` all return as documented.
- Tagged-metadata encoding (`{"kind":"string","str":"acme"}`) and the search response shape match.
- Python surface (`Rostam`, `create_collection`/`upsert`/`search_docs`, `filters as f`) confirmed in the client.
- `mkdocs build --strict` clean; the three intra-page anchors resolve to real headings.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a five-minute try-it path to the top of the quickstart so new users see a working filtered vector search before the requirements and install tabs. The section walks through one `docker run`, `pip install rostam-client`, and a Python create/upsert/search snippet, then links to the deeper sections below. The try-it container now binds to `127.0.0.1` only, since the flow uses a static demo token; remote use needs a generated token with TLS.

<sup>Written for commit b7db97eeaf8a089bcc41386bcf28d2dc8c09db58. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rostamlabs/rostam/pull/83?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added a five-minute quickstart path covering server startup, client installation, collection creation, data insertion, and filtered search.
  - Updated the introduction to highlight installation options, run modes, and Go embedding guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->