### PR TITLE
fix(vector): durable acked deletes + fail-closed WAL on fsync failure

### DIFF
--- a/vector/collection.go
+++ b/vector/collection.go
@@ -1006,7 +1006,14 @@ func (c *Collection) DeleteByFilter(filter Filter) (int, error) {
 	}
 	n := 0
 	for _, id := range ids {
-		if c.Delete(id) {
+		// Use the error-returning delete: a durability failure mid-batch (WAL
+		// append/fsync error, or a poisoned WAL) must surface, not report a clean
+		// batch. Return the count removed so far plus the first error.
+		removed, derr := c.DeleteCAS(id, CASCond{})
+		if derr != nil {
+			return n, derr
+		}
+		if removed {
 			n++
 		}
 	}
@@ -1269,7 +1276,13 @@ func (c *Collection) DeleteByFilterAt(filter Filter, nowMs int64) (int, error) {
 	}
 	n := 0
 	for _, id := range ids {
-		if ok, derr := c.DeleteCASAt(id, CASCond{}, nowMs); derr == nil && ok {
+		// Surface the first durability failure mid-batch instead of silently
+		// reporting a clean batch (mirrors DeleteByFilter).
+		ok, derr := c.DeleteCASAt(id, CASCond{}, nowMs)
+		if derr != nil {
+			return n, derr
+		}
+		if ok {
 			n++
 		}
 	}

--- a/vector/collection.go
+++ b/vector/collection.go
@@ -848,8 +848,12 @@ func (c *Collection) UpsertCASKeyTTL(id uint64, vec []float32, content string, t
 		}
 		// Unconditional delete-then-insert; the CAS was already enforced above
 		// (passing the engine cas here would re-check against the post-delete
-		// version of 0).
-		delSeq := c.idxDeleteLogged(id)
+		// version of 0). A failed delete-WAL-append fails the upsert (delSeq is 0
+		// on error, so nothing is left to wait on).
+		delSeq, derr := c.idxDeleteLogged(id)
+		if derr != nil {
+			return 0, 0, derr
+		}
 		version, keyExpires, err := c.idx.Insert(id, vec, ttl, withContent(meta, content), sparse, keyTTLMs, CASCond{})
 		if err != nil {
 			return 0, delSeq, err
@@ -887,9 +891,13 @@ func (c *Collection) UpsertCASKeyTTL(id uint64, vec []float32, content string, t
 
 // idxDeleteLogged deletes id (unconditionally) and, on a WAL-mode collection,
 // stages the delete's WAL write. Caller holds opMu. Returns the assigned staged
-// sequence, or 0 when nothing was staged (no WAL, the delete was a no-op, or the
-// staged write itself failed — best-effort: delete replay is idempotent, so a
-// failed delete write is not fatal, but there is then nothing to wait on).
+// sequence (0 when nothing was staged: no WAL, or the delete was a no-op) and
+// the WAL append error, if any.
+//
+// The append error is PROPAGATED, not swallowed: idempotent replay tolerates a
+// torn/duplicate delete record, but it must not mask a durability FAILURE — the
+// caller fails the whole upsert so the client is never acked on a replace whose
+// tombstone never reached disk.
 //
 // Does NOT wait on this write's own sequence — the upsert replace path folds it
 // into the FOLLOWING insert's single commit-wait (fix for the double-fsync-per-
@@ -898,16 +906,12 @@ func (c *Collection) UpsertCASKeyTTL(id uint64, vec []float32, content string, t
 // if the insert never reaches its own append, the CALLER must explicitly wait on
 // the returned seq before returning (see UpsertCASKeyTTL): a staged write is
 // never itself durable without a later wait on its seq or a larger one.
-func (c *Collection) idxDeleteLogged(id uint64) uint64 {
+func (c *Collection) idxDeleteLogged(id uint64) (uint64, error) {
 	ok, _ := c.idx.Delete(id, CASCond{})
 	if !ok || c.wal == nil {
-		return 0
+		return 0, nil
 	}
-	seq, err := c.wal.appendDeleteStaged(id)
-	if err != nil {
-		return 0 // best-effort write; nothing durably staged to wait on
-	}
-	return seq
+	return c.wal.appendDeleteStaged(id)
 }
 
 // SearchDocs runs a filtered KNN search and returns each hit enriched with its
@@ -1043,16 +1047,28 @@ func (c *Collection) DeleteCAS(id uint64, cas CASCond) (bool, error) {
 			return derr
 		}
 		if ok {
-			seq, _ = c.wal.appendDeleteStaged(id) // best-effort; delete replay is idempotent
+			// Propagate the WAL append error (mirrors InsertCASKeyTTL). Replay is
+			// idempotent — a torn/duplicate delete record on replay is tolerated —
+			// but that is NOT a licence to swallow a durability FAILURE: a client
+			// acked on a delete whose record never reached disk would see the point
+			// resurrect after a crash. A real append error fails the delete.
+			var serr error
+			seq, serr = c.wal.appendDeleteStaged(id)
+			if serr != nil {
+				return serr
+			}
 		}
 		return nil
 	}()
 	if err != nil {
 		return false, err
 	}
-	// Wait outside opMu. seq == 0 means nothing was staged (no-op delete, or a
-	// failed best-effort write) — commitWaitStaged(0) is a no-op either way.
-	_ = c.wal.commitWaitStaged(seq) // best-effort, matching the append above
+	// Wait outside opMu. seq == 0 means nothing was staged (no-op delete: id was
+	// not live) — commitWaitStaged(0) is a legit no-op returning nil, so a
+	// not-removed delete stays a success. A real fsync failure propagates.
+	if werr := c.wal.commitWaitStaged(seq); werr != nil {
+		return false, werr
+	}
 	return ok, nil
 }
 
@@ -1213,14 +1229,25 @@ func (c *Collection) DeleteCASAt(id uint64, cas CASCond, nowMs int64) (bool, err
 			return derr
 		}
 		if ok {
-			seq, _ = c.wal.appendDeleteStaged(id) // best-effort; delete replay is idempotent
+			// Propagate the WAL append error (mirrors DeleteCAS / InsertCASKeyTTL):
+			// idempotent replay tolerates torn duplicates, but a durability failure
+			// must fail the delete, not silently ack it.
+			var serr error
+			seq, serr = c.wal.appendDeleteStaged(id)
+			if serr != nil {
+				return serr
+			}
 		}
 		return nil
 	}()
 	if err != nil {
 		return false, err
 	}
-	_ = c.wal.commitWaitStaged(seq) // best-effort, matching the append above
+	// seq == 0 (no-op delete) makes commitWaitStaged a no-op returning nil; a real
+	// fsync failure propagates and fails the delete.
+	if werr := c.wal.commitWaitStaged(seq); werr != nil {
+		return false, werr
+	}
 	return ok, nil
 }
 
@@ -1277,7 +1304,14 @@ func (c *Collection) UpsertCASKeyTTLAt(id uint64, vec []float32, content string,
 		// or explicitly waited on by the caller below otherwise.
 		var delSeq uint64
 		if removed && c.wal != nil {
-			delSeq, _ = c.wal.appendDeleteStaged(id) // best-effort write; 0 on failure
+			// Propagate the delete-WAL-append error (mirrors UpsertCASKeyTTL): a
+			// durability failure fails the upsert rather than silently acking a
+			// replace whose tombstone never reached disk. delSeq stays 0 on error.
+			var derr error
+			delSeq, derr = c.wal.appendDeleteStaged(id)
+			if derr != nil {
+				return 0, delSeq, derr
+			}
 		}
 		version, keyExpires, err := c.idx.InsertAt(id, vec, ttl, withContent(meta, content), sparse, keyTTLMs, CASCond{}, nowMs)
 		if err != nil {

--- a/vector/multivector.go
+++ b/vector/multivector.go
@@ -1097,14 +1097,25 @@ func (m *MultiVectorIndex) DeleteCAS(docID uint64, cas CASCond) (removed bool, p
 			return derr
 		}
 		if removed {
-			seq, _ = m.wal.appendMVDeleteStaged(docID) // delete replay is idempotent (best-effort)
+			// Propagate the WAL append error (mirrors dense DeleteCAS): idempotent
+			// replay tolerates torn duplicates, but a durability failure must fail
+			// the delete rather than falsely ack a doc that may resurrect on crash.
+			var serr error
+			seq, serr = m.wal.appendMVDeleteStaged(docID)
+			if serr != nil {
+				return serr
+			}
 		}
 		return nil
 	}()
 	if err != nil {
 		return false, 0, err
 	}
-	_ = m.wal.commitWaitStaged(seq) // best-effort, matching the append above
+	// seq == 0 (no-op delete) makes commitWaitStaged a no-op returning nil; a real
+	// fsync failure propagates and fails the delete.
+	if werr := m.wal.commitWaitStaged(seq); werr != nil {
+		return false, 0, werr
+	}
 	return removed, prevVersion, nil
 }
 

--- a/vector/named.go
+++ b/vector/named.go
@@ -1096,14 +1096,25 @@ func (nc *NamedCollection) DeleteCAS(id uint64, cas CASCond) (removed bool, prev
 			return derr
 		}
 		if removed {
-			seq, _ = nc.wal.appendNamedDeleteStaged(id) // delete replay is idempotent (best-effort)
+			// Propagate the WAL append error (mirrors dense DeleteCAS): idempotent
+			// replay tolerates torn duplicates, but a durability failure must fail
+			// the delete rather than falsely ack a point that may resurrect on crash.
+			var serr error
+			seq, serr = nc.wal.appendNamedDeleteStaged(id)
+			if serr != nil {
+				return serr
+			}
 		}
 		return nil
 	}()
 	if err != nil {
 		return false, 0, err
 	}
-	_ = nc.wal.commitWaitStaged(seq) // best-effort, matching the append above
+	// seq == 0 (no-op delete) makes commitWaitStaged a no-op returning nil; a real
+	// fsync failure propagates and fails the delete.
+	if werr := nc.wal.commitWaitStaged(seq); werr != nil {
+		return false, 0, werr
+	}
 	return removed, prevVersion, nil
 }
 

