### PR TITLE
fix(vector): make checkpoint publishes crash-durable (dir fsync after rename)

### DIFF
--- a/vector/auth.go
+++ b/vector/auth.go
@@ -289,9 +289,5 @@ func (r *KeyRegistry) flushLocked() error {
 	if err != nil {
 		return err
 	}
-	tmp := r.path + ".tmp"
-	if err := os.WriteFile(tmp, data, 0o600); err != nil {
-		return err
-	}
-	return os.Rename(tmp, r.path)
+	return atomicWriteFile(r.path, data)
 }

--- a/vector/collections.go
+++ b/vector/collections.go
@@ -857,7 +857,12 @@ func (s *CollectionStore) writeSnapshotFile(c *Collection, path string) error {
 	if err := f.Close(); err != nil {
 		return err
 	}
-	return os.Rename(tmp, path)
+	// renameDurable (rename + parent-dir fsync), NOT a bare os.Rename: Flush
+	// truncates the WAL on the strength of this checkpoint. Without the dir
+	// fsync the truncate (itself fsync'd) can reach disk BEFORE the rename's
+	// directory entry — a crash in that window reopens on the OLD checkpoint
+	// with an EMPTY log, silently dropping the whole inter-checkpoint delta.
+	return renameDurable(tmp, path)
 }
 
 // Insert inserts a vector with the given TTL, metadata, and sparse vector into
@@ -1456,9 +1461,5 @@ func writeConfig(path string, cfg Config) error {
 	if err != nil {
 		return err
 	}
-	tmp := path + ".tmp"
-	if err := os.WriteFile(tmp, data, 0o600); err != nil {
-		return err
-	}
-	return os.Rename(tmp, path)
+	return atomicWriteFile(path, data)
 }

--- a/vector/collections.go
+++ b/vector/collections.go
@@ -499,6 +499,18 @@ func (s *CollectionStore) CreateCollection(name string, cfg Config) error {
 	}
 	c, err := s.buildCollection(canonical, cfg)
 	if err != nil {
+		// The config marker is the load-time source of truth: OpenCollectionStore
+		// rebuilds the catalog from it. buildCollection can fail AFTER the marker's
+		// rename has landed (the durable publish also fsyncs the parent directory,
+		// which can fail on its own), and it fails after writing the marker whenever
+		// the WAL cannot be opened. Either way the caller is told creation failed and
+		// nothing is registered in memory, so leaving the marker behind would let a
+		// restart resurrect the collection as an empty one. Best-effort remove it.
+		// Done here rather than inside buildCollection because the cold-tier promote
+		// path also builds through it, for a collection whose marker is a live
+		// catalog entry that must survive a failed promote.
+		cfgPath, _ := s.collectionPath(canonical)
+		_ = os.Remove(cfgPath)
 		return err
 	}
 	s.collections[canonical] = c

--- a/vector/collections_multi.go
+++ b/vector/collections_multi.go
@@ -156,6 +156,12 @@ func (s *CollectionStore) CreateMultiVector(name string, cfg MultiVectorConfig) 
 	if writeMarker {
 		if err := writeMVConfig(cfgPath, cfg); err != nil {
 			_ = idx.Close()
+			// The marker is the load-time source of truth (loadMultiVector rebuilds the
+			// index from it), and the durable publish can fail with the rename already
+			// landed — its parent-directory fsync runs after it. Creation is reporting
+			// failure and nothing is registered, so a surviving marker would resurrect
+			// an empty index on restart. Best-effort remove it.
+			_ = os.Remove(cfgPath)
 			return err
 		}
 	}

--- a/vector/collections_multi.go
+++ b/vector/collections_multi.go
@@ -330,7 +330,9 @@ func (s *CollectionStore) writeMVWALSnapshotFile(idx *MultiVectorIndex, path str
 	if err := f.Close(); err != nil {
 		return err
 	}
-	return os.Rename(tmp, path)
+	// rename + parent-dir fsync: the MV Flush truncates the WAL on the
+	// strength of this checkpoint (see writeSnapshotFile in collections.go).
+	return renameDurable(tmp, path)
 }
 
 // DropMultiVector removes the named index, frees it, and deletes its files.
