### PR TITLE
fix(raft/logstore): fail-closed poison latch on fsync failure

### DIFF
--- a/raft/logstore/poison_test.go
+++ b/raft/logstore/poison_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -374,6 +375,9 @@ func TestWriteFloorFsyncFailurePoisons(t *testing.T) {
 // durable. (A 0o000 drop would block the unlink too and only exercise the open
 // failure.) root ignores permission checks — hence the skip.
 func TestDirOpenFailurePoisons(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("os.Chmod on Windows honors only the 0o200 bit; the permission injection cannot restrict directory reads there")
+	}
 	if os.Geteuid() == 0 {
 		t.Skip("root bypasses directory permission checks")
 	}

--- a/raft/logstore/poison_test.go
+++ b/raft/logstore/poison_test.go
@@ -361,14 +361,18 @@ func TestWriteFloorFsyncFailurePoisons(t *testing.T) {
 }
 
 // TestDirOpenFailurePoisons covers syncDir's OPEN failure, which four callers
-// reach without passing through writeFileDurable's defer. The sharp case is the
-// one exercised here: truncateTailLocked has already closed and removed the
-// segments holding a conflicting tail, so an unlatched store would ack the next
-// batch while a crash could still resurrect those segments and collide with the
-// re-appended entries.
+// reach without passing through writeFileDurable's defer. It is driven through
+// truncateTailLocked because that caller is the sharp one in production: it has
+// closed and removed the segments holding a conflicting tail, so an unlatched
+// store would ack the next batch while a crash could still resurrect those
+// segments and collide with the re-appended entries.
 //
 // The open failure is injected by dropping the directory's permissions, which
-// root ignores — hence the skip.
+// root ignores — hence the skip. NOTE the same permission bits also block the
+// unlink (os.Remove needs w+x on the directory, and truncateTailLocked discards
+// its error), so under THIS injection the segment file actually stays on disk:
+// the test pins the poison-on-open-failure latch for this call path, not the
+// removed-then-unresolvable state itself, which no permission trick can create.
 func TestDirOpenFailurePoisons(t *testing.T) {
 	if os.Geteuid() == 0 {
 		t.Skip("root bypasses directory permission checks")
@@ -395,8 +399,11 @@ func TestDirOpenFailurePoisons(t *testing.T) {
 	if err := os.Chmod(dir, 0o000); err != nil {
 		t.Fatal(err)
 	}
-	// Drops entries 2 and 3: segment 3 is removed, then the directory sync that
-	// should make the removal durable cannot even open the directory.
+	// Drops entries 2 and 3: the tail truncation runs (the in-memory index and
+	// the fd truncate need no directory permission), then the directory sync that
+	// should make the segment removal durable cannot even open the directory.
+	// (The unlink itself is also blocked by the 0o000 bits and its error is
+	// discarded — see the doc comment above.)
 	err = w.DeleteRange(2, 3)
 	if err == nil || !strings.Contains(err.Error(), "open dir") {
 		t.Fatalf("want the directory open failure, got %v", err)

--- a/raft/logstore/poison_test.go
+++ b/raft/logstore/poison_test.go
@@ -367,12 +367,12 @@ func TestWriteFloorFsyncFailurePoisons(t *testing.T) {
 // store would ack the next batch while a crash could still resurrect those
 // segments and collide with the re-appended entries.
 //
-// The open failure is injected by dropping the directory's permissions, which
-// root ignores — hence the skip. NOTE the same permission bits also block the
-// unlink (os.Remove needs w+x on the directory, and truncateTailLocked discards
-// its error), so under THIS injection the segment file actually stays on disk:
-// the test pins the poison-on-open-failure latch for this call path, not the
-// removed-then-unresolvable state itself, which no permission trick can create.
+// The open failure is injected by dropping the directory's READ permission
+// while keeping w+x (chmod 0o300): the unlink needs w+x and SUCCEEDS, while
+// syncDir's os.Open needs read and FAILS — so the removed-but-not-durable state
+// is actually created, segment file gone and nothing able to make the removal
+// durable. (A 0o000 drop would block the unlink too and only exercise the open
+// failure.) root ignores permission checks — hence the skip.
 func TestDirOpenFailurePoisons(t *testing.T) {
 	if os.Geteuid() == 0 {
 		t.Skip("root bypasses directory permission checks")
@@ -396,17 +396,22 @@ func TestDirOpenFailurePoisons(t *testing.T) {
 	if len(w.segs) != 3 {
 		t.Fatalf("want one segment per entry, got %d", len(w.segs))
 	}
-	if err := os.Chmod(dir, 0o000); err != nil {
+	seg3 := w.segs[2].path
+	if err := os.Chmod(dir, 0o300); err != nil {
 		t.Fatal(err)
 	}
-	// Drops entries 2 and 3: the tail truncation runs (the in-memory index and
-	// the fd truncate need no directory permission), then the directory sync that
-	// should make the segment removal durable cannot even open the directory.
-	// (The unlink itself is also blocked by the 0o000 bits and its error is
-	// discarded — see the doc comment above.)
+	// Drops entries 2 and 3: the unlink of segment 3 succeeds (w+x on the dir),
+	// then the directory sync that should make that removal durable cannot open
+	// the directory (no read bit) — the exact removed-but-not-durable state the
+	// doc comment describes, and the latch must trip before the next ack.
 	err = w.DeleteRange(2, 3)
 	if err == nil || !strings.Contains(err.Error(), "open dir") {
 		t.Fatalf("want the directory open failure, got %v", err)
+	}
+	// Stat needs only x on the dir: prove the segment file really was unlinked,
+	// i.e. the state is the sharp one, not merely a failed open.
+	if _, serr := os.Stat(seg3); !os.IsNotExist(serr) {
+		t.Fatalf("segment 3 should be unlinked under 0o300, stat: %v", serr)
 	}
 	assertFailClosed(t, w, 2)
 }

--- a/raft/logstore/poison_test.go
+++ b/raft/logstore/poison_test.go
@@ -359,3 +359,47 @@ func TestWriteFloorFsyncFailurePoisons(t *testing.T) {
 	}
 	assertFailClosed(t, w, 4)
 }
+
+// TestDirOpenFailurePoisons covers syncDir's OPEN failure, which four callers
+// reach without passing through writeFileDurable's defer. The sharp case is the
+// one exercised here: truncateTailLocked has already closed and removed the
+// segments holding a conflicting tail, so an unlatched store would ack the next
+// batch while a crash could still resurrect those segments and collide with the
+// re-appended entries.
+//
+// The open failure is injected by dropping the directory's permissions, which
+// root ignores — hence the skip.
+func TestDirOpenFailurePoisons(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("root bypasses directory permission checks")
+	}
+	dir := t.TempDir()
+	// Registered AFTER t.TempDir so it runs BEFORE TempDir's removal (cleanups are
+	// LIFO); otherwise the unreadable directory would fail the test's own cleanup.
+	t.Cleanup(func() { _ = os.Chmod(dir, 0o750) })
+
+	w, err := OpenWAL(dir, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = w.Close() }()
+	w.maxSeg = 1 // one segment per entry, so a tail truncation removes segments
+	for i := uint64(1); i <= 3; i++ {
+		if err := w.StoreLog(mkLog(i, "a")); err != nil {
+			t.Fatalf("seed %d: %v", i, err)
+		}
+	}
+	if len(w.segs) != 3 {
+		t.Fatalf("want one segment per entry, got %d", len(w.segs))
+	}
+	if err := os.Chmod(dir, 0o000); err != nil {
+		t.Fatal(err)
+	}
+	// Drops entries 2 and 3: segment 3 is removed, then the directory sync that
+	// should make the removal durable cannot even open the directory.
+	err = w.DeleteRange(2, 3)
+	if err == nil || !strings.Contains(err.Error(), "open dir") {
+		t.Fatalf("want the directory open failure, got %v", err)
+	}
+	assertFailClosed(t, w, 2)
+}

--- a/raft/logstore/poison_test.go
+++ b/raft/logstore/poison_test.go
@@ -1,0 +1,138 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package logstore
+
+import (
+	"errors"
+	"os"
+	"testing"
+
+	hraft "github.com/hashicorp/raft"
+)
+
+// failNextFsync arms the WAL's fsync seam to fail exactly once with errBoom,
+// then restores the real (*os.File).Sync — modeling post-4.13 Linux, where the
+// fsync AFTER a failure typically returns success (the dirty pages it should
+// have covered were already dropped). Everything the latch protects against
+// happens in that second, falsely-successful sync.
+var errBoom = errors.New("injected fsync failure")
+
+func failNextFsync(w *WAL) {
+	fired := false
+	w.fsyncf = func(f *os.File) error {
+		if fired {
+			return (*os.File).Sync(f)
+		}
+		fired = true
+		return errBoom
+	}
+}
+
+// TestStoreLogsFsyncFailurePoisons pins the fail-closed contract on the log
+// path: the failing batch surfaces the fsync error, and every later write entry
+// point (StoreLogs, Set/SetUint64, DeleteRange) returns ErrWALPoisoned even
+// though the injected seam would now let an fsync "succeed". Reads of
+// already-durable entries stay open.
+func TestStoreLogsFsyncFailurePoisons(t *testing.T) {
+	dir := t.TempDir()
+	w, err := OpenWAL(dir, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = w.Close() }()
+
+	if err := w.StoreLog(mkLog(1, "a")); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	failNextFsync(w)
+	if err := w.StoreLog(mkLog(2, "b")); !errors.Is(err, errBoom) {
+		t.Fatalf("expected injected fsync error, got %v", err)
+	}
+	// The seam now succeeds — exactly the false-success retry the latch exists
+	// to refuse.
+	if err := w.StoreLog(mkLog(3, "c")); !errors.Is(err, ErrWALPoisoned) {
+		t.Fatalf("StoreLogs after fsync failure: want ErrWALPoisoned, got %v", err)
+	}
+	if err := w.SetUint64([]byte("term"), 7); !errors.Is(err, ErrWALPoisoned) {
+		t.Fatalf("Set after fsync failure: want ErrWALPoisoned, got %v", err)
+	}
+	if err := w.DeleteRange(1, 1); !errors.Is(err, ErrWALPoisoned) {
+		t.Fatalf("DeleteRange after fsync failure: want ErrWALPoisoned, got %v", err)
+	}
+	// Reads stay open: entry 1 was durably stored before the failure.
+	var got hraft.Log
+	if err := w.GetLog(1, &got); err != nil {
+		t.Fatalf("GetLog on poisoned WAL: %v", err)
+	}
+}
+
+// TestStableFsyncFailurePoisons pins the same latch on the stable-store path
+// (currentTerm/votedFor): a falsely-durable vote is the split-brain hazard, so
+// the first fsync failure there must poison the whole store too.
+func TestStableFsyncFailurePoisons(t *testing.T) {
+	dir := t.TempDir()
+	w, err := OpenWAL(dir, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = w.Close() }()
+
+	failNextFsync(w)
+	if err := w.Set([]byte("votedFor"), []byte("n1")); !errors.Is(err, errBoom) {
+		t.Fatalf("expected injected fsync error, got %v", err)
+	}
+	if err := w.StoreLog(mkLog(1, "a")); !errors.Is(err, ErrWALPoisoned) {
+		t.Fatalf("StoreLogs after stable fsync failure: want ErrWALPoisoned, got %v", err)
+	}
+}
+
+// TestPoisonClearsOnReopen pins the ONLY sanctioned recovery: a fresh OpenWAL.
+// The reopened store recovers every entry the failed sync did not cover being
+// torn away (here entry 1, durable before the injected failure) and accepts
+// writes again.
+func TestPoisonClearsOnReopen(t *testing.T) {
+	dir := t.TempDir()
+	w, err := OpenWAL(dir, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := w.StoreLog(mkLog(1, "a")); err != nil {
+		t.Fatal(err)
+	}
+	failNextFsync(w)
+	if err := w.StoreLog(mkLog(2, "b")); !errors.Is(err, errBoom) {
+		t.Fatalf("expected injected fsync error, got %v", err)
+	}
+	if err := w.Close(); err != nil {
+		t.Fatalf("close poisoned: %v", err)
+	}
+
+	w2, err := OpenWAL(dir, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = w2.Close() }()
+	last, err := w2.LastIndex()
+	if err != nil || last < 1 {
+		t.Fatalf("reopen lost the durable prefix: last=%d err=%v", last, err)
+	}
+	if err := w2.StoreLog(mkLog(last+1, "c")); err != nil {
+		t.Fatalf("reopened WAL must accept writes: %v", err)
+	}
+}
+
+// TestNoSyncModeNeverPoisonsOnStoreLogs pins the sync=false posture: StoreLogs
+// runs no fsync there, so the latch has nothing to trip on the log path and the
+// documented durability-from-replication contract is unchanged.
+func TestNoSyncModeNeverPoisonsOnStoreLogs(t *testing.T) {
+	dir := t.TempDir()
+	w, err := OpenWAL(dir, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = w.Close() }()
+	w.fsyncf = func(*os.File) error { return errBoom } // would fail if ever called on this path
+	if err := w.StoreLog(mkLog(1, "a")); err != nil {
+		t.Fatalf("nosync StoreLogs must not fsync: %v", err)
+	}
+}

--- a/raft/logstore/poison_test.go
+++ b/raft/logstore/poison_test.go
@@ -404,6 +404,14 @@ func TestDirOpenFailurePoisons(t *testing.T) {
 	if err := os.Chmod(dir, 0o300); err != nil {
 		t.Fatal(err)
 	}
+	// PROBE the injection instead of guessing at the environment: root is already
+	// skipped above, but CAP_DAC_OVERRIDE (common in container runtimes) lets a
+	// non-root euid bypass permission checks too. If the directory still opens,
+	// the injection cannot produce the failure this test exists to observe.
+	if d, perr := os.Open(dir); perr == nil {
+		_ = d.Close()
+		t.Skip("environment bypasses directory permission checks (e.g. CAP_DAC_OVERRIDE); injection ineffective")
+	}
 	// Drops entries 2 and 3: the unlink of segment 3 succeeds (w+x on the dir),
 	// then the directory sync that should make that removal durable cannot open
 	// the directory (no read bit) — the exact removed-but-not-durable state the

--- a/raft/logstore/poison_test.go
+++ b/raft/logstore/poison_test.go
@@ -5,6 +5,8 @@ package logstore
 import (
 	"errors"
 	"os"
+	"path/filepath"
+	"strings"
 	"testing"
 
 	hraft "github.com/hashicorp/raft"
@@ -18,13 +20,50 @@ import (
 var errBoom = errors.New("injected fsync failure")
 
 func failNextFsync(w *WAL) {
+	failFsyncIf(w, func(*os.File) bool { return true })
+}
+
+// failFsyncIf arms the seam to fail exactly once with errBoom, on the first sync
+// whose target matches want; every other sync (and everything after the failure)
+// runs the real (*os.File).Sync. Selecting the target by predicate rather than by
+// call count keeps the latch-site tests independent of how many incidental syncs
+// a path performs. Per the fsyncf contract, arm it only while the WAL is idle.
+func failFsyncIf(w *WAL, want func(*os.File) bool) {
 	fired := false
 	w.fsyncf = func(f *os.File) error {
-		if fired {
+		if fired || !want(f) {
 			return (*os.File).Sync(f)
 		}
 		fired = true
 		return errBoom
+	}
+}
+
+// isDirHandle matches the directory handle syncDir opens, so a test can fail the
+// directory fsync while letting the segment fsyncs ahead of it succeed.
+func isDirHandle(f *os.File) bool {
+	fi, err := f.Stat()
+	return err == nil && fi.IsDir()
+}
+
+// assertFailClosed pins the post-latch contract: every write entry point and the
+// gated stable-store read return ErrWALPoisoned.
+func assertFailClosed(t *testing.T, w *WAL, next uint64) {
+	t.Helper()
+	if !w.poisoned {
+		t.Fatal("latch not tripped")
+	}
+	if err := w.StoreLog(mkLog(next, "after")); !errors.Is(err, ErrWALPoisoned) {
+		t.Fatalf("StoreLogs: want ErrWALPoisoned, got %v", err)
+	}
+	if err := w.SetUint64([]byte("term"), 9); !errors.Is(err, ErrWALPoisoned) {
+		t.Fatalf("Set: want ErrWALPoisoned, got %v", err)
+	}
+	if _, err := w.Get([]byte("votedFor")); !errors.Is(err, ErrWALPoisoned) {
+		t.Fatalf("Get: want ErrWALPoisoned, got %v", err)
+	}
+	if err := w.DeleteRange(1, 1); !errors.Is(err, ErrWALPoisoned) {
+		t.Fatalf("DeleteRange: want ErrWALPoisoned, got %v", err)
 	}
 }
 
@@ -166,4 +205,157 @@ func TestNoSyncModeStillPoisonsOnStablePath(t *testing.T) {
 	if err := w.StoreLog(mkLog(1, "a")); !errors.Is(err, ErrWALPoisoned) {
 		t.Fatalf("nosync StoreLogs after stable fsync failure: want ErrWALPoisoned, got %v", err)
 	}
+}
+
+// TestStableNonFsyncFailurePoisons pins the widened contract: a durable write
+// that fails ANYWHERE — not only at the fsync — is terminal. Set mutates w.kv
+// before persisting, so a failed create (ENOSPC/ENOTDIR on the staging file) or
+// a failed rename leaves the in-memory map holding a term/vote that is not on
+// disk and that no reopen will reproduce. Without the latch the read gate would
+// happily serve it. Both cases are driven through the real filesystem rather
+// than the fsync seam, which by construction cannot reach these paths.
+func TestStableNonFsyncFailurePoisons(t *testing.T) {
+	cases := []struct {
+		name string
+		// stable returns the stable-store path to point the WAL at, having
+		// created whatever makes the durable write fail.
+		stable func(t *testing.T, dir string) string
+		// wantStage is the stage of writeFileDurable expected to fail.
+		wantStage string
+	}{
+		{
+			name: "staging create fails",
+			stable: func(t *testing.T, dir string) string {
+				blocker := filepath.Join(dir, "blocker")
+				if err := os.WriteFile(blocker, []byte("x"), 0o600); err != nil {
+					t.Fatal(err)
+				}
+				return filepath.Join(blocker, "stable") // parent is a FILE => ENOTDIR
+			},
+			wantStage: "create",
+		},
+		{
+			name: "rename fails",
+			stable: func(t *testing.T, dir string) string {
+				target := filepath.Join(dir, "stable-as-dir")
+				if err := os.Mkdir(target, 0o750); err != nil {
+					t.Fatal(err)
+				}
+				return target // renaming a file onto a directory => EISDIR
+			},
+			wantStage: "rename",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			w, err := OpenWAL(dir, true)
+			if err != nil {
+				t.Fatal(err)
+			}
+			w.stablePath = tc.stable(t, dir)
+
+			err = w.Set([]byte("votedFor"), []byte("n1"))
+			if err == nil {
+				t.Fatal("Set must surface the durable-write failure")
+			}
+			if errors.Is(err, ErrWALPoisoned) {
+				t.Fatalf("want the underlying cause, got the latch error: %v", err)
+			}
+			if !strings.Contains(err.Error(), tc.wantStage) {
+				t.Fatalf("want a %s failure, got %v", tc.wantStage, err)
+			}
+			assertFailClosed(t, w, 1)
+			if err := w.Close(); err != nil {
+				t.Fatalf("close poisoned: %v", err)
+			}
+
+			// The latch clears only on a fresh open, which is then fully usable.
+			w2, err := OpenWAL(dir, true)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer func() { _ = w2.Close() }()
+			if err := w2.Set([]byte("votedFor"), []byte("n1")); err != nil {
+				t.Fatalf("reopened WAL must accept Set: %v", err)
+			}
+			if err := w2.StoreLog(mkLog(1, "a")); err != nil {
+				t.Fatalf("reopened WAL must accept writes: %v", err)
+			}
+			if v, err := w2.Get([]byte("votedFor")); err != nil || string(v) != "n1" {
+				t.Fatalf("reopened Get: got %q err=%v", v, err)
+			}
+		})
+	}
+}
+
+// TestRotationDirSyncFailurePoisons covers the syncDir latch site: a batch that
+// rotates must make the NEW segment's directory entry durable, so a failing
+// directory fsync is as terminal as a failing segment fsync (recovery could
+// otherwise not find a segment whose records were acked).
+func TestRotationDirSyncFailurePoisons(t *testing.T) {
+	dir := t.TempDir()
+	w, err := OpenWAL(dir, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = w.Close() }()
+	w.maxSeg = 1 // every append rotates
+
+	if err := w.StoreLog(mkLog(1, "a")); err != nil { // creates the first segment
+		t.Fatalf("seed: %v", err)
+	}
+	failFsyncIf(w, isDirHandle) // let the segment fsyncs through, fail the dir sync
+	err = w.StoreLog(mkLog(2, "b"))
+	if !errors.Is(err, errBoom) || !strings.Contains(err.Error(), "sync dir") {
+		t.Fatalf("want the injected dir-sync failure, got %v", err)
+	}
+	assertFailClosed(t, w, 3)
+}
+
+// TestTruncateTailFsyncFailurePoisons covers the truncateTailLocked latch site:
+// the conflict-truncation fsync is what stops a crash from resurrecting the
+// removed tail, so its failure must fail closed like any other.
+func TestTruncateTailFsyncFailurePoisons(t *testing.T) {
+	dir := t.TempDir()
+	w, err := OpenWAL(dir, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = w.Close() }()
+	for i := uint64(1); i <= 3; i++ {
+		if err := w.StoreLog(mkLog(i, "a")); err != nil {
+			t.Fatalf("seed %d: %v", i, err)
+		}
+	}
+	failNextFsync(w) // the truncation fsync is the next sync on this path
+	err = w.DeleteRange(3, 3)
+	if !errors.Is(err, errBoom) || !strings.Contains(err.Error(), "truncated segment") {
+		t.Fatalf("want the injected truncate fsync failure, got %v", err)
+	}
+	assertFailClosed(t, w, 4)
+}
+
+// TestWriteFloorFsyncFailurePoisons covers the writeFloorLocked latch site: the
+// compaction floor is what makes recovery skip the dropped prefix, and
+// truncateFrontLocked advances w.first in memory before persisting it — so a
+// failed floor write leaves memory ahead of disk and must poison.
+func TestWriteFloorFsyncFailurePoisons(t *testing.T) {
+	dir := t.TempDir()
+	w, err := OpenWAL(dir, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = w.Close() }()
+	for i := uint64(1); i <= 3; i++ {
+		if err := w.StoreLog(mkLog(i, "a")); err != nil {
+			t.Fatalf("seed %d: %v", i, err)
+		}
+	}
+	failNextFsync(w) // the floor file's fsync is the next sync on this path
+	err = w.DeleteRange(1, 1)
+	if !errors.Is(err, errBoom) || !strings.Contains(err.Error(), "first.tmp") {
+		t.Fatalf("want the injected floor fsync failure, got %v", err)
+	}
+	assertFailClosed(t, w, 4)
 }

--- a/raft/logstore/poison_test.go
+++ b/raft/logstore/poison_test.go
@@ -84,6 +84,15 @@ func TestStableFsyncFailurePoisons(t *testing.T) {
 	if err := w.StoreLog(mkLog(1, "a")); !errors.Is(err, ErrWALPoisoned) {
 		t.Fatalf("StoreLogs after stable fsync failure: want ErrWALPoisoned, got %v", err)
 	}
+	// Reads of the stable store are gated too: Set mutated the in-memory map
+	// before the failed persist, so serving it would hand raft a term/vote no
+	// reopen will reproduce (unlike GetLog, which fails loud via CRC on its own).
+	if _, err := w.Get([]byte("votedFor")); !errors.Is(err, ErrWALPoisoned) {
+		t.Fatalf("Get after stable fsync failure: want ErrWALPoisoned, got %v", err)
+	}
+	if _, err := w.GetUint64([]byte("term")); !errors.Is(err, ErrWALPoisoned) {
+		t.Fatalf("GetUint64 after stable fsync failure: want ErrWALPoisoned, got %v", err)
+	}
 }
 
 // TestPoisonClearsOnReopen pins the ONLY sanctioned recovery: a fresh OpenWAL.
@@ -121,9 +130,10 @@ func TestPoisonClearsOnReopen(t *testing.T) {
 	}
 }
 
-// TestNoSyncModeNeverPoisonsOnStoreLogs pins the sync=false posture: StoreLogs
-// runs no fsync there, so the latch has nothing to trip on the log path and the
-// documented durability-from-replication contract is unchanged.
+// TestNoSyncModeNeverPoisonsOnStoreLogs pins the sync=false LOG posture:
+// StoreLogs runs no fsync there, so the latch has nothing to trip on the log
+// path and the documented durability-from-replication contract is unchanged.
+// Only the log path is latch-free in this mode — see the stable-path test below.
 func TestNoSyncModeNeverPoisonsOnStoreLogs(t *testing.T) {
 	dir := t.TempDir()
 	w, err := OpenWAL(dir, false)
@@ -134,5 +144,26 @@ func TestNoSyncModeNeverPoisonsOnStoreLogs(t *testing.T) {
 	w.fsyncf = func(*os.File) error { return errBoom } // would fail if ever called on this path
 	if err := w.StoreLog(mkLog(1, "a")); err != nil {
 		t.Fatalf("nosync StoreLogs must not fsync: %v", err)
+	}
+}
+
+// TestNoSyncModeStillPoisonsOnStablePath pins that sync=false does NOT exempt
+// the stable store (currentTerm/votedFor) or the compaction floor: those are
+// durable-unconditionally by design (see writeStableLocked — a granted vote must
+// survive a crash in EVERY mode, or the node can double-vote), so the fsyncgate
+// hazard and its latch apply there in every mode too.
+func TestNoSyncModeStillPoisonsOnStablePath(t *testing.T) {
+	dir := t.TempDir()
+	w, err := OpenWAL(dir, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = w.Close() }()
+	failNextFsync(w)
+	if err := w.Set([]byte("votedFor"), []byte("n1")); !errors.Is(err, errBoom) {
+		t.Fatalf("expected injected fsync error, got %v", err)
+	}
+	if err := w.StoreLog(mkLog(1, "a")); !errors.Is(err, ErrWALPoisoned) {
+		t.Fatalf("nosync StoreLogs after stable fsync failure: want ErrWALPoisoned, got %v", err)
 	}
 }

--- a/raft/logstore/wal.go
+++ b/raft/logstore/wal.go
@@ -637,6 +637,14 @@ func (w *WAL) Set(key, val []byte) error {
 func (w *WAL) Get(key []byte) ([]byte, error) {
 	w.mu.Lock()
 	defer w.mu.Unlock()
+	// Poison gate on READS too, unlike the log path (whose GetLog fails loud via
+	// the per-record CRC when the kernel dropped pages). The stable map is served
+	// from MEMORY, and Set mutates the map before persisting — so after a failed
+	// stable fsync the map can hold a term/vote that no reopen will reproduce.
+	// Serving it would let raft act on a never-durable vote; fail closed instead.
+	if w.poisoned {
+		return nil, ErrWALPoisoned
+	}
 	v, ok := w.kv[string(key)]
 	if !ok {
 		return nil, nil

--- a/raft/logstore/wal.go
+++ b/raft/logstore/wal.go
@@ -140,8 +140,13 @@ func (w *WAL) Close() error {
 			first = err
 		}
 	}
-	if len(w.segs) > 0 && first == nil {
-		if err := w.syncDir(); err != nil {
+	// Always attempt the directory sync, even after a segment fsync failure:
+	// in sync=false mode the directory entries of segments that DID sync were
+	// never made durable during operation, so skipping this on an unrelated
+	// segment's failure could lose whole healthy segments to recovery. Keep the
+	// FIRST error for the return value.
+	if len(w.segs) > 0 {
+		if err := w.syncDir(); err != nil && first == nil {
 			first = err
 		}
 	}

--- a/raft/logstore/wal.go
+++ b/raft/logstore/wal.go
@@ -4,6 +4,7 @@ package logstore
 
 import (
 	"encoding/binary"
+	"errors"
 	"fmt"
 	"hash/crc32"
 	"log/slog"
@@ -51,6 +52,22 @@ type recPos struct {
 // Concurrency: one mutex guards everything. raft serializes StoreLogs on the
 // leader and reads via replication goroutines; a single lock keeps the index and
 // files consistent, matching bbolt's single-writer model.
+// ErrWALPoisoned marks a WAL whose ack-implies-durable contract can no longer be
+// trusted: an earlier fsync (segment, directory, or durable-file write) FAILED,
+// and on post-4.13 Linux the kernel may have DISCARDED that sync's dirty pages —
+// a subsequent fsync on the same file can then return SUCCESS having synced
+// nothing (the fsyncgate / PostgreSQL PANIC-on-fsync-failure case). If a later
+// StoreLogs or stable-store Set simply retried, the node would ack raft entries
+// (or persist a vote) on bytes that are gone, silently counting toward commit
+// quorum on data no crash recovery can produce. So the WAL fails CLOSED: the
+// first fsync failure trips a terminal latch and every subsequent write entry
+// point returns this error. Reads stay open — a read of dropped pages already
+// fails loud via the per-record CRC. The latch clears ONLY on a fresh OpenWAL:
+// a later fsync that happens to succeed is no proof the device recovered.
+// Mirrors vector/wal.go's poisoned latch (the #87 fix), adapted to this store's
+// single-mutex model.
+var ErrWALPoisoned = errors.New("logstore: WAL poisoned by an earlier fsync failure; reopen required")
+
 type WAL struct {
 	mu      sync.Mutex
 	dir     string
@@ -59,6 +76,17 @@ type WAL struct {
 	offsets []recPos   // offsets[i] locates entry (first + i)
 	maxSeg  int64
 	sync    bool // fsync per StoreLogs batch (durable) vs page-cache only (fast)
+
+	// poisoned is the terminal fail-closed latch (see ErrWALPoisoned). Guarded by
+	// mu like everything else; set at the point an fsync failure is observed,
+	// before the error is returned, so no later write can slip past it.
+	poisoned bool
+
+	// fsyncf is the file-sync seam: production is (*os.File).Sync; tests inject a
+	// failing implementation to exercise the poison latch deterministically. It
+	// covers every durability-bearing sync (segments, the directory handle, and
+	// writeFileDurable's temp file).
+	fsyncf func(*os.File) error
 
 	encBuf  []byte // reused StoreLogs encode buffer (zero-alloc hot path)
 	readBuf []byte // reused GetLog read buffer
@@ -86,6 +114,7 @@ func OpenWAL(dir string, sync bool) (*WAL, error) {
 		sync:       sync,
 		stablePath: filepath.Join(dir, "stable"),
 		kv:         make(map[string][]byte, 8),
+		fsyncf:     (*os.File).Sync,
 	}
 	if err := w.recover(); err != nil {
 		return nil, err
@@ -106,7 +135,8 @@ func (w *WAL) Close() error {
 	// segments were never fsynced during operation) plus the directory, so a
 	// clean shutdown is durable for the whole log.
 	for _, s := range w.segs {
-		if err := s.f.Sync(); err != nil && first == nil {
+		if err := w.fsyncf(s.f); err != nil && first == nil {
+			w.poisoned = true // a reopened handle must not trust a later false-success sync
 			first = err
 		}
 	}
@@ -181,6 +211,9 @@ func (w *WAL) StoreLogs(logs []*hraft.Log) error {
 	}
 	w.mu.Lock()
 	defer w.mu.Unlock()
+	if w.poisoned {
+		return ErrWALPoisoned
+	}
 	preLen := len(w.segs)
 	var preActive *segment
 	if preLen > 0 {
@@ -199,7 +232,8 @@ func (w *WAL) StoreLogs(logs []*hraft.Log) error {
 	// before the batch is acknowledged. Unchanged segments have no dirty pages,
 	// so their fsync is a near-free no-op.
 	for _, s := range w.segs {
-		if err := s.f.Sync(); err != nil {
+		if err := w.fsyncf(s.f); err != nil {
+			w.poisoned = true // fail closed: see ErrWALPoisoned
 			return fmt.Errorf("logstore: fsync segment: %w", err)
 		}
 	}
@@ -272,6 +306,9 @@ func (w *WAL) addSegmentLocked(base uint64) error {
 func (w *WAL) DeleteRange(minIdx, maxIdx uint64) error {
 	w.mu.Lock()
 	defer w.mu.Unlock()
+	if w.poisoned {
+		return ErrWALPoisoned
+	}
 	if len(w.offsets) == 0 {
 		return nil
 	}
@@ -361,7 +398,8 @@ func (w *WAL) truncateTailLocked(newFirstRemoved uint64) error {
 	// cannot leave a removed higher-base segment on disk for recovery to
 	// resurrect as live (its records would collide with the re-appended tail).
 	if w.sync {
-		if err := seg.f.Sync(); err != nil {
+		if err := w.fsyncf(seg.f); err != nil {
+			w.poisoned = true // fail closed: see ErrWALPoisoned
 			return fmt.Errorf("logstore: fsync truncated segment: %w", err)
 		}
 		if removed {
@@ -406,7 +444,8 @@ func (w *WAL) syncDir() error {
 	if err != nil {
 		return fmt.Errorf("logstore: open dir: %w", err)
 	}
-	if err := d.Sync(); err != nil {
+	if err := w.fsyncf(d); err != nil {
+		w.poisoned = true // fail closed: see ErrWALPoisoned
 		_ = d.Close()
 		return fmt.Errorf("logstore: sync dir: %w", err)
 	}
@@ -427,7 +466,8 @@ func (w *WAL) writeFileDurable(path string, data []byte) error {
 		_ = f.Close()
 		return fmt.Errorf("logstore: write %s: %w", tmp, err)
 	}
-	if err := f.Sync(); err != nil {
+	if err := w.fsyncf(f); err != nil {
+		w.poisoned = true // fail closed: see ErrWALPoisoned
 		_ = f.Close()
 		return fmt.Errorf("logstore: fsync %s: %w", tmp, err)
 	}
@@ -587,6 +627,9 @@ func (s *segment) truncateAt(off int64) error {
 func (w *WAL) Set(key, val []byte) error {
 	w.mu.Lock()
 	defer w.mu.Unlock()
+	if w.poisoned {
+		return ErrWALPoisoned
+	}
 	w.kv[string(key)] = append([]byte(nil), val...)
 	return w.writeStableLocked()
 }

--- a/raft/logstore/wal.go
+++ b/raft/logstore/wal.go
@@ -449,9 +449,17 @@ func (w *WAL) floorPath() string { return filepath.Join(w.dir, "first") }
 // syncDir fsyncs the WAL directory. fsync of a file does NOT make its directory
 // entry durable, so a create/rename/remove must be followed by a directory sync
 // for the name change to survive a power loss.
+//
+// Failing to OPEN the directory is as terminal as failing to sync it, and is
+// latched the same way: every caller has already performed the name change the
+// sync was meant to make durable. truncateTailLocked is the sharp case — it has
+// removed the segments holding a conflicting tail, and leaving the store
+// un-poisoned would ack the next batch while a crash could still resurrect
+// those segments and collide with the re-appended entries.
 func (w *WAL) syncDir() error {
 	d, err := os.Open(w.dir)
 	if err != nil {
+		w.poisoned = true // fail closed: see ErrWALPoisoned
 		return fmt.Errorf("logstore: open dir: %w", err)
 	}
 	if err := w.fsyncf(d); err != nil {

--- a/raft/logstore/wal.go
+++ b/raft/logstore/wal.go
@@ -45,13 +45,6 @@ type recPos struct {
 	size   int // total record bytes: frameHdr + payload
 }
 
-// WAL is a durable raft LogStore + StableStore: a segmented append-only log with
-// an in-memory offset index and a fixed binary record format (codec.go), fsync'd
-// per StoreLogs batch. It replaces raft-boltdb for the durable path.
-//
-// Concurrency: one mutex guards everything. raft serializes StoreLogs on the
-// leader and reads via replication goroutines; a single lock keeps the index and
-// files consistent, matching bbolt's single-writer model.
 // ErrWALPoisoned marks a WAL whose ack-implies-durable contract can no longer be
 // trusted: an earlier fsync (segment, directory, or durable-file write) FAILED,
 // and on post-4.13 Linux the kernel may have DISCARDED that sync's dirty pages —
@@ -68,6 +61,13 @@ type recPos struct {
 // single-mutex model.
 var ErrWALPoisoned = errors.New("logstore: WAL poisoned by an earlier fsync failure; reopen required")
 
+// WAL is a durable raft LogStore + StableStore: a segmented append-only log with
+// an in-memory offset index and a fixed binary record format (codec.go), fsync'd
+// per StoreLogs batch. It replaces raft-boltdb for the durable path.
+//
+// Concurrency: one mutex guards everything. raft serializes StoreLogs on the
+// leader and reads via replication goroutines; a single lock keeps the index and
+// files consistent, matching bbolt's single-writer model.
 type WAL struct {
 	mu      sync.Mutex
 	dir     string
@@ -86,6 +86,11 @@ type WAL struct {
 	// failing implementation to exercise the poison latch deterministically. It
 	// covers every durability-bearing sync (segments, the directory handle, and
 	// writeFileDurable's temp file).
+	//
+	// Contract: set it once, before the WAL's first use (right after OpenWAL) and
+	// never concurrently with an in-flight operation. It is READ under mu on the
+	// write paths but tests replace it without holding mu, which is only safe
+	// while the WAL is idle.
 	fsyncf func(*os.File) error
 
 	encBuf  []byte // reused StoreLogs encode buffer (zero-alloc hot path)
@@ -461,7 +466,27 @@ func (w *WAL) syncDir() error {
 // fsynced, renamed into place, and the directory is fsynced. Used for the stable
 // store and the compaction floor, which must be durable regardless of the log's
 // sync mode.
-func (w *WAL) writeFileDurable(path string, data []byte) error {
+//
+// ANY failure here is TERMINAL and trips the poison latch, not just a failing
+// fsync. Every caller mutates in-memory state BEFORE persisting it — Set writes
+// w.kv, truncateFrontLocked advances w.first — so a create, write, close,
+// rename or directory-sync failure leaves memory ahead of disk exactly like a
+// failed fsync does. Without the latch the read gate would keep serving a
+// term/vote (or a compaction floor) that no reopen can reproduce: ENOSPC on the
+// staging write, an EIO surfaced by the deferred writeback in Close, or a failed
+// rename all leave the old file in place while the map claims the new value.
+// Restoring the pre-call value instead would have to be exact for every caller;
+// poisoning is one uniform contract that cannot be got wrong, and matches the
+// fail-closed posture the rest of the store already takes.
+//
+// Callers hold w.mu, so the latch is set under the same mutex discipline as the
+// fsync branches.
+func (w *WAL) writeFileDurable(path string, data []byte) (err error) {
+	defer func() {
+		if err != nil {
+			w.poisoned = true // fail closed on EVERY path: see ErrWALPoisoned
+		}
+	}()
 	tmp := path + ".tmp"
 	f, err := os.OpenFile(tmp, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0o600)
 	if err != nil {
@@ -472,7 +497,6 @@ func (w *WAL) writeFileDurable(path string, data []byte) error {
 		return fmt.Errorf("logstore: write %s: %w", tmp, err)
 	}
 	if err := w.fsyncf(f); err != nil {
-		w.poisoned = true // fail closed: see ErrWALPoisoned
 		_ = f.Close()
 		return fmt.Errorf("logstore: fsync %s: %w", tmp, err)
 	}


### PR DESCRIPTION
Closes #94.

**What.** Adds the same terminal fail-closed latch #87 introduced in `vector/wal.go`, adapted to this store's single-mutex model: `ErrWALPoisoned` + a `poisoned` flag tripped at the point any durability-bearing fsync fails — segment sync in `StoreLogs`, the truncated-segment sync, `syncDir`, and `writeFileDurable` (which carries the stable store's `currentTerm`/`votedFor` and the compaction floor).

Once poisoned, every write entry point (`StoreLogs`, `Set`/`SetUint64`, `DeleteRange`) fails closed instead of letting a post-failure fsync return a false success on dropped dirty pages. Log reads stay open — `GetLog` already fails loud via the per-record CRC if it reads pages the kernel dropped — but stable-store reads (`Get`/`GetUint64`) are gated too: `Set` mutates the in-memory map before persisting, so a poisoned store could otherwise serve a term/vote no reopen will reproduce. The latch clears only on a fresh `OpenWAL`; `Close` still fsyncs and closes every fd but marks the store poisoned on failure.

**`sync=false` semantics (deliberate).** The log path runs no fsync there, so nothing can trip the latch on `StoreLogs` — the durability-from-replication contract is unchanged. The stable store and the compaction floor, however, are durable-unconditionally by design (a granted vote must survive a crash in *every* mode, or the node can double-vote), so their fsync failures poison in every mode. Both halves are pinned by tests.

**Test seam.** `fsyncf` (production: `(*os.File).Sync`) lets the tests trip the latch deterministically, modeling the post-4.13 Linux behavior where the fsync *after* a failure succeeds.

**Tests** (`raft/logstore/poison_test.go`, run with `-race` along the full existing logstore suite, including the crash tests): poison via the log path and via the stable path; fail-closed on all write entry points and on stable reads, with log reads still served; clear-on-reopen with the durable prefix intact; `sync=false` log path latch-free; `sync=false` stable path still latching.

**Not changed.** No wire, format, or API change beyond the new exported sentinel error.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * WAL storage now fails closed after a durability or filesystem persistence failure, preventing subsequent writes from proceeding.
  * Stable-store reads and writes are blocked while the WAL is in a failed state.
  * Existing durable log entries remain readable after a synchronization failure.
  * Reopening the store clears the failed state and restores normal operation.
  * Failure handling is now consistent across synchronization-enabled and no-synchronization modes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->