--- a/vector/wal.go
+++ b/vector/wal.go
@@ -348,13 +348,20 @@ func (w *wal) appendDeleteStaged(id uint64) (uint64, error) {
 // call it from production code; use the staged pair.
 func (w *wal) appendFramed(payload []byte) error {
 	if w.poisoned.Load() {
-		return ErrWALPoisoned // fail closed: a prior fsync failure poisoned the log.
+		return ErrWALPoisoned // fast fail-closed: a prior fsync failure poisoned the log.
 	}
 	// WRITE phase: under mu, append the framed record and assign this writer's
 	// commit sequence (the post-write writeSeq). mu is released BEFORE the fsync so
 	// a concurrent appender can overlap this writer's commit-wait, and a leader's
 	// f.Sync() never holds mu.
 	w.mu.Lock()
+	// AUTHORITATIVE fail-closed re-check under w.mu (see appendFramedStaged): a
+	// leader may have poisoned the WAL after the early check above; never write a
+	// new record into a poisoned log.
+	if w.poisoned.Load() {
+		w.mu.Unlock()
+		return ErrWALPoisoned
+	}
 	var hdr [8]byte
 	binary.BigEndian.PutUint32(hdr[0:4], uint32(len(payload))) //nolint:gosec
 	binary.BigEndian.PutUint32(hdr[4:8], crc32.ChecksumIEEE(payload))
@@ -397,9 +404,17 @@ func (w *wal) appendFramed(payload []byte) error {
 // batches them.
 func (w *wal) appendFramedStaged(payload []byte) (uint64, error) {
 	if w.poisoned.Load() {
-		return 0, ErrWALPoisoned // fail closed: a prior fsync failure poisoned the log.
+		return 0, ErrWALPoisoned // fast fail-closed: a prior fsync failure poisoned the log.
 	}
 	w.mu.Lock()
+	// AUTHORITATIVE fail-closed check, under w.mu: a sync leader can poison the WAL
+	// (in commitWait) between the early check above and here. Re-check before
+	// writing ANY bytes so a poisoned WAL never appends a new, un-ackable record
+	// (which would replay after reopen despite never being acked).
+	if w.poisoned.Load() {
+		w.mu.Unlock()
+		return 0, ErrWALPoisoned
+	}
 	var hdr [8]byte
 	binary.BigEndian.PutUint32(hdr[0:4], uint32(len(payload))) //nolint:gosec
 	binary.BigEndian.PutUint32(hdr[4:8], crc32.ChecksumIEEE(payload))
@@ -424,6 +439,9 @@ func (w *wal) appendFramedStaged(payload []byte) (uint64, error) {
 // own noSync short-circuit), so waiting on syncedSeq would block forever.
 // Staged callers use this instead of calling commitWait directly.
 func (w *wal) commitWaitStaged(seq uint64) error {
+	if seq == 0 {
+		return nil // nothing was staged (e.g. a no-op delete) — a success, even poisoned.
+	}
 	if w.noSync {
 		return nil
 	}
@@ -436,6 +454,12 @@ func (w *wal) commitWaitStaged(seq uint64) error {
 // flight (those whose bytes it covers) or wait for the next flight. f.Sync() runs
 // holding NEITHER mu NOR syncMu so writes overlap the in-flight fsync.
 func (w *wal) commitWait(seq uint64) error {
+	if seq == 0 {
+		// A no-op write (nothing staged) touches no durability, so it stays a
+		// success even on a poisoned WAL — this fast path MUST precede the poison
+		// gate so a no-op delete of an absent id is not turned into ErrWALPoisoned.
+		return nil
+	}
 	w.syncMu.Lock()
 	for {
 		if w.poisoned.Load() {

--- a/vector/wal.go
+++ b/vector/wal.go
@@ -541,8 +541,16 @@ func (w *wal) truncate() error {
 	// durability state unknown, and — like commitWait — a later writer must never
 	// be allowed to retry an fsync that could falsely succeed after the kernel
 	// dropped a prior failure's dirty pages (fsyncgate). Fail closed on any error.
-	// Already-poisoned ⇒ don't issue another Sync at all (a poisoned WAL never
-	// retries fsync); fail closed for symmetry with the append/commit entry points.
+	//
+	// Best-effort fast-fail if the WAL is ALREADY poisoned: skip a pointless
+	// rotation of a known-dead log. This is NOT a full barrier — poison is set
+	// under syncMu (in commitWait) while this checks under w.mu, so a leader Sync
+	// failing between here and truncate's own Sync below can still let one truncate
+	// Sync through. That is harmless: a failed truncate Sync itself poisons and
+	// never advances syncedSeq, and poisoned waiters hit the poison gate before the
+	// syncedSeq check, so no errored write is ever acked. (In practice Flush holds
+	// the caller's opMu across snapshot+truncate, so no concurrent writer op runs
+	// here at all — see the truncate doc comment above.)
 	if w.poisoned.Load() {
 		return ErrWALPoisoned
 	}

--- a/vector/wal.go
+++ b/vector/wal.go
@@ -409,8 +409,18 @@ func (w *wal) appendFramedStaged(payload []byte) (uint64, error) {
 	w.mu.Lock()
 	// AUTHORITATIVE fail-closed check, under w.mu: a sync leader can poison the WAL
 	// (in commitWait) between the early check above and here. Re-check before
-	// writing ANY bytes so a poisoned WAL never appends a new, un-ackable record
-	// (which would replay after reopen despite never being acked).
+	// writing ANY bytes so a poisoned WAL never appends a new record.
+	//
+	// This does NOT close the window where a write's bytes are appended while an
+	// in-flight leader Sync (running under NEITHER lock — that overlap is the whole
+	// point of group commit) then fails and poisons: such a writer's commitWait
+	// returns ErrWALPoisoned, so it is NEVER acked, but its bytes are already in the
+	// file and may replay on reopen. That is intended at-least-once semantics for an
+	// errored/in-flight write — identical to a crash mid-append — NOT a false ack.
+	// Durability is promised only for a write that returned nil: syncedSeq advances
+	// solely after a SUCCESSFUL Sync (see commitWait), so no errored write is ever
+	// acknowledged. Closing this residual would require serializing appends through
+	// f.Sync(), which would destroy group commit.
 	if w.poisoned.Load() {
 		w.mu.Unlock()
 		return 0, ErrWALPoisoned
@@ -531,6 +541,11 @@ func (w *wal) truncate() error {
 	// durability state unknown, and — like commitWait — a later writer must never
 	// be allowed to retry an fsync that could falsely succeed after the kernel
 	// dropped a prior failure's dirty pages (fsyncgate). Fail closed on any error.
+	// Already-poisoned ⇒ don't issue another Sync at all (a poisoned WAL never
+	// retries fsync); fail closed for symmetry with the append/commit entry points.
+	if w.poisoned.Load() {
+		return ErrWALPoisoned
+	}
 	if err := w.f.Truncate(0); err != nil {
 		w.poisoned.Store(true)
 		return err

--- a/vector/wal.go
+++ b/vector/wal.go
@@ -11,6 +11,7 @@ import (
 	"io"
 	"os"
 	"sync"
+	"sync/atomic"
 	"time"
 )
 
@@ -115,6 +116,26 @@ type wal struct {
 	syncedSeq uint64 // highest writeSeq covered by a completed Sync (or truncate)
 	syncing   bool   // a leader is currently running f.Sync()
 
+	// poisoned is a TERMINAL latch tripped on the FIRST f.Sync() failure (in
+	// commitWait or truncate). It exists because of fsyncgate: on a failed
+	// fsync, the kernel may DISCARD the sync's dirty pages, and a SUBSEQUENT
+	// f.Sync() on the same file can then return SUCCESS having synced nothing
+	// (the post-4.13 Linux behavior; the PostgreSQL PANIC-on-fsync-failure
+	// case). If the next writer became fsync leader and retried Sync() after a
+	// failure, it could be acked on bytes the kernel already dropped — silently
+	// breaking the ack-implies-fsynced invariant this file's doc promises.
+	//
+	// So the WAL fails CLOSED: once poisoned, every append/commit-wait entry
+	// point returns ErrWALPoisoned rather than a false success, and no writer is
+	// ever allowed to retry the failed Sync. It is cleared ONLY by a fresh
+	// reopen (openWAL constructs a new struct → zero-value false), because only
+	// a new file handle re-establishes a known-good durability path; a
+	// truncate() that happens to Sync() successfully does NOT clear it (the
+	// underlying device may still be bad — see truncate). Set once under the
+	// leader's post-Sync syncMu; read lock-free via atomic so the hot append
+	// path gates cheaply. Mirrors arena.poisoned's terminal-latch discipline.
+	poisoned atomic.Bool
+
 	// Test hooks (nil in production). onSync runs under syncMu just before the
 	// post-Sync broadcast (counts completed Sync/truncate flushes — group-commit
 	// observability). beforeSync runs in the leader AFTER target is captured and
@@ -124,8 +145,17 @@ type wal struct {
 	beforeSync func()
 }
 
+// ErrWALPoisoned is returned by every append/commit-wait entry point once the
+// WAL has been poisoned by a prior f.Sync() failure (fsyncgate — see the
+// poisoned field). The WAL accepts no further writes or acks until it is
+// reopened; the caller must surface this so a delete/insert is reported failed
+// rather than falsely acked on bytes that may never have reached disk.
+var ErrWALPoisoned = errors.New("vector: wal poisoned by a prior fsync failure")
+
 // openWAL opens (creating if absent) the WAL at path for appending. Replay the
-// existing contents with replayWAL BEFORE calling this if recovering.
+// existing contents with replayWAL BEFORE calling this if recovering. The
+// returned wal starts UN-poisoned (zero-value latch) — a fresh open is the only
+// way a poisoned WAL recovers (see the poisoned field).
 func openWAL(path string, noSync bool) (*wal, error) {
 	f, err := os.OpenFile(path, os.O_RDWR|os.O_CREATE|os.O_APPEND, 0o600) //nolint:gosec // caller-supplied path
 	if err != nil {
@@ -317,6 +347,9 @@ func (w *wal) appendDeleteStaged(id uint64) (uint64, error) {
 // in order to exercise leader-fsync batching (wal_group_commit_test.go). Do NOT
 // call it from production code; use the staged pair.
 func (w *wal) appendFramed(payload []byte) error {
+	if w.poisoned.Load() {
+		return ErrWALPoisoned // fail closed: a prior fsync failure poisoned the log.
+	}
 	// WRITE phase: under mu, append the framed record and assign this writer's
 	// commit sequence (the post-write writeSeq). mu is released BEFORE the fsync so
 	// a concurrent appender can overlap this writer's commit-wait, and a leader's
@@ -363,6 +396,9 @@ func (w *wal) appendFramed(payload []byte) error {
 // concurrent writers' commit-waits overlap and the leader-fsync actually
 // batches them.
 func (w *wal) appendFramedStaged(payload []byte) (uint64, error) {
+	if w.poisoned.Load() {
+		return 0, ErrWALPoisoned // fail closed: a prior fsync failure poisoned the log.
+	}
 	w.mu.Lock()
 	var hdr [8]byte
 	binary.BigEndian.PutUint32(hdr[0:4], uint32(len(payload))) //nolint:gosec
@@ -402,6 +438,13 @@ func (w *wal) commitWaitStaged(seq uint64) error {
 func (w *wal) commitWait(seq uint64) error {
 	w.syncMu.Lock()
 	for {
+		if w.poisoned.Load() {
+			// Fail closed: a prior fsync failed and may have dropped its dirty
+			// pages. Do NOT retry Sync() (a retry can falsely succeed) and do NOT
+			// ack. A follower woken by the poisoning leader's broadcast lands here.
+			w.syncMu.Unlock()
+			return ErrWALPoisoned
+		}
 		if w.syncedSeq >= seq {
 			w.syncMu.Unlock() // a completed Sync already covered our bytes.
 			return nil
@@ -429,7 +472,13 @@ func (w *wal) commitWait(seq uint64) error {
 
 		w.syncMu.Lock()
 		w.syncing = false
-		if err == nil && target > w.syncedSeq {
+		if err != nil {
+			// fsyncgate: poison BEFORE returning (and before the broadcast, so every
+			// woken waiter observes the latch) — a failed fsync may have dropped its
+			// dirty pages, and a follower retrying Sync() could then be acked on bytes
+			// that are gone. Fail closed; only a reopen recovers.
+			w.poisoned.Store(true)
+		} else if target > w.syncedSeq {
 			w.syncedSeq = target
 		}
 		if w.onSync != nil {
@@ -454,15 +503,28 @@ func (w *wal) commitWait(seq uint64) error {
 func (w *wal) truncate() error {
 	w.mu.Lock()
 	defer w.mu.Unlock()
+	// A failure at ANY step of a rotation (truncate/seek/sync) leaves the log's
+	// durability state unknown, and — like commitWait — a later writer must never
+	// be allowed to retry an fsync that could falsely succeed after the kernel
+	// dropped a prior failure's dirty pages (fsyncgate). Fail closed on any error.
 	if err := w.f.Truncate(0); err != nil {
+		w.poisoned.Store(true)
 		return err
 	}
 	if _, err := w.f.Seek(0, io.SeekStart); err != nil {
+		w.poisoned.Store(true)
 		return err
 	}
 	if err := w.f.Sync(); err != nil {
+		w.poisoned.Store(true)
 		return err
 	}
+	// NOTE: a SUCCESSFUL truncate+Sync does NOT clear a pre-existing poison. A
+	// clean rotation only proves this one Sync returned success — on post-4.13
+	// Linux that can happen after the kernel already discarded a prior failure's
+	// dirty pages, so "truncate succeeded" is not evidence the device is healthy.
+	// Poison is therefore cleared ONLY by a fresh reopen (openWAL), which
+	// re-establishes a new file handle and a known durability path.
 	w.syncMu.Lock()
 	if w.writeSeq > w.syncedSeq {
 		w.syncedSeq = w.writeSeq

--- a/vector/wal_durability_test.go
+++ b/vector/wal_durability_test.go
@@ -202,7 +202,9 @@ func TestWALPoisonWakesParkedFollower(t *testing.T) {
 		time.Sleep(time.Millisecond)
 	}
 	if !ready {
-		close(gate) // release the parked leader so it doesn't hang after we fail
+		close(gate)   // release the parked leader so it can finish its in-flight Sync
+		<-leaderErr   // drain it BEFORE t.Fatal so the deferred w.close() can't race the leader's f.Sync()
+		<-followerErr // and the follower, for the same reason
 		t.Fatal("follower never wrote its record (writeSeq did not reach 2) — parked-follower path not exercised")
 	}
 	close(gate) // let the leader's Sync run (and fail)

--- a/vector/wal_durability_test.go
+++ b/vector/wal_durability_test.go
@@ -65,6 +65,16 @@ func TestDeleteCASPropagatesWALSyncError(t *testing.T) {
 	if !c.wal.poisoned.Load() {
 		t.Fatal("WAL not poisoned after the delete's fsync failed")
 	}
+	// A no-op delete of an absent id on the NOW-POISONED WAL stages nothing
+	// (commitWaitStaged(0) is a no-op), so it must still succeed as (false, nil):
+	// a no-op touches no durability and must not be turned into ErrWALPoisoned.
+	noop, nerr := c.DeleteCAS(4242, CASCond{})
+	if nerr != nil {
+		t.Fatalf("no-op DeleteCAS on a poisoned WAL returned %v, want nil (no-op touches no durability)", nerr)
+	}
+	if noop {
+		t.Fatal("no-op DeleteCAS reported removed=true for an absent id")
+	}
 }
 
 // TestDeleteCASNoOpStillSucceeds guards the seq==0 no-op case: deleting an absent
@@ -176,16 +186,24 @@ func TestWALPoisonWakesParkedFollower(t *testing.T) {
 	go func() { followerErr <- w.appendFramed([]byte{byte(walDelete), 2}) }()
 
 	// Wait until the follower has written its bytes (writeSeq == 2) so it is
-	// queued behind the in-flight leader before we let the leader's Sync fail.
+	// queued behind the in-flight leader before we let the leader's Sync fail. A
+	// deadline expiry means the follower never parked — the path under test was
+	// NOT exercised, so this must FAIL (not a silent break / false pass).
+	ready := false
 	deadline := time.Now().Add(2 * time.Second)
-	for {
+	for time.Now().Before(deadline) {
 		w.syncMu.Lock()
 		ws := w.writeSeq
 		w.syncMu.Unlock()
-		if ws == 2 || time.Now().After(deadline) {
+		if ws == 2 {
+			ready = true
 			break
 		}
 		time.Sleep(time.Millisecond)
+	}
+	if !ready {
+		close(gate) // release the parked leader so it doesn't hang after we fail
+		t.Fatal("follower never wrote its record (writeSeq did not reach 2) — parked-follower path not exercised")
 	}
 	close(gate) // let the leader's Sync run (and fail)
 

--- a/vector/wal_durability_test.go
+++ b/vector/wal_durability_test.go
@@ -1,0 +1,219 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package vector
+
+import (
+	"errors"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+)
+
+// Tests for two durability fixes:
+//   BUG A — acked deletes must be durable: a Delete whose WAL append/fsync fails
+//           must return an ERROR (not a false ok), so a client is never told a
+//           point is gone when it can resurrect after a crash.
+//   BUG B — fsyncgate: on the FIRST f.Sync() failure the WAL is POISONED and
+//           fails closed (ErrWALPoisoned) until reopen, so no later writer is
+//           acked on bytes a retried-and-falsely-successful Sync left un-durable.
+//
+// Both use the existing beforeSync seam to force a deterministic Sync() error by
+// closing the underlying fd right before the leader's f.Sync() (Sync on a closed
+// *os.File returns an error) — no production-only test seam is added.
+
+// TestDeleteCASPropagatesWALSyncError is the BUG A proof at the production call
+// path: a WAL-mode DeleteCAS whose durability fsync fails returns (false, err)
+// instead of the pre-fix (true, nil) false-ack.
+func TestDeleteCASPropagatesWALSyncError(t *testing.T) {
+	dir := t.TempDir()
+	cs, err := OpenCollectionStore(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = cs.Close() }()
+	if err := cs.CreateCollection("docs", walCfg()); err != nil {
+		t.Fatal(err)
+	}
+	c, ok := cs.Get("docs")
+	if !ok {
+		t.Fatal("collection missing")
+	}
+
+	vec := make([]float32, 16)
+	for i := range vec {
+		vec[i] = float32(i + 1)
+	}
+	normalize(vec)
+	if _, err := c.InsertCASKeyTTL(1, vec, 0, nil, nil, nil, CASCond{}); err != nil {
+		t.Fatalf("insert: %v", err)
+	}
+
+	// Force the DELETE's fsync to fail: close the WAL fd right before its Sync.
+	var once sync.Once
+	c.wal.beforeSync = func() { once.Do(func() { _ = c.wal.f.Close() }) }
+
+	removed, derr := c.DeleteCAS(1, CASCond{})
+	if derr == nil {
+		t.Fatal("DeleteCAS returned nil error despite a failed WAL fsync — false ack; the point can resurrect after a crash")
+	}
+	if removed {
+		t.Fatalf("DeleteCAS returned removed=true on a durability failure; want removed=false")
+	}
+	// The failed fsync must also have poisoned the WAL (BUG B), so a follow-up
+	// write is fail-closed rather than a fresh false success.
+	if !c.wal.poisoned.Load() {
+		t.Fatal("WAL not poisoned after the delete's fsync failed")
+	}
+}
+
+// TestDeleteCASNoOpStillSucceeds guards the seq==0 no-op case: deleting an absent
+// id stages nothing (commitWaitStaged(0) is a legit no-op), so it must stay a
+// (false, nil) success — the fix must not turn a not-removed delete into an error.
+func TestDeleteCASNoOpStillSucceeds(t *testing.T) {
+	dir := t.TempDir()
+	cs, err := OpenCollectionStore(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = cs.Close() }()
+	if err := cs.CreateCollection("docs", walCfg()); err != nil {
+		t.Fatal(err)
+	}
+	c, ok := cs.Get("docs")
+	if !ok {
+		t.Fatal("collection missing")
+	}
+	removed, derr := c.DeleteCAS(999, CASCond{}) // never inserted
+	if derr != nil {
+		t.Fatalf("no-op DeleteCAS returned error %v, want nil", derr)
+	}
+	if removed {
+		t.Fatal("no-op DeleteCAS reported removed=true for an absent id")
+	}
+}
+
+// TestWALPoisonedAfterSyncFailure is the BUG B proof on the raw wal: after a
+// forced Sync() failure (1) commitWait returns the error AND the wal is poisoned;
+// (2) a subsequent append/commit is fail-closed with ErrWALPoisoned; (3) a fresh
+// reopen clears the poison and works again.
+func TestWALPoisonedAfterSyncFailure(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "p.wal")
+	w, err := openWAL(path, false)
+	if err != nil {
+		t.Fatalf("openWAL: %v", err)
+	}
+
+	var once sync.Once
+	w.beforeSync = func() { once.Do(func() { _ = w.f.Close() }) }
+
+	// (1) the fsync fails: appendFramed surfaces the error and poisons the wal.
+	if err := w.appendFramed([]byte{byte(walDelete), 1, 2, 3}); err == nil {
+		t.Fatal("appendFramed returned nil despite a failed fsync (false ack)")
+	}
+	if !w.poisoned.Load() {
+		t.Fatal("wal not poisoned after fsync failure")
+	}
+
+	// (2) fail-closed: further appends and commit-waits return ErrWALPoisoned.
+	if _, aerr := w.appendDeleteStaged(7); !errors.Is(aerr, ErrWALPoisoned) {
+		t.Fatalf("appendDeleteStaged on poisoned wal = %v, want ErrWALPoisoned", aerr)
+	}
+	if _, aerr := w.appendInsertStaged(8, []float32{1, 2}, 0, nil, nil, nil, 0); !errors.Is(aerr, ErrWALPoisoned) {
+		t.Fatalf("appendInsertStaged on poisoned wal = %v, want ErrWALPoisoned", aerr)
+	}
+	if cerr := w.commitWaitStaged(1); !errors.Is(cerr, ErrWALPoisoned) {
+		t.Fatalf("commitWaitStaged on poisoned wal = %v, want ErrWALPoisoned", cerr)
+	}
+	_ = w.close()
+
+	// (3) a fresh reopen clears the poison and works again.
+	w2, err := openWAL(path, false)
+	if err != nil {
+		t.Fatalf("reopen: %v", err)
+	}
+	defer func() { _ = w2.close() }()
+	if w2.poisoned.Load() {
+		t.Fatal("reopened wal is still poisoned — poison must clear on reopen")
+	}
+	if _, aerr := w2.appendDeleteStaged(9); aerr != nil {
+		t.Fatalf("append after reopen failed: %v", aerr)
+	}
+	if cerr := w2.commitWaitStaged(w2.writeSeq); cerr != nil {
+		t.Fatalf("commit after reopen failed: %v", cerr)
+	}
+}
+
+// TestWALPoisonWakesParkedFollower proves the fail-closed path for a CONCURRENT
+// follower: when the in-flight leader's Sync fails and poisons the wal, a writer
+// parked in commitWait wakes and returns ErrWALPoisoned rather than becoming the
+// next leader and retrying the (fsyncgate-unsafe) Sync.
+func TestWALPoisonWakesParkedFollower(t *testing.T) {
+	dir := t.TempDir()
+	w, err := openWAL(filepath.Join(dir, "pf.wal"), false)
+	if err != nil {
+		t.Fatalf("openWAL: %v", err)
+	}
+	defer func() { _ = w.close() }()
+
+	var once sync.Once
+	parked := make(chan struct{})
+	gate := make(chan struct{})
+	w.beforeSync = func() {
+		once.Do(func() {
+			close(parked) // a leader has captured its target and is about to Sync
+			<-gate        // hold until the follower has queued behind us
+			_ = w.f.Close()
+		})
+	}
+
+	leaderErr := make(chan error, 1)
+	go func() { leaderErr <- w.appendFramed([]byte{byte(walDelete), 1}) }()
+	<-parked // leader is parked in beforeSync (syncing == true)
+
+	followerErr := make(chan error, 1)
+	go func() { followerErr <- w.appendFramed([]byte{byte(walDelete), 2}) }()
+
+	// Wait until the follower has written its bytes (writeSeq == 2) so it is
+	// queued behind the in-flight leader before we let the leader's Sync fail.
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		w.syncMu.Lock()
+		ws := w.writeSeq
+		w.syncMu.Unlock()
+		if ws == 2 || time.Now().After(deadline) {
+			break
+		}
+		time.Sleep(time.Millisecond)
+	}
+	close(gate) // let the leader's Sync run (and fail)
+
+	if lerr := <-leaderErr; lerr == nil {
+		t.Fatal("leader appendFramed returned nil despite a failed fsync")
+	}
+	if ferr := <-followerErr; !errors.Is(ferr, ErrWALPoisoned) {
+		t.Fatalf("parked follower = %v, want ErrWALPoisoned (must not retry the failed Sync)", ferr)
+	}
+	if !w.poisoned.Load() {
+		t.Fatal("wal not poisoned after the leader's fsync failed")
+	}
+}
+
+// TestWALTruncateSyncFailurePoisons proves truncate() (Flush rotation) also fails
+// closed: if its own f.Sync() fails, the wal is poisoned.
+func TestWALTruncateSyncFailurePoisons(t *testing.T) {
+	dir := t.TempDir()
+	w, err := openWAL(filepath.Join(dir, "tr.wal"), false)
+	if err != nil {
+		t.Fatalf("openWAL: %v", err)
+	}
+	// Close the fd so truncate's Truncate/Seek/Sync fails.
+	_ = w.f.Close()
+	if err := w.truncate(); err == nil {
+		t.Fatal("truncate returned nil on a closed fd; expected an error")
+	}
+	if !w.poisoned.Load() {
+		t.Fatal("truncate did not poison the wal after its own sync/IO failure")
+	}
+}


### PR DESCRIPTION
Fixes two single-node WAL/Persistent durability bugs surfaced by an external durability review (thanks to Adel Kaleche for the deep read). Verified against the code before fixing.

## Bug A — acked deletes were not durable
`DeleteCAS` / `DeleteCASAt` (and the named/multivector equivalents) discarded **both** the WAL append error and the commit-wait error (`seq, _ = …appendDeleteStaged`; `_ = …commitWaitStaged`), so a client got `ok` on a delete that may never have reached disk → the point resurrects after a crash. Inserts already propagate both errors; this was an asymmetric oversight, not policy.

**Fix:** the delete paths now propagate append + commit-wait errors (return `removed=false, err`), mirroring the insert path. The `seq==0` no-op (deleting an absent id) still returns `(false, nil)` — only a real append/fsync failure propagates. Applied to `DeleteCAS`, `DeleteCASAt`, the upsert replace-delete, `NamedCollection.DeleteCAS`, and `MultiVectorIndex.DeleteCAS`.

## Bug B — no WAL poisoning after a failed fsync (fsyncgate)
In `wal.go commitWait`, a failed `f.Sync()` surfaced only to its own caller; the next writer became fsync leader and **retried** `Sync()`, which on post-4.13 Linux can return success after the kernel dropped the failed sync's dirty pages → later writers acked on bytes that may be gone. This breaks the `ack-implies-fsynced` invariant (the fsyncgate / PostgreSQL PANIC-on-fsync-failure case).

**Fix:** a terminal `poisoned atomic.Bool` latch (mirroring `arena.poisoned`). On the first `Sync()` failure in `commitWait` or `truncate`, the WAL fails **closed**: every append / commit-wait entry point returns the new `ErrWALPoisoned` instead of a false success, and no writer retries the failed Sync. Cleared **only by a fresh reopen** — a later `truncate` that happens to Sync successfully does NOT clear it (one success isn't proof the device recovered).

## Not in this PR
The third finding — `writeSnapshotFile` missing a parent-dir fsync (checkpoint rename not crash-durable, vs the `syncDir` discipline in `cache/compact.go`) — is a separate incoming PR from the reviewer.

## Tests (new `vector/wal_durability_test.go`, all pass -race)
- `TestDeleteCASPropagatesWALSyncError` — delete whose fsync fails returns `(false, err)`, not the old `(true, nil)` false-ack.
- `TestDeleteCASNoOpStillSucceeds` — `seq==0` no-op stays `(false, nil)`.
- `TestWALPoisonedAfterSyncFailure` — fsync failure surfaces the error, poisons; subsequent append/commit fail-closed with `ErrWALPoisoned`; fresh reopen clears it.
- `TestWALPoisonWakesParkedFollower` — a follower parked in `commitWait` wakes to `ErrWALPoisoned` instead of retrying the fsync (the fsyncgate guarantee).
- `TestWALTruncateSyncFailurePoisons` — `truncate` fails closed on its own IO failure.

Deterministic via the existing `beforeSync` hook (closes the fd right before `Sync()`); no production-only test seam added.

`go build ./...`, `go vet ./vector/`, `gofmt -l` clean; new tests + a `Named|Multi|Upsert|Insert|CAS|Flush|Persist` regression slice pass -race.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes two WAL durability bugs: acked deletes could resurrect after a crash, and a failed fsync could let later writes be falsely acked. Delete paths now propagate WAL append and commit-wait errors, and the WAL poisons itself on the first fsync failure, returning `ErrWALPoisoned` on all writes until it is reopened.

**Bug Fixes**
- `DeleteCAS`, `DeleteCASAt`, `NamedCollection.DeleteCAS`, `MultiVectorIndex.DeleteCAS`, both upsert replace-delete paths, and batch deletes (`DeleteByFilter`/`DeleteByFilterAt`) now return WAL append or fsync errors instead of a false success.
- Deleting an absent id (a no-op) still succeeds, even on a poisoned WAL.
- A failed fsync in `commitWait` or `truncate` trips a terminal poisoned latch; subsequent writes fail closed with `ErrWALPoisoned`, and a parked follower wakes with that error instead of retrying the failed sync. Append paths re-check the latch under the write lock so a poisoned log never accepts a new record.
- A write already in flight when the WAL poisons is never acked, though its appended bytes may replay on a fresh reopen — intended at-least-once WAL semantics.
- Poison clears only on a fresh reopen; a later successful `truncate` does not clear it, and a `truncate` on an already-poisoned WAL fails closed with `ErrWALPoisoned` without issuing another fsync.
- Adds `vector/wal_durability_test.go` covering error propagation, fail-closed behavior, parked-follower wakeup, and truncate poisoning, passing with `-race`.

<sup>Written for commit 4eb5d0f187d1ed868aac658a9726a5fd312a2a7d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rostamlabs/rostam/pull/87?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Delete and update operations now report write and durability failures instead of incorrectly confirming success.
  - Prevented potentially lost changes after storage synchronization or log-rotation failures.
  - Storage writes now fail closed after a durability error until the storage log is reopened.
  - Concurrent operations now receive prompt failure notifications when storage durability is compromised.
  - No-op deletes continue to complete successfully without unnecessary durability work.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->