@@ -779,11 +781,7 @@ func writeMVConfig(path string, cfg MultiVectorConfig) error {
 	if err != nil {
 		return err
 	}
-	tmp := path + ".tmp"
-	if err := os.WriteFile(tmp, b, 0o600); err != nil {
-		return err
-	}
-	return os.Rename(tmp, path)
+	return atomicWriteFile(path, b)
 }
 
 func readMVConfig(path string) (MultiVectorConfig, error) {

--- a/vector/collections_named.go
+++ b/vector/collections_named.go
@@ -117,6 +117,12 @@ func (s *CollectionStore) CreateNamedConfig(name string, cfg NamedConfig) error 
 		}
 		if err := writeNamedConfig(cfgPath, cfg); err != nil {
 			_ = nc.Close()
+			// The marker is the load-time source of truth (loadNamed rebuilds the
+			// collection from it), and the durable publish can fail with the rename
+			// already landed — its parent-directory fsync runs after it. Creation is
+			// reporting failure and nothing is registered, so a surviving marker would
+			// resurrect an empty collection on restart. Best-effort remove it.
+			_ = os.Remove(cfgPath)
 			return err
 		}
 		w, werr := openWAL(walPath, cfg.WALNoSync)

--- a/vector/collections_named.go
+++ b/vector/collections_named.go
@@ -228,7 +228,9 @@ func (s *CollectionStore) writeNamedSnapshotFile(nc *NamedCollection, path strin
 	if err := f.Close(); err != nil {
 		return err
 	}
-	return os.Rename(tmp, path)
+	// rename + parent-dir fsync: the named Flush truncates the WAL on the
+	// strength of this checkpoint (see writeSnapshotFile in collections.go).
+	return renameDurable(tmp, path)
 }
 
 // writeNamedConfig writes the named config marker (spaces + WAL flags) atomically
@@ -239,11 +241,7 @@ func writeNamedConfig(path string, cfg NamedConfig) error {
 	if err != nil {
 		return err
 	}
-	tmp := path + ".tmp"
-	if err := os.WriteFile(tmp, b, 0o600); err != nil {
-		return err
-	}
-	return os.Rename(tmp, path)
+	return atomicWriteFile(path, b)
 }
 
 // readNamedConfig reads a named config marker.

