### PR TITLE
fix(cache): add tests for handling corrupt page tails and improve rec…

### DIFF
--- a/cache/recovery_test.go
+++ b/cache/recovery_test.go
@@ -172,6 +172,54 @@ func TestRebuildCountsCorruptEntries(t *testing.T) {
 	}
 }
 
+// TestRebuildRejectsCorruptPageTail covers the crash-loop hazard: an on-disk
+// page tail that has been corrupted (bit-rot, or a crash mid-setTail) past the
+// page's own capacity must not be trusted straight into entries[cursor:tail] —
+// that slice expression panics before decodeEntry's CRC ever gets a chance to
+// reject it, producing a permanent, unrecoverable crash loop. rebuildIndexFromPages
+// must instead validate 0 <= head <= tail <= len(entries) and treat a violation
+// like any other torn/corrupt page: reset it and bump the corruption counter.
+func TestRebuildRejectsCorruptPageTail(t *testing.T) {
+	cfg := DefaultConfig()
+	cfg.NumShards = 1
+	cfg.PageSize = 1 << 20
+	cfg.MaxMemoryPerShard = 1 << 20 // 1 page
+	cfg.TTLSweepIntervalMs = 0      // no sweeper interference
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "pages.dat")
+	writeCurrentFileWithEntries(t, path, cfg.PageSize, 1, [][2][]byte{
+		{[]byte("k0"), []byte("AAAA")},
+	})
+
+	// Corrupt page 0's on-disk tail field to a huge garbage value, as a bit-flip
+	// or a crash mid-setTail could produce.
+	f, err := os.OpenFile(path, os.O_RDWR, 0o644)
+	if err != nil {
+		t.Fatal(err)
+	}
+	tailAt := int64(headerSize + 4)
+	if _, err := f.WriteAt([]byte{0xF0, 0xFF, 0xFF, 0xFF}, tailAt); err != nil {
+		t.Fatal(err)
+	}
+	if err := f.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	s, err := newShard(cfg, dir)
+	if err != nil {
+		t.Fatalf("newShard: %v, want a clean error/reset instead of a panic", err)
+	}
+	defer func() { _ = s.Close() }()
+
+	if got := s.snapshot().CorruptionErrors; got == 0 {
+		t.Error("CorruptionErrors = 0 after recovering a page with a corrupt tail; corruption was swallowed silently")
+	}
+	if _, err := s.Get([]byte("k0")); err != ErrNotFound {
+		t.Errorf("Get(k0) = %v, want ErrNotFound (page reset after corrupt tail)", err)
+	}
+}
+
 // TestTornEntrySurvivesEviction reproduces the wedged-shard scenario: a page
 // recovered with a torn entry inside [head, tail) must not fail every
 // eviction-triggering Put forever. rebuildIndexFromPages truncates the page to

--- a/cache/recovery_test.go
+++ b/cache/recovery_test.go
@@ -220,6 +220,69 @@ func TestRebuildRejectsCorruptPageTail(t *testing.T) {
 	}
 }
 
+// TestRebuildRejectsCorruptEqualHeadTail covers the case the equality shortcut
+// missed: a page whose on-disk head AND tail are BOTH corrupted to the same
+// out-of-range value (not just an out-of-range tail alone) still satisfies
+// head==tail. Checking bounds only after that shortcut let such a page slip
+// through untouched at recovery: no corruption counted, no reset, and
+// FreeTail() = len(entries) - tail went negative, wedging every future Put
+// against this page behind errPageFull forever. rebuildIndexFromPages must
+// validate 0 <= head <= tail <= len(entries) BEFORE the head==tail shortcut,
+// not after.
+func TestRebuildRejectsCorruptEqualHeadTail(t *testing.T) {
+	cfg := DefaultConfig()
+	cfg.NumShards = 1
+	cfg.PageSize = 1 << 20
+	cfg.MaxMemoryPerShard = 1 << 20 // 1 page
+	cfg.TTLSweepIntervalMs = 0      // no sweeper interference
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "pages.dat")
+	writeCurrentFileWithEntries(t, path, cfg.PageSize, 1, [][2][]byte{
+		{[]byte("k0"), []byte("AAAA")},
+	})
+
+	// Corrupt page 0's on-disk head AND tail to the SAME huge garbage value, as
+	// a bit-flip or a crash mid-setTail could produce. head lives at
+	// region[0:4], tail at region[4:8] (see newMmapPage); page 0's region
+	// starts right after the file header.
+	f, err := os.OpenFile(path, os.O_RDWR, 0o644)
+	if err != nil {
+		t.Fatal(err)
+	}
+	headAt := int64(headerSize)
+	tailAt := int64(headerSize + 4)
+	garbage := []byte{0xF0, 0xFF, 0xFF, 0xFF}
+	if _, err := f.WriteAt(garbage, headAt); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := f.WriteAt(garbage, tailAt); err != nil {
+		t.Fatal(err)
+	}
+	if err := f.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	s, err := newShard(cfg, dir)
+	if err != nil {
+		t.Fatalf("newShard: %v, want a clean error/reset instead of a panic", err)
+	}
+	defer func() { _ = s.Close() }()
+
+	if got := s.snapshot().CorruptionErrors; got == 0 {
+		t.Error("CorruptionErrors = 0 after recovering a page with corrupt equal head/tail; corruption was swallowed silently")
+	}
+	if free := s.pages[0].FreeTail(); free < 0 {
+		t.Errorf("pages[0].FreeTail() = %d, want >= 0 (page must be reset, not left with an out-of-range tail)", free)
+	}
+	if err := s.Put([]byte("k1"), []byte("BBBB"), 0); err != nil {
+		t.Errorf("Put after corrupt-equal-head/tail recovery: %v, want success (page must not be permanently wedged behind errPageFull)", err)
+	}
+	if _, err := s.Get([]byte("k0")); err != ErrNotFound {
+		t.Errorf("Get(k0) = %v, want ErrNotFound (page reset after corrupt head/tail)", err)
+	}
+}
+
 // TestTornEntrySurvivesEviction reproduces the wedged-shard scenario: a page
 // recovered with a torn entry inside [head, tail) must not fail every
 // eviction-triggering Put forever. rebuildIndexFromPages truncates the page to

