### PR TITLE
feat(kv): generic atomic `operate` op with typed, memory-efficient fields

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -30,6 +30,11 @@ var (
 	// ErrUnauthorized indicates the server rejected the request because the
 	// supplied auth token was missing or invalid.
 	ErrUnauthorized = errors.New("client: unauthorized")
+	// ErrOperateArgsTooLarge indicates an Operate call whose key (u16 keyLen),
+	// op count (u32 nOps), or return-spec count (u16 nReturn) exceeds the wire
+	// field's range — rejected before encoding so a silent length wrap can never
+	// desync the client and server.
+	ErrOperateArgsTooLarge = errors.New("client: operate args exceed wire limits")
 )
 
 // RemoteError represents a StatusError response from the server.
@@ -210,7 +215,7 @@ func (c *Client) Call(ctx context.Context, op string, args []byte) ([]byte, erro
 		// another server and retry within the hop budget — but never
 		// replay a non-replayable conditional write across an ambiguous
 		// (post-transmission) failure, which could report a wrong outcome.
-		if isTransportError(err) && hop < maxHops && !(nonReplayableOp(op) && isAmbiguous(err)) {
+		if isTransportError(err) && hop < maxHops && (!nonReplayableOp(op) || !isAmbiguous(err)) {
 			next := c.nextServer()
 			if next != "" && next != target {
 				target = next
@@ -360,7 +365,7 @@ func (c *Client) CompareAndExpire(ctx context.Context, key, expected []byte, ttl
 	return wire.DecodeCASResult(res)
 }
 
-// Operate applies a list of pure-integer ops (INCR / INCRF / SETMAX / SHIFTOR /
+// Operate applies a list of typed numeric ops (INCR / INCRF / SETMAX / SHIFTOR /
 // HALVE_GRP, built as wire.OperateOp with the wire.OperateOp* opcodes and
 // wire.OperateTarget* targets) to ONE record atomically, server-side, in a single
 // round-trip — the primitive for a HOT key where a client CAS-retry loop would
@@ -378,6 +383,11 @@ func (c *Client) CompareAndExpire(ctx context.Context, key, expected []byte, ttl
 // Like the other conditional writes, an ambiguous transport failure returns a
 // non-nil error rather than a possibly-wrong result; the op is not replayed.
 func (c *Client) Operate(ctx context.Context, key []byte, ttl time.Duration, maxEntries uint16, ops []wire.OperateOp, ret []wire.OperateRet) ([]int64, error) {
+	// Reject anything that would overflow a wire length field before encoding, so a
+	// silent u16/u32 wrap can never truncate the frame and desync client and server.
+	if len(key) > 0xFFFF || len(ret) > 0xFFFF || uint64(len(ops)) > 0xFFFFFFFF {
+		return nil, ErrOperateArgsTooLarge
+	}
 	res, err := c.Call(ctx, "operate", wire.EncodeOperateArgs(key, ttl, maxEntries, ops, ret))
 	if err != nil {
 		return nil, err
@@ -561,7 +571,11 @@ func (e *ambiguousError) Unwrap() error { return e.err }
 // surface an ambiguous per-group flush instead of the peer Client re-sending it.
 func nonReplayableOp(op string) bool {
 	switch op {
-	case "set_nx", "cas", "cad", "getdel", "getset", "incr_ex", "caex", "persist", "flush", "__flush_shard__":
+	case "set_nx", "cas", "cad", "getdel", "getset", "incr_ex", "caex", "persist", "flush", "__flush_shard__", "operate":
+		// operate mutates counters non-idempotently (an op-list of increments), so a
+		// blind replay after an ambiguous (post-commit) failure would apply every
+		// increment twice. It surfaces the ambiguous error instead — the whole
+		// no-double-increment guarantee, exactly like incr_ex.
 		return true
 	}
 	return false
@@ -762,7 +776,7 @@ func (c *Client) CallFunc(ctx context.Context, op string, args []byte, fn func(p
 		}
 		// See Call: a non-replayable conditional write is not retried across
 		// an ambiguous (post-transmission) transport failure.
-		if isTransportError(err) && hop < maxHops && !(nonReplayableOp(op) && isAmbiguous(err)) {
+		if isTransportError(err) && hop < maxHops && (!nonReplayableOp(op) || !isAmbiguous(err)) {
 			next := c.nextServer()
 			if next != "" && next != target {
 				target = next

--- a/client/client.go
+++ b/client/client.go
@@ -364,7 +364,11 @@ func (c *Client) CompareAndExpire(ctx context.Context, key, expected []byte, ttl
 // HALVE_GRP, built as wire.OperateOp with the wire.OperateOp* opcodes and
 // wire.OperateTarget* targets) to ONE record atomically, server-side, in a single
 // round-trip — the primitive for a HOT key where a client CAS-retry loop would
-// livelock. The record models a small globals array plus a capped map of entry
+// livelock. Each op carries the field's TYPE (wire.OperateType*, e.g. U8/U16/F32/
+// UVARINT) used to create the field on first touch (the stored type wins for an
+// existing field); narrow types pack the record compactly. Fixed-width int ops
+// saturate at the type's range and SHIFTOR masks to its bit width.
+// The record models a small globals array plus a capped map of entry
 // sub-records; maxEntries==0 leaves the map unbounded, and ttl (0 = no expiry) is
 // applied to the whole record on every call. ret names the fields to read back
 // after the ops apply; the returned i64 slice aligns with ret in order (0 for an

--- a/client/client.go
+++ b/client/client.go
@@ -360,6 +360,27 @@ func (c *Client) CompareAndExpire(ctx context.Context, key, expected []byte, ttl
 	return wire.DecodeCASResult(res)
 }
 
+// Operate applies a list of pure-integer ops (INCR / INCRF / SETMAX / SHIFTOR /
+// HALVE_GRP, built as wire.OperateOp with the wire.OperateOp* opcodes and
+// wire.OperateTarget* targets) to ONE record atomically, server-side, in a single
+// round-trip — the primitive for a HOT key where a client CAS-retry loop would
+// livelock. The record models a small globals array plus a capped map of entry
+// sub-records; maxEntries==0 leaves the map unbounded, and ttl (0 = no expiry) is
+// applied to the whole record on every call. ret names the fields to read back
+// after the ops apply; the returned i64 slice aligns with ret in order (0 for an
+// absent field). Because the whole op-list commits under the shard write lock, NO
+// concurrent increment is lost.
+//
+// Like the other conditional writes, an ambiguous transport failure returns a
+// non-nil error rather than a possibly-wrong result; the op is not replayed.
+func (c *Client) Operate(ctx context.Context, key []byte, ttl time.Duration, maxEntries uint16, ops []wire.OperateOp, ret []wire.OperateRet) ([]int64, error) {
+	res, err := c.Call(ctx, "operate", wire.EncodeOperateArgs(key, ttl, maxEntries, ops, ret))
+	if err != nil {
+		return nil, err
+	}
+	return wire.DecodeOperateResult(res)
+}
+
 // maxMGetKeys caps how many keys ride in one mget call — the u16 count field's
 // range. MGet chunks each shard's key group to this size.
 const maxMGetKeys = 65535

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -500,6 +500,11 @@ func TestClientNewMutationsNotReplayedAcrossAmbiguousFailure(t *testing.T) {
 			return err
 		}},
 		{"persist", func(c *Client) error { _, err := c.Persist(ctx, []byte("k")); return err }},
+		{"operate", func(c *Client) error {
+			_, err := c.Operate(ctx, []byte("k"), 0, 0,
+				[]wire.OperateOp{{Target: wire.OperateTargetGlobal, FieldIdx: 0, Opcode: wire.OperateOpINCR, Type: wire.OperateTypeU64, Arg: 1}}, nil)
+			return err
+		}},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -528,6 +533,25 @@ func TestClientNewMutationsNotReplayedAcrossAmbiguousFailure(t *testing.T) {
 				t.Fatalf("%s: server B calls = %d, want 0 (non-replayable mutation must not replay)", tc.name, n)
 			}
 		})
+	}
+}
+
+// TestOperateRejectsOversizedArgs: Operate rejects a key, op count, or return
+// count that would overflow its wire length field, BEFORE encoding — a silent u16/
+// u32 wrap would truncate the frame and desync client and server.
+func TestOperateRejectsOversizedArgs(t *testing.T) {
+	c, err := New(Config{Servers: []string{"127.0.0.1:1"}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = c.Close() }()
+	ctx := context.Background()
+
+	if _, err := c.Operate(ctx, make([]byte, 0x10000), 0, 0, nil, nil); err != ErrOperateArgsTooLarge {
+		t.Fatalf("oversized key: err = %v, want ErrOperateArgsTooLarge", err)
+	}
+	if _, err := c.Operate(ctx, []byte("k"), 0, 0, nil, make([]wire.OperateRet, 0x10000)); err != ErrOperateArgsTooLarge {
+		t.Fatalf("oversized return count: err = %v, want ErrOperateArgsTooLarge", err)
 	}
 }
 

--- a/client_integration_test.go
+++ b/client_integration_test.go
@@ -229,9 +229,11 @@ func TestClientOperateUpdateAndReadBack(t *testing.T) {
 	ctx := context.Background()
 	key := []byte("rec")
 
-	// Guard-then-increment (HALVE_GRP overflow guard ahead of the increments), a
-	// SETMAX, and an entry counter — all in one atomic op-list.
+	// Guard-then-increment (a HALVE_GRP overflow guard ahead of the increment — a
+	// no-op here since field 0 starts at 0), a SETMAX, and an entry counter — all in
+	// one atomic op-list.
 	ops := []wire.OperateOp{
+		{Target: wire.OperateTargetGlobal, FieldIdx: 0, Opcode: wire.OperateOpHALVEGRP, Type: wire.OperateTypeU16, Arg: 255, Arg2: 1},
 		{Target: wire.OperateTargetGlobal, FieldIdx: 0, Opcode: wire.OperateOpINCR, Type: wire.OperateTypeU16, Arg: 10},
 		{Target: wire.OperateTargetGlobal, FieldIdx: 1, Opcode: wire.OperateOpSETMAX, Type: wire.OperateTypeU16, Arg: 7},
 		{Target: wire.OperateTargetGlobal, FieldIdx: 1, Opcode: wire.OperateOpSETMAX, Type: wire.OperateTypeU16, Arg: 3},

--- a/client_integration_test.go
+++ b/client_integration_test.go
@@ -175,6 +175,93 @@ func TestClientIncrAccumulates(t *testing.T) {
 	}
 }
 
+// TestClientOperateNoLostIncrement is the whole point of operate: many goroutines
+// hammer INCR on ONE hot key/field concurrently, and every increment must survive.
+// A client CAS-retry loop would livelock here; operate applies each op-list under
+// the shard write lock, so the final value equals the exact number of increments.
+func TestClientOperateNoLostIncrement(t *testing.T) {
+	addr, stop := startTestStack(t)
+	defer stop()
+	c, _ := client.New(client.Config{Servers: []string{addr}, MaxConnsPerServer: 8})
+	defer func() { _ = c.Close() }()
+
+	const goroutines = 24
+	const iters = 50
+	key := []byte("hot-session")
+	incr := []wire.OperateOp{{Target: wire.OperateTargetGlobal, FieldIdx: 0, Opcode: wire.OperateOpINCR, Arg: 1}}
+
+	var wg sync.WaitGroup
+	start := make(chan struct{})
+	for range goroutines {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			for range iters {
+				if _, err := c.Operate(context.Background(), key, 0, 0, incr, nil); err != nil {
+					t.Errorf("Operate: %v", err)
+					return
+				}
+			}
+		}()
+	}
+	close(start)
+	wg.Wait()
+
+	got, err := c.Operate(context.Background(), key, 0, 0, nil,
+		[]wire.OperateRet{{Target: wire.OperateTargetGlobal, FieldIdx: 0}})
+	if err != nil {
+		t.Fatalf("Operate read-back: %v", err)
+	}
+	if want := int64(goroutines * iters); got[0] != want {
+		t.Fatalf("counter = %d, want %d (increments were lost)", got[0], want)
+	}
+}
+
+// TestClientOperateUpdateAndReadBack exercises the multi-opcode update-and-read
+// round trip across globals and entry sub-records, plus the deterministic entry
+// cap.
+func TestClientOperateUpdateAndReadBack(t *testing.T) {
+	addr, stop := startTestStack(t)
+	defer stop()
+	c, _ := client.New(client.Config{Servers: []string{addr}})
+	defer func() { _ = c.Close() }()
+	ctx := context.Background()
+	key := []byte("rec")
+
+	// Guard-then-increment (HALVE_GRP overflow guard ahead of the increments), a
+	// SETMAX, and an entry counter — all in one atomic op-list.
+	ops := []wire.OperateOp{
+		{Target: wire.OperateTargetGlobal, FieldIdx: 0, Opcode: wire.OperateOpINCR, Arg: 10},
+		{Target: wire.OperateTargetGlobal, FieldIdx: 1, Opcode: wire.OperateOpSETMAX, Arg: 7},
+		{Target: wire.OperateTargetGlobal, FieldIdx: 1, Opcode: wire.OperateOpSETMAX, Arg: 3},
+		{Target: wire.OperateTargetEntry, EntryKey: 42, FieldIdx: 0, Opcode: wire.OperateOpINCR, Arg: 100},
+	}
+	ret := []wire.OperateRet{
+		{Target: wire.OperateTargetGlobal, FieldIdx: 0},
+		{Target: wire.OperateTargetGlobal, FieldIdx: 1},
+		{Target: wire.OperateTargetEntry, EntryKey: 42, FieldIdx: 0},
+	}
+	got, err := c.Operate(ctx, key, 0, 0, ops, ret)
+	if err != nil {
+		t.Fatalf("Operate: %v", err)
+	}
+	if len(got) != 3 || got[0] != 10 || got[1] != 7 || got[2] != 100 {
+		t.Fatalf("read-back = %v, want [10 7 100]", got)
+	}
+
+	// A second op-list accumulates on the committed state.
+	got, err = c.Operate(ctx, key, 0, 0,
+		[]wire.OperateOp{{Target: wire.OperateTargetGlobal, FieldIdx: 0, Opcode: wire.OperateOpINCR, Arg: 5}},
+		[]wire.OperateRet{{Target: wire.OperateTargetGlobal, FieldIdx: 0}})
+	if err != nil {
+		t.Fatalf("Operate 2: %v", err)
+	}
+	if got[0] != 15 {
+		t.Fatalf("accumulated global[0] = %d, want 15", got[0])
+	}
+}
+
 func TestClientConditionalWrites(t *testing.T) {
 	addr, stop := startTestStack(t)
 	defer stop()

--- a/client_integration_test.go
+++ b/client_integration_test.go
@@ -188,7 +188,7 @@ func TestClientOperateNoLostIncrement(t *testing.T) {
 	const goroutines = 24
 	const iters = 50
 	key := []byte("hot-session")
-	incr := []wire.OperateOp{{Target: wire.OperateTargetGlobal, FieldIdx: 0, Opcode: wire.OperateOpINCR, Arg: 1}}
+	incr := []wire.OperateOp{{Target: wire.OperateTargetGlobal, FieldIdx: 0, Opcode: wire.OperateOpINCR, Type: wire.OperateTypeU64, Arg: 1}}
 
 	var wg sync.WaitGroup
 	start := make(chan struct{})
@@ -232,10 +232,10 @@ func TestClientOperateUpdateAndReadBack(t *testing.T) {
 	// Guard-then-increment (HALVE_GRP overflow guard ahead of the increments), a
 	// SETMAX, and an entry counter — all in one atomic op-list.
 	ops := []wire.OperateOp{
-		{Target: wire.OperateTargetGlobal, FieldIdx: 0, Opcode: wire.OperateOpINCR, Arg: 10},
-		{Target: wire.OperateTargetGlobal, FieldIdx: 1, Opcode: wire.OperateOpSETMAX, Arg: 7},
-		{Target: wire.OperateTargetGlobal, FieldIdx: 1, Opcode: wire.OperateOpSETMAX, Arg: 3},
-		{Target: wire.OperateTargetEntry, EntryKey: 42, FieldIdx: 0, Opcode: wire.OperateOpINCR, Arg: 100},
+		{Target: wire.OperateTargetGlobal, FieldIdx: 0, Opcode: wire.OperateOpINCR, Type: wire.OperateTypeU16, Arg: 10},
+		{Target: wire.OperateTargetGlobal, FieldIdx: 1, Opcode: wire.OperateOpSETMAX, Type: wire.OperateTypeU16, Arg: 7},
+		{Target: wire.OperateTargetGlobal, FieldIdx: 1, Opcode: wire.OperateOpSETMAX, Type: wire.OperateTypeU16, Arg: 3},
+		{Target: wire.OperateTargetEntry, EntryKey: 42, FieldIdx: 0, Opcode: wire.OperateOpINCR, Type: wire.OperateTypeU8, Arg: 100},
 	}
 	ret := []wire.OperateRet{
 		{Target: wire.OperateTargetGlobal, FieldIdx: 0},
@@ -252,7 +252,7 @@ func TestClientOperateUpdateAndReadBack(t *testing.T) {
 
 	// A second op-list accumulates on the committed state.
 	got, err = c.Operate(ctx, key, 0, 0,
-		[]wire.OperateOp{{Target: wire.OperateTargetGlobal, FieldIdx: 0, Opcode: wire.OperateOpINCR, Arg: 5}},
+		[]wire.OperateOp{{Target: wire.OperateTargetGlobal, FieldIdx: 0, Opcode: wire.OperateOpINCR, Type: wire.OperateTypeU16, Arg: 5}},
 		[]wire.OperateRet{{Target: wire.OperateTargetGlobal, FieldIdx: 0}})
 	if err != nil {
 		t.Fatalf("Operate 2: %v", err)

--- a/docs/kv/custom-ops.md
+++ b/docs/kv/custom-ops.md
@@ -108,62 +108,15 @@ Inside a handler, `tx` gives you the shard-local store:
 | `tx.Cache()` | escape hatch to the underlying cache (stats, iteration) |
 | `tx.Vectors()` | the vector `CollectionStore` (nil if the dispatcher has none) |
 
-## Built-in generic op: `operate`
+## Don't need custom Go? Use the built-in `operate`
 
-If you don't want to compile a custom handler, the built-in **`operate`** op is a
-ready-made generic version of the `match` example above: the client sends a *list*
-of pure-integer ops and the server applies them to one record atomically, in one
-round-trip, under the shard lock — so a **hot key updated by many callers in
-parallel loses no update** (what a client CAS-retry loop can't guarantee). The
-business logic stays in your app (the op-list is data), so adding a counter never
-rebuilds Rostam.
-
-One record decodes as a small **globals** array plus a capped map of **entries**
-(`u64` → sub-record, each with a leader-stamped `touchMs` for deterministic LRU
-eviction). Fields are **typed** for memory efficiency — each field is stored
-self-describing as `[type u8][data]`, so a `u8` counter costs 2 bytes instead of 8
-(a typed session record is ~50% smaller than an all-i64 one). The app assigns each
-field index a type; the type rides the op so a field is created on first touch, and
-the **stored type wins** for a field that already exists.
-
-Field types (`wire.OperateType*`): `U8 U16 U32 U64 I8 I16 I32 I64 F32 F64 UVARINT
-IVARINT`. Fixed-width data is native little-endian; `UVARINT`/`IVARINT` are LEB128
-(IVARINT zigzag), a compact growable counter. Opcodes:
-
-| opcode | effect |
-|---|---|
-| `INCR(f, n)` / `INCRF(f, n)` | `f += n`; fixed-width ints **saturate** at the type's min/max (never wrap), floats use IEEE add (operand `n` rides `Arg` as the IEEE bit pattern) |
-| `SETMAX(f, v)` | `f = max(f, v)` in the field's domain |
-| `SHIFTOR(f, b, v)` | `f = ((f << b) \| v)` **masked to the field's bit width** (rolling window; fixed-width int only; `b` ≥ 0) |
-| `HALVE_GRP(f, thr, len)` | if `f ≥ thr`, halve the contiguous fields `[f, f+len)` per each field's type (overflow guard) |
-
-A target is a **global** field or a **(entryKey, field)** inside the map;
-referencing an absent entry upserts it (subject to `maxEntries` — `0` = unbounded —
-evicting the smallest `touchMs`, ties by smallest key). Return specs read fields
-back after the ops apply (the returned i64 is the field's raw bits — interpret per
-its type), so one call can update *and* read the record.
-
-```go
-import "github.com/rostamlabs/rostam/sdk/wire"
-
-ops := []wire.OperateOp{
-    {Target: wire.OperateTargetGlobal, FieldIdx: 0, Type: wire.OperateTypeU8, Opcode: wire.OperateOpHALVEGRP, Arg: 255, Arg2: 2}, // guard
-    {Target: wire.OperateTargetGlobal, FieldIdx: 0, Type: wire.OperateTypeU8, Opcode: wire.OperateOpINCR, Arg: 1},                 // request count (saturates at 255)
-    {Target: wire.OperateTargetEntry, EntryKey: bidderID, FieldIdx: 0, Type: wire.OperateTypeU16, Opcode: wire.OperateOpINCR, Arg: 1},
-}
-ret := []wire.OperateRet{{Target: wire.OperateTargetGlobal, FieldIdx: 0}}
-vals, err := c.Operate(ctx, []byte("session:42"), 90*time.Second, 1024, ops, ret) // vals[i] ← ret[i]
-```
-
-Wire (args): `[keyLen u16][key][ttlMs u64][maxEntries u16][nOps u32]` then per op
-`[tgt u8][entryKey u64 iff tgt=1][fieldIdx u16][opcode u8][ftype u8][arg i64][arg2 i64]`,
-then `[nReturn u16]` and per return `[tgt u8][entryKey u64 iff tgt=1][fieldIdx u16]`;
-the result is the requested field values as i64 big-endian in request order. Every
-mutation is pure integer/float arithmetic stamped only by the leader clock (and
-IEEE float encodings are deterministic), so a replicated apply is byte-identical
-across the group. The whole op-list is all-or-nothing: an invalid op (unknown
-opcode/type, negative shift, SHIFTOR on a non-fixed-int field) aborts it with the
-record unchanged.
+If your update is just atomic counter/bitfield math (like the `match` example
+above), you don't need to compile a handler at all — the built-in **`operate`** op
+is a ready-made generic version: the client sends a *list* of typed integer ops and
+the server applies them to one record atomically under the shard lock. The op-list
+is data, so the logic stays in your app. See
+[Atomic multi-field updates: `operate`](overview.md#atomic-multi-field-updates-operate).
+Reach for a custom Go op only when the math isn't expressible as that op-list.
 
 ## Native Go vs WASM
 

--- a/docs/kv/custom-ops.md
+++ b/docs/kv/custom-ops.md
@@ -112,7 +112,8 @@ Inside a handler, `tx` gives you the shard-local store:
 
 If your update is just atomic counter/bitfield math (like the `match` example
 above), you don't need to compile a handler at all — the built-in **`operate`** op
-is a ready-made generic version: the client sends a *list* of typed integer ops and
+is a ready-made generic version: the client sends a *list* of typed numeric ops
+(integer and IEEE float) and
 the server applies them to one record atomically under the shard lock. The op-list
 is data, so the logic stays in your app. See
 [Atomic multi-field updates: `operate`](overview.md#atomic-multi-field-updates-operate).

--- a/docs/kv/custom-ops.md
+++ b/docs/kv/custom-ops.md
@@ -118,41 +118,51 @@ parallel loses no update** (what a client CAS-retry loop can't guarantee). The
 business logic stays in your app (the op-list is data), so adding a counter never
 rebuilds Rostam.
 
-One record decodes as a small **globals** array (`[]i64`) plus a capped map of
-**entries** (`u64 → []i64` sub-records, each with a leader-stamped `touchMs` for
-deterministic LRU eviction). Opcodes:
+One record decodes as a small **globals** array plus a capped map of **entries**
+(`u64` → sub-record, each with a leader-stamped `touchMs` for deterministic LRU
+eviction). Fields are **typed** for memory efficiency — each field is stored
+self-describing as `[type u8][data]`, so a `u8` counter costs 2 bytes instead of 8
+(a typed session record is ~50% smaller than an all-i64 one). The app assigns each
+field index a type; the type rides the op so a field is created on first touch, and
+the **stored type wins** for a field that already exists.
+
+Field types (`wire.OperateType*`): `U8 U16 U32 U64 I8 I16 I32 I64 F32 F64 UVARINT
+IVARINT`. Fixed-width data is native little-endian; `UVARINT`/`IVARINT` are LEB128
+(IVARINT zigzag), a compact growable counter. Opcodes:
 
 | opcode | effect |
 |---|---|
-| `INCR(f, n)` / `INCRF(f, n)` | `f += n` (i64 / fixed-point) |
-| `SETMAX(f, v)` | `f = max(f, v)` |
-| `SHIFTOR(f, b, v)` | `f = (f << b) \| v` (rolling bitfield; `b` must be ≥ 0) |
-| `HALVE_GRP(f, thr, len)` | if `f ≥ thr`, halve the contiguous fields `[f, f+len)` (overflow guard) |
+| `INCR(f, n)` / `INCRF(f, n)` | `f += n`; fixed-width ints **saturate** at the type's min/max (never wrap), floats use IEEE add (operand `n` rides `Arg` as the IEEE bit pattern) |
+| `SETMAX(f, v)` | `f = max(f, v)` in the field's domain |
+| `SHIFTOR(f, b, v)` | `f = ((f << b) \| v)` **masked to the field's bit width** (rolling window; fixed-width int only; `b` ≥ 0) |
+| `HALVE_GRP(f, thr, len)` | if `f ≥ thr`, halve the contiguous fields `[f, f+len)` per each field's type (overflow guard) |
 
 A target is a **global** field or a **(entryKey, field)** inside the map;
 referencing an absent entry upserts it (subject to `maxEntries` — `0` = unbounded —
 evicting the smallest `touchMs`, ties by smallest key). Return specs read fields
-back after the ops apply, so one call can update *and* read the record.
+back after the ops apply (the returned i64 is the field's raw bits — interpret per
+its type), so one call can update *and* read the record.
 
 ```go
 import "github.com/rostamlabs/rostam/sdk/wire"
 
 ops := []wire.OperateOp{
-    {Target: wire.OperateTargetGlobal, FieldIdx: 0, Opcode: wire.OperateOpHALVEGRP, Arg: 255, Arg2: 2}, // guard
-    {Target: wire.OperateTargetGlobal, FieldIdx: 0, Opcode: wire.OperateOpINCR, Arg: 1},                 // request count
-    {Target: wire.OperateTargetEntry, EntryKey: bidderID, FieldIdx: 0, Opcode: wire.OperateOpINCR, Arg: 1},
+    {Target: wire.OperateTargetGlobal, FieldIdx: 0, Type: wire.OperateTypeU8, Opcode: wire.OperateOpHALVEGRP, Arg: 255, Arg2: 2}, // guard
+    {Target: wire.OperateTargetGlobal, FieldIdx: 0, Type: wire.OperateTypeU8, Opcode: wire.OperateOpINCR, Arg: 1},                 // request count (saturates at 255)
+    {Target: wire.OperateTargetEntry, EntryKey: bidderID, FieldIdx: 0, Type: wire.OperateTypeU16, Opcode: wire.OperateOpINCR, Arg: 1},
 }
 ret := []wire.OperateRet{{Target: wire.OperateTargetGlobal, FieldIdx: 0}}
-vals, err := c.Operate(ctx, []byte("session:42"), 90*time.Second, 1024, ops, ret) // vals[i] ← ret[i], i64
+vals, err := c.Operate(ctx, []byte("session:42"), 90*time.Second, 1024, ops, ret) // vals[i] ← ret[i]
 ```
 
 Wire (args): `[keyLen u16][key][ttlMs u64][maxEntries u16][nOps u32]` then per op
-`[tgt u8][entryKey u64 iff tgt=1][fieldIdx u16][opcode u8][arg i64][arg2 i64]`,
+`[tgt u8][entryKey u64 iff tgt=1][fieldIdx u16][opcode u8][ftype u8][arg i64][arg2 i64]`,
 then `[nReturn u16]` and per return `[tgt u8][entryKey u64 iff tgt=1][fieldIdx u16]`;
 the result is the requested field values as i64 big-endian in request order. Every
-mutation is pure integer arithmetic stamped only by the leader clock, so a
-replicated apply is byte-identical across the group. The whole op-list is
-all-or-nothing: an invalid op (unknown opcode, negative shift) aborts it with the
+mutation is pure integer/float arithmetic stamped only by the leader clock (and
+IEEE float encodings are deterministic), so a replicated apply is byte-identical
+across the group. The whole op-list is all-or-nothing: an invalid op (unknown
+opcode/type, negative shift, SHIFTOR on a non-fixed-int field) aborts it with the
 record unchanged.
 
 ## Native Go vs WASM

--- a/docs/kv/custom-ops.md
+++ b/docs/kv/custom-ops.md
@@ -108,6 +108,53 @@ Inside a handler, `tx` gives you the shard-local store:
 | `tx.Cache()` | escape hatch to the underlying cache (stats, iteration) |
 | `tx.Vectors()` | the vector `CollectionStore` (nil if the dispatcher has none) |
 
+## Built-in generic op: `operate`
+
+If you don't want to compile a custom handler, the built-in **`operate`** op is a
+ready-made generic version of the `match` example above: the client sends a *list*
+of pure-integer ops and the server applies them to one record atomically, in one
+round-trip, under the shard lock — so a **hot key updated by many callers in
+parallel loses no update** (what a client CAS-retry loop can't guarantee). The
+business logic stays in your app (the op-list is data), so adding a counter never
+rebuilds Rostam.
+
+One record decodes as a small **globals** array (`[]i64`) plus a capped map of
+**entries** (`u64 → []i64` sub-records, each with a leader-stamped `touchMs` for
+deterministic LRU eviction). Opcodes:
+
+| opcode | effect |
+|---|---|
+| `INCR(f, n)` / `INCRF(f, n)` | `f += n` (i64 / fixed-point) |
+| `SETMAX(f, v)` | `f = max(f, v)` |
+| `SHIFTOR(f, b, v)` | `f = (f << b) \| v` (rolling bitfield; `b` must be ≥ 0) |
+| `HALVE_GRP(f, thr, len)` | if `f ≥ thr`, halve the contiguous fields `[f, f+len)` (overflow guard) |
+
+A target is a **global** field or a **(entryKey, field)** inside the map;
+referencing an absent entry upserts it (subject to `maxEntries` — `0` = unbounded —
+evicting the smallest `touchMs`, ties by smallest key). Return specs read fields
+back after the ops apply, so one call can update *and* read the record.
+
+```go
+import "github.com/rostamlabs/rostam/sdk/wire"
+
+ops := []wire.OperateOp{
+    {Target: wire.OperateTargetGlobal, FieldIdx: 0, Opcode: wire.OperateOpHALVEGRP, Arg: 255, Arg2: 2}, // guard
+    {Target: wire.OperateTargetGlobal, FieldIdx: 0, Opcode: wire.OperateOpINCR, Arg: 1},                 // request count
+    {Target: wire.OperateTargetEntry, EntryKey: bidderID, FieldIdx: 0, Opcode: wire.OperateOpINCR, Arg: 1},
+}
+ret := []wire.OperateRet{{Target: wire.OperateTargetGlobal, FieldIdx: 0}}
+vals, err := c.Operate(ctx, []byte("session:42"), 90*time.Second, 1024, ops, ret) // vals[i] ← ret[i], i64
+```
+
+Wire (args): `[keyLen u16][key][ttlMs u64][maxEntries u16][nOps u32]` then per op
+`[tgt u8][entryKey u64 iff tgt=1][fieldIdx u16][opcode u8][arg i64][arg2 i64]`,
+then `[nReturn u16]` and per return `[tgt u8][entryKey u64 iff tgt=1][fieldIdx u16]`;
+the result is the requested field values as i64 big-endian in request order. Every
+mutation is pure integer arithmetic stamped only by the leader clock, so a
+replicated apply is byte-identical across the group. The whole op-list is
+all-or-nothing: an invalid op (unknown opcode, negative shift) aborts it with the
+record unchanged.
+
 ## Native Go vs WASM
 
 A native Go op lives in the server process, so it works on `Direct` and

--- a/docs/kv/overview.md
+++ b/docs/kv/overview.md
@@ -43,8 +43,10 @@ protocol over a socket.
     `r.kv.<operation>` raises `TransportError` on an HTTP-connected client (`Rostam("http://...")`);
     KV has no REST surface.
 
-Beyond get/put/del, two built-in atomic ops run server-side — no
-read-modify-write race, no extra round trips:
+Beyond get/put/del, several built-in atomic ops run server-side — no
+read-modify-write race, no extra round trips. `incr` and `expire` are shown here;
+the generic multi-field [`operate`](#atomic-multi-field-updates-operate) is below,
+and there are conditional writes (`set_nx`, `cas`, `cad`, `caex`) and more:
 
 === "Go"
 
@@ -77,7 +79,8 @@ the extension point for [custom ops](custom-ops.md) and
 
 ## Atomic multi-field updates: `operate`
 
-The built-in **`operate`** op applies a *list* of pure-integer ops to one record
+The built-in **`operate`** op applies a *list* of typed numeric ops (integer and
+IEEE float — see the type table) to one record
 atomically, server-side, in one round-trip under the shard lock — so a **hot key
 updated by many callers in parallel loses no update** (what a client CAS-retry
 loop can't guarantee). The op-list is data, so the update logic lives in your app
@@ -110,8 +113,16 @@ evicting the smallest `touchMs`, ties by smallest key). Return specs read fields
 back after the ops apply (the returned i64 is the field's raw bits — interpret per
 its type), so one call can update *and* read the record.
 
+`Operate` is a method on the smart **`client.Client`** (from `client.New`), not the
+`rostam.Store` facade:
+
 ```go
-import "github.com/rostamlabs/rostam/sdk/wire"
+import (
+    "github.com/rostamlabs/rostam/client"
+    "github.com/rostamlabs/rostam/sdk/wire"
+)
+
+c, _ := client.New(client.Config{Servers: []string{"127.0.0.1:7000"}})
 
 ops := []wire.OperateOp{
     {Target: wire.OperateTargetGlobal, FieldIdx: 0, Type: wire.OperateTypeU8, Opcode: wire.OperateOpHALVEGRP, Arg: 255, Arg2: 2}, // guard
@@ -122,15 +133,21 @@ ret := []wire.OperateRet{{Target: wire.OperateTargetGlobal, FieldIdx: 0}}
 vals, err := c.Operate(ctx, []byte("session:42"), 90*time.Second, 1024, ops, ret) // vals[i] ← ret[i]
 ```
 
-Wire (args): `[keyLen u16][key][ttlMs u64][maxEntries u16][nOps u32]` then per op
-`[tgt u8][entryKey u64 iff tgt=1][fieldIdx u16][opcode u8][ftype u8][arg i64][arg2 i64]`,
+Wire (args, **big-endian**): `[keyLen u16][key][ttlMs u64][maxEntries u16][nOps u32]`
+then per op `[tgt u8][entryKey u64 iff tgt=1][fieldIdx u16][opcode u8][ftype u8][arg i64][arg2 i64]`,
 then `[nReturn u16]` and per return `[tgt u8][entryKey u64 iff tgt=1][fieldIdx u16]`;
-the result is the requested field values as i64 big-endian in request order. Every
-mutation is pure integer/float arithmetic stamped only by the leader clock (and
-IEEE float encodings are deterministic), so a replicated apply is byte-identical
-across the group. The whole op-list is all-or-nothing: an invalid op (unknown
-opcode/type, negative shift, SHIFTOR on a non-fixed-int field) aborts it with the
-record unchanged.
+the result is the requested field values as i64 **big-endian** in request order. In
+the *stored* record, by contrast, fixed-width int/float fields are **little-endian**
+and UVARINT/IVARINT are LEB128.
+
+Every mutation is integer/float arithmetic driven only by the leader-stamped clock,
+and IEEE float encodings are deterministic — so **when apply-stamping is enabled
+(`EnableApplyStamp`)** a replicated apply is byte-identical across the group. On the
+unstamped `Direct` (single-node) path the per-entry `touchMs` falls back to the
+local wall clock (there is no follower to diverge, and it keeps LRU cap-eviction
+meaningful). The whole op-list is all-or-nothing: an invalid op (unknown
+opcode/type, negative shift, SHIFTOR on a non-fixed-int field, an out-of-range
+field or group length) aborts it with the record unchanged.
 
 ## TTL semantics
 

--- a/docs/kv/overview.md
+++ b/docs/kv/overview.md
@@ -122,7 +122,11 @@ import (
     "github.com/rostamlabs/rostam/sdk/wire"
 )
 
-c, _ := client.New(client.Config{Servers: []string{"127.0.0.1:7000"}})
+c, err := client.New(client.Config{Servers: []string{"127.0.0.1:7000"}})
+if err != nil {
+    panic(err)
+}
+defer c.Close()
 
 ops := []wire.OperateOp{
     {Target: wire.OperateTargetGlobal, FieldIdx: 0, Type: wire.OperateTypeU8, Opcode: wire.OperateOpHALVEGRP, Arg: 255, Arg2: 2}, // guard
@@ -140,14 +144,21 @@ the result is the requested field values as i64 **big-endian** in request order.
 the *stored* record, by contrast, fixed-width int/float fields are **little-endian**
 and UVARINT/IVARINT are LEB128.
 
-Every mutation is integer/float arithmetic driven only by the leader-stamped clock,
-and IEEE float encodings are deterministic — so **when apply-stamping is enabled
-(`EnableApplyStamp`)** a replicated apply is byte-identical across the group. On the
-unstamped `Direct` (single-node) path the per-entry `touchMs` falls back to the
-local wall clock (there is no follower to diverge, and it keeps LRU cap-eviction
-meaningful). The whole op-list is all-or-nothing: an invalid op (unknown
-opcode/type, negative shift, SHIFTOR on a non-fixed-int field, an out-of-range
-field or group length) aborts it with the record unchanged.
+Every mutation is integer/float arithmetic whose only external input is the
+apply-stamp clock, and IEEE float encodings are deterministic, so a replicated
+apply is byte-identical across the group. The handler never reads a wall clock —
+that would diverge, since an unstamped apply is not necessarily single-node. The
+consequence is a deliberate trade-off on the per-entry `touchMs` used for LRU
+cap-eviction: **with apply-stamping enabled (`EnableApplyStamp`)** it is the
+leader-stamped time, giving true least-recently-used eviction; **with stamping off**
+every entry shares `touchMs = 0`, so cap-eviction degrades to deterministic
+lowest-key eviction (determinism is never sacrificed for LRU quality). The entry
+map is also bounded by a hard ceiling regardless of `maxEntries`, and the record's
+total field count and size are capped, so a crafted op-list cannot exhaust memory.
+The whole op-list is all-or-nothing: an invalid op (unknown opcode/type, negative
+shift, SHIFTOR on a non-fixed-int field, an out-of-range field or group length, or
+one that would exceed the record's field/size budget) aborts it with the record
+unchanged.
 
 ## TTL semantics
 

--- a/docs/kv/overview.md
+++ b/docs/kv/overview.md
@@ -75,6 +75,63 @@ shard's Raft log on `Embedded` (and under the shard lock on `Direct`). This is
 the extension point for [custom ops](custom-ops.md) and
 [WASM procedures](wasm.md).
 
+## Atomic multi-field updates: `operate`
+
+The built-in **`operate`** op applies a *list* of pure-integer ops to one record
+atomically, server-side, in one round-trip under the shard lock — so a **hot key
+updated by many callers in parallel loses no update** (what a client CAS-retry
+loop can't guarantee). The op-list is data, so the update logic lives in your app
+and adding a counter never rebuilds Rostam. (For arbitrary Go logic, a
+[custom op](custom-ops.md) is the escape hatch; `operate` is the ready-made
+generic form.)
+
+One record decodes as a small **globals** array plus a capped map of **entries**
+(`u64` → sub-record, each with a leader-stamped `touchMs` for deterministic LRU
+eviction). Fields are **typed** for memory efficiency — each field is stored
+self-describing as `[type u8][data]`, so a `u8` counter costs 2 bytes instead of 8
+(a typed record is ~50% smaller than an all-i64 one). The app assigns each field
+index a type; the type rides the op so a field is created on first touch, and the
+**stored type wins** for a field that already exists.
+
+Field types (`wire.OperateType*`): `U8 U16 U32 U64 I8 I16 I32 I64 F32 F64 UVARINT
+IVARINT`. Fixed-width data is native little-endian; `UVARINT`/`IVARINT` are LEB128
+(IVARINT zigzag), a compact growable counter. Opcodes:
+
+| opcode | effect |
+|---|---|
+| `INCR(f, n)` / `INCRF(f, n)` | `f += n`; fixed-width ints **saturate** at the type's min/max (never wrap), floats use IEEE add (operand `n` rides `Arg` as the IEEE bit pattern) |
+| `SETMAX(f, v)` | `f = max(f, v)` in the field's domain |
+| `SHIFTOR(f, b, v)` | `f = ((f << b) \| v)` **masked to the field's bit width** (rolling window; fixed-width int only; `b` ≥ 0) |
+| `HALVE_GRP(f, thr, len)` | if `f ≥ thr`, halve the contiguous fields `[f, f+len)` per each field's type (overflow guard) |
+
+A target is a **global** field or a **(entryKey, field)** inside the map;
+referencing an absent entry upserts it (subject to `maxEntries` — `0` = unbounded —
+evicting the smallest `touchMs`, ties by smallest key). Return specs read fields
+back after the ops apply (the returned i64 is the field's raw bits — interpret per
+its type), so one call can update *and* read the record.
+
+```go
+import "github.com/rostamlabs/rostam/sdk/wire"
+
+ops := []wire.OperateOp{
+    {Target: wire.OperateTargetGlobal, FieldIdx: 0, Type: wire.OperateTypeU8, Opcode: wire.OperateOpHALVEGRP, Arg: 255, Arg2: 2}, // guard
+    {Target: wire.OperateTargetGlobal, FieldIdx: 0, Type: wire.OperateTypeU8, Opcode: wire.OperateOpINCR, Arg: 1},                 // request count (saturates at 255)
+    {Target: wire.OperateTargetEntry, EntryKey: bidderID, FieldIdx: 0, Type: wire.OperateTypeU16, Opcode: wire.OperateOpINCR, Arg: 1},
+}
+ret := []wire.OperateRet{{Target: wire.OperateTargetGlobal, FieldIdx: 0}}
+vals, err := c.Operate(ctx, []byte("session:42"), 90*time.Second, 1024, ops, ret) // vals[i] ← ret[i]
+```
+
+Wire (args): `[keyLen u16][key][ttlMs u64][maxEntries u16][nOps u32]` then per op
+`[tgt u8][entryKey u64 iff tgt=1][fieldIdx u16][opcode u8][ftype u8][arg i64][arg2 i64]`,
+then `[nReturn u16]` and per return `[tgt u8][entryKey u64 iff tgt=1][fieldIdx u16]`;
+the result is the requested field values as i64 big-endian in request order. Every
+mutation is pure integer/float arithmetic stamped only by the leader clock (and
+IEEE float encodings are deterministic), so a replicated apply is byte-identical
+across the group. The whole op-list is all-or-nothing: an invalid op (unknown
+opcode/type, negative shift, SHIFTOR on a non-fixed-int field) aborts it with the
+record unchanged.
+
 ## TTL semantics
 
 TTLs are absolute deadlines computed at write time. Expiry is enforced lazily on

--- a/ops/builtin.go
+++ b/ops/builtin.go
@@ -71,6 +71,11 @@ var builtinHandlers = map[string]Handler{
 	"incr_ex": handleIncrEx,
 	"caex":    handleCAEX,
 	"mget":    handleMGet,
+	// operate is the generic atomic multi-field update op: it decodes ONE Rostam
+	// value into {globals []i64; entries map[u64]*entry}, applies a client-supplied
+	// op-list (pure integer arithmetic, leader-stamped clock only) under the shard
+	// write lock, and writes it back in one round-trip. See handleOperate.
+	"operate": handleOperate,
 	// flush wipes the ENTIRE KV keyspace (keyless, no args). The cluster path
 	// broadcasts it to every shard group; each group applies it here against its own
 	// cache. See handleFlush.

--- a/ops/hostile_decode_test.go
+++ b/ops/hostile_decode_test.go
@@ -140,6 +140,8 @@ var hostileDecoders = []struct {
 	{"DecodeNamedSearchArgsOpts", DecodeNamedSearchArgsOpts},
 	{"DecodeNamedSparseSearchArgs", DecodeNamedSparseSearchArgs},
 	{"DecodeNamedSparseSearchArgsOpts", DecodeNamedSparseSearchArgsOpts},
+	{"DecodeOperateArgs", DecodeOperateArgs},
+	{"DecodeOperateResult", DecodeOperateResult},
 	{"DecodePayloadResult", DecodePayloadResult},
 	{"DecodePutArgs", DecodePutArgs},
 	{"DecodePutBatchArgs", DecodePutBatchArgs},
@@ -246,7 +248,7 @@ func TestNoDecoderPanicsOnHostileBytes(t *testing.T) {
 	// A floor on the roster, because the failure mode of this sweep is silent:
 	// deleting entries makes it pass faster, not fail. Raise it when decoders are
 	// added; only lower it deliberately, when an op is genuinely removed.
-	const minDecoders = 144
+	const minDecoders = 146
 	if len(hostileDecoders) < minDecoders {
 		t.Fatalf("only %d decoders in the sweep (floor %d) — entries were removed, "+
 			"which narrows the coverage without failing anything", len(hostileDecoders), minDecoders)

--- a/ops/operate.go
+++ b/ops/operate.go
@@ -1,0 +1,362 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package ops
+
+import (
+	"encoding/binary"
+	"errors"
+	"sort"
+
+	"github.com/rostamlabs/rostam/cache"
+	"github.com/rostamlabs/rostam/sdk/wire"
+)
+
+// operate is the generic atomic multi-field update op (the native alternative to a
+// client CAS-retry loop on a HOT key). One Rostam value is modelled as:
+//
+//   - globals: a small fixed []i64 array of counters.
+//   - entries: a map[u64]*operateEntry of dynamic sub-records, each a []i64 plus a
+//     leader-stamped touchMs used for DETERMINISTIC LRU eviction under a cap.
+//
+// The client sends an op-list (INCR / INCRF / SETMAX / SHIFTOR / HALVE_GRP); the
+// handler decodes the value, applies every op under the shard write lock (pure
+// integer arithmetic, the ONLY external input being the leader-stamped clock), and
+// writes it back in one round-trip. Rostam stays schema-agnostic: the app owns
+// which index means what, so a new counter is an app-side change with no rebuild.
+//
+// DETERMINISM (RF>1 safety): every mutation is integer-only; touchMs and the TTL
+// come solely from tx.applyStamp() (the leader-stamped nowMs), so a follower
+// re-applying the same committed op-list recomputes byte-identical state. The
+// encoded record sorts entries by key, and eviction picks the smallest touchMs
+// (ties → smallest key), so neither the stored bytes nor the evicted victim depend
+// on Go map iteration order.
+
+// maxOperateFields caps a globals/entry-fields array LENGTH. The record encoding
+// prefixes each array with a u16 count (nGlobals / nFields), so an array can hold
+// at most 65535 fields; a fieldIdx that would grow it past that is rejected. A
+// field index is a u16 on the wire, so the only rejected index is 65535 (which
+// would need length 65536) — 64K counters per array is ample for a session record.
+const maxOperateFields = 65535
+
+// minOperateEntryBytes is the smallest honest encoded entry: key(8) + touchMs(8) +
+// nFields(2), with zero fields. Used to bound the declared entry count in
+// decodeRec before any allocation (CountFitsIn), the same discipline the wire
+// batch decoders use.
+const minOperateEntryBytes = 18
+
+var (
+	errOperateOpcode     = errors.New("ops: operate unknown opcode")
+	errOperateShift      = errors.New("ops: operate SHIFTOR negative shift")
+	errOperateGroup      = errors.New("ops: operate HALVE_GRP group length < 1")
+	errOperateFieldRange = errors.New("ops: operate field index out of range")
+)
+
+// operateEntry is one dynamic sub-record: a small []i64 plus the leader-stamped
+// last-touch time driving deterministic LRU eviction.
+type operateEntry struct {
+	touchMs int64
+	fields  []int64
+}
+
+// operateRec is the decoded value: the globals array and the entry map.
+type operateRec struct {
+	globals []int64
+	entries map[uint64]*operateEntry
+}
+
+// handleOperate applies a client op-list to one record atomically under the shard
+// write lock. On any op error (unknown opcode, negative shift, out-of-range field)
+// it returns BEFORE the Put, so a rejected op-list leaves the record unchanged —
+// the whole operate is all-or-nothing. Registered OpReadWrite.
+func handleOperate(tx *TxContext, args []byte) ([]byte, error) {
+	key, ttl, maxEntries, opsList, ret, err := wire.DecodeOperateArgs(args)
+	if err != nil {
+		return nil, err
+	}
+	cur, err := tx.Get(key)
+	if err != nil && err != cache.ErrNotFound {
+		return nil, err
+	}
+	// cur aliases the page but decodeRec copies every int out into fresh slices, so
+	// rec retains no alias; the Put below writes an independently-built buffer.
+	rec, err := decodeRec(cur)
+	if err != nil {
+		return nil, err
+	}
+	nowMs, _ := tx.applyStamp() // leader-stamped ⇒ deterministic on followers (0 on the unstamped Direct path)
+	for _, o := range opsList {
+		if err := applyOp(&rec, o, nowMs, int(maxEntries)); err != nil {
+			return nil, err
+		}
+	}
+	if err := tx.Put(key, encodeRec(rec), ttl); err != nil {
+		return nil, err
+	}
+	return encodeReturn(&rec, ret), nil
+}
+
+// applyOp applies one op to rec. Global ops act on rec.globals; entry ops upsert
+// (and, on a new key over the cap, deterministically evict) the sub-record and
+// stamp its touchMs before acting on its fields. The target array is grown as
+// needed (bounded by maxOperateFields).
+func applyOp(rec *operateRec, o wire.OperateOp, nowMs int64, maxEntries int) error {
+	arr, err := rec.targetArray(o, nowMs, maxEntries)
+	if err != nil {
+		return err
+	}
+	switch o.Opcode {
+	case wire.OperateOpINCR, wire.OperateOpINCRF:
+		// INCRF is fixed-point add — arithmetically the same i64 addition; the
+		// fixed-point scale lives in the app's interpretation, not here.
+		a, ok := growI64(*arr, int(o.FieldIdx)+1)
+		if !ok {
+			return errOperateFieldRange
+		}
+		a[o.FieldIdx] += o.Arg
+		*arr = a
+	case wire.OperateOpSETMAX:
+		a, ok := growI64(*arr, int(o.FieldIdx)+1)
+		if !ok {
+			return errOperateFieldRange
+		}
+		if o.Arg > a[o.FieldIdx] {
+			a[o.FieldIdx] = o.Arg
+		}
+		*arr = a
+	case wire.OperateOpSHIFTOR:
+		// A negative shift count panics in Go, so reject it deterministically. A
+		// count >= 64 shifts every bit out (f<<64 == 0), so the result is just arg2 —
+		// computed explicitly to stay off the wrap path.
+		if o.Arg < 0 {
+			return errOperateShift
+		}
+		a, ok := growI64(*arr, int(o.FieldIdx)+1)
+		if !ok {
+			return errOperateFieldRange
+		}
+		if o.Arg >= 64 {
+			a[o.FieldIdx] = o.Arg2
+		} else {
+			a[o.FieldIdx] = (a[o.FieldIdx] << uint(o.Arg)) | o.Arg2
+		}
+		*arr = a
+	case wire.OperateOpHALVEGRP:
+		// HALVE_GRP(thr=Arg, len=Arg2): the group is the contiguous field range
+		// [FieldIdx, FieldIdx+len); FieldIdx is the guard field. If the guard is >=
+		// the threshold, halve every field in the group. (The fixed op wire carries
+		// one fieldIdx + two i64 args, so a group is expressed as a contiguous range
+		// rather than an explicit field list — the design's `HALVE_GRP(thr, f…)` with
+		// f… the range starting at the guard.)
+		if o.Arg2 < 1 {
+			return errOperateGroup
+		}
+		end := int(o.FieldIdx) + int(o.Arg2)
+		a, ok := growI64(*arr, end)
+		if !ok {
+			return errOperateFieldRange
+		}
+		if a[o.FieldIdx] >= o.Arg {
+			for i := int(o.FieldIdx); i < end; i++ {
+				a[i] /= 2 // integer halving; deterministic (rounds toward zero for negatives)
+			}
+		}
+		*arr = a
+	default:
+		return errOperateOpcode
+	}
+	return nil
+}
+
+// targetArray returns a pointer to the []i64 an op mutates. For a global target
+// that is &rec.globals; for an entry target it upserts the sub-record (evicting
+// deterministically if a NEW key would exceed the cap), stamps its touchMs, and
+// returns &entry.fields. Any op referencing an entry counts as a touch.
+func (rec *operateRec) targetArray(o wire.OperateOp, nowMs int64, maxEntries int) (*[]int64, error) {
+	if o.Target != wire.OperateTargetEntry {
+		return &rec.globals, nil
+	}
+	e := rec.upsertEntry(o.EntryKey, nowMs, maxEntries)
+	e.touchMs = nowMs
+	return &e.fields, nil
+}
+
+// upsertEntry returns the entry for key, creating an all-zero one (stamped
+// touchMs=nowMs) if absent. When creating would exceed maxEntries (>0) it first
+// evicts the deterministic LRU victim, so the cap holds under concurrency without
+// app coordination.
+func (rec *operateRec) upsertEntry(key uint64, nowMs int64, maxEntries int) *operateEntry {
+	if e, ok := rec.entries[key]; ok {
+		return e
+	}
+	if maxEntries > 0 && len(rec.entries) >= maxEntries {
+		rec.evictOne()
+	}
+	e := &operateEntry{touchMs: nowMs}
+	rec.entries[key] = e
+	return e
+}
+
+// evictOne removes the entry with the smallest touchMs, ties broken by the
+// smallest key. The winner is a deterministic function of the (already
+// deterministic) map contents, so it does not depend on Go's map iteration order —
+// every replica evicts the same entry.
+func (rec *operateRec) evictOne() {
+	var (
+		victim uint64
+		bestMs int64
+		found  bool
+	)
+	for k, e := range rec.entries {
+		if !found || e.touchMs < bestMs || (e.touchMs == bestMs && k < victim) {
+			victim, bestMs, found = k, e.touchMs, true
+		}
+	}
+	if found {
+		delete(rec.entries, victim)
+	}
+}
+
+// growI64 returns s grown to at least length n (zero-filled), or s unchanged when
+// it is already long enough. It returns ok=false when n exceeds maxOperateFields,
+// so a hostile field index cannot drive an unbounded allocation.
+func growI64(s []int64, n int) ([]int64, bool) {
+	if n > maxOperateFields {
+		return s, false
+	}
+	if len(s) >= n {
+		return s, true
+	}
+	ns := make([]int64, n)
+	copy(ns, s)
+	return ns, true
+}
+
+// encodeReturn reads each requested field's post-apply value (0 if the global
+// index / entry / entry field is absent) and encodes them i64 BE in request order.
+func encodeReturn(rec *operateRec, ret []wire.OperateRet) []byte {
+	if len(ret) == 0 {
+		return nil
+	}
+	vals := make([]int64, len(ret))
+	for i, r := range ret {
+		vals[i] = rec.readField(r.Target, r.EntryKey, r.FieldIdx)
+	}
+	return wire.EncodeOperateResult(vals)
+}
+
+func (rec *operateRec) readField(target uint8, entryKey uint64, fieldIdx uint16) int64 {
+	var arr []int64
+	if target == wire.OperateTargetEntry {
+		e, ok := rec.entries[entryKey]
+		if !ok {
+			return 0
+		}
+		arr = e.fields
+	} else {
+		arr = rec.globals
+	}
+	if int(fieldIdx) < len(arr) {
+		return arr[fieldIdx]
+	}
+	return 0
+}
+
+// decodeRec parses a stored operate value:
+//
+//	[nGlobals u16][global i64 × nGlobals]
+//	[nEntries u32]
+//	  per entry: [key u64][touchMs i64][nFields u16][field i64 × nFields]
+//
+// All fields are LITTLE-ENDIAN (the value model's own encoding; the arg wire is
+// big-endian, independently). nil/empty bytes decode to an empty record. Because
+// operate reads whatever value is stored under the key — which a plain put could
+// have set to arbitrary bytes — this decoder is HARDENED like the wire decoders:
+// every count is CountFitsIn-bounded before allocation and every read is
+// truncation-checked, so a malformed value returns an error, never a panic (which
+// on the replicated apply path would take down every replica).
+func decodeRec(b []byte) (operateRec, error) {
+	rec := operateRec{entries: make(map[uint64]*operateEntry)}
+	if len(b) == 0 {
+		return rec, nil
+	}
+	off := 0
+	if len(b)-off < 2 {
+		return operateRec{}, wire.ErrShortArgs
+	}
+	nGlobals := int(binary.LittleEndian.Uint16(b[off : off+2]))
+	off += 2
+	if !wire.CountFitsIn(nGlobals, len(b)-off, 8) {
+		return operateRec{}, wire.ErrShortArgs
+	}
+	if nGlobals > 0 {
+		rec.globals = make([]int64, nGlobals)
+		for i := range rec.globals {
+			rec.globals[i] = int64(binary.LittleEndian.Uint64(b[off : off+8])) //nolint:gosec // reinterpret stored u64 as i64
+			off += 8
+		}
+	}
+	if len(b)-off < 4 {
+		return operateRec{}, wire.ErrShortArgs
+	}
+	nEntries := int(binary.LittleEndian.Uint32(b[off : off+4]))
+	off += 4
+	if !wire.CountFitsIn(nEntries, len(b)-off, minOperateEntryBytes) {
+		return operateRec{}, wire.ErrShortArgs
+	}
+	for range nEntries {
+		if len(b)-off < minOperateEntryBytes {
+			return operateRec{}, wire.ErrShortArgs
+		}
+		key := binary.LittleEndian.Uint64(b[off : off+8])
+		off += 8
+		touchMs := int64(binary.LittleEndian.Uint64(b[off : off+8])) //nolint:gosec // reinterpret stored u64 as i64
+		off += 8
+		nFields := int(binary.LittleEndian.Uint16(b[off : off+2]))
+		off += 2
+		if !wire.CountFitsIn(nFields, len(b)-off, 8) {
+			return operateRec{}, wire.ErrShortArgs
+		}
+		e := &operateEntry{touchMs: touchMs}
+		if nFields > 0 {
+			e.fields = make([]int64, nFields)
+			for i := range e.fields {
+				e.fields[i] = int64(binary.LittleEndian.Uint64(b[off : off+8])) //nolint:gosec // reinterpret stored u64 as i64
+				off += 8
+			}
+		}
+		rec.entries[key] = e
+	}
+	return rec, nil
+}
+
+// encodeRec serializes rec in the decodeRec layout, LITTLE-ENDIAN, with entries
+// emitted in ASCENDING key order so the bytes are a deterministic function of the
+// record's contents (independent of Go map iteration order) — the property a
+// follower's byte-identical re-apply relies on. Trailing operations never shrink
+// the globals array, so its length is stable across a committed op-list.
+func encodeRec(rec operateRec) []byte {
+	total := 2 + len(rec.globals)*8 + 4
+	keys := make([]uint64, 0, len(rec.entries))
+	for k := range rec.entries {
+		keys = append(keys, k)
+		total += minOperateEntryBytes + len(rec.entries[k].fields)*8
+	}
+	sort.Slice(keys, func(i, j int) bool { return keys[i] < keys[j] })
+
+	buf := make([]byte, 0, total)
+	buf = binary.LittleEndian.AppendUint16(buf, uint16(len(rec.globals))) //nolint:gosec // bounded by maxOperateFields
+	for _, g := range rec.globals {
+		buf = binary.LittleEndian.AppendUint64(buf, uint64(g)) //nolint:gosec // reinterpret i64 as u64
+	}
+	buf = binary.LittleEndian.AppendUint32(buf, uint32(len(keys))) //nolint:gosec // entry count
+	for _, k := range keys {
+		e := rec.entries[k]
+		buf = binary.LittleEndian.AppendUint64(buf, k)
+		buf = binary.LittleEndian.AppendUint64(buf, uint64(e.touchMs))     //nolint:gosec // reinterpret i64 as u64
+		buf = binary.LittleEndian.AppendUint16(buf, uint16(len(e.fields))) //nolint:gosec // bounded by maxOperateFields
+		for _, f := range e.fields {
+			buf = binary.LittleEndian.AppendUint64(buf, uint64(f)) //nolint:gosec // reinterpret i64 as u64
+		}
+	}
+	return buf
+}

--- a/ops/operate.go
+++ b/ops/operate.go
@@ -47,22 +47,32 @@ import (
 const maxOperateFields = 65535
 
 // minOperateEntryBytes is the smallest honest encoded entry: key(8) + touchMs(8) +
-// nFields(2), with zero fields. minOperateFieldBytes is the smallest field: a
-// type tag + one data byte (U8/I8, or a 1-byte varint). Both bound declared counts
-// in decodeRec before any allocation (CountFitsIn), the wire batch-decoder
+// nFields(2), with zero fields. minOperateFieldBytes is the smallest field: a bare
+// type tag with no data (an UNSET hole is exactly 1 byte). Both bound declared
+// counts in decodeRec before any allocation (CountFitsIn), the wire batch-decoder
 // discipline.
 const (
 	minOperateEntryBytes = 18
-	minOperateFieldBytes = 2
+	minOperateFieldBytes = 1
 )
 
+// maxOperateRecordBytes caps the encoded record size. It guards against a
+// pathological op-list (up to 65535 entries × 65535 fields) building a value so
+// large the Put would fail cryptically deep in the cache write path; instead the
+// op returns errOperateRecordTooLarge cleanly, atomically (before the Put), with
+// the record unchanged. 16 MiB is far beyond any real session record yet well
+// under the cache's hard value limit (~4 GiB). A var (not const) only so a focused
+// test can lower it to exercise the guard cheaply.
+var maxOperateRecordBytes = 16 << 20
+
 var (
-	errOperateOpcode     = errors.New("ops: operate unknown opcode")
-	errOperateShift      = errors.New("ops: operate SHIFTOR negative shift")
-	errOperateShiftType  = errors.New("ops: operate SHIFTOR requires a fixed-width int field")
-	errOperateGroup      = errors.New("ops: operate HALVE_GRP group length < 1")
-	errOperateFieldRange = errors.New("ops: operate field index out of range")
-	errOperateType       = errors.New("ops: operate unknown field type")
+	errOperateOpcode         = errors.New("ops: operate unknown opcode")
+	errOperateShift          = errors.New("ops: operate SHIFTOR negative shift")
+	errOperateShiftType      = errors.New("ops: operate SHIFTOR requires a fixed-width int field")
+	errOperateGroup          = errors.New("ops: operate HALVE_GRP group length out of range")
+	errOperateFieldRange     = errors.New("ops: operate field index out of range")
+	errOperateType           = errors.New("ops: operate unknown field type")
+	errOperateRecordTooLarge = errors.New("ops: operate record exceeds max size")
 )
 
 // operateField is one typed field. Integer/varint values live in u (unsigned types
@@ -107,13 +117,27 @@ func handleOperate(tx *TxContext, args []byte) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	nowMs, _ := tx.applyStamp() // leader-stamped ⇒ deterministic on followers (0 on the unstamped Direct path)
+	// touchMs source: the leader-stamped clock on the replicated path (deterministic
+	// across replicas — every follower re-applies with the identical stamp), else
+	// the cache's effective wall clock on the Direct/single-node path. Using the
+	// wall clock when unstamped is safe (no follower to diverge) and gives real LRU
+	// ordering for cap-eviction — without it every Direct entry would share touchMs=0
+	// and eviction would degrade to lowest-key. It is the same clock ttl/get read on
+	// the unstamped path (tx.Cache().NowMs()), so liveness and touch agree.
+	nowMs, stamped := tx.applyStamp()
+	if !stamped {
+		nowMs = int64(tx.Cache().NowMs()) //nolint:gosec // ms timestamp fits int64
+	}
 	for _, o := range opsList {
 		if err := applyOp(&rec, o, nowMs, int(maxEntries)); err != nil {
 			return nil, err
 		}
 	}
-	if err := tx.Put(key, encodeRec(rec), ttl); err != nil {
+	enc := encodeRec(rec)
+	if len(enc) > maxOperateRecordBytes {
+		return nil, errOperateRecordTooLarge
+	}
+	if err := tx.Put(key, enc, ttl); err != nil {
 		return nil, err
 	}
 	return encodeReturn(&rec, ret), nil
@@ -131,11 +155,12 @@ func applyOp(rec *operateRec, o wire.OperateOp, nowMs int64, maxEntries int) err
 	switch o.Opcode {
 	case wire.OperateOpINCR, wire.OperateOpINCRF, wire.OperateOpSETMAX, wire.OperateOpSHIFTOR:
 		idx := int(o.FieldIdx)
-		arr, ok := ensureLen(*arrp, idx+1, o.Type)
+		arr, ok := ensureLen(*arrp, idx+1)
 		if !ok {
 			return errOperateFieldRange
 		}
 		*arrp = arr
+		adoptType(&arr[idx], o.Type) // a hole or new slot takes this write's type; a real type stays
 		return applyScalar(&arr[idx], o.Opcode, o.Arg, o.Arg2)
 	case wire.OperateOpHALVEGRP:
 		// HALVE_GRP(thr=Arg, len=Arg2): the group is the contiguous field range
@@ -144,12 +169,17 @@ func applyOp(rec *operateRec, o wire.OperateOp, nowMs int64, maxEntries int) err
 		// wire carries one fieldIdx + two i64 args, so a group is a contiguous range
 		// rather than an explicit field list — the design's `HALVE_GRP(thr, f…)` with
 		// f… the range starting at the guard.)
-		if o.Arg2 < 1 {
+		//
+		// Bound Arg2 BEFORE computing end: an unbounded group length would overflow
+		// `idx + int(Arg2)` (CWE-190) and then index out of range in the loop below —
+		// on the replicated apply path that would panic every replica's FSM. Rejecting
+		// aborts the whole op-list atomically with the record unchanged.
+		if o.Arg2 < 1 || o.Arg2 > maxOperateFields {
 			return errOperateGroup
 		}
 		idx := int(o.FieldIdx)
-		end := idx + int(o.Arg2)
-		arr, ok := ensureLen(*arrp, end, o.Type)
+		end := idx + int(o.Arg2) // safe: idx <= 65535, Arg2 <= 65535 ⇒ no int overflow
+		arr, ok := ensureLen(*arrp, end)
 		if !ok {
 			return errOperateFieldRange
 		}
@@ -330,29 +360,29 @@ func (rec *operateRec) evictOne() {
 	}
 }
 
-// ensureLen grows arr to at least length n, filling holes below the top with a U8
-// zero and creating the top slot (index n-1) with newType. It returns arr
-// unchanged when already long enough (the STORED field type wins for an existing
-// index). ok=false when n exceeds maxOperateFields or a to-be-created top slot's
-// newType is unknown.
-func ensureLen(arr []operateField, n int, newType uint8) ([]operateField, bool) {
+// ensureLen grows arr to at least length n, filling every new slot with an UNSET
+// hole (a 1-byte zero-valued placeholder that adopts its real type on first
+// write). It returns arr unchanged when already long enough. ok=false when n
+// exceeds maxOperateFields. Growth NEVER assigns a real type — so a field's type
+// is set only by its first real write (adoptType), never by the order in which
+// higher indices were touched.
+func ensureLen(arr []operateField, n int) ([]operateField, bool) {
 	if n > maxOperateFields {
 		return arr, false
 	}
-	if n <= len(arr) {
-		return arr, true
-	}
-	if newType >= wire.OperateTypeCount {
-		return arr, false
-	}
 	for len(arr) < n {
-		if len(arr) == n-1 {
-			arr = append(arr, operateField{typ: newType}) // the addressed field
-		} else {
-			arr = append(arr, operateField{typ: wire.OperateTypeU8}) // a hole
-		}
+		arr = append(arr, operateField{typ: wire.OperateTypeUnset})
 	}
 	return arr, true
+}
+
+// adoptType sets an UNSET hole's type to newType (its first real write); a field
+// that already has a real type keeps it (the stored type wins), so a repeated or
+// wider-then-narrower write cannot change a field's type or silently truncate.
+func adoptType(f *operateField, newType uint8) {
+	if f.typ == wire.OperateTypeUnset {
+		f.typ = newType
+	}
 }
 
 // encodeReturn reads each requested field's post-apply raw bits (0 if the index /
@@ -616,6 +646,8 @@ func decodeField(b []byte) (operateField, int, error) {
 	f := operateField{typ: t}
 	need := func(n int) bool { return len(b)-off >= n }
 	switch t {
+	case wire.OperateTypeUnset:
+		// A hole: the 1-byte tag carries no data and decodes to a zero value.
 	case wire.OperateTypeU8:
 		if !need(1) {
 			return operateField{}, 0, wire.ErrShortArgs
@@ -724,6 +756,8 @@ func encodeRec(rec operateRec) []byte {
 func encodeField(buf []byte, f operateField) []byte {
 	buf = append(buf, f.typ)
 	switch f.typ {
+	case wire.OperateTypeUnset:
+		// A hole: just the 1-byte tag, no data.
 	case wire.OperateTypeU8, wire.OperateTypeI8:
 		buf = append(buf, byte(f.u))
 	case wire.OperateTypeU16, wire.OperateTypeI16:

--- a/ops/operate.go
+++ b/ops/operate.go
@@ -34,11 +34,16 @@ import (
 //     old bits fall off); it is rejected on varint and float types.
 //   - HALVE_GRP halves each field in the group per that field's own type.
 //
-// DETERMINISM (RF>1 safety): every mutation is integer/float-only; touchMs and the
-// TTL come solely from tx.applyStamp() (the leader-stamped nowMs); float encodings
-// are IEEE-deterministic; the record encodes entries sorted by key and fields in
-// index order; eviction picks the smallest touchMs (ties → smallest key). A
-// follower re-applying the same committed op-list recomputes byte-identical state.
+// DETERMINISM (RF>1 safety): every mutation is integer/float-only; the ONLY
+// external input is tx.applyStamp() — the leader-stamped nowMs when apply-stamping
+// is enabled, else 0 — used for touchMs and the TTL; float encodings are
+// IEEE-deterministic; the record encodes entries sorted by key and fields in index
+// order; eviction picks the smallest touchMs (ties → smallest key). A follower
+// re-applying the same committed op-list recomputes byte-identical state. We never
+// read a wall clock: applyStamp==false does NOT imply single-node (a replicated
+// apply with EnableApplyStamp off lands there too), so a per-replica wall clock
+// would diverge. The cost is that with stamping off every entry shares touchMs=0
+// and cap-eviction degrades to deterministic lowest-key; true-LRU needs stamping.
 
 // maxOperateFields caps a globals/entry-fields array LENGTH. The record encoding
 // prefixes each array with a u16 count, so an array holds at most 65535 fields; a
@@ -56,13 +61,31 @@ const (
 	minOperateFieldBytes = 1
 )
 
-// maxOperateRecordBytes caps the encoded record size. It guards against a
-// pathological op-list (up to 65535 entries × 65535 fields) building a value so
-// large the Put would fail cryptically deep in the cache write path; instead the
-// op returns errOperateRecordTooLarge cleanly, atomically (before the Put), with
-// the record unchanged. 16 MiB is far beyond any real session record yet well
-// under the cache's hard value limit (~4 GiB). A var (not const) only so a focused
-// test can lower it to exercise the guard cheaply.
+// maxOperateEntries is the HARD ceiling on the entry map, enforced regardless of
+// the wire maxEntries (which is a u16, and where 0 means "no app cap"). It bounds
+// the entry-map allocation for a maxEntries=0 op-list; beyond it, upsert evicts the
+// LRU victim so the map never grows past the ceiling. 65535 matches the u16
+// maxEntries range, so maxEntries=0 behaves as maxEntries=65535 (LRU-capped).
+const maxOperateEntries = 65535
+
+// maxOperateTotalFields is the HARD ceiling on the TOTAL number of fields
+// materialized across the whole record (globals + every entry). It is enforced
+// INCREMENTALLY as arrays grow (grow()), BEFORE any allocation, so a crafted
+// op-list of many entries each growing a large UNSET-hole array cannot allocate
+// gigabytes of operateField before a post-encode check — the classic amplification
+// DoS. 1<<20 fields bounds the in-memory record to a few tens of MiB and is far
+// beyond any real session record (hundreds of counters). maxOperateFields still
+// caps EACH array; this caps their sum.
+const maxOperateTotalFields = 1 << 20
+
+// maxOperateRecordBytes is a BACKSTOP cap on the encoded record size, checked
+// after encodeRec. The incremental entry/field ceilings above are the primary
+// defence (they reject before the big allocation); this catches a record whose
+// bytes exceed the cache-value budget even within those counts (e.g. many wide
+// fields), returning errOperateRecordTooLarge cleanly and atomically (before the
+// Put) rather than failing cryptically deep in the cache write path. 16 MiB is far
+// beyond any real session record yet well under the cache's hard value limit
+// (~4 GiB). A var (not const) only so a focused test can lower it cheaply.
 var maxOperateRecordBytes = 16 << 20
 
 var (
@@ -91,10 +114,13 @@ type operateEntry struct {
 	fields  []operateField
 }
 
-// operateRec is the decoded value: the globals array and the entry map.
+// operateRec is the decoded value: the globals array and the entry map. fieldTotal
+// tracks the sum of all array lengths (globals + every entry's fields) so grow()
+// can enforce maxOperateTotalFields incrementally, before allocating.
 type operateRec struct {
-	globals []operateField
-	entries map[uint64]*operateEntry
+	globals    []operateField
+	entries    map[uint64]*operateEntry
+	fieldTotal int
 }
 
 // handleOperate applies a client op-list to one record atomically under the shard
@@ -117,17 +143,18 @@ func handleOperate(tx *TxContext, args []byte) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	// touchMs source: the leader-stamped clock on the replicated path (deterministic
-	// across replicas — every follower re-applies with the identical stamp), else
-	// the cache's effective wall clock on the Direct/single-node path. Using the
-	// wall clock when unstamped is safe (no follower to diverge) and gives real LRU
-	// ordering for cap-eviction — without it every Direct entry would share touchMs=0
-	// and eviction would degrade to lowest-key. It is the same clock ttl/get read on
-	// the unstamped path (tx.Cache().NowMs()), so liveness and touch agree.
-	nowMs, stamped := tx.applyStamp()
-	if !stamped {
-		nowMs = int64(tx.Cache().NowMs()) //nolint:gosec // ms timestamp fits int64
-	}
+	// touchMs is the ONLY external input, and it MUST be identical on every replica
+	// or the encoded record diverges. applyStamp returns the leader-stamped clock
+	// when apply-stamping is enabled (deterministic — every replica re-applies with
+	// the identical stamp) and 0 otherwise. We deliberately do NOT fall back to a
+	// wall clock when unstamped: applyStamp==false does NOT mean single-node — a
+	// REPLICATED apply with EnableApplyStamp off also lands here, and reading each
+	// replica's own wall clock would write divergent touchMs → divergent record bytes
+	// → possibly different LRU victims → cluster divergence. Determinism wins over LRU
+	// quality: with stamping off every entry shares touchMs=0, so cap-eviction
+	// degrades to deterministic lowest-key (documented in docs/kv/overview.md).
+	// True-LRU cap-eviction therefore requires apply-stamping (EnableApplyStamp).
+	nowMs, _ := tx.applyStamp()
 	for _, o := range opsList {
 		if err := applyOp(&rec, o, nowMs, int(maxEntries)); err != nil {
 			return nil, err
@@ -155,11 +182,10 @@ func applyOp(rec *operateRec, o wire.OperateOp, nowMs int64, maxEntries int) err
 	switch o.Opcode {
 	case wire.OperateOpINCR, wire.OperateOpINCRF, wire.OperateOpSETMAX, wire.OperateOpSHIFTOR:
 		idx := int(o.FieldIdx)
-		arr, ok := ensureLen(*arrp, idx+1)
-		if !ok {
+		if !rec.grow(arrp, idx+1) {
 			return errOperateFieldRange
 		}
-		*arrp = arr
+		arr := *arrp
 		adoptType(&arr[idx], o.Type) // a hole or new slot takes this write's type; a real type stays
 		return applyScalar(&arr[idx], o.Opcode, o.Arg, o.Arg2)
 	case wire.OperateOpHALVEGRP:
@@ -179,11 +205,17 @@ func applyOp(rec *operateRec, o wire.OperateOp, nowMs int64, maxEntries int) err
 		}
 		idx := int(o.FieldIdx)
 		end := idx + int(o.Arg2) // safe: idx <= 65535, Arg2 <= 65535 ⇒ no int overflow
-		arr, ok := ensureLen(*arrp, end)
-		if !ok {
+		if !rec.grow(arrp, end) {
 			return errOperateFieldRange
 		}
-		*arrp = arr
+		arr := *arrp
+		// The group carries ONE declared type (o.Type). Any UNSET slot the group
+		// materializes adopts it now, so the field's effective type is fixed by this
+		// op and a later write can't adopt a different (e.g. wider) type and bypass the
+		// group's saturation. A slot that already has a real type keeps it.
+		for i := idx; i < end; i++ {
+			adoptType(&arr[i], o.Type)
+		}
 		if guardTriggered(&arr[idx], o.Arg) {
 			for i := idx; i < end; i++ {
 				halveField(&arr[i])
@@ -326,15 +358,23 @@ func (rec *operateRec) targetArray(o wire.OperateOp, nowMs int64, maxEntries int
 }
 
 // upsertEntry returns the entry for key, creating an empty one (stamped
-// touchMs=nowMs) if absent. When creating would exceed maxEntries (>0) it first
-// evicts the deterministic LRU victim, so the cap holds under concurrency without
-// app coordination.
+// touchMs=nowMs) if absent. The entry map is bounded by a HARD ceiling
+// (maxOperateEntries) as well as any app-supplied maxEntries (>0): before creating
+// a new entry it evicts LRU victims until the map is below the effective cap, so a
+// maxEntries=0 ("no app cap") op-list still cannot grow the map without bound. The
+// loop also trims a stored record whose entry count already exceeds the cap.
 func (rec *operateRec) upsertEntry(key uint64, nowMs int64, maxEntries int) *operateEntry {
 	if e, ok := rec.entries[key]; ok {
 		return e
 	}
-	if maxEntries > 0 && len(rec.entries) >= maxEntries {
-		rec.evictOne()
+	effCap := maxOperateEntries
+	if maxEntries > 0 && maxEntries < effCap {
+		effCap = maxEntries
+	}
+	for len(rec.entries) >= effCap {
+		if !rec.evictOne() {
+			break
+		}
 	}
 	e := &operateEntry{touchMs: nowMs}
 	rec.entries[key] = e
@@ -343,8 +383,10 @@ func (rec *operateRec) upsertEntry(key uint64, nowMs int64, maxEntries int) *ope
 
 // evictOne removes the entry with the smallest touchMs, ties broken by the
 // smallest key — a deterministic function of the (already deterministic) map
-// contents, so every replica evicts the same entry regardless of map order.
-func (rec *operateRec) evictOne() {
+// contents, so every replica evicts the same entry regardless of map order. It
+// subtracts the victim's field count from fieldTotal and reports whether an entry
+// was removed (false only when the map is already empty).
+func (rec *operateRec) evictOne() bool {
 	var (
 		victim uint64
 		bestMs int64
@@ -355,25 +397,40 @@ func (rec *operateRec) evictOne() {
 			victim, bestMs, found = k, e.touchMs, true
 		}
 	}
-	if found {
-		delete(rec.entries, victim)
+	if !found {
+		return false
 	}
+	rec.fieldTotal -= len(rec.entries[victim].fields)
+	delete(rec.entries, victim)
+	return true
 }
 
-// ensureLen grows arr to at least length n, filling every new slot with an UNSET
-// hole (a 1-byte zero-valued placeholder that adopts its real type on first
-// write). It returns arr unchanged when already long enough. ok=false when n
-// exceeds maxOperateFields. Growth NEVER assigns a real type — so a field's type
-// is set only by its first real write (adoptType), never by the order in which
+// grow grows the array *arrp to at least length n, filling every new slot with an
+// UNSET hole (a 1-byte zero-valued placeholder that adopts its real type on first
+// write). It returns false — WITHOUT allocating — when n would exceed the per-array
+// cap (maxOperateFields) or the whole-record field budget (maxOperateTotalFields),
+// so a crafted op-list cannot amplify a small request into a gigabyte allocation.
+// On success it updates rec.fieldTotal. Growth NEVER assigns a real type: a field's
+// type is set only by its first real write (adoptType), never by the order in which
 // higher indices were touched.
-func ensureLen(arr []operateField, n int) ([]operateField, bool) {
+func (rec *operateRec) grow(arrp *[]operateField, n int) bool {
+	arr := *arrp
+	if n <= len(arr) {
+		return true
+	}
 	if n > maxOperateFields {
-		return arr, false
+		return false
+	}
+	delta := n - len(arr)
+	if rec.fieldTotal+delta > maxOperateTotalFields {
+		return false
 	}
 	for len(arr) < n {
 		arr = append(arr, operateField{typ: wire.OperateTypeUnset})
 	}
-	return arr, true
+	rec.fieldTotal += delta
+	*arrp = arr
+	return true
 }
 
 // adoptType sets an UNSET hole's type to newType (its first real write); a field
@@ -579,9 +636,16 @@ func decodeRec(b []byte) (operateRec, error) {
 	}
 	nGlobals := int(binary.LittleEndian.Uint16(b[off : off+2]))
 	off += 2
-	if !wire.CountFitsIn(nGlobals, len(b)-off, minOperateFieldBytes) {
+	// Two guards beyond CountFitsIn's byte bound: cap the whole-record field count and
+	// the entry count at the SAME hard ceilings the write path enforces, so a hostile
+	// raw put of a huge value (operate reads whatever bytes are stored under the key)
+	// cannot make decodeRec itself allocate gigabytes of fields/entries. operate never
+	// writes past these ceilings, so a record exceeding them is corrupt/hostile and is
+	// rejected rather than materialized.
+	if !wire.CountFitsIn(nGlobals, len(b)-off, minOperateFieldBytes) || nGlobals > maxOperateTotalFields {
 		return operateRec{}, wire.ErrShortArgs
 	}
+	total := nGlobals
 	if nGlobals > 0 {
 		rec.globals = make([]operateField, nGlobals)
 		for i := range rec.globals {
@@ -598,7 +662,7 @@ func decodeRec(b []byte) (operateRec, error) {
 	}
 	nEntries := int(binary.LittleEndian.Uint32(b[off : off+4]))
 	off += 4
-	if !wire.CountFitsIn(nEntries, len(b)-off, minOperateEntryBytes) {
+	if !wire.CountFitsIn(nEntries, len(b)-off, minOperateEntryBytes) || nEntries > maxOperateEntries {
 		return operateRec{}, wire.ErrShortArgs
 	}
 	for range nEntries {
@@ -611,9 +675,11 @@ func decodeRec(b []byte) (operateRec, error) {
 		off += 8
 		nFields := int(binary.LittleEndian.Uint16(b[off : off+2]))
 		off += 2
-		if !wire.CountFitsIn(nFields, len(b)-off, minOperateFieldBytes) {
+		// Bound the cumulative field count before allocating this entry's array.
+		if !wire.CountFitsIn(nFields, len(b)-off, minOperateFieldBytes) || total+nFields > maxOperateTotalFields {
 			return operateRec{}, wire.ErrShortArgs
 		}
+		total += nFields
 		e := &operateEntry{touchMs: touchMs}
 		if nFields > 0 {
 			e.fields = make([]operateField, nFields)
@@ -628,6 +694,7 @@ func decodeRec(b []byte) (operateRec, error) {
 		}
 		rec.entries[key] = e
 	}
+	rec.fieldTotal = total
 	return rec, nil
 }
 

--- a/ops/operate.go
+++ b/ops/operate.go
@@ -5,6 +5,7 @@ package ops
 import (
 	"encoding/binary"
 	"errors"
+	"math"
 	"sort"
 
 	"github.com/rostamlabs/rostam/cache"
@@ -14,60 +15,83 @@ import (
 // operate is the generic atomic multi-field update op (the native alternative to a
 // client CAS-retry loop on a HOT key). One Rostam value is modelled as:
 //
-//   - globals: a small fixed []i64 array of counters.
-//   - entries: a map[u64]*operateEntry of dynamic sub-records, each a []i64 plus a
-//     leader-stamped touchMs used for DETERMINISTIC LRU eviction under a cap.
+//   - globals: a small array of TYPED counters.
+//   - entries: a map[u64]*operateEntry of dynamic sub-records, each a typed field
+//     array plus a leader-stamped touchMs used for DETERMINISTIC LRU eviction.
 //
-// The client sends an op-list (INCR / INCRF / SETMAX / SHIFTOR / HALVE_GRP); the
-// handler decodes the value, applies every op under the shard write lock (pure
-// integer arithmetic, the ONLY external input being the leader-stamped clock), and
-// writes it back in one round-trip. Rostam stays schema-agnostic: the app owns
-// which index means what, so a new counter is an app-side change with no rebuild.
+// Fields are TYPED for memory efficiency: each field is stored self-describing as
+// [type u8][data], where data is the native fixed width (1/2/4/8 bytes for
+// U8..I64), 4/8 bytes for F32/F64, or LEB128 for UVARINT/IVARINT (zigzag). A u8
+// counter costs 2 bytes instead of 8. The app owns which type each field is; the
+// type rides the op-entry so a field is created on first touch, and the STORED
+// type wins for a field that already exists (the op's type is ignored then).
 //
-// DETERMINISM (RF>1 safety): every mutation is integer-only; touchMs and the TTL
-// come solely from tx.applyStamp() (the leader-stamped nowMs), so a follower
-// re-applying the same committed op-list recomputes byte-identical state. The
-// encoded record sorts entries by key, and eviction picks the smallest touchMs
-// (ties → smallest key), so neither the stored bytes nor the evicted victim depend
-// on Go map iteration order.
+// Per-type arithmetic (all internal math in i64/u64/f64, stored back per type):
+//   - INCR/INCRF/SETMAX on a fixed-width INT type SATURATE at that type's min/max
+//     (never wrap); on a float type they use IEEE math; UVARINT/IVARINT saturate
+//     only at the u64/i64 boundary (effectively uncapped, byte length may change).
+//   - SHIFTOR on a fixed-width int MASKS to the field's bit width (rolling window,
+//     old bits fall off); it is rejected on varint and float types.
+//   - HALVE_GRP halves each field in the group per that field's own type.
+//
+// DETERMINISM (RF>1 safety): every mutation is integer/float-only; touchMs and the
+// TTL come solely from tx.applyStamp() (the leader-stamped nowMs); float encodings
+// are IEEE-deterministic; the record encodes entries sorted by key and fields in
+// index order; eviction picks the smallest touchMs (ties → smallest key). A
+// follower re-applying the same committed op-list recomputes byte-identical state.
 
 // maxOperateFields caps a globals/entry-fields array LENGTH. The record encoding
-// prefixes each array with a u16 count (nGlobals / nFields), so an array can hold
-// at most 65535 fields; a fieldIdx that would grow it past that is rejected. A
-// field index is a u16 on the wire, so the only rejected index is 65535 (which
-// would need length 65536) — 64K counters per array is ample for a session record.
+// prefixes each array with a u16 count, so an array holds at most 65535 fields; a
+// fieldIdx that would grow it past that is rejected. 64K counters per array is
+// ample for a session record.
 const maxOperateFields = 65535
 
 // minOperateEntryBytes is the smallest honest encoded entry: key(8) + touchMs(8) +
-// nFields(2), with zero fields. Used to bound the declared entry count in
-// decodeRec before any allocation (CountFitsIn), the same discipline the wire
-// batch decoders use.
-const minOperateEntryBytes = 18
+// nFields(2), with zero fields. minOperateFieldBytes is the smallest field: a
+// type tag + one data byte (U8/I8, or a 1-byte varint). Both bound declared counts
+// in decodeRec before any allocation (CountFitsIn), the wire batch-decoder
+// discipline.
+const (
+	minOperateEntryBytes = 18
+	minOperateFieldBytes = 2
+)
 
 var (
 	errOperateOpcode     = errors.New("ops: operate unknown opcode")
 	errOperateShift      = errors.New("ops: operate SHIFTOR negative shift")
+	errOperateShiftType  = errors.New("ops: operate SHIFTOR requires a fixed-width int field")
 	errOperateGroup      = errors.New("ops: operate HALVE_GRP group length < 1")
 	errOperateFieldRange = errors.New("ops: operate field index out of range")
+	errOperateType       = errors.New("ops: operate unknown field type")
 )
 
-// operateEntry is one dynamic sub-record: a small []i64 plus the leader-stamped
-// last-touch time driving deterministic LRU eviction.
+// operateField is one typed field. Integer/varint values live in u (unsigned types
+// hold the value; signed types hold the sign-extended two's-complement, read via
+// int64(u)); float values live in f. typ selects which and how it encodes.
+type operateField struct {
+	typ uint8
+	u   uint64
+	f   float64
+}
+
+// operateEntry is one dynamic sub-record: a typed field array plus the
+// leader-stamped last-touch time driving deterministic LRU eviction.
 type operateEntry struct {
 	touchMs int64
-	fields  []int64
+	fields  []operateField
 }
 
 // operateRec is the decoded value: the globals array and the entry map.
 type operateRec struct {
-	globals []int64
+	globals []operateField
 	entries map[uint64]*operateEntry
 }
 
 // handleOperate applies a client op-list to one record atomically under the shard
-// write lock. On any op error (unknown opcode, negative shift, out-of-range field)
-// it returns BEFORE the Put, so a rejected op-list leaves the record unchanged —
-// the whole operate is all-or-nothing. Registered OpReadWrite.
+// write lock. On any op error (unknown opcode/type, negative shift, SHIFTOR on a
+// non-int field, out-of-range field) it returns BEFORE the Put, so a rejected
+// op-list leaves the record unchanged — the whole operate is all-or-nothing.
+// Registered OpReadWrite.
 func handleOperate(tx *TxContext, args []byte) ([]byte, error) {
 	key, ttl, maxEntries, opsList, ret, err := wire.DecodeOperateArgs(args)
 	if err != nil {
@@ -77,7 +101,7 @@ func handleOperate(tx *TxContext, args []byte) ([]byte, error) {
 	if err != nil && err != cache.ErrNotFound {
 		return nil, err
 	}
-	// cur aliases the page but decodeRec copies every int out into fresh slices, so
+	// cur aliases the page but decodeRec copies every value out into fresh fields, so
 	// rec retains no alias; the Put below writes an independently-built buffer.
 	rec, err := decodeRec(cur)
 	if err != nil {
@@ -98,80 +122,171 @@ func handleOperate(tx *TxContext, args []byte) ([]byte, error) {
 // applyOp applies one op to rec. Global ops act on rec.globals; entry ops upsert
 // (and, on a new key over the cap, deterministically evict) the sub-record and
 // stamp its touchMs before acting on its fields. The target array is grown as
-// needed (bounded by maxOperateFields).
+// needed (bounded by maxOperateFields), creating new fields with the op's type.
 func applyOp(rec *operateRec, o wire.OperateOp, nowMs int64, maxEntries int) error {
-	arr, err := rec.targetArray(o, nowMs, maxEntries)
+	arrp, err := rec.targetArray(o, nowMs, maxEntries)
 	if err != nil {
 		return err
 	}
 	switch o.Opcode {
-	case wire.OperateOpINCR, wire.OperateOpINCRF:
-		// INCRF is fixed-point add — arithmetically the same i64 addition; the
-		// fixed-point scale lives in the app's interpretation, not here.
-		a, ok := growI64(*arr, int(o.FieldIdx)+1)
+	case wire.OperateOpINCR, wire.OperateOpINCRF, wire.OperateOpSETMAX, wire.OperateOpSHIFTOR:
+		idx := int(o.FieldIdx)
+		arr, ok := ensureLen(*arrp, idx+1, o.Type)
 		if !ok {
 			return errOperateFieldRange
 		}
-		a[o.FieldIdx] += o.Arg
-		*arr = a
-	case wire.OperateOpSETMAX:
-		a, ok := growI64(*arr, int(o.FieldIdx)+1)
-		if !ok {
-			return errOperateFieldRange
-		}
-		if o.Arg > a[o.FieldIdx] {
-			a[o.FieldIdx] = o.Arg
-		}
-		*arr = a
-	case wire.OperateOpSHIFTOR:
-		// A negative shift count panics in Go, so reject it deterministically. A
-		// count >= 64 shifts every bit out (f<<64 == 0), so the result is just arg2 —
-		// computed explicitly to stay off the wrap path.
-		if o.Arg < 0 {
-			return errOperateShift
-		}
-		a, ok := growI64(*arr, int(o.FieldIdx)+1)
-		if !ok {
-			return errOperateFieldRange
-		}
-		if o.Arg >= 64 {
-			a[o.FieldIdx] = o.Arg2
-		} else {
-			a[o.FieldIdx] = (a[o.FieldIdx] << uint(o.Arg)) | o.Arg2
-		}
-		*arr = a
+		*arrp = arr
+		return applyScalar(&arr[idx], o.Opcode, o.Arg, o.Arg2)
 	case wire.OperateOpHALVEGRP:
 		// HALVE_GRP(thr=Arg, len=Arg2): the group is the contiguous field range
-		// [FieldIdx, FieldIdx+len); FieldIdx is the guard field. If the guard is >=
-		// the threshold, halve every field in the group. (The fixed op wire carries
-		// one fieldIdx + two i64 args, so a group is expressed as a contiguous range
+		// [FieldIdx, FieldIdx+len); FieldIdx is the guard field. If the guard is >= the
+		// threshold, halve every field in the group per its own type. (The fixed op
+		// wire carries one fieldIdx + two i64 args, so a group is a contiguous range
 		// rather than an explicit field list — the design's `HALVE_GRP(thr, f…)` with
 		// f… the range starting at the guard.)
 		if o.Arg2 < 1 {
 			return errOperateGroup
 		}
-		end := int(o.FieldIdx) + int(o.Arg2)
-		a, ok := growI64(*arr, end)
+		idx := int(o.FieldIdx)
+		end := idx + int(o.Arg2)
+		arr, ok := ensureLen(*arrp, end, o.Type)
 		if !ok {
 			return errOperateFieldRange
 		}
-		if a[o.FieldIdx] >= o.Arg {
-			for i := int(o.FieldIdx); i < end; i++ {
-				a[i] /= 2 // integer halving; deterministic (rounds toward zero for negatives)
+		*arrp = arr
+		if guardTriggered(&arr[idx], o.Arg) {
+			for i := idx; i < end; i++ {
+				halveField(&arr[i])
 			}
 		}
-		*arr = a
+		return nil
+	default:
+		return errOperateOpcode
+	}
+}
+
+// applyScalar applies a single-field op (INCR/INCRF/SETMAX/SHIFTOR) to f, routing
+// on the field's stored type.
+func applyScalar(f *operateField, opcode uint8, arg, arg2 int64) error {
+	if typeIsFloat(f.typ) {
+		return applyScalarFloat(f, opcode, arg)
+	}
+	return applyScalarInt(f, opcode, arg, arg2)
+}
+
+func applyScalarInt(f *operateField, opcode uint8, arg, arg2 int64) error {
+	switch opcode {
+	case wire.OperateOpINCR, wire.OperateOpINCRF:
+		// INCRF (fixed-point add) is the same integer add as INCR; the fixed-point
+		// scale lives in the app's interpretation.
+		if typeIsUnsigned(f.typ) {
+			f.u = addSatUnsigned(f.u, arg, typeUMax(f.typ))
+		} else {
+			lo, hi := typeSignedRange(f.typ)
+			f.u = uint64(addSatSigned(int64(f.u), arg, lo, hi)) //nolint:gosec // two's-complement store
+		}
+	case wire.OperateOpSETMAX:
+		if typeIsUnsigned(f.typ) {
+			if arg >= 0 { // a negative candidate is below every unsigned value
+				cand := uint64(arg)
+				if m := typeUMax(f.typ); cand > m {
+					cand = m
+				}
+				if cand > f.u {
+					f.u = cand
+				}
+			}
+		} else {
+			lo, hi := typeSignedRange(f.typ)
+			cand := arg
+			if cand < lo {
+				cand = lo
+			} else if cand > hi {
+				cand = hi
+			}
+			if cand > int64(f.u) { //nolint:gosec // signed field value
+				f.u = uint64(cand) //nolint:gosec // two's-complement store
+			}
+		}
+	case wire.OperateOpSHIFTOR:
+		// A rolling bitfield: shift then OR in the new bits then MASK to the field
+		// width so old bits fall off. Only defined for a fixed-width int (a varint has
+		// no width). A negative shift panics in Go, so reject it.
+		if !typeIsFixedInt(f.typ) {
+			return errOperateShiftType
+		}
+		if arg < 0 {
+			return errOperateShift
+		}
+		bits := typeBits(f.typ)
+		mask := widthMask(bits)
+		var shifted uint64
+		if arg < 64 {
+			shifted = f.u << uint(arg)
+		}
+		res := (shifted | uint64(arg2)) & mask //nolint:gosec // bit pattern
+		if !typeIsUnsigned(f.typ) {
+			res = uint64(signExtend(res, bits)) //nolint:gosec // canonicalize signed value
+		}
+		f.u = res
 	default:
 		return errOperateOpcode
 	}
 	return nil
 }
 
-// targetArray returns a pointer to the []i64 an op mutates. For a global target
-// that is &rec.globals; for an entry target it upserts the sub-record (evicting
-// deterministically if a NEW key would exceed the cap), stamps its touchMs, and
-// returns &entry.fields. Any op referencing an entry counts as a touch.
-func (rec *operateRec) targetArray(o wire.OperateOp, nowMs int64, maxEntries int) (*[]int64, error) {
+func applyScalarFloat(f *operateField, opcode uint8, arg int64) error {
+	// A float operand rides Arg as its IEEE bit pattern (F32 = low 32 bits).
+	val := floatFromArg(f.typ, arg)
+	switch opcode {
+	case wire.OperateOpINCR, wire.OperateOpINCRF:
+		f.f = canonFloat(f.typ, f.f+val)
+	case wire.OperateOpSETMAX:
+		if val > f.f { // IEEE compare; NaN never replaces, deterministic
+			f.f = canonFloat(f.typ, val)
+		}
+	case wire.OperateOpSHIFTOR:
+		return errOperateShiftType
+	default:
+		return errOperateOpcode
+	}
+	return nil
+}
+
+// guardTriggered reports whether f's value is >= the HALVE_GRP threshold arg,
+// compared in f's own domain.
+func guardTriggered(f *operateField, arg int64) bool {
+	if typeIsFloat(f.typ) {
+		return f.f >= float64(arg)
+	}
+	if typeIsUnsigned(f.typ) {
+		if arg < 0 {
+			return true // every unsigned value exceeds a negative threshold
+		}
+		return f.u >= uint64(arg)
+	}
+	return int64(f.u) >= arg //nolint:gosec // signed field value
+}
+
+// halveField integer/float-halves f in place, per its type (integer division
+// rounds toward zero for signed, which is deterministic).
+func halveField(f *operateField) {
+	switch {
+	case typeIsFloat(f.typ):
+		f.f = canonFloat(f.typ, f.f/2)
+	case typeIsUnsigned(f.typ):
+		f.u /= 2
+	default:
+		f.u = uint64(int64(f.u) / 2) //nolint:gosec // signed field value
+	}
+}
+
+// targetArray returns a pointer to the field array an op mutates. For a global
+// target that is &rec.globals; for an entry target it upserts the sub-record
+// (evicting deterministically if a NEW key would exceed the cap), stamps its
+// touchMs, and returns &entry.fields. Any op referencing an entry counts as a
+// touch.
+func (rec *operateRec) targetArray(o wire.OperateOp, nowMs int64, maxEntries int) (*[]operateField, error) {
 	if o.Target != wire.OperateTargetEntry {
 		return &rec.globals, nil
 	}
@@ -180,7 +295,7 @@ func (rec *operateRec) targetArray(o wire.OperateOp, nowMs int64, maxEntries int
 	return &e.fields, nil
 }
 
-// upsertEntry returns the entry for key, creating an all-zero one (stamped
+// upsertEntry returns the entry for key, creating an empty one (stamped
 // touchMs=nowMs) if absent. When creating would exceed maxEntries (>0) it first
 // evicts the deterministic LRU victim, so the cap holds under concurrency without
 // app coordination.
@@ -197,9 +312,8 @@ func (rec *operateRec) upsertEntry(key uint64, nowMs int64, maxEntries int) *ope
 }
 
 // evictOne removes the entry with the smallest touchMs, ties broken by the
-// smallest key. The winner is a deterministic function of the (already
-// deterministic) map contents, so it does not depend on Go's map iteration order —
-// every replica evicts the same entry.
+// smallest key — a deterministic function of the (already deterministic) map
+// contents, so every replica evicts the same entry regardless of map order.
 func (rec *operateRec) evictOne() {
 	var (
 		victim uint64
@@ -216,23 +330,33 @@ func (rec *operateRec) evictOne() {
 	}
 }
 
-// growI64 returns s grown to at least length n (zero-filled), or s unchanged when
-// it is already long enough. It returns ok=false when n exceeds maxOperateFields,
-// so a hostile field index cannot drive an unbounded allocation.
-func growI64(s []int64, n int) ([]int64, bool) {
+// ensureLen grows arr to at least length n, filling holes below the top with a U8
+// zero and creating the top slot (index n-1) with newType. It returns arr
+// unchanged when already long enough (the STORED field type wins for an existing
+// index). ok=false when n exceeds maxOperateFields or a to-be-created top slot's
+// newType is unknown.
+func ensureLen(arr []operateField, n int, newType uint8) ([]operateField, bool) {
 	if n > maxOperateFields {
-		return s, false
+		return arr, false
 	}
-	if len(s) >= n {
-		return s, true
+	if n <= len(arr) {
+		return arr, true
 	}
-	ns := make([]int64, n)
-	copy(ns, s)
-	return ns, true
+	if newType >= wire.OperateTypeCount {
+		return arr, false
+	}
+	for len(arr) < n {
+		if len(arr) == n-1 {
+			arr = append(arr, operateField{typ: newType}) // the addressed field
+		} else {
+			arr = append(arr, operateField{typ: wire.OperateTypeU8}) // a hole
+		}
+	}
+	return arr, true
 }
 
-// encodeReturn reads each requested field's post-apply value (0 if the global
-// index / entry / entry field is absent) and encodes them i64 BE in request order.
+// encodeReturn reads each requested field's post-apply raw bits (0 if the index /
+// entry / entry field is absent) and encodes them i64 BE in request order.
 func encodeReturn(rec *operateRec, ret []wire.OperateRet) []byte {
 	if len(ret) == 0 {
 		return nil
@@ -245,7 +369,7 @@ func encodeReturn(rec *operateRec, ret []wire.OperateRet) []byte {
 }
 
 func (rec *operateRec) readField(target uint8, entryKey uint64, fieldIdx uint16) int64 {
-	var arr []int64
+	var arr []operateField
 	if target == wire.OperateTargetEntry {
 		e, ok := rec.entries[entryKey]
 		if !ok {
@@ -256,24 +380,164 @@ func (rec *operateRec) readField(target uint8, entryKey uint64, fieldIdx uint16)
 		arr = rec.globals
 	}
 	if int(fieldIdx) < len(arr) {
-		return arr[fieldIdx]
+		return fieldRaw(arr[fieldIdx])
 	}
 	return 0
 }
 
+// fieldRaw returns a field's value as raw i64 bits: the integer value for
+// int/varint types, or the IEEE bit pattern for floats (F32 in the low 32 bits).
+func fieldRaw(f operateField) int64 {
+	switch f.typ {
+	case wire.OperateTypeF64:
+		return int64(math.Float64bits(f.f)) //nolint:gosec // raw bits
+	case wire.OperateTypeF32:
+		return int64(uint64(math.Float32bits(float32(f.f)))) //nolint:gosec // raw bits (low 32)
+	default:
+		return int64(f.u) //nolint:gosec // raw value bits
+	}
+}
+
+// --- type property helpers ---------------------------------------------------
+
+func typeIsFloat(t uint8) bool { return t == wire.OperateTypeF32 || t == wire.OperateTypeF64 }
+
+func typeIsUnsigned(t uint8) bool {
+	switch t {
+	case wire.OperateTypeU8, wire.OperateTypeU16, wire.OperateTypeU32, wire.OperateTypeU64, wire.OperateTypeUVARINT:
+		return true
+	default:
+		return false
+	}
+}
+
+// typeIsFixedInt reports the fixed-width integer types (U8..I64) — the ones
+// SHIFTOR's width mask is defined for.
+func typeIsFixedInt(t uint8) bool {
+	return t <= wire.OperateTypeI64 // U8..I64 are contiguous 0..7
+}
+
+func typeUMax(t uint8) uint64 {
+	switch t {
+	case wire.OperateTypeU8:
+		return math.MaxUint8
+	case wire.OperateTypeU16:
+		return math.MaxUint16
+	case wire.OperateTypeU32:
+		return math.MaxUint32
+	default: // U64, UVARINT
+		return math.MaxUint64
+	}
+}
+
+func typeSignedRange(t uint8) (lo, hi int64) {
+	switch t {
+	case wire.OperateTypeI8:
+		return math.MinInt8, math.MaxInt8
+	case wire.OperateTypeI16:
+		return math.MinInt16, math.MaxInt16
+	case wire.OperateTypeI32:
+		return math.MinInt32, math.MaxInt32
+	default: // I64, IVARINT
+		return math.MinInt64, math.MaxInt64
+	}
+}
+
+func typeBits(t uint8) int {
+	switch t {
+	case wire.OperateTypeU8, wire.OperateTypeI8:
+		return 8
+	case wire.OperateTypeU16, wire.OperateTypeI16:
+		return 16
+	case wire.OperateTypeU32, wire.OperateTypeI32:
+		return 32
+	default:
+		return 64
+	}
+}
+
+func widthMask(bits int) uint64 {
+	if bits >= 64 {
+		return math.MaxUint64
+	}
+	return (uint64(1) << uint(bits)) - 1
+}
+
+func signExtend(v uint64, bits int) int64 {
+	if bits >= 64 {
+		return int64(v) //nolint:gosec // full width
+	}
+	shift := uint(64 - bits)
+	return int64(v<<shift) >> shift //nolint:gosec // arithmetic shift sign-extends
+}
+
+func floatFromArg(t uint8, arg int64) float64 {
+	if t == wire.OperateTypeF32 {
+		return float64(math.Float32frombits(uint32(arg))) //nolint:gosec // low 32 bits are the F32 pattern
+	}
+	return math.Float64frombits(uint64(arg)) //nolint:gosec // 64-bit IEEE pattern
+}
+
+func canonFloat(t uint8, x float64) float64 {
+	if t == wire.OperateTypeF32 {
+		return float64(float32(x)) // round to F32 precision so storage round-trips exactly
+	}
+	return x
+}
+
+// addSatUnsigned adds a signed delta to an unsigned value, saturating at [0, max]
+// (never wrapping). uint64(-delta) yields the correct magnitude even for MinInt64.
+func addSatUnsigned(cur uint64, delta int64, max uint64) uint64 {
+	if delta >= 0 {
+		d := uint64(delta)
+		if d > max-cur {
+			return max
+		}
+		return cur + d
+	}
+	d := uint64(-delta) //nolint:gosec // magnitude; correct even at MinInt64
+	if d > cur {
+		return 0
+	}
+	return cur - d
+}
+
+// addSatSigned adds delta to cur, saturating at [lo, hi] and detecting the int64
+// wrap first (so I64 saturates at the int64 boundary instead of wrapping).
+func addSatSigned(cur, delta, lo, hi int64) int64 {
+	sum := cur + delta
+	switch {
+	case delta > 0 && sum < cur:
+		return hi // overflowed positive
+	case delta < 0 && sum > cur:
+		return lo // overflowed negative
+	case sum < lo:
+		return lo
+	case sum > hi:
+		return hi
+	default:
+		return sum
+	}
+}
+
+// --- record encode / decode --------------------------------------------------
+
 // decodeRec parses a stored operate value:
 //
-//	[nGlobals u16][global i64 × nGlobals]
+//	[nGlobals u16][ field × nGlobals ]
 //	[nEntries u32]
-//	  per entry: [key u64][touchMs i64][nFields u16][field i64 × nFields]
+//	  per entry: [key u64][touchMs i64][nFields u16][ field × nFields ]
+//	  field:     [type u8][data]  (data: native width; F32/F64 4/8 bytes; U/IVARINT LEB128)
 //
-// All fields are LITTLE-ENDIAN (the value model's own encoding; the arg wire is
-// big-endian, independently). nil/empty bytes decode to an empty record. Because
-// operate reads whatever value is stored under the key — which a plain put could
-// have set to arbitrary bytes — this decoder is HARDENED like the wire decoders:
-// every count is CountFitsIn-bounded before allocation and every read is
-// truncation-checked, so a malformed value returns an error, never a panic (which
-// on the replicated apply path would take down every replica).
+// Integers/floats are LITTLE-ENDIAN (the value model's own encoding; the arg wire
+// is big-endian, independently). nil/empty bytes decode to an empty record.
+// Because operate reads whatever value is stored under the key — which a plain put
+// could have set to arbitrary bytes — this decoder is HARDENED like the wire
+// decoders: every count is CountFitsIn-bounded before allocation, each field type
+// tag is validated, each varint is read with binary.Uvarint (bounded to 10 bytes,
+// no over-read), and every read is truncation-checked, so a malformed value
+// returns an error, never a panic (which on the replicated apply path would take
+// down every replica).
 func decodeRec(b []byte) (operateRec, error) {
 	rec := operateRec{entries: make(map[uint64]*operateEntry)}
 	if len(b) == 0 {
@@ -285,14 +549,18 @@ func decodeRec(b []byte) (operateRec, error) {
 	}
 	nGlobals := int(binary.LittleEndian.Uint16(b[off : off+2]))
 	off += 2
-	if !wire.CountFitsIn(nGlobals, len(b)-off, 8) {
+	if !wire.CountFitsIn(nGlobals, len(b)-off, minOperateFieldBytes) {
 		return operateRec{}, wire.ErrShortArgs
 	}
 	if nGlobals > 0 {
-		rec.globals = make([]int64, nGlobals)
+		rec.globals = make([]operateField, nGlobals)
 		for i := range rec.globals {
-			rec.globals[i] = int64(binary.LittleEndian.Uint64(b[off : off+8])) //nolint:gosec // reinterpret stored u64 as i64
-			off += 8
+			f, n, err := decodeField(b[off:])
+			if err != nil {
+				return operateRec{}, err
+			}
+			rec.globals[i] = f
+			off += n
 		}
 	}
 	if len(b)-off < 4 {
@@ -313,15 +581,19 @@ func decodeRec(b []byte) (operateRec, error) {
 		off += 8
 		nFields := int(binary.LittleEndian.Uint16(b[off : off+2]))
 		off += 2
-		if !wire.CountFitsIn(nFields, len(b)-off, 8) {
+		if !wire.CountFitsIn(nFields, len(b)-off, minOperateFieldBytes) {
 			return operateRec{}, wire.ErrShortArgs
 		}
 		e := &operateEntry{touchMs: touchMs}
 		if nFields > 0 {
-			e.fields = make([]int64, nFields)
+			e.fields = make([]operateField, nFields)
 			for i := range e.fields {
-				e.fields[i] = int64(binary.LittleEndian.Uint64(b[off : off+8])) //nolint:gosec // reinterpret stored u64 as i64
-				off += 8
+				f, n, err := decodeField(b[off:])
+				if err != nil {
+					return operateRec{}, err
+				}
+				e.fields[i] = f
+				off += n
 			}
 		}
 		rec.entries[key] = e
@@ -329,24 +601,110 @@ func decodeRec(b []byte) (operateRec, error) {
 	return rec, nil
 }
 
+// decodeField reads one [type u8][data] field from the front of b, returning the
+// field and the number of bytes consumed. It rejects an unknown type tag and any
+// truncation, and reads varints with binary.Uvarint (self-bounding, no over-read).
+func decodeField(b []byte) (operateField, int, error) {
+	if len(b) < 1 {
+		return operateField{}, 0, wire.ErrShortArgs
+	}
+	t := b[0]
+	if t >= wire.OperateTypeCount {
+		return operateField{}, 0, errOperateType
+	}
+	off := 1
+	f := operateField{typ: t}
+	need := func(n int) bool { return len(b)-off >= n }
+	switch t {
+	case wire.OperateTypeU8:
+		if !need(1) {
+			return operateField{}, 0, wire.ErrShortArgs
+		}
+		f.u = uint64(b[off])
+		off++
+	case wire.OperateTypeI8:
+		if !need(1) {
+			return operateField{}, 0, wire.ErrShortArgs
+		}
+		f.u = uint64(int64(int8(b[off]))) //nolint:gosec // sign-extend
+		off++
+	case wire.OperateTypeU16:
+		if !need(2) {
+			return operateField{}, 0, wire.ErrShortArgs
+		}
+		f.u = uint64(binary.LittleEndian.Uint16(b[off : off+2]))
+		off += 2
+	case wire.OperateTypeI16:
+		if !need(2) {
+			return operateField{}, 0, wire.ErrShortArgs
+		}
+		f.u = uint64(int64(int16(binary.LittleEndian.Uint16(b[off : off+2])))) //nolint:gosec // sign-extend
+		off += 2
+	case wire.OperateTypeU32:
+		if !need(4) {
+			return operateField{}, 0, wire.ErrShortArgs
+		}
+		f.u = uint64(binary.LittleEndian.Uint32(b[off : off+4]))
+		off += 4
+	case wire.OperateTypeI32:
+		if !need(4) {
+			return operateField{}, 0, wire.ErrShortArgs
+		}
+		f.u = uint64(int64(int32(binary.LittleEndian.Uint32(b[off : off+4])))) //nolint:gosec // sign-extend
+		off += 4
+	case wire.OperateTypeU64, wire.OperateTypeI64:
+		if !need(8) {
+			return operateField{}, 0, wire.ErrShortArgs
+		}
+		f.u = binary.LittleEndian.Uint64(b[off : off+8])
+		off += 8
+	case wire.OperateTypeF32:
+		if !need(4) {
+			return operateField{}, 0, wire.ErrShortArgs
+		}
+		f.f = float64(math.Float32frombits(binary.LittleEndian.Uint32(b[off : off+4])))
+		off += 4
+	case wire.OperateTypeF64:
+		if !need(8) {
+			return operateField{}, 0, wire.ErrShortArgs
+		}
+		f.f = math.Float64frombits(binary.LittleEndian.Uint64(b[off : off+8]))
+		off += 8
+	case wire.OperateTypeUVARINT:
+		v, n := binary.Uvarint(b[off:])
+		if n <= 0 { // 0 = truncated, <0 = overflow (> 10 bytes / > 64 bits)
+			return operateField{}, 0, wire.ErrShortArgs
+		}
+		f.u = v
+		off += n
+	case wire.OperateTypeIVARINT:
+		v, n := binary.Uvarint(b[off:])
+		if n <= 0 {
+			return operateField{}, 0, wire.ErrShortArgs
+		}
+		f.u = uint64(unzigzag(v)) //nolint:gosec // store signed value bits
+		off += n
+	default:
+		return operateField{}, 0, errOperateType
+	}
+	return f, off, nil
+}
+
 // encodeRec serializes rec in the decodeRec layout, LITTLE-ENDIAN, with entries
-// emitted in ASCENDING key order so the bytes are a deterministic function of the
-// record's contents (independent of Go map iteration order) — the property a
-// follower's byte-identical re-apply relies on. Trailing operations never shrink
-// the globals array, so its length is stable across a committed op-list.
+// emitted in ASCENDING key order and fields in index order so the bytes are a
+// deterministic function of the record's contents (independent of Go map iteration
+// order) — the property a follower's byte-identical re-apply relies on.
 func encodeRec(rec operateRec) []byte {
-	total := 2 + len(rec.globals)*8 + 4
 	keys := make([]uint64, 0, len(rec.entries))
 	for k := range rec.entries {
 		keys = append(keys, k)
-		total += minOperateEntryBytes + len(rec.entries[k].fields)*8
 	}
 	sort.Slice(keys, func(i, j int) bool { return keys[i] < keys[j] })
 
-	buf := make([]byte, 0, total)
+	buf := make([]byte, 0, 6+len(rec.globals)*3+len(keys)*minOperateEntryBytes)
 	buf = binary.LittleEndian.AppendUint16(buf, uint16(len(rec.globals))) //nolint:gosec // bounded by maxOperateFields
-	for _, g := range rec.globals {
-		buf = binary.LittleEndian.AppendUint64(buf, uint64(g)) //nolint:gosec // reinterpret i64 as u64
+	for i := range rec.globals {
+		buf = encodeField(buf, rec.globals[i])
 	}
 	buf = binary.LittleEndian.AppendUint32(buf, uint32(len(keys))) //nolint:gosec // entry count
 	for _, k := range keys {
@@ -354,9 +712,37 @@ func encodeRec(rec operateRec) []byte {
 		buf = binary.LittleEndian.AppendUint64(buf, k)
 		buf = binary.LittleEndian.AppendUint64(buf, uint64(e.touchMs))     //nolint:gosec // reinterpret i64 as u64
 		buf = binary.LittleEndian.AppendUint16(buf, uint16(len(e.fields))) //nolint:gosec // bounded by maxOperateFields
-		for _, f := range e.fields {
-			buf = binary.LittleEndian.AppendUint64(buf, uint64(f)) //nolint:gosec // reinterpret i64 as u64
+		for i := range e.fields {
+			buf = encodeField(buf, e.fields[i])
 		}
 	}
 	return buf
 }
+
+// encodeField appends one [type u8][data] field: native fixed width for U8..I64,
+// 4/8 bytes for F32/F64, or LEB128 for U/IVARINT (IVARINT zigzagged).
+func encodeField(buf []byte, f operateField) []byte {
+	buf = append(buf, f.typ)
+	switch f.typ {
+	case wire.OperateTypeU8, wire.OperateTypeI8:
+		buf = append(buf, byte(f.u))
+	case wire.OperateTypeU16, wire.OperateTypeI16:
+		buf = binary.LittleEndian.AppendUint16(buf, uint16(f.u)) //nolint:gosec // low 16 bits
+	case wire.OperateTypeU32, wire.OperateTypeI32:
+		buf = binary.LittleEndian.AppendUint32(buf, uint32(f.u)) //nolint:gosec // low 32 bits
+	case wire.OperateTypeU64, wire.OperateTypeI64:
+		buf = binary.LittleEndian.AppendUint64(buf, f.u)
+	case wire.OperateTypeF32:
+		buf = binary.LittleEndian.AppendUint32(buf, math.Float32bits(float32(f.f)))
+	case wire.OperateTypeF64:
+		buf = binary.LittleEndian.AppendUint64(buf, math.Float64bits(f.f))
+	case wire.OperateTypeUVARINT:
+		buf = binary.AppendUvarint(buf, f.u)
+	case wire.OperateTypeIVARINT:
+		buf = binary.AppendUvarint(buf, zigzag(int64(f.u))) //nolint:gosec // signed value bits
+	}
+	return buf
+}
+
+func zigzag(i int64) uint64   { return uint64((i << 1) ^ (i >> 63)) } //nolint:gosec // standard zigzag
+func unzigzag(u uint64) int64 { return int64(u>>1) ^ -int64(u&1) }    //nolint:gosec // standard zigzag

--- a/ops/operate_test.go
+++ b/ops/operate_test.go
@@ -8,7 +8,6 @@ import (
 	"math"
 	"testing"
 
-	"github.com/rostamlabs/rostam/cache"
 	"github.com/rostamlabs/rostam/sdk/wire"
 )
 
@@ -469,23 +468,13 @@ func TestOperateRecordTooLargeRejected(t *testing.T) {
 	}
 }
 
-// TestOperateDirectModeLRU: on the UNSTAMPED (Direct) path touchMs comes from the
-// cache wall clock, so cap-eviction still evicts the least-recently-touched entry
-// rather than degrading to lowest-key. The cache clock is injected so the test is
-// deterministic.
-func TestOperateDirectModeLRU(t *testing.T) {
-	cfg := cache.DefaultConfig()
-	cfg.NumShards = 1
-	c, err := cache.New(cfg)
-	if err != nil {
-		t.Fatal(err)
-	}
-	t.Cleanup(func() { _ = c.Close() })
-	var now uint64 = 1000
-	c.SetNowFunc(func() uint64 { return now })
-	tx := NewTxContext(c) // UNSTAMPED (Direct) TxContext
-	key := []byte("direct")
-
+// TestOperateUnstampedEvictionIsDeterministicLowestKey: on the UNSTAMPED path
+// touchMs is 0 for every entry (never a per-replica wall clock), so cap-eviction
+// deterministically evicts the smallest key. This is the documented trade-off:
+// determinism over LRU quality when apply-stamping is off.
+func TestOperateUnstampedEvictionIsDeterministicLowestKey(t *testing.T) {
+	_, tx := newTestSetup(t) // NewTxContext ⇒ unstamped
+	key := []byte("unstamped")
 	do := func(ops []wire.OperateOp, ret []wire.OperateRet) []int64 {
 		res, err := handleOperate(tx, wire.EncodeOperateArgs(key, 0, 2, ops, ret))
 		if err != nil {
@@ -494,20 +483,94 @@ func TestOperateDirectModeLRU(t *testing.T) {
 		vals, _ := wire.DecodeOperateResult(res)
 		return vals
 	}
-	now = 1000
-	do([]wire.OperateOp{eOp(9, 0, wire.OperateTypeU8, wire.OperateOpINCR, 90, 0)}, nil) // touch entry 9 (high key) recently-ish
-	now = 2000
-	do([]wire.OperateOp{eOp(1, 0, wire.OperateTypeU8, wire.OperateOpINCR, 10, 0)}, nil) // touch entry 1 (low key) LATER
-	now = 3000
-	// Insert entry 5 over the cap of 2: the LRU victim is entry 9 (oldest touchMs),
-	// NOT the lowest key (which would wrongly evict entry 1).
+	// Touch entry 9 first, then entry 1 (later) — but unstamped, both touchMs=0.
+	do([]wire.OperateOp{eOp(9, 0, wire.OperateTypeU8, wire.OperateOpINCR, 90, 0)}, nil)
+	do([]wire.OperateOp{eOp(1, 0, wire.OperateTypeU8, wire.OperateOpINCR, 10, 0)}, nil)
+	// Insert entry 5 over the cap of 2: tie on touchMs=0 ⇒ smallest KEY (1) evicted.
 	got := do([]wire.OperateOp{eOp(5, 0, wire.OperateTypeU8, wire.OperateOpINCR, 50, 0)},
-		[]wire.OperateRet{eRet(9, 0), eRet(1, 0), eRet(5, 0)})
+		[]wire.OperateRet{eRet(1, 0), eRet(9, 0), eRet(5, 0)})
 	if got[0] != 0 {
-		t.Fatalf("Direct LRU: entry 9 (oldest) should be evicted, got %d", got[0])
+		t.Fatalf("unstamped eviction: smallest key 1 should be evicted, got %d", got[0])
 	}
-	if got[1] != 10 || got[2] != 50 {
-		t.Fatalf("Direct LRU: entry 1/5 = %d/%d, want 10/50", got[1], got[2])
+	if got[1] != 90 || got[2] != 50 {
+		t.Fatalf("unstamped eviction: entry 9/5 = %d/%d, want 90/50", got[1], got[2])
+	}
+}
+
+// TestOperateUnstampedReplicaReapplyMatches: two independent "replicas" (separate
+// caches) applying the SAME committed op-list on the UNSTAMPED path produce
+// byte-identical stored records — the regression guard for the wall-clock
+// divergence bug (a per-replica wall clock would write different touchMs).
+func TestOperateUnstampedReplicaReapplyMatches(t *testing.T) {
+	opsList := []wire.OperateOp{
+		gOp(0, wire.OperateTypeU16, wire.OperateOpINCR, 7, 0),
+		eOp(100, 0, wire.OperateTypeUVARINT, wire.OperateOpINCR, 1, 0),
+		eOp(5, 0, wire.OperateTypeU8, wire.OperateOpINCR, 3, 0),
+		eOp(100, 1, wire.OperateTypeI64, wire.OperateOpSETMAX, 9, 0),
+	}
+	key := []byte("repl")
+	stored := func() []byte {
+		_, tx := newTestSetup(t) // unstamped, fresh cache = one "replica"
+		if _, err := handleOperate(tx, wire.EncodeOperateArgs(key, 0, 0, opsList, nil)); err != nil {
+			t.Fatalf("handleOperate: %v", err)
+		}
+		v, err := tx.Get(key)
+		if err != nil {
+			t.Fatalf("Get: %v", err)
+		}
+		out := make([]byte, len(v))
+		copy(out, v)
+		return out
+	}
+	if a, b := stored(), stored(); !bytes.Equal(a, b) {
+		t.Fatal("two unstamped replicas produced divergent record bytes")
+	}
+}
+
+// TestOperateAmplificationDoSRejected: an op-list that tries to materialize more
+// than the whole-record field budget is rejected INCREMENTALLY (before allocating
+// gigabytes). Each op grows a distinct entry's array to the per-array max; the op
+// that would push the record's total field count past maxOperateTotalFields fails,
+// aborting the whole op-list with nothing written.
+func TestOperateAmplificationDoSRejected(t *testing.T) {
+	_, tx := newTestSetup(t)
+	// Each op grows entry k's array to maxOperateFields; after ~16 of them the total
+	// crosses maxOperateTotalFields (1<<20). Build a few more than needed.
+	nOps := maxOperateTotalFields/maxOperateFields + 3
+	ops := make([]wire.OperateOp, nOps)
+	for k := range ops {
+		ops[k] = eOp(uint64(k), uint16(maxOperateFields-1), wire.OperateTypeU8, wire.OperateOpINCR, 1, 0)
+	}
+	tx.SetApplyStamp(1, true)
+	_, err := handleOperate(tx, wire.EncodeOperateArgs([]byte("dos"), 0, 0, ops, nil))
+	tx.SetApplyStamp(0, false)
+	if err != errOperateFieldRange {
+		t.Fatalf("amplification op-list: err = %v, want errOperateFieldRange", err)
+	}
+	// Atomic: nothing written.
+	got := callOperate(t, tx, 2, []byte("dos"), 0, nil, []wire.OperateRet{eRet(0, uint16(maxOperateFields-1))})
+	if got[0] != 0 {
+		t.Fatalf("record written despite DoS rejection: got %d", got[0])
+	}
+}
+
+// TestOperateHalveGroupTypesUnsetSlots: a HALVE_GRP that first materializes a field
+// must fix that field's type to the group's declared type, so a LATER wider write
+// cannot adopt a different type and bypass the group's saturation.
+func TestOperateHalveGroupTypesUnsetSlots(t *testing.T) {
+	_, tx := newTestSetup(t)
+	key := []byte("hgtype")
+	// HALVE_GRP declares U8 for fields [0,2); it creates them as U8 (threshold 0
+	// fires, halving 0→0). A subsequent INCR declaring U32 must NOT re-type field 0:
+	// the U8 saturation must hold (300 → 255).
+	callOperate(t, tx, 1, key, 0, []wire.OperateOp{
+		gOp(0, wire.OperateTypeU8, wire.OperateOpHALVEGRP, 0, 2),
+	}, nil)
+	got := callOperate(t, tx, 2, key, 0,
+		[]wire.OperateOp{gOp(0, wire.OperateTypeU32, wire.OperateOpINCR, 300, 0)},
+		[]wire.OperateRet{gRet(0)})
+	if got[0] != 255 {
+		t.Fatalf("HALVE_GRP-typed field = %d, want 255 (U8 saturation held, not re-typed to U32)", got[0])
 	}
 }
 

--- a/ops/operate_test.go
+++ b/ops/operate_test.go
@@ -5,6 +5,7 @@ package ops
 import (
 	"bytes"
 	"encoding/binary"
+	"math"
 	"testing"
 
 	"github.com/rostamlabs/rostam/sdk/wire"
@@ -28,11 +29,11 @@ func callOperate(t *testing.T, tx *TxContext, nowMs int64, key []byte, maxEntrie
 	return vals
 }
 
-func gOp(field uint16, op uint8, arg, arg2 int64) wire.OperateOp {
-	return wire.OperateOp{Target: wire.OperateTargetGlobal, FieldIdx: field, Opcode: op, Arg: arg, Arg2: arg2}
+func gOp(field uint16, typ, op uint8, arg, arg2 int64) wire.OperateOp {
+	return wire.OperateOp{Target: wire.OperateTargetGlobal, FieldIdx: field, Opcode: op, Type: typ, Arg: arg, Arg2: arg2}
 }
-func eOp(key uint64, field uint16, op uint8, arg, arg2 int64) wire.OperateOp {
-	return wire.OperateOp{Target: wire.OperateTargetEntry, EntryKey: key, FieldIdx: field, Opcode: op, Arg: arg, Arg2: arg2}
+func eOp(key uint64, field uint16, typ, op uint8, arg, arg2 int64) wire.OperateOp {
+	return wire.OperateOp{Target: wire.OperateTargetEntry, EntryKey: key, FieldIdx: field, Opcode: op, Type: typ, Arg: arg, Arg2: arg2}
 }
 func gRet(field uint16) wire.OperateRet {
 	return wire.OperateRet{Target: wire.OperateTargetGlobal, FieldIdx: field}
@@ -40,6 +41,9 @@ func gRet(field uint16) wire.OperateRet {
 func eRet(key uint64, field uint16) wire.OperateRet {
 	return wire.OperateRet{Target: wire.OperateTargetEntry, EntryKey: key, FieldIdx: field}
 }
+
+func f32arg(x float32) int64 { return int64(uint64(math.Float32bits(x))) }
+func f64arg(x float64) int64 { return int64(math.Float64bits(x)) }
 
 func TestOperateOpcodes(t *testing.T) {
 	tests := []struct {
@@ -49,41 +53,29 @@ func TestOperateOpcodes(t *testing.T) {
 		want []int64
 	}{
 		{
-			name: "INCR accumulates",
-			ops:  []wire.OperateOp{gOp(0, wire.OperateOpINCR, 5, 0), gOp(0, wire.OperateOpINCR, -2, 0)},
+			name: "INCR i64 accumulates",
+			ops:  []wire.OperateOp{gOp(0, wire.OperateTypeI64, wire.OperateOpINCR, 5, 0), gOp(0, wire.OperateTypeI64, wire.OperateOpINCR, -2, 0)},
 			ret:  []wire.OperateRet{gRet(0)},
 			want: []int64{3},
 		},
 		{
-			name: "INCRF is integer add",
-			ops:  []wire.OperateOp{gOp(1, wire.OperateOpINCRF, 1500, 0), gOp(1, wire.OperateOpINCRF, 250, 0)},
-			ret:  []wire.OperateRet{gRet(1)},
-			want: []int64{1750},
-		},
-		{
-			name: "SETMAX keeps the larger",
-			ops:  []wire.OperateOp{gOp(2, wire.OperateOpSETMAX, 10, 0), gOp(2, wire.OperateOpSETMAX, 4, 0), gOp(2, wire.OperateOpSETMAX, 12, 0)},
+			name: "SETMAX i32 keeps the larger",
+			ops:  []wire.OperateOp{gOp(2, wire.OperateTypeI32, wire.OperateOpSETMAX, 10, 0), gOp(2, wire.OperateTypeI32, wire.OperateOpSETMAX, 4, 0), gOp(2, wire.OperateTypeI32, wire.OperateOpSETMAX, 12, 0)},
 			ret:  []wire.OperateRet{gRet(2)},
 			want: []int64{12},
 		},
 		{
-			name: "SHIFTOR builds a bitfield",
-			ops:  []wire.OperateOp{gOp(3, wire.OperateOpSHIFTOR, 4, 0x1), gOp(3, wire.OperateOpSHIFTOR, 4, 0x2)},
+			name: "SHIFTOR u32 builds a bitfield",
+			ops:  []wire.OperateOp{gOp(3, wire.OperateTypeU32, wire.OperateOpSHIFTOR, 4, 0x1), gOp(3, wire.OperateTypeU32, wire.OperateOpSHIFTOR, 4, 0x2)},
 			ret:  []wire.OperateRet{gRet(3)},
 			want: []int64{0x12},
 		},
 		{
-			name: "SHIFTOR shift>=64 yields arg2",
-			ops:  []wire.OperateOp{gOp(0, wire.OperateOpINCR, 999, 0), gOp(0, wire.OperateOpSHIFTOR, 64, 7)},
-			ret:  []wire.OperateRet{gRet(0)},
-			want: []int64{7},
-		},
-		{
 			name: "HALVE_GRP halves when guard >= threshold",
 			ops: []wire.OperateOp{
-				gOp(0, wire.OperateOpINCR, 300, 0), // guard field 0 = 300
-				gOp(1, wire.OperateOpINCR, 80, 0),  // field 1 = 80
-				gOp(0, wire.OperateOpHALVEGRP, 255, 2),
+				gOp(0, wire.OperateTypeU16, wire.OperateOpINCR, 300, 0),
+				gOp(1, wire.OperateTypeU16, wire.OperateOpINCR, 80, 0),
+				gOp(0, wire.OperateTypeU16, wire.OperateOpHALVEGRP, 255, 2),
 			},
 			ret:  []wire.OperateRet{gRet(0), gRet(1)},
 			want: []int64{150, 40},
@@ -91,16 +83,16 @@ func TestOperateOpcodes(t *testing.T) {
 		{
 			name: "HALVE_GRP no-op when guard < threshold",
 			ops: []wire.OperateOp{
-				gOp(0, wire.OperateOpINCR, 100, 0),
-				gOp(1, wire.OperateOpINCR, 80, 0),
-				gOp(0, wire.OperateOpHALVEGRP, 255, 2),
+				gOp(0, wire.OperateTypeU16, wire.OperateOpINCR, 100, 0),
+				gOp(1, wire.OperateTypeU16, wire.OperateOpINCR, 80, 0),
+				gOp(0, wire.OperateTypeU16, wire.OperateOpHALVEGRP, 255, 2),
 			},
 			ret:  []wire.OperateRet{gRet(0), gRet(1)},
 			want: []int64{100, 80},
 		},
 		{
 			name: "entry fields are independent of globals",
-			ops:  []wire.OperateOp{gOp(0, wire.OperateOpINCR, 1, 0), eOp(7, 0, wire.OperateOpINCR, 42, 0)},
+			ops:  []wire.OperateOp{gOp(0, wire.OperateTypeU8, wire.OperateOpINCR, 1, 0), eOp(7, 0, wire.OperateTypeU8, wire.OperateOpINCR, 42, 0)},
 			ret:  []wire.OperateRet{gRet(0), eRet(7, 0), eRet(7, 5)},
 			want: []int64{1, 42, 0}, // absent entry field reads 0
 		},
@@ -121,12 +113,207 @@ func TestOperateOpcodes(t *testing.T) {
 	}
 }
 
+func TestOperateUnsignedSaturation(t *testing.T) {
+	cases := []struct {
+		name string
+		typ  uint8
+		max  uint64
+	}{
+		{"u8", wire.OperateTypeU8, math.MaxUint8},
+		{"u16", wire.OperateTypeU16, math.MaxUint16},
+		{"u32", wire.OperateTypeU32, math.MaxUint32},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			_, tx := newTestSetup(t)
+			// Add far past the type max in two steps; must cap, not wrap.
+			got := callOperate(t, tx, 1, []byte(c.name), 0, []wire.OperateOp{
+				gOp(0, c.typ, wire.OperateOpINCR, int64(c.max), 0),
+				gOp(0, c.typ, wire.OperateOpINCR, 1000, 0),
+			}, []wire.OperateRet{gRet(0)})
+			if uint64(got[0]) != c.max {
+				t.Fatalf("%s saturated to %d, want %d", c.name, uint64(got[0]), c.max)
+			}
+			// Decrement below zero must floor at 0, not underflow.
+			got = callOperate(t, tx, 2, []byte(c.name), 0, []wire.OperateOp{
+				gOp(0, c.typ, wire.OperateOpINCR, math.MinInt64, 0),
+			}, []wire.OperateRet{gRet(0)})
+			if got[0] != 0 {
+				t.Fatalf("%s underflow to %d, want 0", c.name, got[0])
+			}
+		})
+	}
+}
+
+func TestOperateU64Saturation(t *testing.T) {
+	_, tx := newTestSetup(t)
+	got := callOperate(t, tx, 1, []byte("u64"), 0, []wire.OperateOp{
+		gOp(0, wire.OperateTypeU64, wire.OperateOpINCR, math.MaxInt64, 0),
+		gOp(0, wire.OperateTypeU64, wire.OperateOpINCR, math.MaxInt64, 0),
+		gOp(0, wire.OperateTypeU64, wire.OperateOpINCR, 100, 0),
+	}, []wire.OperateRet{gRet(0)})
+	if uint64(got[0]) != math.MaxUint64 {
+		t.Fatalf("u64 saturated to %d, want MaxUint64", uint64(got[0]))
+	}
+}
+
+func TestOperateSignedSaturation(t *testing.T) {
+	_, tx := newTestSetup(t)
+	// i8 caps at 127 going up and -128 going down.
+	got := callOperate(t, tx, 1, []byte("i8hi"), 0, []wire.OperateOp{
+		gOp(0, wire.OperateTypeI8, wire.OperateOpINCR, 200, 0),
+	}, []wire.OperateRet{gRet(0)})
+	if got[0] != 127 {
+		t.Fatalf("i8 up = %d, want 127", got[0])
+	}
+	got = callOperate(t, tx, 2, []byte("i8lo"), 0, []wire.OperateOp{
+		gOp(0, wire.OperateTypeI8, wire.OperateOpINCR, -200, 0),
+	}, []wire.OperateRet{gRet(0)})
+	if got[0] != -128 {
+		t.Fatalf("i8 down = %d, want -128", got[0])
+	}
+	// i64 caps at the int64 boundary instead of wrapping.
+	got = callOperate(t, tx, 3, []byte("i64"), 0, []wire.OperateOp{
+		gOp(0, wire.OperateTypeI64, wire.OperateOpINCR, math.MaxInt64, 0),
+		gOp(0, wire.OperateTypeI64, wire.OperateOpINCR, 10, 0),
+	}, []wire.OperateRet{gRet(0)})
+	if got[0] != math.MaxInt64 {
+		t.Fatalf("i64 up = %d, want MaxInt64", got[0])
+	}
+}
+
+func TestOperateFloatArithmetic(t *testing.T) {
+	_, tx := newTestSetup(t)
+	// F64 INCRF adds IEEE doubles.
+	got := callOperate(t, tx, 1, []byte("f64"), 0, []wire.OperateOp{
+		gOp(0, wire.OperateTypeF64, wire.OperateOpINCRF, f64arg(1.5), 0),
+		gOp(0, wire.OperateTypeF64, wire.OperateOpINCRF, f64arg(2.5), 0),
+	}, []wire.OperateRet{gRet(0)})
+	if v := math.Float64frombits(uint64(got[0])); v != 4.0 {
+		t.Fatalf("f64 = %v, want 4.0", v)
+	}
+	// F32 INCRF + SETMAX, read back through the low-32 bit pattern.
+	got = callOperate(t, tx, 2, []byte("f32"), 0, []wire.OperateOp{
+		gOp(0, wire.OperateTypeF32, wire.OperateOpINCRF, f32arg(1.5), 0),
+		gOp(0, wire.OperateTypeF32, wire.OperateOpINCRF, f32arg(2.25), 0),
+		gOp(1, wire.OperateTypeF32, wire.OperateOpSETMAX, f32arg(9.5), 0),
+		gOp(1, wire.OperateTypeF32, wire.OperateOpSETMAX, f32arg(3.0), 0),
+	}, []wire.OperateRet{gRet(0), gRet(1)})
+	if v := math.Float32frombits(uint32(got[0])); v != 3.75 {
+		t.Fatalf("f32 sum = %v, want 3.75", v)
+	}
+	if v := math.Float32frombits(uint32(got[1])); v != 9.5 {
+		t.Fatalf("f32 max = %v, want 9.5", v)
+	}
+}
+
+func TestOperateShiftOrMasksToWidth(t *testing.T) {
+	_, tx := newTestSetup(t)
+	// Three shift-4/OR-0xF ops: a u8 field masks to 0xFF (old bits fall off), while
+	// a u32 field keeps growing (0xFFF), proving the mask is per-type-width.
+	got := callOperate(t, tx, 1, []byte("mask"), 0, []wire.OperateOp{
+		gOp(0, wire.OperateTypeU8, wire.OperateOpSHIFTOR, 4, 0xF),
+		gOp(0, wire.OperateTypeU8, wire.OperateOpSHIFTOR, 4, 0xF),
+		gOp(0, wire.OperateTypeU8, wire.OperateOpSHIFTOR, 4, 0xF),
+		gOp(1, wire.OperateTypeU32, wire.OperateOpSHIFTOR, 4, 0xF),
+		gOp(1, wire.OperateTypeU32, wire.OperateOpSHIFTOR, 4, 0xF),
+		gOp(1, wire.OperateTypeU32, wire.OperateOpSHIFTOR, 4, 0xF),
+	}, []wire.OperateRet{gRet(0), gRet(1)})
+	if got[0] != 0xFF {
+		t.Fatalf("u8 SHIFTOR = %#x, want 0xFF (masked to 8 bits)", got[0])
+	}
+	if got[1] != 0xFFF {
+		t.Fatalf("u32 SHIFTOR = %#x, want 0xFFF (unmasked at 32 bits)", got[1])
+	}
+}
+
+func TestOperateShiftOrRejectedOnVarintAndFloat(t *testing.T) {
+	for _, typ := range []uint8{wire.OperateTypeUVARINT, wire.OperateTypeIVARINT, wire.OperateTypeF32, wire.OperateTypeF64} {
+		_, tx := newTestSetup(t)
+		tx.SetApplyStamp(1, true)
+		_, err := handleOperate(tx, wire.EncodeOperateArgs([]byte("s"), 0, 0,
+			[]wire.OperateOp{gOp(0, typ, wire.OperateOpSHIFTOR, 1, 0)}, nil))
+		tx.SetApplyStamp(0, false)
+		if err == nil {
+			t.Fatalf("SHIFTOR on type %d accepted, want error", typ)
+		}
+	}
+}
+
+func TestOperateVarintRoundTripAndGrow(t *testing.T) {
+	_, tx := newTestSetup(t)
+	// UVARINT crosses the 1→2 byte boundary (127 → 300) and keeps the exact value.
+	got := callOperate(t, tx, 1, []byte("uv"), 0, []wire.OperateOp{
+		gOp(0, wire.OperateTypeUVARINT, wire.OperateOpINCR, 100, 0),
+		gOp(0, wire.OperateTypeUVARINT, wire.OperateOpINCR, 200, 0),
+	}, []wire.OperateRet{gRet(0)})
+	if uint64(got[0]) != 300 {
+		t.Fatalf("uvarint = %d, want 300", uint64(got[0]))
+	}
+	// A large UVARINT (multi-byte) round-trips exactly.
+	got = callOperate(t, tx, 2, []byte("uvbig"), 0, []wire.OperateOp{
+		gOp(0, wire.OperateTypeUVARINT, wire.OperateOpINCR, 1<<40, 0),
+	}, []wire.OperateRet{gRet(0)})
+	if uint64(got[0]) != 1<<40 {
+		t.Fatalf("uvarint big = %d, want %d", uint64(got[0]), uint64(1<<40))
+	}
+	// IVARINT holds negatives (zigzag) and round-trips.
+	got = callOperate(t, tx, 3, []byte("iv"), 0, []wire.OperateOp{
+		gOp(0, wire.OperateTypeIVARINT, wire.OperateOpINCR, -5, 0),
+		gOp(0, wire.OperateTypeIVARINT, wire.OperateOpINCR, -1000, 0),
+	}, []wire.OperateRet{gRet(0)})
+	if got[0] != -1005 {
+		t.Fatalf("ivarint = %d, want -1005", got[0])
+	}
+}
+
+func TestOperateVarintEncodingGrows(t *testing.T) {
+	// Directly assert the stored encoding grows across a varint byte boundary.
+	small := operateRec{entries: map[uint64]*operateEntry{}, globals: []operateField{{typ: wire.OperateTypeUVARINT, u: 127}}}
+	big := operateRec{entries: map[uint64]*operateEntry{}, globals: []operateField{{typ: wire.OperateTypeUVARINT, u: 128}}}
+	if len(encodeRec(big)) <= len(encodeRec(small)) {
+		t.Fatalf("uvarint 128 should encode longer than 127: %d vs %d", len(encodeRec(big)), len(encodeRec(small)))
+	}
+}
+
+func TestOperateStoredTypeWins(t *testing.T) {
+	_, tx := newTestSetup(t)
+	key := []byte("stw")
+	// Create field 0 as U8.
+	callOperate(t, tx, 1, key, 0, []wire.OperateOp{gOp(0, wire.OperateTypeU8, wire.OperateOpINCR, 10, 0)}, nil)
+	// A later op DECLARES I64 but the stored U8 wins → still saturates at 255.
+	got := callOperate(t, tx, 2, key, 0, []wire.OperateOp{gOp(0, wire.OperateTypeI64, wire.OperateOpINCR, 300, 0)}, []wire.OperateRet{gRet(0)})
+	if got[0] != 255 {
+		t.Fatalf("stored-type-wins: got %d, want 255 (U8 saturation held)", got[0])
+	}
+}
+
+func TestOperateTypedRecordShrinks(t *testing.T) {
+	// A record of narrow typed fields encodes materially smaller than the same
+	// logical record stored all-i64.
+	narrow := operateRec{entries: map[uint64]*operateEntry{}, globals: []operateField{
+		{typ: wire.OperateTypeU8, u: 200},
+		{typ: wire.OperateTypeU16, u: 5000},
+		{typ: wire.OperateTypeF32, f: 1.5},
+	}}
+	wide := operateRec{entries: map[uint64]*operateEntry{}, globals: []operateField{
+		{typ: wire.OperateTypeI64, u: 200},
+		{typ: wire.OperateTypeI64, u: 5000},
+		{typ: wire.OperateTypeI64, u: 1},
+	}}
+	nn, wn := len(encodeRec(narrow)), len(encodeRec(wide))
+	if nn >= wn {
+		t.Fatalf("typed record (%d bytes) not smaller than all-i64 (%d bytes)", nn, wn)
+	}
+	t.Logf("typed=%d bytes, all-i64=%d bytes (%.0f%% smaller)", nn, wn, 100*(1-float64(nn)/float64(wn)))
+}
+
 func TestOperatePersistsAcrossCalls(t *testing.T) {
 	_, tx := newTestSetup(t)
 	key := []byte("counter")
-	callOperate(t, tx, 100, key, 0, []wire.OperateOp{gOp(0, wire.OperateOpINCR, 1, 0)}, nil)
-	callOperate(t, tx, 200, key, 0, []wire.OperateOp{gOp(0, wire.OperateOpINCR, 1, 0)}, nil)
-	got := callOperate(t, tx, 300, key, 0, []wire.OperateOp{gOp(0, wire.OperateOpINCR, 1, 0)}, []wire.OperateRet{gRet(0)})
+	callOperate(t, tx, 100, key, 0, []wire.OperateOp{gOp(0, wire.OperateTypeU32, wire.OperateOpINCR, 1, 0)}, nil)
+	callOperate(t, tx, 200, key, 0, []wire.OperateOp{gOp(0, wire.OperateTypeU32, wire.OperateOpINCR, 1, 0)}, nil)
+	got := callOperate(t, tx, 300, key, 0, []wire.OperateOp{gOp(0, wire.OperateTypeU32, wire.OperateOpINCR, 1, 0)}, []wire.OperateRet{gRet(0)})
 	if got[0] != 3 {
 		t.Fatalf("accumulated = %d, want 3", got[0])
 	}
@@ -135,13 +322,10 @@ func TestOperatePersistsAcrossCalls(t *testing.T) {
 func TestOperateCapEvictsDeterministicLRU(t *testing.T) {
 	_, tx := newTestSetup(t)
 	key := []byte("sess")
-	// Create entry 1 at t=100, entry 2 at t=200 (cap 2). Mark each so a read
-	// distinguishes present (marker) from evicted (0).
-	callOperate(t, tx, 100, key, 2, []wire.OperateOp{eOp(1, 0, wire.OperateOpINCR, 11, 0)}, nil)
-	callOperate(t, tx, 200, key, 2, []wire.OperateOp{eOp(2, 0, wire.OperateOpINCR, 22, 0)}, nil)
-	// Insert entry 3 at t=300 over the cap → smallest touchMs (entry 1) evicted.
+	callOperate(t, tx, 100, key, 2, []wire.OperateOp{eOp(1, 0, wire.OperateTypeU8, wire.OperateOpINCR, 11, 0)}, nil)
+	callOperate(t, tx, 200, key, 2, []wire.OperateOp{eOp(2, 0, wire.OperateTypeU8, wire.OperateOpINCR, 22, 0)}, nil)
 	got := callOperate(t, tx, 300, key, 2,
-		[]wire.OperateOp{eOp(3, 0, wire.OperateOpINCR, 33, 0)},
+		[]wire.OperateOp{eOp(3, 0, wire.OperateTypeU8, wire.OperateOpINCR, 33, 0)},
 		[]wire.OperateRet{eRet(1, 0), eRet(2, 0), eRet(3, 0)})
 	if got[0] != 0 {
 		t.Fatalf("entry 1 should be evicted (0), got %d", got[0])
@@ -154,14 +338,12 @@ func TestOperateCapEvictsDeterministicLRU(t *testing.T) {
 func TestOperateCapEvictionTieBreaksBySmallestKey(t *testing.T) {
 	_, tx := newTestSetup(t)
 	key := []byte("tie")
-	// Two entries created in the SAME op-list share one touchMs; the tie must break
-	// toward the smallest key (5 evicted, not 9) when a third arrives at the cap.
 	callOperate(t, tx, 100, key, 2, []wire.OperateOp{
-		eOp(9, 0, wire.OperateOpINCR, 99, 0),
-		eOp(5, 0, wire.OperateOpINCR, 55, 0),
+		eOp(9, 0, wire.OperateTypeU8, wire.OperateOpINCR, 99, 0),
+		eOp(5, 0, wire.OperateTypeU8, wire.OperateOpINCR, 55, 0),
 	}, nil)
 	got := callOperate(t, tx, 100, key, 2,
-		[]wire.OperateOp{eOp(7, 0, wire.OperateOpINCR, 77, 0)},
+		[]wire.OperateOp{eOp(7, 0, wire.OperateTypeU8, wire.OperateOpINCR, 77, 0)},
 		[]wire.OperateRet{eRet(5, 0), eRet(9, 0), eRet(7, 0)})
 	if got[0] != 0 {
 		t.Fatalf("smallest-key entry 5 should be evicted (0), got %d", got[0])
@@ -174,13 +356,11 @@ func TestOperateCapEvictionTieBreaksBySmallestKey(t *testing.T) {
 func TestOperateBadOpcodeAbortsAtomically(t *testing.T) {
 	_, tx := newTestSetup(t)
 	key := []byte("atomic")
-	callOperate(t, tx, 100, key, 0, []wire.OperateOp{gOp(0, wire.OperateOpINCR, 5, 0)}, nil)
-	// An op-list whose second op is invalid must leave the record at 5 (the first
-	// op's mutation is discarded — the whole operate is all-or-nothing).
+	callOperate(t, tx, 100, key, 0, []wire.OperateOp{gOp(0, wire.OperateTypeU16, wire.OperateOpINCR, 5, 0)}, nil)
 	tx.SetApplyStamp(200, true)
 	_, err := handleOperate(tx, wire.EncodeOperateArgs(key, 0, 0, []wire.OperateOp{
-		gOp(0, wire.OperateOpINCR, 100, 0),
-		{Target: wire.OperateTargetGlobal, FieldIdx: 0, Opcode: 250 /* unknown */},
+		gOp(0, wire.OperateTypeU16, wire.OperateOpINCR, 100, 0),
+		{Target: wire.OperateTargetGlobal, FieldIdx: 0, Opcode: 250 /* unknown */, Type: wire.OperateTypeU16},
 	}, nil))
 	tx.SetApplyStamp(0, false)
 	if err == nil {
@@ -197,7 +377,7 @@ func TestOperateNegativeShiftRejected(t *testing.T) {
 	tx.SetApplyStamp(1, true)
 	defer tx.SetApplyStamp(0, false)
 	_, err := handleOperate(tx, wire.EncodeOperateArgs([]byte("s"), 0, 0,
-		[]wire.OperateOp{gOp(0, wire.OperateOpSHIFTOR, -1, 0)}, nil))
+		[]wire.OperateOp{gOp(0, wire.OperateTypeU32, wire.OperateOpSHIFTOR, -1, 0)}, nil))
 	if err == nil {
 		t.Fatal("negative shift accepted, want error")
 	}
@@ -207,9 +387,8 @@ func TestOperateFieldIndexOverflowRejected(t *testing.T) {
 	_, tx := newTestSetup(t)
 	tx.SetApplyStamp(1, true)
 	defer tx.SetApplyStamp(0, false)
-	// fieldIdx 65535 needs a globals length of 65536, above maxOperateFields.
 	_, err := handleOperate(tx, wire.EncodeOperateArgs([]byte("o"), 0, 0,
-		[]wire.OperateOp{gOp(65535, wire.OperateOpINCR, 1, 0)}, nil))
+		[]wire.OperateOp{gOp(65535, wire.OperateTypeU8, wire.OperateOpINCR, 1, 0)}, nil))
 	if err == nil {
 		t.Fatal("overflowing field index accepted, want error")
 	}
@@ -220,13 +399,12 @@ func TestOperateFieldIndexOverflowRejected(t *testing.T) {
 func TestOperateEncodeDeterministic(t *testing.T) {
 	build := func() operateRec {
 		rec := operateRec{entries: map[uint64]*operateEntry{}}
-		// Insert in different orders each call to perturb map layout.
 		for _, k := range []uint64{50, 3, 900, 1, 42, 7} {
-			applyOp(&rec, eOp(k, 0, wire.OperateOpINCR, int64(k), 0), 1234, 0) //nolint:errcheck // fixed valid ops
-			applyOp(&rec, eOp(k, 1, wire.OperateOpINCR, int64(k*2), 0), 1234, 0)
+			applyOp(&rec, eOp(k, 0, wire.OperateTypeU16, wire.OperateOpINCR, int64(k), 0), 1234, 0) //nolint:errcheck // fixed valid ops
+			applyOp(&rec, eOp(k, 1, wire.OperateTypeUVARINT, wire.OperateOpINCR, int64(k*2), 0), 1234, 0)
 		}
-		applyOp(&rec, gOp(0, wire.OperateOpINCR, 111, 0), 1234, 0)
-		applyOp(&rec, gOp(2, wire.OperateOpINCR, 222, 0), 1234, 0)
+		applyOp(&rec, gOp(0, wire.OperateTypeF64, wire.OperateOpINCRF, f64arg(1.25), 0), 1234, 0)
+		applyOp(&rec, gOp(2, wire.OperateTypeI32, wire.OperateOpINCR, 222, 0), 1234, 0)
 		return rec
 	}
 	want := encodeRec(build())
@@ -235,7 +413,6 @@ func TestOperateEncodeDeterministic(t *testing.T) {
 			t.Fatal("encodeRec is not deterministic across map layouts")
 		}
 	}
-	// Decode/encode round-trips to the identical bytes.
 	dec, err := decodeRec(want)
 	if err != nil {
 		t.Fatalf("decodeRec: %v", err)
@@ -246,15 +423,16 @@ func TestOperateEncodeDeterministic(t *testing.T) {
 }
 
 // TestOperateReplicaReapplyMatches: two independent decode→apply→encode passes of
-// the SAME committed op-list (the leader vs a follower) produce byte-identical
-// state. This is the RF>1 determinism contract.
+// the SAME committed op-list (leader vs follower) produce byte-identical state,
+// including typed + varint + float fields. This is the RF>1 determinism contract.
 func TestOperateReplicaReapplyMatches(t *testing.T) {
 	opsList := []wire.OperateOp{
-		gOp(0, wire.OperateOpINCR, 7, 0),
-		eOp(100, 0, wire.OperateOpINCR, 1, 0),
-		eOp(5, 2, wire.OperateOpSHIFTOR, 3, 1),
-		eOp(100, 1, wire.OperateOpSETMAX, 9, 0),
-		gOp(1, wire.OperateOpHALVEGRP, 0, 2), // threshold 0 always fires
+		gOp(0, wire.OperateTypeU16, wire.OperateOpINCR, 7, 0),
+		eOp(100, 0, wire.OperateTypeUVARINT, wire.OperateOpINCR, 1, 0),
+		eOp(5, 2, wire.OperateTypeU32, wire.OperateOpSHIFTOR, 3, 1),
+		eOp(100, 1, wire.OperateTypeI64, wire.OperateOpSETMAX, 9, 0),
+		gOp(1, wire.OperateTypeF32, wire.OperateOpINCRF, f32arg(2.5), 0),
+		gOp(2, wire.OperateTypeU8, wire.OperateOpHALVEGRP, 0, 2), // threshold 0 always fires
 	}
 	const nowMs = 987654
 	apply := func(start []byte) []byte {
@@ -274,49 +452,63 @@ func TestOperateReplicaReapplyMatches(t *testing.T) {
 	if !bytes.Equal(leader, follower) {
 		t.Fatal("leader and follower diverged on the same op-list")
 	}
-	// Applying the committed op-list again on top of a prior committed state also
-	// stays identical between replicas.
 	if !bytes.Equal(apply(leader), apply(follower)) {
 		t.Fatal("second-round apply diverged")
 	}
 }
 
-// TestDecodeRecHostile: decodeRec reads whatever bytes are stored under the key
-// (a plain put can set arbitrary bytes), so it must never panic on hostile input.
+// TestDecodeRecHostile: decodeRec reads whatever bytes are stored under the key (a
+// plain put can set arbitrary bytes), so it must never panic on hostile input,
+// including unknown type tags and truncated/over-long varints.
 func TestDecodeRecHostile(t *testing.T) {
 	seeds := [][]byte{
 		nil,
 		{},
 		{1},
 		{0xFF, 0xFF}, // nGlobals=65535, no data
+		func() []byte { // one global field with an unknown type tag
+			b := binary.LittleEndian.AppendUint16(nil, 1)
+			return append(b, 200) // type 200 (unknown)
+		}(),
+		func() []byte { // one global UVARINT that never terminates (all continuation bits)
+			b := binary.LittleEndian.AppendUint16(nil, 1)
+			b = append(b, wire.OperateTypeUVARINT)
+			for range 12 {
+				b = append(b, 0x80) // continuation bit set, no terminator → over-long
+			}
+			return b
+		}(),
 		func() []byte { // nGlobals sane, nEntries hostile
-			b := make([]byte, 0)
-			b = binary.LittleEndian.AppendUint16(b, 0)
+			b := binary.LittleEndian.AppendUint16(nil, 0)
 			b = binary.LittleEndian.AppendUint32(b, 0xFFFFFFFF)
 			return b
 		}(),
 		func() []byte { // one entry with hostile nFields
-			b := make([]byte, 0)
-			b = binary.LittleEndian.AppendUint16(b, 0) // nGlobals
-			b = binary.LittleEndian.AppendUint32(b, 1) // nEntries
-			b = binary.LittleEndian.AppendUint64(b, 1) // key
-			b = binary.LittleEndian.AppendUint64(b, 0) // touchMs
+			b := binary.LittleEndian.AppendUint16(nil, 0) // nGlobals
+			b = binary.LittleEndian.AppendUint32(b, 1)    // nEntries
+			b = binary.LittleEndian.AppendUint64(b, 1)    // key
+			b = binary.LittleEndian.AppendUint64(b, 0)    // touchMs
 			b = binary.LittleEndian.AppendUint16(b, 0xFFFF)
 			return b
 		}(),
 	}
-	for i, s := range seeds {
-		if _, err := decodeRec(s); err == nil && len(s) > 4 {
-			// Some seeds are legitimately decodable; we only require NO PANIC. The
-			// call above returning is the assertion.
-			_ = i
-		}
+	for range seeds {
+		// The assertion is simply that decodeRec returns (no panic) on each seed.
+	}
+	for _, s := range seeds {
+		_, _ = decodeRec(s)
 	}
 }
 
 func FuzzDecodeRec(f *testing.F) {
 	f.Add([]byte{})
 	f.Add([]byte{0, 0, 0, 0, 0, 0})
+	// A valid multi-type record as a structured seed.
+	neg := int64(-4)
+	rec := operateRec{entries: map[uint64]*operateEntry{
+		7: {touchMs: 1, fields: []operateField{{typ: wire.OperateTypeUVARINT, u: 300}, {typ: wire.OperateTypeF32, f: 1.5}}},
+	}, globals: []operateField{{typ: wire.OperateTypeU8, u: 9}, {typ: wire.OperateTypeIVARINT, u: uint64(neg)}}}
+	f.Add(encodeRec(rec))
 	f.Fuzz(func(t *testing.T, b []byte) {
 		_, _ = decodeRec(b) // contract: never panic
 	})

--- a/ops/operate_test.go
+++ b/ops/operate_test.go
@@ -8,6 +8,7 @@ import (
 	"math"
 	"testing"
 
+	"github.com/rostamlabs/rostam/cache"
 	"github.com/rostamlabs/rostam/sdk/wire"
 )
 
@@ -394,6 +395,122 @@ func TestOperateFieldIndexOverflowRejected(t *testing.T) {
 	}
 }
 
+func TestOperateHalveGroupHostileLengthRejected(t *testing.T) {
+	// A huge/overflowing HALVE_GRP group length must be rejected (no idx+len overflow,
+	// no index-out-of-range panic on the replicated apply path), leaving the record
+	// unchanged.
+	for _, arg2 := range []int64{math.MaxInt64, math.MinInt64, -1, 0, int64(maxOperateFields) + 1} {
+		_, tx := newTestSetup(t)
+		key := []byte("hg")
+		callOperate(t, tx, 1, key, 0, []wire.OperateOp{gOp(0, wire.OperateTypeU8, wire.OperateOpINCR, 5, 0)}, nil)
+		tx.SetApplyStamp(2, true)
+		_, err := handleOperate(tx, wire.EncodeOperateArgs(key, 0, 0,
+			[]wire.OperateOp{gOp(0, wire.OperateTypeU8, wire.OperateOpHALVEGRP, 1, arg2)}, nil))
+		tx.SetApplyStamp(0, false)
+		if err == nil {
+			t.Fatalf("HALVE_GRP arg2=%d accepted, want error", arg2)
+		}
+		// Record unchanged: field 0 still 5.
+		got := callOperate(t, tx, 3, key, 0, nil, []wire.OperateRet{gRet(0)})
+		if got[0] != 5 {
+			t.Fatalf("record mutated by rejected HALVE_GRP arg2=%d: got %d, want 5", arg2, got[0])
+		}
+	}
+}
+
+// TestOperateHoleTypeOrderIndependent: creating a high field index first must NOT
+// force the lower (hole) indices to a narrow type — a later write to a hole adopts
+// ITS declared type, independent of order (no silent truncation).
+func TestOperateHoleTypeOrderIndependent(t *testing.T) {
+	_, tx := newTestSetup(t)
+	key := []byte("holes")
+	// Create field 5 (U8) first, which materializes 0..4 as holes.
+	callOperate(t, tx, 1, key, 0, []wire.OperateOp{gOp(5, wire.OperateTypeU8, wire.OperateOpINCR, 1, 0)}, nil)
+	// Now write field 0 as U32 with a value that would truncate under U8.
+	got := callOperate(t, tx, 2, key, 0,
+		[]wire.OperateOp{gOp(0, wire.OperateTypeU32, wire.OperateOpINCR, 100000, 0)},
+		[]wire.OperateRet{gRet(0), gRet(5)})
+	if got[0] != 100000 {
+		t.Fatalf("hole field 0 = %d, want 100000 (U32, not truncated to U8)", got[0])
+	}
+	if got[1] != 1 {
+		t.Fatalf("field 5 = %d, want 1", got[1])
+	}
+	// The other holes (1..4) read as 0 and are still untyped: writing field 2 as
+	// IVARINT with a negative value must hold the negative, not a U8 clamp.
+	got = callOperate(t, tx, 3, key, 0,
+		[]wire.OperateOp{gOp(2, wire.OperateTypeIVARINT, wire.OperateOpINCR, -7, 0)},
+		[]wire.OperateRet{gRet(2)})
+	if got[0] != -7 {
+		t.Fatalf("hole field 2 = %d, want -7 (IVARINT adopted)", got[0])
+	}
+}
+
+func TestOperateRecordTooLargeRejected(t *testing.T) {
+	old := maxOperateRecordBytes
+	maxOperateRecordBytes = 8 // tiny cap so a couple of fields exceed it
+	defer func() { maxOperateRecordBytes = old }()
+
+	_, tx := newTestSetup(t)
+	key := []byte("big")
+	tx.SetApplyStamp(1, true)
+	_, err := handleOperate(tx, wire.EncodeOperateArgs(key, 0, 0, []wire.OperateOp{
+		gOp(0, wire.OperateTypeU64, wire.OperateOpINCR, 1, 0),
+		gOp(1, wire.OperateTypeU64, wire.OperateOpINCR, 1, 0),
+	}, nil))
+	tx.SetApplyStamp(0, false)
+	if err != errOperateRecordTooLarge {
+		t.Fatalf("oversized record: err = %v, want errOperateRecordTooLarge", err)
+	}
+	// Atomic: nothing was written.
+	got := callOperate(t, tx, 2, key, 0, nil, []wire.OperateRet{gRet(0)})
+	if got[0] != 0 {
+		t.Fatalf("record written despite size rejection: got %d, want 0", got[0])
+	}
+}
+
+// TestOperateDirectModeLRU: on the UNSTAMPED (Direct) path touchMs comes from the
+// cache wall clock, so cap-eviction still evicts the least-recently-touched entry
+// rather than degrading to lowest-key. The cache clock is injected so the test is
+// deterministic.
+func TestOperateDirectModeLRU(t *testing.T) {
+	cfg := cache.DefaultConfig()
+	cfg.NumShards = 1
+	c, err := cache.New(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = c.Close() })
+	var now uint64 = 1000
+	c.SetNowFunc(func() uint64 { return now })
+	tx := NewTxContext(c) // UNSTAMPED (Direct) TxContext
+	key := []byte("direct")
+
+	do := func(ops []wire.OperateOp, ret []wire.OperateRet) []int64 {
+		res, err := handleOperate(tx, wire.EncodeOperateArgs(key, 0, 2, ops, ret))
+		if err != nil {
+			t.Fatalf("handleOperate: %v", err)
+		}
+		vals, _ := wire.DecodeOperateResult(res)
+		return vals
+	}
+	now = 1000
+	do([]wire.OperateOp{eOp(9, 0, wire.OperateTypeU8, wire.OperateOpINCR, 90, 0)}, nil) // touch entry 9 (high key) recently-ish
+	now = 2000
+	do([]wire.OperateOp{eOp(1, 0, wire.OperateTypeU8, wire.OperateOpINCR, 10, 0)}, nil) // touch entry 1 (low key) LATER
+	now = 3000
+	// Insert entry 5 over the cap of 2: the LRU victim is entry 9 (oldest touchMs),
+	// NOT the lowest key (which would wrongly evict entry 1).
+	got := do([]wire.OperateOp{eOp(5, 0, wire.OperateTypeU8, wire.OperateOpINCR, 50, 0)},
+		[]wire.OperateRet{eRet(9, 0), eRet(1, 0), eRet(5, 0)})
+	if got[0] != 0 {
+		t.Fatalf("Direct LRU: entry 9 (oldest) should be evicted, got %d", got[0])
+	}
+	if got[1] != 10 || got[2] != 50 {
+		t.Fatalf("Direct LRU: entry 1/5 = %d/%d, want 10/50", got[1], got[2])
+	}
+}
+
 // TestOperateEncodeDeterministic: encodeRec is a pure function of record contents,
 // independent of Go map iteration order, and stable across a decode/encode cycle.
 func TestOperateEncodeDeterministic(t *testing.T) {
@@ -492,9 +609,8 @@ func TestDecodeRecHostile(t *testing.T) {
 			return b
 		}(),
 	}
-	for range seeds {
-		// The assertion is simply that decodeRec returns (no panic) on each seed.
-	}
+	// The contract is simply that decodeRec RETURNS (never panics) on each hostile
+	// seed — reaching the end of the loop is the assertion.
 	for _, s := range seeds {
 		_, _ = decodeRec(s)
 	}

--- a/ops/operate_test.go
+++ b/ops/operate_test.go
@@ -1,0 +1,323 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package ops
+
+import (
+	"bytes"
+	"encoding/binary"
+	"testing"
+
+	"github.com/rostamlabs/rostam/sdk/wire"
+)
+
+// callOperate applies an operate op-list under a leader stamp of nowMs and returns
+// the decoded return-field values. It stamps the tx so touchMs and the eviction
+// order are the deterministic leader-clock path (not the wall clock).
+func callOperate(t *testing.T, tx *TxContext, nowMs int64, key []byte, maxEntries uint16, ops []wire.OperateOp, ret []wire.OperateRet) []int64 {
+	t.Helper()
+	tx.SetApplyStamp(uint64(nowMs), true)
+	defer tx.SetApplyStamp(0, false)
+	res, err := handleOperate(tx, wire.EncodeOperateArgs(key, 0, maxEntries, ops, ret))
+	if err != nil {
+		t.Fatalf("handleOperate: %v", err)
+	}
+	vals, err := wire.DecodeOperateResult(res)
+	if err != nil {
+		t.Fatalf("decode result: %v", err)
+	}
+	return vals
+}
+
+func gOp(field uint16, op uint8, arg, arg2 int64) wire.OperateOp {
+	return wire.OperateOp{Target: wire.OperateTargetGlobal, FieldIdx: field, Opcode: op, Arg: arg, Arg2: arg2}
+}
+func eOp(key uint64, field uint16, op uint8, arg, arg2 int64) wire.OperateOp {
+	return wire.OperateOp{Target: wire.OperateTargetEntry, EntryKey: key, FieldIdx: field, Opcode: op, Arg: arg, Arg2: arg2}
+}
+func gRet(field uint16) wire.OperateRet {
+	return wire.OperateRet{Target: wire.OperateTargetGlobal, FieldIdx: field}
+}
+func eRet(key uint64, field uint16) wire.OperateRet {
+	return wire.OperateRet{Target: wire.OperateTargetEntry, EntryKey: key, FieldIdx: field}
+}
+
+func TestOperateOpcodes(t *testing.T) {
+	tests := []struct {
+		name string
+		ops  []wire.OperateOp
+		ret  []wire.OperateRet
+		want []int64
+	}{
+		{
+			name: "INCR accumulates",
+			ops:  []wire.OperateOp{gOp(0, wire.OperateOpINCR, 5, 0), gOp(0, wire.OperateOpINCR, -2, 0)},
+			ret:  []wire.OperateRet{gRet(0)},
+			want: []int64{3},
+		},
+		{
+			name: "INCRF is integer add",
+			ops:  []wire.OperateOp{gOp(1, wire.OperateOpINCRF, 1500, 0), gOp(1, wire.OperateOpINCRF, 250, 0)},
+			ret:  []wire.OperateRet{gRet(1)},
+			want: []int64{1750},
+		},
+		{
+			name: "SETMAX keeps the larger",
+			ops:  []wire.OperateOp{gOp(2, wire.OperateOpSETMAX, 10, 0), gOp(2, wire.OperateOpSETMAX, 4, 0), gOp(2, wire.OperateOpSETMAX, 12, 0)},
+			ret:  []wire.OperateRet{gRet(2)},
+			want: []int64{12},
+		},
+		{
+			name: "SHIFTOR builds a bitfield",
+			ops:  []wire.OperateOp{gOp(3, wire.OperateOpSHIFTOR, 4, 0x1), gOp(3, wire.OperateOpSHIFTOR, 4, 0x2)},
+			ret:  []wire.OperateRet{gRet(3)},
+			want: []int64{0x12},
+		},
+		{
+			name: "SHIFTOR shift>=64 yields arg2",
+			ops:  []wire.OperateOp{gOp(0, wire.OperateOpINCR, 999, 0), gOp(0, wire.OperateOpSHIFTOR, 64, 7)},
+			ret:  []wire.OperateRet{gRet(0)},
+			want: []int64{7},
+		},
+		{
+			name: "HALVE_GRP halves when guard >= threshold",
+			ops: []wire.OperateOp{
+				gOp(0, wire.OperateOpINCR, 300, 0), // guard field 0 = 300
+				gOp(1, wire.OperateOpINCR, 80, 0),  // field 1 = 80
+				gOp(0, wire.OperateOpHALVEGRP, 255, 2),
+			},
+			ret:  []wire.OperateRet{gRet(0), gRet(1)},
+			want: []int64{150, 40},
+		},
+		{
+			name: "HALVE_GRP no-op when guard < threshold",
+			ops: []wire.OperateOp{
+				gOp(0, wire.OperateOpINCR, 100, 0),
+				gOp(1, wire.OperateOpINCR, 80, 0),
+				gOp(0, wire.OperateOpHALVEGRP, 255, 2),
+			},
+			ret:  []wire.OperateRet{gRet(0), gRet(1)},
+			want: []int64{100, 80},
+		},
+		{
+			name: "entry fields are independent of globals",
+			ops:  []wire.OperateOp{gOp(0, wire.OperateOpINCR, 1, 0), eOp(7, 0, wire.OperateOpINCR, 42, 0)},
+			ret:  []wire.OperateRet{gRet(0), eRet(7, 0), eRet(7, 5)},
+			want: []int64{1, 42, 0}, // absent entry field reads 0
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			_, tx := newTestSetup(t)
+			got := callOperate(t, tx, 1000, []byte(tc.name), 0, tc.ops, tc.ret)
+			if len(got) != len(tc.want) {
+				t.Fatalf("ret len = %d, want %d", len(got), len(tc.want))
+			}
+			for i := range tc.want {
+				if got[i] != tc.want[i] {
+					t.Fatalf("ret[%d] = %d, want %d (all=%v)", i, got[i], tc.want[i], got)
+				}
+			}
+		})
+	}
+}
+
+func TestOperatePersistsAcrossCalls(t *testing.T) {
+	_, tx := newTestSetup(t)
+	key := []byte("counter")
+	callOperate(t, tx, 100, key, 0, []wire.OperateOp{gOp(0, wire.OperateOpINCR, 1, 0)}, nil)
+	callOperate(t, tx, 200, key, 0, []wire.OperateOp{gOp(0, wire.OperateOpINCR, 1, 0)}, nil)
+	got := callOperate(t, tx, 300, key, 0, []wire.OperateOp{gOp(0, wire.OperateOpINCR, 1, 0)}, []wire.OperateRet{gRet(0)})
+	if got[0] != 3 {
+		t.Fatalf("accumulated = %d, want 3", got[0])
+	}
+}
+
+func TestOperateCapEvictsDeterministicLRU(t *testing.T) {
+	_, tx := newTestSetup(t)
+	key := []byte("sess")
+	// Create entry 1 at t=100, entry 2 at t=200 (cap 2). Mark each so a read
+	// distinguishes present (marker) from evicted (0).
+	callOperate(t, tx, 100, key, 2, []wire.OperateOp{eOp(1, 0, wire.OperateOpINCR, 11, 0)}, nil)
+	callOperate(t, tx, 200, key, 2, []wire.OperateOp{eOp(2, 0, wire.OperateOpINCR, 22, 0)}, nil)
+	// Insert entry 3 at t=300 over the cap → smallest touchMs (entry 1) evicted.
+	got := callOperate(t, tx, 300, key, 2,
+		[]wire.OperateOp{eOp(3, 0, wire.OperateOpINCR, 33, 0)},
+		[]wire.OperateRet{eRet(1, 0), eRet(2, 0), eRet(3, 0)})
+	if got[0] != 0 {
+		t.Fatalf("entry 1 should be evicted (0), got %d", got[0])
+	}
+	if got[1] != 22 || got[2] != 33 {
+		t.Fatalf("entry 2/3 = %d/%d, want 22/33", got[1], got[2])
+	}
+}
+
+func TestOperateCapEvictionTieBreaksBySmallestKey(t *testing.T) {
+	_, tx := newTestSetup(t)
+	key := []byte("tie")
+	// Two entries created in the SAME op-list share one touchMs; the tie must break
+	// toward the smallest key (5 evicted, not 9) when a third arrives at the cap.
+	callOperate(t, tx, 100, key, 2, []wire.OperateOp{
+		eOp(9, 0, wire.OperateOpINCR, 99, 0),
+		eOp(5, 0, wire.OperateOpINCR, 55, 0),
+	}, nil)
+	got := callOperate(t, tx, 100, key, 2,
+		[]wire.OperateOp{eOp(7, 0, wire.OperateOpINCR, 77, 0)},
+		[]wire.OperateRet{eRet(5, 0), eRet(9, 0), eRet(7, 0)})
+	if got[0] != 0 {
+		t.Fatalf("smallest-key entry 5 should be evicted (0), got %d", got[0])
+	}
+	if got[1] != 99 || got[2] != 77 {
+		t.Fatalf("entry 9/7 = %d/%d, want 99/77", got[1], got[2])
+	}
+}
+
+func TestOperateBadOpcodeAbortsAtomically(t *testing.T) {
+	_, tx := newTestSetup(t)
+	key := []byte("atomic")
+	callOperate(t, tx, 100, key, 0, []wire.OperateOp{gOp(0, wire.OperateOpINCR, 5, 0)}, nil)
+	// An op-list whose second op is invalid must leave the record at 5 (the first
+	// op's mutation is discarded — the whole operate is all-or-nothing).
+	tx.SetApplyStamp(200, true)
+	_, err := handleOperate(tx, wire.EncodeOperateArgs(key, 0, 0, []wire.OperateOp{
+		gOp(0, wire.OperateOpINCR, 100, 0),
+		{Target: wire.OperateTargetGlobal, FieldIdx: 0, Opcode: 250 /* unknown */},
+	}, nil))
+	tx.SetApplyStamp(0, false)
+	if err == nil {
+		t.Fatal("bad opcode accepted, want error")
+	}
+	got := callOperate(t, tx, 300, key, 0, nil, []wire.OperateRet{gRet(0)})
+	if got[0] != 5 {
+		t.Fatalf("record mutated by aborted op-list: got %d, want 5", got[0])
+	}
+}
+
+func TestOperateNegativeShiftRejected(t *testing.T) {
+	_, tx := newTestSetup(t)
+	tx.SetApplyStamp(1, true)
+	defer tx.SetApplyStamp(0, false)
+	_, err := handleOperate(tx, wire.EncodeOperateArgs([]byte("s"), 0, 0,
+		[]wire.OperateOp{gOp(0, wire.OperateOpSHIFTOR, -1, 0)}, nil))
+	if err == nil {
+		t.Fatal("negative shift accepted, want error")
+	}
+}
+
+func TestOperateFieldIndexOverflowRejected(t *testing.T) {
+	_, tx := newTestSetup(t)
+	tx.SetApplyStamp(1, true)
+	defer tx.SetApplyStamp(0, false)
+	// fieldIdx 65535 needs a globals length of 65536, above maxOperateFields.
+	_, err := handleOperate(tx, wire.EncodeOperateArgs([]byte("o"), 0, 0,
+		[]wire.OperateOp{gOp(65535, wire.OperateOpINCR, 1, 0)}, nil))
+	if err == nil {
+		t.Fatal("overflowing field index accepted, want error")
+	}
+}
+
+// TestOperateEncodeDeterministic: encodeRec is a pure function of record contents,
+// independent of Go map iteration order, and stable across a decode/encode cycle.
+func TestOperateEncodeDeterministic(t *testing.T) {
+	build := func() operateRec {
+		rec := operateRec{entries: map[uint64]*operateEntry{}}
+		// Insert in different orders each call to perturb map layout.
+		for _, k := range []uint64{50, 3, 900, 1, 42, 7} {
+			applyOp(&rec, eOp(k, 0, wire.OperateOpINCR, int64(k), 0), 1234, 0) //nolint:errcheck // fixed valid ops
+			applyOp(&rec, eOp(k, 1, wire.OperateOpINCR, int64(k*2), 0), 1234, 0)
+		}
+		applyOp(&rec, gOp(0, wire.OperateOpINCR, 111, 0), 1234, 0)
+		applyOp(&rec, gOp(2, wire.OperateOpINCR, 222, 0), 1234, 0)
+		return rec
+	}
+	want := encodeRec(build())
+	for range 20 {
+		if got := encodeRec(build()); !bytes.Equal(got, want) {
+			t.Fatal("encodeRec is not deterministic across map layouts")
+		}
+	}
+	// Decode/encode round-trips to the identical bytes.
+	dec, err := decodeRec(want)
+	if err != nil {
+		t.Fatalf("decodeRec: %v", err)
+	}
+	if got := encodeRec(dec); !bytes.Equal(got, want) {
+		t.Fatal("decode∘encode is not stable")
+	}
+}
+
+// TestOperateReplicaReapplyMatches: two independent decode→apply→encode passes of
+// the SAME committed op-list (the leader vs a follower) produce byte-identical
+// state. This is the RF>1 determinism contract.
+func TestOperateReplicaReapplyMatches(t *testing.T) {
+	opsList := []wire.OperateOp{
+		gOp(0, wire.OperateOpINCR, 7, 0),
+		eOp(100, 0, wire.OperateOpINCR, 1, 0),
+		eOp(5, 2, wire.OperateOpSHIFTOR, 3, 1),
+		eOp(100, 1, wire.OperateOpSETMAX, 9, 0),
+		gOp(1, wire.OperateOpHALVEGRP, 0, 2), // threshold 0 always fires
+	}
+	const nowMs = 987654
+	apply := func(start []byte) []byte {
+		rec, err := decodeRec(start)
+		if err != nil {
+			t.Fatalf("decodeRec: %v", err)
+		}
+		for _, o := range opsList {
+			if err := applyOp(&rec, o, nowMs, 8); err != nil {
+				t.Fatalf("applyOp: %v", err)
+			}
+		}
+		return encodeRec(rec)
+	}
+	leader := apply(nil)
+	follower := apply(nil)
+	if !bytes.Equal(leader, follower) {
+		t.Fatal("leader and follower diverged on the same op-list")
+	}
+	// Applying the committed op-list again on top of a prior committed state also
+	// stays identical between replicas.
+	if !bytes.Equal(apply(leader), apply(follower)) {
+		t.Fatal("second-round apply diverged")
+	}
+}
+
+// TestDecodeRecHostile: decodeRec reads whatever bytes are stored under the key
+// (a plain put can set arbitrary bytes), so it must never panic on hostile input.
+func TestDecodeRecHostile(t *testing.T) {
+	seeds := [][]byte{
+		nil,
+		{},
+		{1},
+		{0xFF, 0xFF}, // nGlobals=65535, no data
+		func() []byte { // nGlobals sane, nEntries hostile
+			b := make([]byte, 0)
+			b = binary.LittleEndian.AppendUint16(b, 0)
+			b = binary.LittleEndian.AppendUint32(b, 0xFFFFFFFF)
+			return b
+		}(),
+		func() []byte { // one entry with hostile nFields
+			b := make([]byte, 0)
+			b = binary.LittleEndian.AppendUint16(b, 0) // nGlobals
+			b = binary.LittleEndian.AppendUint32(b, 1) // nEntries
+			b = binary.LittleEndian.AppendUint64(b, 1) // key
+			b = binary.LittleEndian.AppendUint64(b, 0) // touchMs
+			b = binary.LittleEndian.AppendUint16(b, 0xFFFF)
+			return b
+		}(),
+	}
+	for i, s := range seeds {
+		if _, err := decodeRec(s); err == nil && len(s) > 4 {
+			// Some seeds are legitimately decodable; we only require NO PANIC. The
+			// call above returning is the assertion.
+			_ = i
+		}
+	}
+}
+
+func FuzzDecodeRec(f *testing.F) {
+	f.Add([]byte{})
+	f.Add([]byte{0, 0, 0, 0, 0, 0})
+	f.Fuzz(func(t *testing.T, b []byte) {
+		_, _ = decodeRec(b) // contract: never panic
+	})
+}

--- a/ops/wire_aliases.go
+++ b/ops/wire_aliases.go
@@ -29,6 +29,8 @@ type (
 	KeysAddArgs          = wire.KeysAddArgs
 	MVGetBatchRow        = wire.MVGetBatchRow
 	NamedGetBatchRow     = wire.NamedGetBatchRow
+	OperateOp            = wire.OperateOp
+	OperateRet           = wire.OperateRet
 	OrderKeyVal          = wire.OrderKeyVal
 	PutEntry             = wire.PutEntry
 	RedactedKeyEntry     = wire.RedactedKeyEntry
@@ -123,6 +125,10 @@ var (
 	EncodeCollectionsResult                   = wire.EncodeCollectionsResult
 	DecodeIncrExArgs                          = wire.DecodeIncrExArgs
 	EncodeIncrExArgs                          = wire.EncodeIncrExArgs
+	DecodeOperateArgs                         = wire.DecodeOperateArgs
+	EncodeOperateArgs                         = wire.EncodeOperateArgs
+	DecodeOperateResult                       = wire.DecodeOperateResult
+	EncodeOperateResult                       = wire.EncodeOperateResult
 	DecodeMGetArgs                            = wire.DecodeMGetArgs
 	EncodeMGetArgs                            = wire.EncodeMGetArgs
 	DecodeMGetResult                          = wire.DecodeMGetResult

--- a/sdk/wire/builtin_routing.go
+++ b/sdk/wire/builtin_routing.go
@@ -45,6 +45,11 @@ var BuiltinOps = []BuiltinOp{
 	{"ttl", OpReadOnly, StdKeyExtractor, RouteLayoutNone, false},
 	{"incr_ex", OpReadWrite, StdKeyExtractor, RouteLayoutNone, false},
 	{"caex", OpReadWrite, StdKeyExtractor, RouteLayoutNone, false},
+	// operate is the generic atomic multi-field update op. Its args lead with
+	// [keyLen u16][key], so it routes by that key via StdKeyExtractor exactly like
+	// get/put/incr; it is a write (applies its whole op-list under the shard write
+	// lock in one round-trip).
+	{"operate", OpReadWrite, StdKeyExtractor, RouteLayoutNone, false},
 	// put_batch packs N puts into one Raft log entry. It routes by its FIRST key,
 	// so every key in a batch must hash to the same shard — the cluster fan-out
 	// (Node.PutBatch) guarantees that by grouping before it calls.

--- a/sdk/wire/operate.go
+++ b/sdk/wire/operate.go
@@ -51,7 +51,14 @@ const (
 	OperateTypeF64     uint8 = 9
 	OperateTypeUVARINT uint8 = 10
 	OperateTypeIVARINT uint8 = 11
-	OperateTypeCount   uint8 = 12 // exclusive bound: a tag >= this is unknown
+	// OperateTypeUnset marks an unaddressed HOLE in a dense stored field array — a
+	// slot that has never had a real write. It encodes as just its 1-byte tag (no
+	// data), reads back as 0, and ADOPTS the type of its first real write regardless
+	// of op order (so creating field 5 before field 0 never forces 0 to a narrow
+	// type). It is a valid STORED type but is NEVER valid on an op-entry (an op must
+	// declare a real numeric type), so the arg decoder rejects it.
+	OperateTypeUnset uint8 = 12
+	OperateTypeCount uint8 = 13 // exclusive bound: a stored tag >= this is unknown
 )
 
 // Operate targets (the op / return-spec target byte). A target byte outside this
@@ -74,8 +81,9 @@ var ErrBadOperateType = errors.New("wire: operate field type invalid")
 
 // OperateOp is one op-list entry. For a global target EntryKey is ignored; for an
 // entry target it selects the sub-record. Type is the field's type, used to CREATE
-// the field on first touch (ignored if the field already exists — the stored type
-// wins); it must be a valid OperateType*. Arg/Arg2 carry the per-opcode operands
+// the field on first touch or to type a previously-unset hole (ignored once the
+// field has a real type — the stored type then wins); it must be a real numeric
+// OperateType* (0..IVARINT), never OperateTypeUnset. Arg/Arg2 carry the per-opcode operands
 // (INCR/INCRF/SETMAX use only Arg — for a float field Arg is the IEEE bit pattern
 // of the operand; SHIFTOR uses Arg=shift, Arg2=value; HALVE_GRP uses Arg=threshold,
 // Arg2=group length).
@@ -235,7 +243,9 @@ func DecodeOperateArgs(args []byte) (key []byte, ttl time.Duration, maxEntries u
 		off++
 		o.Type = args[off]
 		off++
-		if o.Type >= OperateTypeCount {
+		// An op must declare a real numeric type: reject unknown tags AND the
+		// internal UNSET hole marker (which is a stored-only type).
+		if o.Type >= OperateTypeUnset {
 			return nil, 0, 0, nil, nil, ErrBadOperateType
 		}
 		o.Arg = int64(binary.BigEndian.Uint64(args[off : off+8])) //nolint:gosec // reinterpret stored u64 as i64

--- a/sdk/wire/operate.go
+++ b/sdk/wire/operate.go
@@ -1,0 +1,264 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package wire
+
+import (
+	"encoding/binary"
+	"errors"
+	"time"
+)
+
+// operate is a generic atomic multi-field update op: the client sends a list of
+// pure-integer ops (INCR/INCRF/SETMAX/SHIFTOR/HALVE_GRP) against one Rostam value
+// modelled as a small globals array + a dynamic map of entry sub-records, and the
+// server applies them all atomically under the shard write lock in one round-trip
+// (no client CAS-retry). This file carries only the WIRE codec (args + result);
+// the value model (decodeRec/encodeRec) and the arithmetic (applyOp) live in the
+// ops package, which is the sole authority on opcode semantics.
+
+// Operate opcodes (the op-list entry's opcode byte). The decoder passes the
+// opcode through verbatim; the ops-package handler validates it and is the
+// authority on its arithmetic.
+const (
+	OperateOpINCR     uint8 = 0 // f += arg (i64)
+	OperateOpINCRF    uint8 = 1 // fixed-point add: f += arg (same integer add; distinct for app clarity)
+	OperateOpSETMAX   uint8 = 2 // f = max(f, arg)
+	OperateOpSHIFTOR  uint8 = 3 // f = (f << arg) | arg2  (arg = shift bits, arg2 = value)
+	OperateOpHALVEGRP uint8 = 4 // if f[fieldIdx] >= arg, halve fields [fieldIdx, fieldIdx+arg2)
+)
+
+// Operate targets (the op / return-spec target byte). A target byte outside this
+// set is a malformed frame (the decoder cannot know whether an entryKey follows),
+// so the decoder rejects it rather than guessing.
+const (
+	OperateTargetGlobal uint8 = 0 // fieldIdx indexes the globals array
+	OperateTargetEntry  uint8 = 1 // (entryKey, fieldIdx) indexes a field inside an entry sub-record
+)
+
+// ErrBadOperateTarget indicates an operate op or return spec whose target byte is
+// neither Global nor Entry — a malformed frame, since the target byte determines
+// whether an 8-byte entryKey follows.
+var ErrBadOperateTarget = errors.New("wire: operate target byte invalid")
+
+// OperateOp is one op-list entry. For a global target EntryKey is ignored; for an
+// entry target it selects the sub-record. Arg/Arg2 carry the per-opcode operands
+// (INCR/INCRF/SETMAX use only Arg; SHIFTOR uses Arg=shift, Arg2=value; HALVE_GRP
+// uses Arg=threshold, Arg2=group length).
+type OperateOp struct {
+	Target   uint8
+	EntryKey uint64
+	FieldIdx uint16
+	Opcode   uint8
+	Arg      int64
+	Arg2     int64
+}
+
+// OperateRet is one return spec: the field whose post-apply i64 value the op
+// should read back (so a single round-trip can update and read like Aerospike's
+// Operate returning the record). EntryKey is ignored for a global target.
+type OperateRet struct {
+	Target   uint8
+	EntryKey uint64
+	FieldIdx uint16
+}
+
+// operateOpWireLen is the encoded size of one op: [tgt u8][entryKey u64 iff
+// entry][fieldIdx u16][opcode u8][arg i64][arg2 i64]. A global op omits the
+// entryKey (20 bytes); an entry op includes it (28 bytes). operateMinOpBytes is
+// the smallest honest per-op size, used to bound the declared nOps before any
+// allocation (CountFitsIn), exactly like the batch decoders.
+const (
+	operateMinOpBytes  = 20 // global op: 1 + 2 + 1 + 8 + 8
+	operateMinRetBytes = 3  // global return spec: 1 + 2
+)
+
+func operateOpWireLen(o OperateOp) int {
+	n := operateMinOpBytes
+	if o.Target == OperateTargetEntry {
+		n += 8
+	}
+	return n
+}
+
+func operateRetWireLen(r OperateRet) int {
+	n := operateMinRetBytes
+	if r.Target == OperateTargetEntry {
+		n += 8
+	}
+	return n
+}
+
+// EncodeOperateArgs encodes the operate args:
+//
+//	[keyLen u16][key][ttlMs u64][maxEntries u16][nOps u32]
+//	  per op: [tgt u8][entryKey u64 iff tgt=1][fieldIdx u16][opcode u8][arg i64][arg2 i64]
+//	[nReturn u16][ per return: [tgt u8][entryKey u64 iff tgt=1][fieldIdx u16] ]
+//
+// maxEntries==0 means the entry map is unbounded; ttl==0 stores the record with
+// no expiry (ttl is applied to the whole record on every call, like put).
+func EncodeOperateArgs(key []byte, ttl time.Duration, maxEntries uint16, ops []OperateOp, ret []OperateRet) []byte {
+	total := 2 + len(key) + 8 + 2 + 4
+	for _, o := range ops {
+		total += operateOpWireLen(o)
+	}
+	total += 2
+	for _, r := range ret {
+		total += operateRetWireLen(r)
+	}
+	buf := make([]byte, 0, total)
+	buf = binary.BigEndian.AppendUint16(buf, uint16(len(key))) //nolint:gosec // bounded by upstream key length limits
+	buf = append(buf, key...)
+	buf = binary.BigEndian.AppendUint64(buf, uint64(ttl/time.Millisecond)) //nolint:gosec // duration to milliseconds always positive
+	buf = binary.BigEndian.AppendUint16(buf, maxEntries)
+	buf = binary.BigEndian.AppendUint32(buf, uint32(len(ops))) //nolint:gosec // caller-supplied op count
+	for _, o := range ops {
+		buf = append(buf, o.Target)
+		if o.Target == OperateTargetEntry {
+			buf = binary.BigEndian.AppendUint64(buf, o.EntryKey)
+		}
+		buf = binary.BigEndian.AppendUint16(buf, o.FieldIdx)
+		buf = append(buf, o.Opcode)
+		buf = binary.BigEndian.AppendUint64(buf, uint64(o.Arg))  //nolint:gosec // reinterpret i64 as u64 for binary write
+		buf = binary.BigEndian.AppendUint64(buf, uint64(o.Arg2)) //nolint:gosec // reinterpret i64 as u64 for binary write
+	}
+	buf = binary.BigEndian.AppendUint16(buf, uint16(len(ret))) //nolint:gosec // caller-supplied return count (<= 65535)
+	for _, r := range ret {
+		buf = append(buf, r.Target)
+		if r.Target == OperateTargetEntry {
+			buf = binary.BigEndian.AppendUint64(buf, r.EntryKey)
+		}
+		buf = binary.BigEndian.AppendUint16(buf, r.FieldIdx)
+	}
+	return buf
+}
+
+// DecodeOperateArgs reads args produced by EncodeOperateArgs. Every length/count
+// is bounds-checked BEFORE use in the 32-bit-safe `len(args)-off < need` form:
+// nOps (a u32, the real overflow hazard) is bounded by CountFitsIn against the
+// smallest honest op size before the ops slice is reserved, so a hostile count
+// cannot drive an out-of-memory reservation; each op/return spec is then read
+// with per-field truncation checks. A malformed frame returns an error — never a
+// panic or an over-read (see ops.TestNoDecoderPanicsOnHostileBytes). ttlMs is
+// rejected via ttlFromMs if it would overflow the time.Duration.
+func DecodeOperateArgs(args []byte) (key []byte, ttl time.Duration, maxEntries uint16, ops []OperateOp, ret []OperateRet, err error) {
+	if len(args) < 2 {
+		return nil, 0, 0, nil, nil, ErrShortArgs
+	}
+	klen := int(binary.BigEndian.Uint16(args[0:2]))
+	off := 2
+	if len(args)-off < klen+8+2+4 { // key + ttlMs(8) + maxEntries(2) + nOps(4)
+		return nil, 0, 0, nil, nil, ErrShortArgs
+	}
+	key = args[off : off+klen]
+	off += klen
+	ttl, err = ttlFromMs(binary.BigEndian.Uint64(args[off : off+8]))
+	if err != nil {
+		return nil, 0, 0, nil, nil, err
+	}
+	off += 8
+	maxEntries = binary.BigEndian.Uint16(args[off : off+2])
+	off += 2
+	nOps := int(binary.BigEndian.Uint32(args[off : off+4]))
+	off += 4
+	// Bound nOps before reserving: the smallest honest op is operateMinOpBytes, so a
+	// count above remaining/that cannot be honest (and CountFitsIn also rejects the
+	// 32-bit-negative widening of the u32).
+	if !CountFitsIn(nOps, len(args)-off, operateMinOpBytes) {
+		return nil, 0, 0, nil, nil, ErrShortArgs
+	}
+	ops = make([]OperateOp, 0, nOps)
+	for range nOps {
+		var o OperateOp
+		if len(args)-off < 1 {
+			return nil, 0, 0, nil, nil, ErrShortArgs
+		}
+		o.Target = args[off]
+		off++
+		switch o.Target {
+		case OperateTargetGlobal:
+			// no entryKey
+		case OperateTargetEntry:
+			if len(args)-off < 8 {
+				return nil, 0, 0, nil, nil, ErrShortArgs
+			}
+			o.EntryKey = binary.BigEndian.Uint64(args[off : off+8])
+			off += 8
+		default:
+			return nil, 0, 0, nil, nil, ErrBadOperateTarget
+		}
+		if len(args)-off < 2+1+8+8 { // fieldIdx(2) + opcode(1) + arg(8) + arg2(8)
+			return nil, 0, 0, nil, nil, ErrShortArgs
+		}
+		o.FieldIdx = binary.BigEndian.Uint16(args[off : off+2])
+		off += 2
+		o.Opcode = args[off]
+		off++
+		o.Arg = int64(binary.BigEndian.Uint64(args[off : off+8])) //nolint:gosec // reinterpret stored u64 as i64
+		off += 8
+		o.Arg2 = int64(binary.BigEndian.Uint64(args[off : off+8])) //nolint:gosec // reinterpret stored u64 as i64
+		off += 8
+		ops = append(ops, o)
+	}
+	if len(args)-off < 2 {
+		return nil, 0, 0, nil, nil, ErrShortArgs
+	}
+	nRet := int(binary.BigEndian.Uint16(args[off : off+2]))
+	off += 2
+	// nRet is a u16 (<= 65535) so it cannot widen negative, but bound it anyway
+	// against the smallest honest return-spec size before reserving.
+	if !CountFitsIn(nRet, len(args)-off, operateMinRetBytes) {
+		return nil, 0, 0, nil, nil, ErrShortArgs
+	}
+	ret = make([]OperateRet, 0, nRet)
+	for range nRet {
+		var r OperateRet
+		if len(args)-off < 1 {
+			return nil, 0, 0, nil, nil, ErrShortArgs
+		}
+		r.Target = args[off]
+		off++
+		switch r.Target {
+		case OperateTargetGlobal:
+			// no entryKey
+		case OperateTargetEntry:
+			if len(args)-off < 8 {
+				return nil, 0, 0, nil, nil, ErrShortArgs
+			}
+			r.EntryKey = binary.BigEndian.Uint64(args[off : off+8])
+			off += 8
+		default:
+			return nil, 0, 0, nil, nil, ErrBadOperateTarget
+		}
+		if len(args)-off < 2 {
+			return nil, 0, 0, nil, nil, ErrShortArgs
+		}
+		r.FieldIdx = binary.BigEndian.Uint16(args[off : off+2])
+		off += 2
+		ret = append(ret, r)
+	}
+	return key, ttl, maxEntries, ops, ret, nil
+}
+
+// EncodeOperateResult encodes the operate result: the requested field values as
+// i64 BE in request order (one 8-byte slot per return spec).
+func EncodeOperateResult(vals []int64) []byte {
+	buf := make([]byte, 0, len(vals)*8)
+	for _, v := range vals {
+		buf = binary.BigEndian.AppendUint64(buf, uint64(v)) //nolint:gosec // reinterpret i64 as u64 for binary write
+	}
+	return buf
+}
+
+// DecodeOperateResult reads a result produced by EncodeOperateResult back into a
+// slice of i64 (one per return spec). The result must be a whole number of 8-byte
+// slots.
+func DecodeOperateResult(b []byte) ([]int64, error) {
+	if len(b)%8 != 0 {
+		return nil, ErrShortArgs
+	}
+	out := make([]int64, len(b)/8)
+	for i := range out {
+		out[i] = int64(binary.BigEndian.Uint64(b[i*8 : i*8+8])) //nolint:gosec // reinterpret stored u64 as i64
+	}
+	return out, nil
+}

--- a/sdk/wire/operate.go
+++ b/sdk/wire/operate.go
@@ -9,22 +9,49 @@ import (
 )
 
 // operate is a generic atomic multi-field update op: the client sends a list of
-// pure-integer ops (INCR/INCRF/SETMAX/SHIFTOR/HALVE_GRP) against one Rostam value
-// modelled as a small globals array + a dynamic map of entry sub-records, and the
-// server applies them all atomically under the shard write lock in one round-trip
-// (no client CAS-retry). This file carries only the WIRE codec (args + result);
-// the value model (decodeRec/encodeRec) and the arithmetic (applyOp) live in the
-// ops package, which is the sole authority on opcode semantics.
+// pure-integer/float ops (INCR/INCRF/SETMAX/SHIFTOR/HALVE_GRP) against one Rostam
+// value modelled as a small globals array + a dynamic map of entry sub-records,
+// and the server applies them all atomically under the shard write lock in one
+// round-trip (no client CAS-retry). This file carries only the WIRE codec (args +
+// result); the value model (decodeRec/encodeRec) and the arithmetic (applyOp) live
+// in the ops package, which is the sole authority on opcode/type semantics.
+//
+// Fields are TYPED for memory efficiency: each field carries a 1-byte type tag so
+// a u8 counter costs 2 bytes stored (tag + data) instead of 8. The app owns which
+// type each field is; the type rides the op-entry so a field can be created on
+// first touch, and the STORED type wins for a field that already exists.
 
 // Operate opcodes (the op-list entry's opcode byte). The decoder passes the
 // opcode through verbatim; the ops-package handler validates it and is the
 // authority on its arithmetic.
 const (
-	OperateOpINCR     uint8 = 0 // f += arg (i64)
-	OperateOpINCRF    uint8 = 1 // fixed-point add: f += arg (same integer add; distinct for app clarity)
+	OperateOpINCR     uint8 = 0 // f += arg (integer add, or float add on a float field)
+	OperateOpINCRF    uint8 = 1 // same as INCR (kept distinct for app clarity; float fields do IEEE add)
 	OperateOpSETMAX   uint8 = 2 // f = max(f, arg)
-	OperateOpSHIFTOR  uint8 = 3 // f = (f << arg) | arg2  (arg = shift bits, arg2 = value)
+	OperateOpSHIFTOR  uint8 = 3 // f = ((f << arg) | arg2) masked to the field width (fixed-width int only)
 	OperateOpHALVEGRP uint8 = 4 // if f[fieldIdx] >= arg, halve fields [fieldIdx, fieldIdx+arg2)
+)
+
+// Operate field types (the type tag on an op-entry and on every stored field). The
+// app assigns each field index a type; INCR/INCRF/SETMAX on a fixed-width int
+// SATURATE at that type's range, SHIFTOR masks to its bit width, and floats use
+// IEEE math. UVARINT/IVARINT are LEB128 (IVARINT zigzag) with no fixed width — a
+// compact, growable counter. OperateTypeCount is the exclusive upper bound used to
+// reject an unknown tag.
+const (
+	OperateTypeU8      uint8 = 0
+	OperateTypeU16     uint8 = 1
+	OperateTypeU32     uint8 = 2
+	OperateTypeU64     uint8 = 3
+	OperateTypeI8      uint8 = 4
+	OperateTypeI16     uint8 = 5
+	OperateTypeI32     uint8 = 6
+	OperateTypeI64     uint8 = 7
+	OperateTypeF32     uint8 = 8
+	OperateTypeF64     uint8 = 9
+	OperateTypeUVARINT uint8 = 10
+	OperateTypeIVARINT uint8 = 11
+	OperateTypeCount   uint8 = 12 // exclusive bound: a tag >= this is unknown
 )
 
 // Operate targets (the op / return-spec target byte). A target byte outside this
@@ -40,36 +67,46 @@ const (
 // whether an 8-byte entryKey follows.
 var ErrBadOperateTarget = errors.New("wire: operate target byte invalid")
 
+// ErrBadOperateType indicates an op-entry whose field type tag is unknown (>=
+// OperateTypeCount) — rejected at decode so an op can never create a field of an
+// unknown type.
+var ErrBadOperateType = errors.New("wire: operate field type invalid")
+
 // OperateOp is one op-list entry. For a global target EntryKey is ignored; for an
-// entry target it selects the sub-record. Arg/Arg2 carry the per-opcode operands
-// (INCR/INCRF/SETMAX use only Arg; SHIFTOR uses Arg=shift, Arg2=value; HALVE_GRP
-// uses Arg=threshold, Arg2=group length).
+// entry target it selects the sub-record. Type is the field's type, used to CREATE
+// the field on first touch (ignored if the field already exists — the stored type
+// wins); it must be a valid OperateType*. Arg/Arg2 carry the per-opcode operands
+// (INCR/INCRF/SETMAX use only Arg — for a float field Arg is the IEEE bit pattern
+// of the operand; SHIFTOR uses Arg=shift, Arg2=value; HALVE_GRP uses Arg=threshold,
+// Arg2=group length).
 type OperateOp struct {
 	Target   uint8
 	EntryKey uint64
 	FieldIdx uint16
 	Opcode   uint8
+	Type     uint8
 	Arg      int64
 	Arg2     int64
 }
 
-// OperateRet is one return spec: the field whose post-apply i64 value the op
-// should read back (so a single round-trip can update and read like Aerospike's
-// Operate returning the record). EntryKey is ignored for a global target.
+// OperateRet is one return spec: the field whose post-apply value the op reads
+// back (so one round-trip can update and read like Aerospike's Operate returning
+// the record). EntryKey is ignored for a global target. The returned i64 is the
+// field's RAW bits — the integer value for int/varint types, or the IEEE bit
+// pattern for F32 (low 32 bits) / F64 — interpreted by the caller per the type.
 type OperateRet struct {
 	Target   uint8
 	EntryKey uint64
 	FieldIdx uint16
 }
 
-// operateOpWireLen is the encoded size of one op: [tgt u8][entryKey u64 iff
-// entry][fieldIdx u16][opcode u8][arg i64][arg2 i64]. A global op omits the
-// entryKey (20 bytes); an entry op includes it (28 bytes). operateMinOpBytes is
-// the smallest honest per-op size, used to bound the declared nOps before any
-// allocation (CountFitsIn), exactly like the batch decoders.
+// operateMinOpBytes is the smallest honest per-op size — a global op:
+// [tgt u8][fieldIdx u16][opcode u8][ftype u8][arg i64][arg2 i64] = 21. An entry op
+// adds an 8-byte entryKey. operateMinRetBytes is the smallest return spec (global,
+// [tgt u8][fieldIdx u16] = 3). Both bound a declared count before allocation.
 const (
-	operateMinOpBytes  = 20 // global op: 1 + 2 + 1 + 8 + 8
-	operateMinRetBytes = 3  // global return spec: 1 + 2
+	operateMinOpBytes  = 21
+	operateMinRetBytes = 3
 )
 
 func operateOpWireLen(o OperateOp) int {
@@ -91,7 +128,7 @@ func operateRetWireLen(r OperateRet) int {
 // EncodeOperateArgs encodes the operate args:
 //
 //	[keyLen u16][key][ttlMs u64][maxEntries u16][nOps u32]
-//	  per op: [tgt u8][entryKey u64 iff tgt=1][fieldIdx u16][opcode u8][arg i64][arg2 i64]
+//	  per op: [tgt u8][entryKey u64 iff tgt=1][fieldIdx u16][opcode u8][ftype u8][arg i64][arg2 i64]
 //	[nReturn u16][ per return: [tgt u8][entryKey u64 iff tgt=1][fieldIdx u16] ]
 //
 // maxEntries==0 means the entry map is unbounded; ttl==0 stores the record with
@@ -118,6 +155,7 @@ func EncodeOperateArgs(key []byte, ttl time.Duration, maxEntries uint16, ops []O
 		}
 		buf = binary.BigEndian.AppendUint16(buf, o.FieldIdx)
 		buf = append(buf, o.Opcode)
+		buf = append(buf, o.Type)
 		buf = binary.BigEndian.AppendUint64(buf, uint64(o.Arg))  //nolint:gosec // reinterpret i64 as u64 for binary write
 		buf = binary.BigEndian.AppendUint64(buf, uint64(o.Arg2)) //nolint:gosec // reinterpret i64 as u64 for binary write
 	}
@@ -137,9 +175,11 @@ func EncodeOperateArgs(key []byte, ttl time.Duration, maxEntries uint16, ops []O
 // nOps (a u32, the real overflow hazard) is bounded by CountFitsIn against the
 // smallest honest op size before the ops slice is reserved, so a hostile count
 // cannot drive an out-of-memory reservation; each op/return spec is then read
-// with per-field truncation checks. A malformed frame returns an error — never a
-// panic or an over-read (see ops.TestNoDecoderPanicsOnHostileBytes). ttlMs is
-// rejected via ttlFromMs if it would overflow the time.Duration.
+// with per-field truncation checks. Each op's field type tag is validated (unknown
+// → ErrBadOperateType) so an op can never create an unknown-typed field. A
+// malformed frame returns an error — never a panic or an over-read (see
+// ops.TestNoDecoderPanicsOnHostileBytes). ttlMs is rejected via ttlFromMs if it
+// would overflow the time.Duration.
 func DecodeOperateArgs(args []byte) (key []byte, ttl time.Duration, maxEntries uint16, ops []OperateOp, ret []OperateRet, err error) {
 	if len(args) < 2 {
 		return nil, 0, 0, nil, nil, ErrShortArgs
@@ -186,13 +226,18 @@ func DecodeOperateArgs(args []byte) (key []byte, ttl time.Duration, maxEntries u
 		default:
 			return nil, 0, 0, nil, nil, ErrBadOperateTarget
 		}
-		if len(args)-off < 2+1+8+8 { // fieldIdx(2) + opcode(1) + arg(8) + arg2(8)
+		if len(args)-off < 2+1+1+8+8 { // fieldIdx(2) + opcode(1) + ftype(1) + arg(8) + arg2(8)
 			return nil, 0, 0, nil, nil, ErrShortArgs
 		}
 		o.FieldIdx = binary.BigEndian.Uint16(args[off : off+2])
 		off += 2
 		o.Opcode = args[off]
 		off++
+		o.Type = args[off]
+		off++
+		if o.Type >= OperateTypeCount {
+			return nil, 0, 0, nil, nil, ErrBadOperateType
+		}
 		o.Arg = int64(binary.BigEndian.Uint64(args[off : off+8])) //nolint:gosec // reinterpret stored u64 as i64
 		off += 8
 		o.Arg2 = int64(binary.BigEndian.Uint64(args[off : off+8])) //nolint:gosec // reinterpret stored u64 as i64
@@ -240,7 +285,8 @@ func DecodeOperateArgs(args []byte) (key []byte, ttl time.Duration, maxEntries u
 }
 
 // EncodeOperateResult encodes the operate result: the requested field values as
-// i64 BE in request order (one 8-byte slot per return spec).
+// i64 BE in request order (one 8-byte slot per return spec). Each value is the
+// field's raw bits (see OperateRet).
 func EncodeOperateResult(vals []int64) []byte {
 	buf := make([]byte, 0, len(vals)*8)
 	for _, v := range vals {

--- a/sdk/wire/operate_test.go
+++ b/sdk/wire/operate_test.go
@@ -143,6 +143,10 @@ func TestDecodeOperateArgsBadType(t *testing.T) {
 	if _, _, _, _, _, err := DecodeOperateArgs(buildOperateFrame(OperateTargetGlobal, OperateOpINCR, 200)); err != ErrBadOperateType {
 		t.Fatalf("bad type 200: err = %v, want ErrBadOperateType", err)
 	}
+	// The UNSET hole marker is a stored-only type; it must be rejected on an op-entry.
+	if _, _, _, _, _, err := DecodeOperateArgs(buildOperateFrame(OperateTargetGlobal, OperateOpINCR, OperateTypeUnset)); err != ErrBadOperateType {
+		t.Fatalf("UNSET on op: err = %v, want ErrBadOperateType", err)
+	}
 }
 
 func TestDecodeOperateArgsHostileNOps(t *testing.T) {
@@ -174,8 +178,9 @@ func FuzzDecodeOperateArgs(f *testing.F) {
 	f.Add(EncodeOperateArgs([]byte("k"), time.Second, 4,
 		[]OperateOp{{Target: OperateTargetGlobal, FieldIdx: 0, Opcode: OperateOpINCR, Type: OperateTypeU8, Arg: 1}},
 		[]OperateRet{{Target: OperateTargetGlobal, FieldIdx: 0}}))
-	// One seed per field type so the corpus exercises every tag.
-	for ty := uint8(0); ty < OperateTypeCount; ty++ {
+	// One seed per real op field type so the corpus exercises every tag (UNSET is
+	// stored-only and invalid on an op, so stop below it).
+	for ty := uint8(0); ty < OperateTypeUnset; ty++ {
 		f.Add(EncodeOperateArgs([]byte("t"), 0, 2,
 			[]OperateOp{{Target: OperateTargetEntry, EntryKey: 1, FieldIdx: 0, Opcode: OperateOpINCR, Type: ty, Arg: 3}},
 			[]OperateRet{{Target: OperateTargetEntry, EntryKey: 1, FieldIdx: 0}}))

--- a/sdk/wire/operate_test.go
+++ b/sdk/wire/operate_test.go
@@ -38,11 +38,11 @@ func TestOperateArgsRoundtrip(t *testing.T) {
 	ttl := 90 * time.Second
 	maxEntries := uint16(1024)
 	ops := []OperateOp{
-		{Target: OperateTargetGlobal, FieldIdx: 0, Opcode: OperateOpINCR, Arg: 1},
-		{Target: OperateTargetGlobal, FieldIdx: 3, Opcode: OperateOpINCRF, Arg: 12345},
-		{Target: OperateTargetGlobal, FieldIdx: 2, Opcode: OperateOpSETMAX, Arg: -7},
-		{Target: OperateTargetEntry, EntryKey: 0xDEADBEEF, FieldIdx: 1, Opcode: OperateOpSHIFTOR, Arg: 4, Arg2: 0xF},
-		{Target: OperateTargetEntry, EntryKey: 99, FieldIdx: 0, Opcode: OperateOpHALVEGRP, Arg: 255, Arg2: 2},
+		{Target: OperateTargetGlobal, FieldIdx: 0, Opcode: OperateOpINCR, Type: OperateTypeU8, Arg: 1},
+		{Target: OperateTargetGlobal, FieldIdx: 3, Opcode: OperateOpINCRF, Type: OperateTypeF32, Arg: 12345},
+		{Target: OperateTargetGlobal, FieldIdx: 2, Opcode: OperateOpSETMAX, Type: OperateTypeI16, Arg: -7},
+		{Target: OperateTargetEntry, EntryKey: 0xDEADBEEF, FieldIdx: 1, Opcode: OperateOpSHIFTOR, Type: OperateTypeU32, Arg: 4, Arg2: 0xF},
+		{Target: OperateTargetEntry, EntryKey: 99, FieldIdx: 0, Opcode: OperateOpHALVEGRP, Type: OperateTypeUVARINT, Arg: 255, Arg2: 2},
 	}
 	ret := []OperateRet{
 		{Target: OperateTargetGlobal, FieldIdx: 0},
@@ -102,7 +102,7 @@ func TestOperateResultRejectsRagged(t *testing.T) {
 
 func TestDecodeOperateArgsTruncation(t *testing.T) {
 	full := EncodeOperateArgs([]byte("abc"), time.Second, 8,
-		[]OperateOp{{Target: OperateTargetEntry, EntryKey: 5, FieldIdx: 1, Opcode: OperateOpINCR, Arg: 1}},
+		[]OperateOp{{Target: OperateTargetEntry, EntryKey: 5, FieldIdx: 1, Opcode: OperateOpINCR, Type: OperateTypeU16, Arg: 1}},
 		[]OperateRet{{Target: OperateTargetEntry, EntryKey: 5, FieldIdx: 1}})
 	// Every prefix short of the whole frame must be rejected, never panic.
 	for n := 0; n < len(full); n++ {
@@ -112,20 +112,36 @@ func TestDecodeOperateArgsTruncation(t *testing.T) {
 	}
 }
 
-func TestDecodeOperateArgsBadTarget(t *testing.T) {
-	// One op with an out-of-range target byte (2).
+// buildOperateFrame assembles an args frame with one global op carrying the given
+// target/opcode/type bytes, for the malformed-tag tests.
+func buildOperateFrame(target, opcode, ftype uint8) []byte {
 	frame := make([]byte, 0)
 	frame = binary.BigEndian.AppendUint16(frame, 0) // keyLen=0
 	frame = binary.BigEndian.AppendUint64(frame, 0) // ttlMs
 	frame = binary.BigEndian.AppendUint16(frame, 0) // maxEntries
 	frame = binary.BigEndian.AppendUint32(frame, 1) // nOps=1
-	frame = append(frame, 2)                        // tgt=2 (invalid)
+	frame = append(frame, target)
 	frame = binary.BigEndian.AppendUint16(frame, 0) // fieldIdx
-	frame = append(frame, OperateOpINCR)            // opcode
+	frame = append(frame, opcode)
+	frame = append(frame, ftype)
 	frame = binary.BigEndian.AppendUint64(frame, 0) // arg
 	frame = binary.BigEndian.AppendUint64(frame, 0) // arg2
-	if _, _, _, _, _, err := DecodeOperateArgs(frame); err != ErrBadOperateTarget {
+	frame = binary.BigEndian.AppendUint16(frame, 0) // nRet=0
+	return frame
+}
+
+func TestDecodeOperateArgsBadTarget(t *testing.T) {
+	if _, _, _, _, _, err := DecodeOperateArgs(buildOperateFrame(2, OperateOpINCR, OperateTypeU8)); err != ErrBadOperateTarget {
 		t.Fatalf("bad target: err = %v, want ErrBadOperateTarget", err)
+	}
+}
+
+func TestDecodeOperateArgsBadType(t *testing.T) {
+	if _, _, _, _, _, err := DecodeOperateArgs(buildOperateFrame(OperateTargetGlobal, OperateOpINCR, OperateTypeCount)); err != ErrBadOperateType {
+		t.Fatalf("bad type: err = %v, want ErrBadOperateType", err)
+	}
+	if _, _, _, _, _, err := DecodeOperateArgs(buildOperateFrame(OperateTargetGlobal, OperateOpINCR, 200)); err != ErrBadOperateType {
+		t.Fatalf("bad type 200: err = %v, want ErrBadOperateType", err)
 	}
 }
 
@@ -156,8 +172,14 @@ func TestDecodeOperateArgsTTLOverflow(t *testing.T) {
 
 func FuzzDecodeOperateArgs(f *testing.F) {
 	f.Add(EncodeOperateArgs([]byte("k"), time.Second, 4,
-		[]OperateOp{{Target: OperateTargetGlobal, FieldIdx: 0, Opcode: OperateOpINCR, Arg: 1}},
+		[]OperateOp{{Target: OperateTargetGlobal, FieldIdx: 0, Opcode: OperateOpINCR, Type: OperateTypeU8, Arg: 1}},
 		[]OperateRet{{Target: OperateTargetGlobal, FieldIdx: 0}}))
+	// One seed per field type so the corpus exercises every tag.
+	for ty := uint8(0); ty < OperateTypeCount; ty++ {
+		f.Add(EncodeOperateArgs([]byte("t"), 0, 2,
+			[]OperateOp{{Target: OperateTargetEntry, EntryKey: 1, FieldIdx: 0, Opcode: OperateOpINCR, Type: ty, Arg: 3}},
+			[]OperateRet{{Target: OperateTargetEntry, EntryKey: 1, FieldIdx: 0}}))
+	}
 	f.Add([]byte{})
 	f.Add([]byte{0, 1})
 	f.Fuzz(func(t *testing.T, b []byte) {

--- a/sdk/wire/operate_test.go
+++ b/sdk/wire/operate_test.go
@@ -1,0 +1,167 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package wire
+
+import (
+	"encoding/binary"
+	"math"
+	"testing"
+	"time"
+)
+
+func opsRoundtripEqual(t *testing.T, a, b []OperateOp) {
+	t.Helper()
+	if len(a) != len(b) {
+		t.Fatalf("ops len = %d, want %d", len(b), len(a))
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			t.Fatalf("op[%d] = %+v, want %+v", i, b[i], a[i])
+		}
+	}
+}
+
+func retRoundtripEqual(t *testing.T, a, b []OperateRet) {
+	t.Helper()
+	if len(a) != len(b) {
+		t.Fatalf("ret len = %d, want %d", len(b), len(a))
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			t.Fatalf("ret[%d] = %+v, want %+v", i, b[i], a[i])
+		}
+	}
+}
+
+func TestOperateArgsRoundtrip(t *testing.T) {
+	key := []byte("session:42")
+	ttl := 90 * time.Second
+	maxEntries := uint16(1024)
+	ops := []OperateOp{
+		{Target: OperateTargetGlobal, FieldIdx: 0, Opcode: OperateOpINCR, Arg: 1},
+		{Target: OperateTargetGlobal, FieldIdx: 3, Opcode: OperateOpINCRF, Arg: 12345},
+		{Target: OperateTargetGlobal, FieldIdx: 2, Opcode: OperateOpSETMAX, Arg: -7},
+		{Target: OperateTargetEntry, EntryKey: 0xDEADBEEF, FieldIdx: 1, Opcode: OperateOpSHIFTOR, Arg: 4, Arg2: 0xF},
+		{Target: OperateTargetEntry, EntryKey: 99, FieldIdx: 0, Opcode: OperateOpHALVEGRP, Arg: 255, Arg2: 2},
+	}
+	ret := []OperateRet{
+		{Target: OperateTargetGlobal, FieldIdx: 0},
+		{Target: OperateTargetEntry, EntryKey: 0xDEADBEEF, FieldIdx: 1},
+	}
+
+	enc := EncodeOperateArgs(key, ttl, maxEntries, ops, ret)
+	gotKey, gotTTL, gotMax, gotOps, gotRet, err := DecodeOperateArgs(enc)
+	if err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if string(gotKey) != string(key) {
+		t.Fatalf("key = %q, want %q", gotKey, key)
+	}
+	if gotTTL != ttl {
+		t.Fatalf("ttl = %v, want %v", gotTTL, ttl)
+	}
+	if gotMax != maxEntries {
+		t.Fatalf("maxEntries = %d, want %d", gotMax, maxEntries)
+	}
+	opsRoundtripEqual(t, ops, gotOps)
+	retRoundtripEqual(t, ret, gotRet)
+}
+
+func TestOperateArgsEmptyOpsAndRet(t *testing.T) {
+	enc := EncodeOperateArgs([]byte("k"), 0, 0, nil, nil)
+	k, ttl, max, ops, ret, err := DecodeOperateArgs(enc)
+	if err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if string(k) != "k" || ttl != 0 || max != 0 || len(ops) != 0 || len(ret) != 0 {
+		t.Fatalf("unexpected: k=%q ttl=%v max=%d ops=%d ret=%d", k, ttl, max, len(ops), len(ret))
+	}
+}
+
+func TestOperateResultRoundtrip(t *testing.T) {
+	vals := []int64{0, -1, math.MaxInt64, math.MinInt64, 42}
+	got, err := DecodeOperateResult(EncodeOperateResult(vals))
+	if err != nil {
+		t.Fatalf("decode result: %v", err)
+	}
+	if len(got) != len(vals) {
+		t.Fatalf("len = %d, want %d", len(got), len(vals))
+	}
+	for i := range vals {
+		if got[i] != vals[i] {
+			t.Fatalf("val[%d] = %d, want %d", i, got[i], vals[i])
+		}
+	}
+}
+
+func TestOperateResultRejectsRagged(t *testing.T) {
+	if _, err := DecodeOperateResult([]byte{0, 0, 0}); err == nil {
+		t.Fatal("ragged result accepted, want error")
+	}
+}
+
+func TestDecodeOperateArgsTruncation(t *testing.T) {
+	full := EncodeOperateArgs([]byte("abc"), time.Second, 8,
+		[]OperateOp{{Target: OperateTargetEntry, EntryKey: 5, FieldIdx: 1, Opcode: OperateOpINCR, Arg: 1}},
+		[]OperateRet{{Target: OperateTargetEntry, EntryKey: 5, FieldIdx: 1}})
+	// Every prefix short of the whole frame must be rejected, never panic.
+	for n := 0; n < len(full); n++ {
+		if _, _, _, _, _, err := DecodeOperateArgs(full[:n]); err == nil {
+			t.Fatalf("prefix len %d accepted, want error", n)
+		}
+	}
+}
+
+func TestDecodeOperateArgsBadTarget(t *testing.T) {
+	// One op with an out-of-range target byte (2).
+	frame := make([]byte, 0)
+	frame = binary.BigEndian.AppendUint16(frame, 0) // keyLen=0
+	frame = binary.BigEndian.AppendUint64(frame, 0) // ttlMs
+	frame = binary.BigEndian.AppendUint16(frame, 0) // maxEntries
+	frame = binary.BigEndian.AppendUint32(frame, 1) // nOps=1
+	frame = append(frame, 2)                        // tgt=2 (invalid)
+	frame = binary.BigEndian.AppendUint16(frame, 0) // fieldIdx
+	frame = append(frame, OperateOpINCR)            // opcode
+	frame = binary.BigEndian.AppendUint64(frame, 0) // arg
+	frame = binary.BigEndian.AppendUint64(frame, 0) // arg2
+	if _, _, _, _, _, err := DecodeOperateArgs(frame); err != ErrBadOperateTarget {
+		t.Fatalf("bad target: err = %v, want ErrBadOperateTarget", err)
+	}
+}
+
+func TestDecodeOperateArgsHostileNOps(t *testing.T) {
+	// A huge declared nOps with a tiny body must be rejected by CountFitsIn before
+	// any allocation — never a panic or OOM.
+	frame := make([]byte, 0)
+	frame = binary.BigEndian.AppendUint16(frame, 0) // keyLen=0
+	frame = binary.BigEndian.AppendUint64(frame, 0) // ttlMs
+	frame = binary.BigEndian.AppendUint16(frame, 0) // maxEntries
+	frame = binary.BigEndian.AppendUint32(frame, 0xFFFFFFFF)
+	if _, _, _, _, _, err := DecodeOperateArgs(frame); err == nil {
+		t.Fatal("hostile nOps accepted, want error")
+	}
+}
+
+func TestDecodeOperateArgsTTLOverflow(t *testing.T) {
+	frame := make([]byte, 0)
+	frame = binary.BigEndian.AppendUint16(frame, 0)              // keyLen=0
+	frame = binary.BigEndian.AppendUint64(frame, math.MaxUint64) // ttlMs overflow
+	frame = binary.BigEndian.AppendUint16(frame, 0)              // maxEntries
+	frame = binary.BigEndian.AppendUint32(frame, 0)              // nOps=0
+	frame = binary.BigEndian.AppendUint16(frame, 0)              // nRet=0
+	if _, _, _, _, _, err := DecodeOperateArgs(frame); err != ErrTTLOutOfRange {
+		t.Fatalf("ttl overflow: err = %v, want ErrTTLOutOfRange", err)
+	}
+}
+
+func FuzzDecodeOperateArgs(f *testing.F) {
+	f.Add(EncodeOperateArgs([]byte("k"), time.Second, 4,
+		[]OperateOp{{Target: OperateTargetGlobal, FieldIdx: 0, Opcode: OperateOpINCR, Arg: 1}},
+		[]OperateRet{{Target: OperateTargetGlobal, FieldIdx: 0}}))
+	f.Add([]byte{})
+	f.Add([]byte{0, 1})
+	f.Fuzz(func(t *testing.T, b []byte) {
+		// Contract: never panic on arbitrary bytes.
+		_, _, _, _, _, _ = DecodeOperateArgs(b)
+	})
+}


### PR DESCRIPTION
## What

A generic **server-side atomic multi-field update** op — Aerospike-`Operate` parity for Rostam's KV. The client sends an op-list; the server applies it atomically under the shard write lock in **one round-trip**. No new engine surface — it's a registry builtin like `incr`/`cas`.

## Why

For a hot-key counter workload (e.g. a session cache updated by many callers in parallel), client-side CAS retry collapses — measured ~90% CAS-conflict on memcached for exactly this pattern. A server-side atomic op removes the client compare entirely (the concurrency test does 24×50 concurrent increments on one key and loses **zero**). And because the update is an op-list (data), the business logic stays in the *caller* — Rostam is never rebuilt when a counter/rule changes (unlike a hardcoded native op), and there's no WASM per-call overhead.

## Value model & opcodes

Value = globals `[]field` + entries `map[u64][]field` (dynamic sub-records, e.g. per-bidder), with deterministic **LRU cap-eviction** (leader-stamped `touchMs`, ties by smallest key). Opcodes: `INCR`, `INCRF` (float), `SETMAX`, `SHIFTOR` (rolling bitfield — shift+OR+mask to width), `HALVE_GRP` (overflow guard).

## Typed fields (memory)

Each field carries a type tag — `u8/u16/u32/u64`, signed `i8..i64`, `f32/f64`, and `uvarint/ivarint` — stored at native/compact width instead of padding to i64. A u8/u16/f32 record encodes **16 B vs 33 B all-i64 (52% smaller)**. Int increments **saturate** at the type's min/max (never silently wrap); SHIFTOR masks to the field width; varints grow freely.

## Correctness / safety

- **Deterministic** (RF>1 safe): integer/float-only math + `tx.applyStamp()` as the only clock; sorted-by-key encode; leader/follower reapply verified byte-identical (incl. typed+varint+float).
- **Hardened decoders**: op-entry + stored-value type tags validated; every count `CountFitsIn`-bounded; varints self-bounded; malformed input errors, never panics — added to the hostile-decode sweep + fuzzed (`FuzzDecodeOperateArgs`, `FuzzDecodeRec`).

## Tests
Per-opcode + per-type (saturation, float, shiftor-mask, varint round-trip/grow), stored-type-wins, cap-eviction + tie-break, atomic-abort, determinism/replica-reapply, size-shrink, and a hot-key no-lost-increment integration test — all `-race`. `go build ./...`, `go vet`, `gofmt` clean.

## Not included
No caller/session-cache adapter and no cross-engine benchmark yet — those are follow-ups. This PR is just the primitive.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a generic server-side atomic multi-field update op (`operate`) to Rostam's KV, so hot-key counters stop losing updates under concurrency — a client CAS-retry loop can't guarantee that, and the integration test runs 24×50 concurrent increments on one key with zero lost. The client sends an op-list and the server applies it under the shard write lock in one round-trip; the business logic stays in the caller, so adding a counter needs no rebuild and there's no WASM per-call overhead.

- Opcodes are INCR/INCRF, SETMAX, SHIFTOR (a rolling bitfield), and HALVE_GRP (an overflow guard that adopts the declared type for empty slots).
- A record is a globals array plus a capped entries map (u64 → sub-record) with deterministic LRU eviction (`touchMs` tie-broken by smallest key).
- Fields are typed (`u8`–`i64`, `f32`/`f64`, `uvarint`/`ivarint`) and stored at native or compact width — a `u8`/`u16`/`f32` record is ~50% smaller than the all-i64 equivalent; unaddressed slots are an `UNSET` sentinel that adopts the type of its first real write, independent of op order.
- Fixed-width int ops saturate at the type's range, SHIFTOR masks to field width, varints grow freely, and the stored type wins for existing fields.
- Determinism (RF>1): only integer/float math and the leader stamp feed state; `touchMs` is the leader stamp when stamped, else 0, so eviction degrades to lowest key (true LRU requires `EnableApplyStamp`); records encode sorted by key, so follower reapply is byte-identical.
- Both decoders are hardened — bounded counts, validated type tags, self-bounded varints, and incremental allocation budgets (hard entry-map ceiling, capped total fields) so a hostile op-list can't amplify memory before the 16 MiB encoded-record backstop; `Client.Operate` rejects args that would overflow a wire length field, and `operate` is non-replayable so an ambiguous transport failure never double-applies increments.
- No caller/session-cache adapter or cross-engine benchmark yet; those are follow-ups.

<sup>Written for commit fcf63b8569646c3dc8acf526172b211a6c5cf608. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rostamlabs/rostam/pull/96?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an atomic `operate` operation for applying multiple typed numeric updates to a single record in one round trip.
  * Supports increments, maximum updates, bit shifts, grouped halving, field typing, entry limits, and returning updated values.
  * Added client and wire-format support for configuring operations and reading results.
* **Documentation**
  * Documented operation behavior, supported fields, targets, return values, and all-or-nothing processing.
* **Bug Fixes**
  * Added validation for malformed or oversized requests and stored values.
  * Prevented ambiguous operation failures from being replayed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->