--- a/vector/create_marker_cleanup_test.go
+++ b/vector/create_marker_cleanup_test.go
@@ -1,0 +1,165 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package vector
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// errInjectedDirSync is the failure a dirSyncTrap returns from the seam.
+var errInjectedDirSync = errors.New("vector: injected directory-fsync failure")
+
+// dirSyncTrap swaps the directory-fsync seam for one that records the directory
+// and fails. That reproduces the only window where a durable publish reports
+// failure with the RENAME ALREADY LANDED: the marker is on disk, but the create
+// that wrote it returns an error. Recording the directory lets each test assert
+// the failure really happened at the marker's publish (so the test still covers
+// the intended path if an earlier step ever starts failing first).
+//
+// Tests using it must not call t.Parallel: the seam is a package-level var.
+type dirSyncTrap struct {
+	dirs    []string
+	restore func()
+}
+
+func trapSyncDir(t *testing.T) *dirSyncTrap {
+	t.Helper()
+	orig := syncDirf
+	tr := &dirSyncTrap{}
+	tr.restore = func() { syncDirf = orig }
+	syncDirf = func(dir string) error {
+		tr.dirs = append(tr.dirs, dir)
+		return errInjectedDirSync
+	}
+	t.Cleanup(tr.restore)
+	return tr
+}
+
+// sawDirOf reports whether the seam was reached for path's parent directory,
+// i.e. whether path's rename landed before the publish failed.
+func (tr *dirSyncTrap) sawDirOf(path string) bool {
+	want := filepath.Dir(path)
+	for _, d := range tr.dirs {
+		if d == want {
+			return true
+		}
+	}
+	return false
+}
+
+// assertMarkerCleaned pins the shared post-condition of a failed create: the
+// publish reached the directory fsync (so the marker had landed), the marker is
+// gone again, and nothing survives to be reloaded.
+func assertMarkerCleaned(t *testing.T, tr *dirSyncTrap, cfgPath string) {
+	t.Helper()
+	if !tr.sawDirOf(cfgPath) {
+		t.Fatalf("create failed before publishing %s; the test no longer covers the landed-rename window", cfgPath)
+	}
+	if _, err := os.Stat(cfgPath); !os.IsNotExist(err) {
+		t.Fatalf("config marker %s survived a failed create: %v", cfgPath, err)
+	}
+}
+
+// TestCreateCollectionRemovesMarkerWhenPublishFails covers the dense family: a
+// create whose config publish fails after the rename landed must leave no marker,
+// or a restart would resurrect the collection as an empty one.
+func TestCreateCollectionRemovesMarkerWhenPublishFails(t *testing.T) {
+	dir := t.TempDir()
+	cs, err := OpenCollectionStore(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	tr := trapSyncDir(t)
+	cerr := cs.CreateCollection("docs", Config{Dim: 2, M: 4, EfConstruction: 10, EfSearch: 10, Seed: 1, Metric: L2})
+	tr.restore()
+	if cerr == nil {
+		t.Fatal("CreateCollection: expected an error when the durable publish fails, got nil")
+	}
+
+	cfgPath, _ := cs.collectionPath("default/docs")
+	assertMarkerCleaned(t, tr, cfgPath)
+	if _, ok := cs.Get("docs"); ok {
+		t.Error("collection registered in memory despite a failed create")
+	}
+	_ = cs.Close()
+
+	cs2, err := OpenCollectionStore(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = cs2.Close() }()
+	if names := cs2.CollectionNames(); len(names) != 0 {
+		t.Errorf("reopened store listed %v after a failed create; want none", names)
+	}
+}
+
+// TestCreateNamedRemovesMarkerWhenPublishFails is the named-vector shape of
+// TestCreateCollectionRemovesMarkerWhenPublishFails (WAL mode is the only named
+// mode that writes a marker).
+func TestCreateNamedRemovesMarkerWhenPublishFails(t *testing.T) {
+	dir := t.TempDir()
+	cs, err := OpenCollectionStore(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	tr := trapSyncDir(t)
+	cerr := cs.CreateNamedConfig("named", NamedConfig{Spaces: namedTestConfig(), WAL: true})
+	tr.restore()
+	if cerr == nil {
+		t.Fatal("CreateNamedConfig: expected an error when the durable publish fails, got nil")
+	}
+
+	cfgPath, _, _ := cs.namedPaths("default/named")
+	assertMarkerCleaned(t, tr, cfgPath)
+	if _, ok := cs.GetNamed("named"); ok {
+		t.Error("named collection registered in memory despite a failed create")
+	}
+	_ = cs.Close()
+
+	cs2, err := OpenCollectionStore(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = cs2.Close() }()
+	if _, ok := cs2.GetNamed("named"); ok {
+		t.Error("named collection reloaded after a failed create")
+	}
+}
+
+// TestCreateMultiVectorRemovesMarkerWhenPublishFails is the multi-vector shape of
+// TestCreateCollectionRemovesMarkerWhenPublishFails.
+func TestCreateMultiVectorRemovesMarkerWhenPublishFails(t *testing.T) {
+	dir := t.TempDir()
+	cs, err := OpenCollectionStore(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	tr := trapSyncDir(t)
+	cerr := cs.CreateMultiVector("mv", mvWALConfig())
+	tr.restore()
+	if cerr == nil {
+		t.Fatal("CreateMultiVector: expected an error when the durable publish fails, got nil")
+	}
+
+	cfgPath, _, _ := cs.mvPaths("default/mv")
+	assertMarkerCleaned(t, tr, cfgPath)
+	if _, ok := cs.GetMultiVector("mv"); ok {
+		t.Error("multi-vector index registered in memory despite a failed create")
+	}
+	_ = cs.Close()
+
+	cs2, err := OpenCollectionStore(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = cs2.Close() }()
+	if _, ok := cs2.GetMultiVector("mv"); ok {
+		t.Error("multi-vector index reloaded after a failed create")
+	}
+}

--- a/vector/dirsync.go
+++ b/vector/dirsync.go
@@ -44,6 +44,7 @@ func syncDir(dir string) error {
 // the directory ENTRY durable, the half temp+fsync+rename alone does not cover.
 func renameDurable(tmp, path string) error {
 	if err := os.Rename(tmp, path); err != nil {
+		_ = os.Remove(tmp) // best-effort: don't leave the fsync'd staging file behind
 		return err
 	}
 	if err := syncDir(filepath.Dir(path)); err != nil {

--- a/vector/dirsync.go
+++ b/vector/dirsync.go
@@ -38,6 +38,14 @@ func syncDir(dir string) error {
 	return serr
 }
 
+// syncDirf is the directory-fsync seam. Production always runs syncDir; tests
+// replace it to exercise the one window a real fsync failure opens — the rename
+// has LANDED but the publish reports failure — which is how a caller can be told
+// its write failed while the new bytes are already visible on disk. Mirrors the
+// fsyncf seam in raft/logstore. Not for concurrent use: a test swaps it in and
+// restores it around a single sequential call.
+var syncDirf = syncDir
+
 // renameDurable completes an atomic publish: rename tmp over path, then fsync
 // the parent directory so the rename survives a crash. The caller must already
 // have fsynced tmp's CONTENTS (directly, or via atomicWriteFile) — this makes
@@ -47,7 +55,7 @@ func renameDurable(tmp, path string) error {
 		_ = os.Remove(tmp) // best-effort: don't leave the fsync'd staging file behind
 		return err
 	}
-	if err := syncDir(filepath.Dir(path)); err != nil {
+	if err := syncDirf(filepath.Dir(path)); err != nil {
 		return fmt.Errorf("vector: fsync dir %s: %w", filepath.Dir(path), err)
 	}
 	return nil

--- a/vector/dirsync.go
+++ b/vector/dirsync.go
@@ -1,0 +1,81 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package vector
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// syncDir fsyncs a directory so a rename within it is durable. Mirrors
+// cache.syncDir (cache/compact.go): a temp+fsync+rename publish makes the NEW
+// bytes durable, but the rename itself lives in the directory — without a
+// directory fsync a crash can roll the entry back to the OLD file even though
+// the rename returned nil.
+//
+// Unlike the cache's warn-and-continue posture, callers here PROPAGATE the
+// error: every vector-package rename publishes a checkpoint whose durability a
+// follow-up step relies on (most critically Flush, which truncates the WAL on
+// the strength of "the checkpoint subsumes the log" — see CollectionStore.Flush).
+// Failing the publish keeps that follow-up from running against a checkpoint
+// that may not survive a crash.
+func syncDir(dir string) error {
+	// Nothing to force where the platform has no directory fsync (Windows): the
+	// rename's metadata is the filesystem's own to commit there. See
+	// dirsync_windows.go.
+	if !dirSyncSupported {
+		return nil
+	}
+	d, err := os.Open(dir) //nolint:gosec // G304: dir derives from a store-managed path
+	if err != nil {
+		return err
+	}
+	serr := d.Sync()
+	if cerr := d.Close(); cerr != nil && serr == nil {
+		serr = cerr
+	}
+	return serr
+}
+
+// renameDurable completes an atomic publish: rename tmp over path, then fsync
+// the parent directory so the rename survives a crash. The caller must already
+// have fsynced tmp's CONTENTS (directly, or via atomicWriteFile) — this makes
+// the directory ENTRY durable, the half temp+fsync+rename alone does not cover.
+func renameDurable(tmp, path string) error {
+	if err := os.Rename(tmp, path); err != nil {
+		return err
+	}
+	if err := syncDir(filepath.Dir(path)); err != nil {
+		return fmt.Errorf("vector: fsync dir %s: %w", filepath.Dir(path), err)
+	}
+	return nil
+}
+
+// atomicWriteFile durably publishes data at path via the full
+// temp→fsync→rename→dir-fsync sequence. It replaces the bare
+// os.WriteFile(tmp)+os.Rename pattern the small JSON markers used, which
+// fsynced NEITHER the bytes NOR the rename: a crash could publish a truncated
+// (or vanished) config/registry even though the write returned nil.
+func atomicWriteFile(path string, data []byte) error {
+	tmp := path + ".tmp"
+	f, err := os.OpenFile(tmp, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0o600) //nolint:gosec // store-managed path
+	if err != nil {
+		return err
+	}
+	if _, err := f.Write(data); err != nil {
+		_ = f.Close()
+		_ = os.Remove(tmp)
+		return err
+	}
+	if err := f.Sync(); err != nil {
+		_ = f.Close()
+		_ = os.Remove(tmp)
+		return err
+	}
+	if err := f.Close(); err != nil {
+		_ = os.Remove(tmp)
+		return err
+	}
+	return renameDurable(tmp, path)
+}

--- a/vector/dirsync_other.go
+++ b/vector/dirsync_other.go
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: Apache-2.0
+//go:build !windows
+
+package vector
+
+// dirSyncSupported reports whether the platform can be asked to make a
+// directory entry durable. See syncDir in dirsync.go.
+const dirSyncSupported = true

--- a/vector/dirsync_test.go
+++ b/vector/dirsync_test.go
@@ -82,6 +82,26 @@ func TestRenameDurable(t *testing.T) {
 	if err := renameDurable(src, filepath.Join(dir, "nope", "dst")); err == nil {
 		t.Fatal("expected error renaming into missing dir, got nil")
 	}
+	if _, err := os.Stat(src); !os.IsNotExist(err) {
+		t.Fatalf("staging file left behind after failed rename: %v", err)
+	}
+}
+
+// TestAtomicWriteFileRenameFailureCleansTmp pins the failed-rename cleanup: a
+// target that is an existing DIRECTORY makes the final rename fail after the
+// staging file was written and fsync'd, and the .tmp must not survive it.
+func TestAtomicWriteFileRenameFailureCleansTmp(t *testing.T) {
+	dir := t.TempDir()
+	target := filepath.Join(dir, "occupied")
+	if err := os.Mkdir(target, 0o750); err != nil {
+		t.Fatal(err)
+	}
+	if err := atomicWriteFile(target, []byte("x")); err == nil {
+		t.Fatal("expected error publishing onto an existing directory, got nil")
+	}
+	if _, err := os.Stat(target + ".tmp"); !os.IsNotExist(err) {
+		t.Fatalf("staging file left behind after failed rename: %v", err)
+	}
 }
 
 // TestSyncDir smoke-checks the platform seam: on platforms with directory

--- a/vector/dirsync_test.go
+++ b/vector/dirsync_test.go
@@ -1,0 +1,99 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package vector
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestAtomicWriteFile pins the durable-publish contract of the helper the JSON
+// markers (config, named/MV config, key registry) now share: the payload lands
+// byte-exact at the target, the .tmp staging file never survives (success or
+// not), and a second publish over an existing file replaces it atomically.
+func TestAtomicWriteFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "marker.json")
+
+	want := []byte(`{"a":1}`)
+	if err := atomicWriteFile(path, want); err != nil {
+		t.Fatalf("atomicWriteFile: %v", err)
+	}
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read back: %v", err)
+	}
+	if !bytes.Equal(got, want) {
+		t.Fatalf("content mismatch: got %q want %q", got, want)
+	}
+	if _, err := os.Stat(path + ".tmp"); !os.IsNotExist(err) {
+		t.Fatalf("staging file left behind: %v", err)
+	}
+
+	// Overwrite publish: the old content must be fully replaced.
+	want2 := []byte(`{"a":2,"b":"longer than before"}`)
+	if err := atomicWriteFile(path, want2); err != nil {
+		t.Fatalf("atomicWriteFile overwrite: %v", err)
+	}
+	got2, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read back 2: %v", err)
+	}
+	if !bytes.Equal(got2, want2) {
+		t.Fatalf("overwrite mismatch: got %q want %q", got2, want2)
+	}
+}
+
+// TestAtomicWriteFileMissingDir pins fail-loud on an unpublishable target: a
+// missing parent directory must surface an error (and never a false success a
+// caller like Flush would then truncate a WAL on).
+func TestAtomicWriteFileMissingDir(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "nope", "marker.json")
+	if err := atomicWriteFile(path, []byte("x")); err == nil {
+		t.Fatal("expected error for missing parent dir, got nil")
+	}
+}
+
+// TestRenameDurable pins the happy path (rename lands, source gone) and the
+// fail-loud path (renaming onto a target in a nonexistent directory errors).
+func TestRenameDurable(t *testing.T) {
+	dir := t.TempDir()
+	src := filepath.Join(dir, "src")
+	dst := filepath.Join(dir, "dst")
+	if err := os.WriteFile(src, []byte("payload"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := renameDurable(src, dst); err != nil {
+		t.Fatalf("renameDurable: %v", err)
+	}
+	if _, err := os.Stat(src); !os.IsNotExist(err) {
+		t.Fatalf("source still present after rename: %v", err)
+	}
+	got, err := os.ReadFile(dst)
+	if err != nil || string(got) != "payload" {
+		t.Fatalf("dest read: %q, %v", got, err)
+	}
+
+	if err := os.WriteFile(src, []byte("x"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := renameDurable(src, filepath.Join(dir, "nope", "dst")); err == nil {
+		t.Fatal("expected error renaming into missing dir, got nil")
+	}
+}
+
+// TestSyncDir smoke-checks the platform seam: on platforms with directory
+// fsync it must succeed on a real directory and error on a missing one; where
+// dirSyncSupported is false it is a documented no-op either way.
+func TestSyncDir(t *testing.T) {
+	if err := syncDir(t.TempDir()); err != nil {
+		t.Fatalf("syncDir on real dir: %v", err)
+	}
+	if dirSyncSupported {
+		if err := syncDir(filepath.Join(t.TempDir(), "nope")); err == nil {
+			t.Fatal("expected error for missing dir, got nil")
+		}
+	}
+}

--- a/vector/dirsync_windows.go
+++ b/vector/dirsync_windows.go
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: Apache-2.0
+//go:build windows
+
+package vector
+
+// dirSyncSupported is false because Windows exposes no directory fsync: a
+// directory handle opened through os.Open cannot be flushed (FlushFileBuffers
+// answers ERROR_ACCESS_DENIED), and NTFS carries the rename through its own
+// metadata log rather than leaving it for the caller to force. Mirrors
+// cache/dirsync_windows.go. See syncDir in dirsync.go.
+const dirSyncSupported = false

--- a/vector/ivf_persist.go
+++ b/vector/ivf_persist.go
@@ -383,7 +383,7 @@ func (ix *ivf) savePersist(metaPath string) error {
 	if err := f.Close(); err != nil {
 		return err
 	}
-	return os.Rename(tmp, metaPath) // atomic publish
+	return renameDurable(tmp, metaPath) // atomic publish (rename + dir fsync)
 }
 
 // openPersistIVF reopens an IVF index saved with SavePersist, mapping its vecs file

--- a/vector/multivector_persist.go
+++ b/vector/multivector_persist.go
@@ -151,7 +151,7 @@ func (m *MultiVectorIndex) writeMapsSidecar() error {
 	if err := f.Close(); err != nil {
 		return err
 	}
-	return os.Rename(tmp, m.mapsPath)
+	return renameDurable(tmp, m.mapsPath)
 }
 
 func (m *MultiVectorIndex) encodeMaps(w io.Writer) error {

--- a/vector/persist.go
+++ b/vector/persist.go
@@ -156,20 +156,28 @@ func (h *hnsw) SavePersist(metaPath string) error {
 	if err != nil {
 		return err
 	}
+	// Every failure below drops the staging file: an abandoned .tmp is dead weight
+	// next to the sidecar it never became, and a later save reuses the same fixed
+	// name. Matches the writers in collections.go / dirsync.go, and renameDurable
+	// covers the failed-rename case itself.
 	bw := bufio.NewWriterSize(f, 1<<16)
 	if err := h.writeMeta(bw, n); err != nil {
 		_ = f.Close()
+		_ = os.Remove(tmp)
 		return err
 	}
 	if err := bw.Flush(); err != nil {
 		_ = f.Close()
+		_ = os.Remove(tmp)
 		return err
 	}
 	if err := f.Sync(); err != nil {
 		_ = f.Close()
+		_ = os.Remove(tmp)
 		return err
 	}
 	if err := f.Close(); err != nil {
+		_ = os.Remove(tmp)
 		return err
 	}
 	return renameDurable(tmp, metaPath) // atomic publish (rename + dir fsync)

--- a/vector/persist.go
+++ b/vector/persist.go
@@ -172,7 +172,7 @@ func (h *hnsw) SavePersist(metaPath string) error {
 	if err := f.Close(); err != nil {
 		return err
 	}
-	return os.Rename(tmp, metaPath) // atomic publish
+	return renameDurable(tmp, metaPath) // atomic publish (rename + dir fsync)
 }
 
 // writeMeta serializes the sidecar: header + per-slot ids/levels/level0Len +


### PR DESCRIPTION
Closes #92.

**What.** Adds `syncDir`/`renameDurable` to the vector package (platform seam mirrors `cache/dirsync_*`: no directory fsync on Windows, NTFS journals the rename itself) and finishes every atomic publish with a parent-dir fsync. The six snapshot/meta writers switch to `renameDurable`; the four JSON markers (`writeConfig`, `writeNamedConfig`, `writeMVConfig`, key-registry `flushLocked`) switch to a shared `atomicWriteFile` (temp → write → fsync → close → rename → dir-fsync), since `os.WriteFile(tmp)+os.Rename` fsynced neither the bytes nor the rename.

**One deliberate divergence from the cache**: `cache/compact.go` warns and continues on a failed dir fsync; here the error **propagates**. Every vector-package rename publishes a checkpoint that a follow-up step relies on — most critically Flush, which truncates the WAL on the strength of "the checkpoint subsumes the log". A publish that may not survive a crash must fail the Flush so the truncate never runs.

**Tests.** `vector/dirsync_test.go`: `atomicWriteFile` round-trip, overwrite, no leftover `.tmp`, fail-loud on a missing parent; `renameDurable` happy/error paths; `syncDir` smoke on both sides of the platform seam. Full vector suite: failure set identical to `main` on my machine (the 34 pre-existing mmap-not-supported-on-darwin failures), zero new ones. `go build ./... && go vet ./vector/` clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes vector checkpoint publishes crash-durable by fsyncing the parent directory after every atomic rename, closing a window where a crash could silently drop the inter-checkpoint delta.

- Adds `syncDir` and `renameDurable` (platform seam mirrors `cache/dirsync_*`: no directory fsync on Windows) plus `atomicWriteFile` for the JSON markers.
- All six snapshot/meta writers switch to `renameDurable`; the four JSON markers (config, named/MV config, key registry) switch to `atomicWriteFile`, which also fsyncs the file bytes.
- Errors propagate instead of warn-and-continue: a checkpoint that may not survive a crash fails the Flush so the WAL truncate never runs against it.
- Failed publishes remove the staging `.tmp` file, and failed creates remove the config marker so a restart can't resurrect an empty collection.

<sup>Written for commit be84a8c1c7e5d6f6e2bcad54c90afc3f777cd141. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rostamlabs/rostam/pull/93?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved durability of saved data, snapshots, configuration, and metadata during unexpected crashes or power loss.
  * Ensured checkpoint updates are safely committed before related log data is truncated.
  * Preserved atomic file replacement while reducing the risk of incomplete or lost persisted state.
* **Tests**
  * Added coverage for durable file writes, replacements, renames, cleanup, and error handling across supported platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->