--- a/cache/shard.go
+++ b/cache/shard.go
@@ -1055,6 +1055,19 @@ func (s *shard) rebuildIndexFromPages() {
 			continue
 		}
 		entries := p.entries()
+		if head < 0 || tail < head || tail > len(entries) {
+			// Corrupt head/tail (e.g. bit-rot or a crash mid-setTail): trusting
+			// these raw values into entries[cursor:tail] below would either panic
+			// (tail beyond the mmap region) or silently skip the whole page
+			// (head > tail, so the walk below never runs). Treat it like the
+			// torn-entry path: drop the page and count the loss instead of
+			// crash-looping or losing data with no signal.
+			s.corrupt.Add(1)
+			slog.Warn("corrupt page head/tail during recovery; resetting page",
+				"component", "cache", "page", pageIdx, "head", head, "tail", tail, "cap", len(entries))
+			p.Reset()
+			continue
+		}
 		cursor := head
 		for cursor < tail {
 			key, value, _, meta, err := decodeEntry(entries[cursor:tail])

--- a/cache/shard.go
+++ b/cache/shard.go
@@ -1051,10 +1051,16 @@ func (s *shard) rebuildIndexFromPages() {
 	for pageIdx, p := range s.pages {
 		head := p.head()
 		tail := p.tail()
-		if head == tail {
-			continue
-		}
 		entries := p.entries()
+		// Validate BEFORE the head==tail shortcut below: head/tail are read
+		// straight off disk, and a corrupt page can have them bit-rotted (or
+		// crash-torn mid-setTail) to the SAME out-of-range value — e.g. both
+		// 0xFFFFFFF0. That still satisfies head==tail, so checking bounds only
+		// in the else branch let such a page slip through untouched: no
+		// corruption counted, no reset, and FreeTail() = len(entries) - tail
+		// goes negative, wedging the page's writes behind errPageFull forever.
+		// head is `int(uint32(...))`, so it is never negative in practice; the
+		// `head < 0` check is kept only as defense in depth.
 		if head < 0 || tail < head || tail > len(entries) {
 			// Corrupt head/tail (e.g. bit-rot or a crash mid-setTail): trusting
 			// these raw values into entries[cursor:tail] below would either panic
@@ -1066,6 +1072,9 @@ func (s *shard) rebuildIndexFromPages() {
 			slog.Warn("corrupt page head/tail during recovery; resetting page",
 				"component", "cache", "page", pageIdx, "head", head, "tail", tail, "cap", len(entries))
 			p.Reset()
+			continue
+		}
+		if head == tail {
 			continue
 		}
 		cursor := head


### PR DESCRIPTION
## Summary
- `rebuildIndexFromPages` trusted a page's raw on-disk head/tail offsets directly into `entries[cursor:tail]` with no bounds check. A corrupted tail beyond the page's capacity (bit-rot, or a crash mid-`setTail`) panics before `decodeEntry`'s own CRC check ever runs, producing a permanent crash loop on every restart. A corrupted head past tail silently drops the whole page instead (zero loop iterations, no log, no counter).
- Adds a bounds check (`0 <= head <= tail <= len(entries)`) before the page is walked, and on violation treats it like the existing torn-entry path: reset the page, bump the corruption counter, log a warning.
- Adds `TestRebuildRejectsCorruptPageTail`, which corrupts a page's on-disk tail field to a garbage value and asserts the shard recovers cleanly instead of panicking.

## Test plan
- [x] Verified in a Linux container: pre-fix reproduces the exact panic (`slice bounds out of range`); post-fix logs a warning and resets the page instead
- [x] Existing corruption tests (`TestRebuildCountsCorruptEntries`, `TestTornEntrySurvivesEviction`) still pass

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes cache recovery so corrupted page head/tail offsets no longer cause a permanent crash loop or a silently dropped page. The rebuild path now validates `0 <= head <= tail <= len(entries)` before the empty-page shortcut, so out-of-range values — including an equal corrupt head/tail pair that previously wedged the page behind `errPageFull` — are caught, reset, counted as corruption, and logged like any torn entry.

**Testing**

- Adds tests covering a corrupt tail beyond page capacity and a corrupt equal head/tail pair, asserting the shard recovers cleanly instead of panicking or leaving the page unwritable.

<sup>Written for commit 6f751b948d462e8f1ddc90950d5decada5dbeff3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rostamlabs/rostam/pull/91?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved shard recovery when persisted page metadata is corrupted.
  - Invalid page boundaries, including matching out-of-range head and tail values, are now detected and safely reset.
  - Corrupted entries are discarded and recovery continues without panicking or leaving the shard unusable.
  - Subsequent writes can proceed normally after recovery.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->