### PR TITLE
feat(kv): operate v2 — atomic multi-field update with schema and dynamic modes

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -534,9 +534,14 @@ func (e *ambiguousError) Unwrap() error { return e.err }
 // made in the interval. The wrapper must carry the same guard as "flush" or the
 // double-apply hole reopens one layer down — cluster.proposeFlush relies on this to
 // surface an ambiguous per-group flush instead of the peer Client re-sending it.
+//
+// "operate" mutates counters non-idempotently (ADD/MUL/SHL/…, and CHECK's
+// server-side CAS), so a blind replay after an ambiguous post-commit failure
+// would apply every increment twice; it surfaces the ambiguous error instead,
+// exactly like "incr_ex".
 func nonReplayableOp(op string) bool {
 	switch op {
-	case "set_nx", "cas", "cad", "getdel", "getset", "incr_ex", "caex", "persist", "flush", "__flush_shard__":
+	case "set_nx", "cas", "cad", "getdel", "getset", "incr_ex", "caex", "persist", "flush", "__flush_shard__", "operate":
 		return true
 	}
 	return false

--- a/client/operate.go
+++ b/client/operate.go
@@ -563,6 +563,9 @@ func (ob *OperateBuilder) resolveOp(op builderOp) (wire.OperateOp, error) {
 	}
 	wop := wire.OperateOp{Opcode: op.opcode, Type: op.typ, Aux: op.aux, Path: path, A: op.a, B: op.b, Bytes: op.bytes}
 	if op.opcode == wire.OperateOpCONFIG || op.opcode == wire.OperateOpTRIM {
+		if (op.aux == wire.OperatePolicyMinCol || op.aux == wire.OperatePolicyMaxCol) && op.byColName == "" {
+			return wire.OperateOp{}, fmt.Errorf("client: operate: *_COL policy needs a column name")
+		}
 		wop.Bytes = []byte(op.byColName)
 		if op.byColName != "" && ob.schema != nil {
 			pos, cerr := ob.tableColPos(path, op.byColName)

--- a/client/operate.go
+++ b/client/operate.go
@@ -1,0 +1,685 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package client
+
+import (
+	"context"
+	"encoding/binary"
+	"fmt"
+	"math"
+	"time"
+
+	"github.com/rostamlabs/rostam/sdk/wire"
+)
+
+// Operate runs one atomic multi-field update against a's key and returns
+// its result (design doc for operate v2, §3-§3.5): a generic list of
+// scalar/table/control ops applied to a record, evaluated in order, with
+// return specs read back in the same round trip.
+//
+// An error from wire.EncodeOperateArgs (a's op/ret list, key, or schema
+// blob exceeds a wire cap, or carries a structurally invalid field) is
+// returned unchanged, without a network round trip — build a's OperateArgs
+// with OperateBuilder to avoid ever hitting one by hand.
+func (c *Client) Operate(ctx context.Context, a *wire.OperateArgs) (*wire.OperateResult, error) {
+	args, err := wire.EncodeOperateArgs(a)
+	if err != nil {
+		return nil, err
+	}
+	res, err := c.Call(ctx, "operate", args)
+	if err != nil {
+		return nil, err
+	}
+	return wire.DecodeOperateResult(res)
+}
+
+// DecodeOperateValue decodes one scalar value from an OperateResult.Values
+// entry (design doc §3.4's tagged VALUE encoding: [type u8][n iff
+// FIXED][data]). An absent node ([]byte{wire.OperateTypeUnset}) decodes to
+// wire.Cell{Type: wire.OperateTypeUnset} rather than an error, so a caller
+// can read res.Values[i] uniformly without special-casing "not present"
+// against a decode failure.
+func DecodeOperateValue(b []byte) (wire.Cell, error) {
+	c, _, err := wire.DecodeTaggedCell(b)
+	return c, err
+}
+
+// Path addresses one node inside an operate record (design doc §2.4): the
+// record itself (RecordPath), a record field (F), a whole row of a table
+// field (Row), or one column of that row (Col). Field and Col are always
+// names here; OperateBuilder.Args resolves them to schema positions when a
+// schema is attached (WithSchema) and otherwise carries them as name
+// segments on the wire (Dynamic).
+type Path struct {
+	Field  string
+	Col    string
+	Key    []byte
+	HasKey bool
+	HasCol bool
+}
+
+// F addresses the record field named field.
+func F(field string) Path { return Path{Field: field} }
+
+// Row addresses the row keyed by key in the table field named field.
+func Row(field string, key []byte) Path {
+	return Path{Field: field, Key: key, HasKey: true}
+}
+
+// Col addresses the column named col of the row keyed by key in the table
+// field named field.
+func Col(field string, key []byte, col string) Path {
+	return Path{Field: field, Key: key, HasKey: true, Col: col, HasCol: true}
+}
+
+// RecordPath addresses the record itself — the only valid path for
+// CHECK EXISTS/ABSENT, DEL, and a whole-record return (design doc §2.4).
+func RecordPath() Path { return Path{} }
+
+// KeyU64 encodes k as the little-endian 8-byte row key a schema-mode table
+// with a U64 key type expects (design doc §2.3: numeric keys are stored
+// little-endian and compared as integers).
+func KeyU64(k uint64) []byte {
+	b := make([]byte, 8)
+	binary.LittleEndian.PutUint64(b, k)
+	return b
+}
+
+// KeyU32 encodes k as the little-endian 4-byte row key a schema-mode table
+// with a U32 key type expects.
+func KeyU32(k uint32) []byte {
+	b := make([]byte, 4)
+	binary.LittleEndian.PutUint32(b, k)
+	return b
+}
+
+// KeyU16 encodes k as the little-endian 2-byte row key a schema-mode table
+// with a U16 key type expects.
+func KeyU16(k uint16) []byte {
+	b := make([]byte, 2)
+	binary.LittleEndian.PutUint16(b, k)
+	return b
+}
+
+// KeyU8 encodes k as the 1-byte row key a schema-mode table with a U8 key
+// type expects.
+func KeyU8(k uint8) []byte { return []byte{k} }
+
+// floatBits is a float operand's wire encoding (design doc §2.4): always
+// the float64 bit pattern, F32 fields included — storage rounds.
+func floatBits(v float64) int64 {
+	return int64(math.Float64bits(v)) //nolint:gosec // reinterpret float bits as int64, per the wire convention
+}
+
+// builderOp is one not-yet-resolved op: its Path (a name, not yet a
+// position) and, for CONFIG/TRIM, its byCol name are resolved against the
+// builder's schema (if any) in OperateBuilder.Args, once the whole call is
+// known.
+type builderOp struct {
+	opcode, typ, aux uint8
+	path             Path
+	a, b             int64
+	bytes            []byte
+	byColName        string
+}
+
+// builderRet is one not-yet-resolved return spec.
+type builderRet struct {
+	mode uint8
+	path Path
+}
+
+// OperateBuilder builds a wire.OperateArgs for one Client.Operate call
+// (design doc §3-§4): a fluent alternative to constructing
+// wire.OperateOp/wire.OperateRet by hand. With a schema attached
+// (WithSchema), every Field/Col name is resolved to its schema position and
+// an untyped op's Type is wire.OperateTypeFromSchema; without one
+// (Dynamic), names ride the wire as name segments and a typed op's Type is
+// whatever the caller passed.
+//
+// Every method except Args returns the builder so calls chain (see the
+// package example in design doc §4). The first resolution error
+// encountered — an unknown field name, a wrong-width row key, a column path
+// into a non-table field, a typed op whose type disagrees with the schema —
+// is recorded and returned by Args, so no intermediate call needs its own
+// error check.
+type OperateBuilder struct {
+	key     []byte
+	schema  *wire.Schema
+	create  uint8
+	ttl     time.Duration
+	ttlMode uint8
+	ops     []builderOp
+	rets    []builderRet
+	err     error
+}
+
+// NewOperate starts building an operate call against key. The call defaults
+// to wire.OperateCreateNone (valid only against an existing record) until
+// WithSchema or Dynamic is called.
+func NewOperate(key []byte) *OperateBuilder {
+	return &OperateBuilder{key: key}
+}
+
+// WithSchema attaches s to the builder: the call creates an absent record
+// in schema mode with s's encoded blob (design doc §2.8), and every
+// subsequent Field/Col name is resolved against s. s is validated once,
+// here; a nil s or a validation failure is recorded and returned by Args
+// rather than panicking.
+func (ob *OperateBuilder) WithSchema(s *wire.Schema) *OperateBuilder {
+	if ob.err == nil {
+		if s == nil {
+			ob.err = fmt.Errorf("client: operate: WithSchema requires a non-nil schema")
+			return ob
+		}
+		if err := s.Validate(); err != nil {
+			ob.err = err
+			return ob
+		}
+	}
+	ob.schema = s
+	ob.create = wire.OperateCreateSchema
+	return ob
+}
+
+// Dynamic marks the call as creating an absent record in dynamic mode
+// (design doc §2.9): no schema, every field and column named and typed by
+// the ops that first touch it.
+func (ob *OperateBuilder) Dynamic() *OperateBuilder {
+	ob.create = wire.OperateCreateDynamic
+	return ob
+}
+
+// TTL sets the call's TTL and ttlMode (design doc §3.5: KEEP, SET, or
+// CREATE_ONLY).
+func (ob *OperateBuilder) TTL(d time.Duration, mode uint8) *OperateBuilder {
+	ob.ttl = d
+	ob.ttlMode = mode
+	return ob
+}
+
+func (ob *OperateBuilder) addOp(op builderOp) *OperateBuilder {
+	ob.ops = append(ob.ops, op)
+	return ob
+}
+
+// Set writes v to the int/float-domain scalar at path, typed from the
+// schema (design doc §3.1). Use SetT in dynamic mode to create a new
+// target, or SetFloat/SetBytes for a float or bytes/fixed operand.
+func (ob *OperateBuilder) Set(path Path, v int64) *OperateBuilder {
+	return ob.addOp(builderOp{opcode: wire.OperateOpSET, typ: wire.OperateTypeFromSchema, path: path, a: v})
+}
+
+// SetFloat writes v to the float scalar at path, typed from the schema.
+func (ob *OperateBuilder) SetFloat(path Path, v float64) *OperateBuilder {
+	return ob.addOp(builderOp{opcode: wire.OperateOpSET, typ: wire.OperateTypeFromSchema, path: path, a: floatBits(v)})
+}
+
+// SetBytes writes v to the bytes/fixed scalar at path, typed from the
+// schema.
+func (ob *OperateBuilder) SetBytes(path Path, v []byte) *OperateBuilder {
+	return ob.addOp(builderOp{opcode: wire.OperateOpSET, typ: wire.OperateTypeFromSchema, path: path, bytes: v})
+}
+
+// Add adds v (saturating) to the int scalar at path, typed from the schema.
+func (ob *OperateBuilder) Add(path Path, v int64) *OperateBuilder {
+	return ob.addOp(builderOp{opcode: wire.OperateOpADD, typ: wire.OperateTypeFromSchema, path: path, a: v})
+}
+
+// AddFloat adds v (IEEE) to the float scalar at path, typed from the
+// schema.
+func (ob *OperateBuilder) AddFloat(path Path, v float64) *OperateBuilder {
+	return ob.addOp(builderOp{opcode: wire.OperateOpADD, typ: wire.OperateTypeFromSchema, path: path, a: floatBits(v)})
+}
+
+// Mul multiplies (saturating) the int scalar at path by v, typed from the
+// schema.
+func (ob *OperateBuilder) Mul(path Path, v int64) *OperateBuilder {
+	return ob.addOp(builderOp{opcode: wire.OperateOpMUL, typ: wire.OperateTypeFromSchema, path: path, a: v})
+}
+
+// MulFloat multiplies (IEEE) the float scalar at path by v, typed from the
+// schema.
+func (ob *OperateBuilder) MulFloat(path Path, v float64) *OperateBuilder {
+	return ob.addOp(builderOp{opcode: wire.OperateOpMUL, typ: wire.OperateTypeFromSchema, path: path, a: floatBits(v)})
+}
+
+// Min sets the int scalar at path to min(current, v), typed from the
+// schema.
+func (ob *OperateBuilder) Min(path Path, v int64) *OperateBuilder {
+	return ob.addOp(builderOp{opcode: wire.OperateOpMIN, typ: wire.OperateTypeFromSchema, path: path, a: v})
+}
+
+// Max sets the int scalar at path to max(current, v), typed from the
+// schema.
+func (ob *OperateBuilder) Max(path Path, v int64) *OperateBuilder {
+	return ob.addOp(builderOp{opcode: wire.OperateOpMAX, typ: wire.OperateTypeFromSchema, path: path, a: v})
+}
+
+// MinFloat sets the float scalar at path to min(current, v), typed from the
+// schema.
+func (ob *OperateBuilder) MinFloat(path Path, v float64) *OperateBuilder {
+	return ob.addOp(builderOp{opcode: wire.OperateOpMIN, typ: wire.OperateTypeFromSchema, path: path, a: floatBits(v)})
+}
+
+// MaxFloat sets the float scalar at path to max(current, v), typed from the
+// schema.
+func (ob *OperateBuilder) MaxFloat(path Path, v float64) *OperateBuilder {
+	return ob.addOp(builderOp{opcode: wire.OperateOpMAX, typ: wire.OperateTypeFromSchema, path: path, a: floatBits(v)})
+}
+
+// And bitwise-ANDs the fixed-width int scalar at path with v (masked to the
+// field width), typed from the schema.
+func (ob *OperateBuilder) And(path Path, v int64) *OperateBuilder {
+	return ob.addOp(builderOp{opcode: wire.OperateOpAND, typ: wire.OperateTypeFromSchema, path: path, a: v})
+}
+
+// Or bitwise-ORs the fixed-width int scalar at path with v, typed from the
+// schema.
+func (ob *OperateBuilder) Or(path Path, v int64) *OperateBuilder {
+	return ob.addOp(builderOp{opcode: wire.OperateOpOR, typ: wire.OperateTypeFromSchema, path: path, a: v})
+}
+
+// Xor bitwise-XORs the fixed-width int scalar at path with v, typed from
+// the schema.
+func (ob *OperateBuilder) Xor(path Path, v int64) *OperateBuilder {
+	return ob.addOp(builderOp{opcode: wire.OperateOpXOR, typ: wire.OperateTypeFromSchema, path: path, a: v})
+}
+
+// Shl shifts the fixed-width int scalar at path left by n (0..64, masked to
+// the field width), typed from the schema.
+func (ob *OperateBuilder) Shl(path Path, n int64) *OperateBuilder {
+	return ob.addOp(builderOp{opcode: wire.OperateOpSHL, typ: wire.OperateTypeFromSchema, path: path, a: n})
+}
+
+// Shr shifts the fixed-width int scalar at path right by n (0..64;
+// arithmetic for signed fields, logical for unsigned), typed from the
+// schema.
+func (ob *OperateBuilder) Shr(path Path, n int64) *OperateBuilder {
+	return ob.addOp(builderOp{opcode: wire.OperateOpSHR, typ: wire.OperateTypeFromSchema, path: path, a: n})
+}
+
+// Stamp writes tx.applyStamp() (in unit's resolution — wire.OperateStampMs
+// or wire.OperateStampS) to the int scalar at path, typed from the schema.
+func (ob *OperateBuilder) Stamp(path Path, unit uint8) *OperateBuilder {
+	return ob.addOp(builderOp{opcode: wire.OperateOpSTAMP, typ: wire.OperateTypeFromSchema, aux: unit, path: path})
+}
+
+// Del removes path: a record field becomes UNSET, a row is removed, a table
+// field is emptied, and the record path deletes the whole record (design
+// doc §2.5/§3.1).
+func (ob *OperateBuilder) Del(path Path) *OperateBuilder {
+	return ob.addOp(builderOp{opcode: wire.OperateOpDEL, typ: wire.OperateTypeFromSchema, path: path})
+}
+
+// SetT writes v to the int/float-domain scalar at path, creating it with
+// type typ in dynamic mode (or checking typ against the schema's type in
+// schema mode).
+func (ob *OperateBuilder) SetT(path Path, typ uint8, v int64) *OperateBuilder {
+	return ob.addOp(builderOp{opcode: wire.OperateOpSET, typ: typ, path: path, a: v})
+}
+
+// SetBytesT writes v (BYTES or FIXED) to the scalar at path, creating it
+// with type typ in dynamic mode (or checking typ against the schema's type
+// in schema mode).
+func (ob *OperateBuilder) SetBytesT(path Path, typ uint8, v []byte) *OperateBuilder {
+	return ob.addOp(builderOp{opcode: wire.OperateOpSET, typ: typ, path: path, bytes: v})
+}
+
+// AddT adds v (saturating) to the scalar at path, creating it with type typ
+// in dynamic mode (or checking typ against the schema's type in schema
+// mode).
+func (ob *OperateBuilder) AddT(path Path, typ uint8, v int64) *OperateBuilder {
+	return ob.addOp(builderOp{opcode: wire.OperateOpADD, typ: typ, path: path, a: v})
+}
+
+// MulT multiplies (saturating) the scalar at path by v, creating it with
+// type typ in dynamic mode (or checking typ against the schema's type in
+// schema mode).
+func (ob *OperateBuilder) MulT(path Path, typ uint8, v int64) *OperateBuilder {
+	return ob.addOp(builderOp{opcode: wire.OperateOpMUL, typ: typ, path: path, a: v})
+}
+
+// MinT sets the scalar at path to min(current, v), creating it with type
+// typ in dynamic mode (or checking typ against the schema's type in schema
+// mode).
+func (ob *OperateBuilder) MinT(path Path, typ uint8, v int64) *OperateBuilder {
+	return ob.addOp(builderOp{opcode: wire.OperateOpMIN, typ: typ, path: path, a: v})
+}
+
+// MaxT sets the scalar at path to max(current, v), creating it with type
+// typ in dynamic mode (or checking typ against the schema's type in schema
+// mode).
+func (ob *OperateBuilder) MaxT(path Path, typ uint8, v int64) *OperateBuilder {
+	return ob.addOp(builderOp{opcode: wire.OperateOpMAX, typ: typ, path: path, a: v})
+}
+
+// AndT bitwise-ANDs the scalar at path with v, creating it with type typ in
+// dynamic mode (or checking typ against the schema's type in schema mode).
+func (ob *OperateBuilder) AndT(path Path, typ uint8, v int64) *OperateBuilder {
+	return ob.addOp(builderOp{opcode: wire.OperateOpAND, typ: typ, path: path, a: v})
+}
+
+// OrT bitwise-ORs the scalar at path with v, creating it with type typ in
+// dynamic mode (or checking typ against the schema's type in schema mode).
+func (ob *OperateBuilder) OrT(path Path, typ uint8, v int64) *OperateBuilder {
+	return ob.addOp(builderOp{opcode: wire.OperateOpOR, typ: typ, path: path, a: v})
+}
+
+// XorT bitwise-XORs the scalar at path with v, creating it with type typ in
+// dynamic mode (or checking typ against the schema's type in schema mode).
+func (ob *OperateBuilder) XorT(path Path, typ uint8, v int64) *OperateBuilder {
+	return ob.addOp(builderOp{opcode: wire.OperateOpXOR, typ: typ, path: path, a: v})
+}
+
+// StampT writes tx.applyStamp() (in unit's resolution) to the scalar at
+// path, creating it with type typ in dynamic mode (or checking typ against
+// the schema's type in schema mode).
+func (ob *OperateBuilder) StampT(path Path, typ uint8, unit uint8) *OperateBuilder {
+	return ob.addOp(builderOp{opcode: wire.OperateOpSTAMP, typ: typ, aux: unit, path: path})
+}
+
+// SetFloatT writes v to the float scalar at path, creating it with type typ
+// (wire.OperateTypeF32 or F64) in dynamic mode (or checking typ against the
+// schema's type in schema mode).
+func (ob *OperateBuilder) SetFloatT(path Path, typ uint8, v float64) *OperateBuilder {
+	return ob.addOp(builderOp{opcode: wire.OperateOpSET, typ: typ, path: path, a: floatBits(v)})
+}
+
+// AddFloatT adds v (IEEE) to the float scalar at path, creating it with
+// type typ in dynamic mode (or checking typ against the schema's type in
+// schema mode).
+func (ob *OperateBuilder) AddFloatT(path Path, typ uint8, v float64) *OperateBuilder {
+	return ob.addOp(builderOp{opcode: wire.OperateOpADD, typ: typ, path: path, a: floatBits(v)})
+}
+
+// MulFloatT multiplies (IEEE) the float scalar at path by v, creating it
+// with type typ in dynamic mode (or checking typ against the schema's type
+// in schema mode).
+func (ob *OperateBuilder) MulFloatT(path Path, typ uint8, v float64) *OperateBuilder {
+	return ob.addOp(builderOp{opcode: wire.OperateOpMUL, typ: typ, path: path, a: floatBits(v)})
+}
+
+// MinFloatT sets the float scalar at path to min(current, v), creating it
+// with type typ in dynamic mode (or checking typ against the schema's type
+// in schema mode).
+func (ob *OperateBuilder) MinFloatT(path Path, typ uint8, v float64) *OperateBuilder {
+	return ob.addOp(builderOp{opcode: wire.OperateOpMIN, typ: typ, path: path, a: floatBits(v)})
+}
+
+// MaxFloatT sets the float scalar at path to max(current, v), creating it
+// with type typ in dynamic mode (or checking typ against the schema's type
+// in schema mode).
+func (ob *OperateBuilder) MaxFloatT(path Path, typ uint8, v float64) *OperateBuilder {
+	return ob.addOp(builderOp{opcode: wire.OperateOpMAX, typ: typ, path: path, a: floatBits(v)})
+}
+
+// Config sets the eviction triple (capacity, policy, and, for a *_COL
+// policy, byCol) on the dynamic-mode table field at path, creating an empty
+// table if absent (design doc §3.2: dynamic mode only — in schema mode
+// eviction is part of the schema and changes via Migrate). byCol may be ""
+// when policy does not need one.
+func (ob *OperateBuilder) Config(path Path, capacity uint32, policy uint8, byCol string) *OperateBuilder {
+	return ob.addOp(builderOp{opcode: wire.OperateOpCONFIG, aux: policy, path: path, a: int64(capacity), byColName: byCol})
+}
+
+// Trim shrinks the table field at path to at most keep rows by policy (and,
+// for a *_COL policy, byCol), without changing the table's stored eviction
+// config (design doc §3.2). byCol may be "" when policy does not need one.
+func (ob *OperateBuilder) Trim(path Path, keep uint32, policy uint8, byCol string) *OperateBuilder {
+	return ob.addOp(builderOp{opcode: wire.OperateOpTRIM, aux: policy, path: path, a: int64(keep), byColName: byCol})
+}
+
+// Migrate moves the record from its stored version (from, or
+// wire.OperateMigrateFromDynamic when the record is dynamic-mode) to s's
+// version in this atomic call, an append-only evolution or a dynamic-mode
+// freeze (design doc §2.8/§2.9). It must be the first op in the list.
+// dropExtra sets wire.OperateMigrateDropExtra, discarding dynamic fields s
+// does not declare rather than rejecting the call. A nil s is recorded and
+// returned by Args rather than panicking.
+func (ob *OperateBuilder) Migrate(from int64, s *wire.Schema, dropExtra bool) *OperateBuilder {
+	if s == nil {
+		if ob.err == nil {
+			ob.err = fmt.Errorf("client: operate: Migrate requires a non-nil schema")
+		}
+		return ob
+	}
+	var aux uint8
+	if dropExtra {
+		aux = wire.OperateMigrateDropExtra
+	}
+	return ob.addOp(builderOp{opcode: wire.OperateOpMIGRATE, aux: aux, path: RecordPath(), a: from, bytes: s.Encode()})
+}
+
+// If skips the next n ops when node(path) cmp v is false (design doc §3.3);
+// n is bounded by the remaining op list. Use IfBytes to compare against a
+// bytes/fixed operand.
+func (ob *OperateBuilder) If(path Path, cmp uint8, v int64, n int) *OperateBuilder {
+	return ob.addOp(builderOp{opcode: wire.OperateOpIF, aux: cmp, path: path, a: v, b: int64(n)})
+}
+
+// IfBytes skips the next n ops when node(path) cmp v is false, comparing
+// bytewise.
+func (ob *OperateBuilder) IfBytes(path Path, cmp uint8, v []byte, n int) *OperateBuilder {
+	return ob.addOp(builderOp{opcode: wire.OperateOpIF, aux: cmp, path: path, bytes: v, b: int64(n)})
+}
+
+// Check aborts the whole call (record unchanged, result status
+// OperateStatusCheckFailed) when node(path) cmp v is false — the
+// server-side compare-and-swap primitive on any field (design doc §3.3).
+// Use CheckBytes to compare against a bytes/fixed operand.
+func (ob *OperateBuilder) Check(path Path, cmp uint8, v int64) *OperateBuilder {
+	return ob.addOp(builderOp{opcode: wire.OperateOpCHECK, aux: cmp, path: path, a: v})
+}
+
+// CheckBytes aborts the whole call when node(path) cmp v is false,
+// comparing bytewise.
+func (ob *OperateBuilder) CheckBytes(path Path, cmp uint8, v []byte) *OperateBuilder {
+	return ob.addOp(builderOp{opcode: wire.OperateOpCHECK, aux: cmp, path: path, bytes: v})
+}
+
+// Return adds a return spec that reads back path's full, self-describing
+// value after all ops apply (design doc §3.4).
+func (ob *OperateBuilder) Return(path Path) *OperateBuilder {
+	ob.rets = append(ob.rets, builderRet{mode: wire.OperateRetValue, path: path})
+	return ob
+}
+
+// Count adds a return spec that reads back path's count after all ops
+// apply: row count for a table, field count for the record, 1/0 for a
+// present/absent scalar or row (design doc §3.4).
+func (ob *OperateBuilder) Count(path Path) *OperateBuilder {
+	ob.rets = append(ob.rets, builderRet{mode: wire.OperateRetCount, path: path})
+	return ob
+}
+
+// Args resolves every op and return spec's Path against the builder's
+// schema (if any) and returns the finished wire.OperateArgs. It never
+// panics on a malformed builder: WithSchema's validation failure, or any
+// resolution error hit along the way (an unknown field name, a wrong-width
+// row key, a column path into a non-table field, a typed op whose type
+// disagrees with the schema), is returned here instead.
+func (ob *OperateBuilder) Args() (*wire.OperateArgs, error) {
+	if ob.err != nil {
+		return nil, ob.err
+	}
+	args := &wire.OperateArgs{
+		Key:     ob.key,
+		TTL:     ob.ttl,
+		TTLMode: ob.ttlMode,
+		Create:  ob.create,
+	}
+	if ob.schema != nil {
+		args.Schema = ob.schema.Encode()
+	}
+	for _, op := range ob.ops {
+		wop, err := ob.resolveOp(op)
+		if err != nil {
+			return nil, err
+		}
+		args.Ops = append(args.Ops, wop)
+	}
+	for _, ret := range ob.rets {
+		p, err := ob.resolvePath(ret.path)
+		if err != nil {
+			return nil, err
+		}
+		args.Rets = append(args.Rets, wire.OperateRet{Mode: ret.mode, Path: p})
+	}
+	return args, nil
+}
+
+// isScalarOpcode reports whether opcode is one of the scalar ops (design
+// doc §3.1) whose Type names a field's domain and so must, in schema mode,
+// agree with the schema's own type for a typed op. MIGRATE/CONFIG/TRIM
+// don't carry a field type in this sense, and IF/CHECK never declare one
+// (design doc §2.4).
+func isScalarOpcode(opcode uint8) bool {
+	switch opcode {
+	case wire.OperateOpSET, wire.OperateOpADD, wire.OperateOpMUL, wire.OperateOpMIN, wire.OperateOpMAX,
+		wire.OperateOpAND, wire.OperateOpOR, wire.OperateOpXOR, wire.OperateOpSHL, wire.OperateOpSHR, wire.OperateOpSTAMP:
+		return true
+	default:
+		return false
+	}
+}
+
+// resolveOp resolves one builderOp's Path (and, for CONFIG/TRIM, byColName)
+// against ob's schema, and, for a typed scalar op in schema mode, checks
+// typ against the schema's own type at that path.
+func (ob *OperateBuilder) resolveOp(op builderOp) (wire.OperateOp, error) {
+	path, err := ob.resolvePath(op.path)
+	if err != nil {
+		return wire.OperateOp{}, err
+	}
+	if ob.schema != nil && isScalarOpcode(op.opcode) && op.typ != wire.OperateTypeFromSchema {
+		actual, aerr := ob.actualType(path)
+		if aerr != nil {
+			return wire.OperateOp{}, aerr
+		}
+		if actual != op.typ {
+			return wire.OperateOp{}, fmt.Errorf("client: operate: op type %d does not match schema type %d for field %q", op.typ, actual, op.path.Field)
+		}
+	}
+	wop := wire.OperateOp{Opcode: op.opcode, Type: op.typ, Aux: op.aux, Path: path, A: op.a, B: op.b, Bytes: op.bytes}
+	if op.opcode == wire.OperateOpCONFIG || op.opcode == wire.OperateOpTRIM {
+		wop.Bytes = []byte(op.byColName)
+		if op.byColName != "" && ob.schema != nil {
+			pos, cerr := ob.tableColPos(path, op.byColName)
+			if cerr != nil {
+				return wire.OperateOp{}, cerr
+			}
+			wop.B = int64(pos)
+		}
+	}
+	return wop, nil
+}
+
+// resolvePath turns a client Path into a wire.OperatePath: an empty Path
+// (no field, key, or column) is the record path; otherwise Field is
+// resolved (by schema position, or as a name segment without a schema),
+// and, if Key is set, checked against the field's table (schema mode: the
+// field must be a table, and the key must be exactly the table's key
+// width) before Col (if set) is resolved against that table's columns.
+func (ob *OperateBuilder) resolvePath(p Path) (wire.OperatePath, error) {
+	if p.Field == "" && !p.HasKey && !p.HasCol {
+		return wire.OperatePath{Kind: wire.OperatePathRecord}, nil
+	}
+	fseg, tdef, err := ob.resolveField(p.Field)
+	if err != nil {
+		return wire.OperatePath{}, err
+	}
+	if !p.HasKey {
+		return wire.OperatePath{Kind: wire.OperatePathField, Field: fseg}, nil
+	}
+	if ob.schema != nil {
+		if tdef == nil {
+			return wire.OperatePath{}, fmt.Errorf("client: operate: field %q is not a table", p.Field)
+		}
+		width := wire.CellWidth(tdef.KeyType, tdef.KeyN)
+		if len(p.Key) != width {
+			return wire.OperatePath{}, fmt.Errorf("client: operate: key for field %q must be %d bytes, got %d", p.Field, width, len(p.Key))
+		}
+	}
+	if !p.HasCol {
+		return wire.OperatePath{Kind: wire.OperatePathRow, Field: fseg, Key: p.Key}, nil
+	}
+	cseg, err := ob.resolveCol(tdef, p.Col)
+	if err != nil {
+		return wire.OperatePath{}, err
+	}
+	return wire.OperatePath{Kind: wire.OperatePathCol, Field: fseg, Key: p.Key, Col: cseg}, nil
+}
+
+// resolveField resolves name to a wire.OperateSeg: a schema position (and
+// that field's TableDef, nil unless it is a table field) when ob.schema is
+// set, or a name segment otherwise.
+func (ob *OperateBuilder) resolveField(name string) (wire.OperateSeg, *wire.TableDef, error) {
+	if ob.schema == nil {
+		return wire.OperateSeg{ByName: true, Name: name}, nil, nil
+	}
+	pos, ok := ob.schema.FieldPos(name)
+	if !ok {
+		return wire.OperateSeg{}, nil, fmt.Errorf("client: operate: unknown field %q", name)
+	}
+	return wire.OperateSeg{Pos: uint32(pos)}, ob.schema.Fields[pos].Table, nil //nolint:gosec // FieldPos returns a valid slice index
+}
+
+// resolveCol resolves name to a wire.OperateSeg within tdef's columns: a
+// position when ob.schema is set (tdef is guaranteed non-nil by
+// resolvePath's caller in that case), or a name segment otherwise.
+func (ob *OperateBuilder) resolveCol(tdef *wire.TableDef, name string) (wire.OperateSeg, error) {
+	if ob.schema == nil {
+		return wire.OperateSeg{ByName: true, Name: name}, nil
+	}
+	for i, c := range tdef.Cols {
+		if c.Name == name {
+			return wire.OperateSeg{Pos: uint32(i)}, nil //nolint:gosec // i indexes tdef.Cols, bounded by OperateMaxCols
+		}
+	}
+	return wire.OperateSeg{}, fmt.Errorf("client: operate: unknown column %q", name)
+}
+
+// tableColPos resolves colName to a column position within the table field
+// path addresses (used by Config/Trim's byCol operand). ob.schema is
+// non-nil whenever this is called.
+func (ob *OperateBuilder) tableColPos(path wire.OperatePath, colName string) (int, error) {
+	fi := int(path.Field.Pos)
+	if fi < 0 || fi >= len(ob.schema.Fields) {
+		return 0, fmt.Errorf("client: operate: field position %d out of range", fi)
+	}
+	tdef := ob.schema.Fields[fi].Table
+	if tdef == nil {
+		return 0, fmt.Errorf("client: operate: field at position %d is not a table", fi)
+	}
+	seg, err := ob.resolveCol(tdef, colName)
+	if err != nil {
+		return 0, err
+	}
+	return int(seg.Pos), nil
+}
+
+// actualType returns the schema's own type for the field or column p
+// addresses. ob.schema is non-nil whenever this is called.
+func (ob *OperateBuilder) actualType(p wire.OperatePath) (uint8, error) {
+	fi := int(p.Field.Pos)
+	if fi < 0 || fi >= len(ob.schema.Fields) {
+		return 0, fmt.Errorf("client: operate: field position %d out of range", fi)
+	}
+	switch p.Kind {
+	case wire.OperatePathField:
+		return ob.schema.Fields[fi].Type, nil
+	case wire.OperatePathCol:
+		tdef := ob.schema.Fields[fi].Table
+		if tdef == nil {
+			return 0, fmt.Errorf("client: operate: field at position %d is not a table", fi)
+		}
+		ci := int(p.Col.Pos)
+		if ci < 0 || ci >= len(tdef.Cols) {
+			return 0, fmt.Errorf("client: operate: column position %d out of range", ci)
+		}
+		return tdef.Cols[ci].Type, nil
+	default:
+		return 0, fmt.Errorf("client: operate: path kind %d has no scalar type", p.Kind)
+	}
+}

--- a/client/operate.go
+++ b/client/operate.go
@@ -166,7 +166,20 @@ func NewOperate(key []byte) *OperateBuilder {
 // subsequent Field/Col name is resolved against s. s is validated once,
 // here; a nil s or a validation failure is recorded and returned by Args
 // rather than panicking.
+//
+// It is exclusive with Dynamic: the two set the same `create` byte to
+// opposite values, and a builder that has been through both would ship a
+// dynamic call carrying a schema blob and schema-POSITION paths. The wire
+// decoder accepts that frame, so nothing catches it until the dynamic
+// engine rejects every path with wire.ErrOperatePath — calling the second
+// one is recorded as an error here instead.
 func (ob *OperateBuilder) WithSchema(s *wire.Schema) *OperateBuilder {
+	if ob.create == wire.OperateCreateDynamic {
+		if ob.err == nil {
+			ob.err = fmt.Errorf("client: operate: builder is already in dynamic mode; WithSchema and Dynamic are exclusive")
+		}
+		return ob
+	}
 	if ob.err == nil {
 		if s == nil {
 			ob.err = fmt.Errorf("client: operate: WithSchema requires a non-nil schema")
@@ -184,8 +197,15 @@ func (ob *OperateBuilder) WithSchema(s *wire.Schema) *OperateBuilder {
 
 // Dynamic marks the call as creating an absent record in dynamic mode
 // (design doc §2.9): no schema, every field and column named and typed by
-// the ops that first touch it.
+// the ops that first touch it. It is exclusive with WithSchema, for the
+// reason given there.
 func (ob *OperateBuilder) Dynamic() *OperateBuilder {
+	if ob.create == wire.OperateCreateSchema || ob.schema != nil {
+		if ob.err == nil {
+			ob.err = fmt.Errorf("client: operate: builder is already in schema mode; Dynamic and WithSchema are exclusive")
+		}
+		return ob
+	}
 	ob.create = wire.OperateCreateDynamic
 	return ob
 }
@@ -606,7 +626,17 @@ func (ob *OperateBuilder) resolveOp(op builderOp) (wire.OperateOp, error) {
 // and, if Key is set, checked against the field's table (schema mode: the
 // field must be a table, and the key must be exactly the table's key
 // width) before Col (if set) is resolved against that table's columns.
+//
+// A column belongs to a row, so a Path carrying Col without Key addresses
+// nothing (design doc §2.4). It is rejected rather than narrowed: the wire
+// form for such a path is OperatePathField, which silently DROPS the column
+// and aims the op at the field itself — in dynamic mode that means a SET
+// meant for one column of one row would overwrite a scalar field of the
+// same name.
 func (ob *OperateBuilder) resolvePath(p Path) (wire.OperatePath, error) {
+	if p.HasCol && !p.HasKey {
+		return wire.OperatePath{}, fmt.Errorf("client: operate: column %q of field %q needs a row key; use Col(field, key, col)", p.Col, p.Field)
+	}
 	if p.Field == "" && !p.HasKey && !p.HasCol {
 		return wire.OperatePath{Kind: wire.OperatePathRecord}, nil
 	}

--- a/client/operate.go
+++ b/client/operate.go
@@ -419,13 +419,20 @@ func (ob *OperateBuilder) MaxFloatT(path Path, typ uint8, v float64) *OperateBui
 // table if absent (design doc §3.2: dynamic mode only — in schema mode
 // eviction is part of the schema and changes via Migrate). byCol may be ""
 // when policy does not need one.
+//
+// Because it is dynamic-mode only, Args returns an error rather than a call
+// when a schema is attached (WithSchema): the server would answer
+// wire.ErrOperateOpcode for it.
 func (ob *OperateBuilder) Config(path Path, capacity uint32, policy uint8, byCol string) *OperateBuilder {
 	return ob.addOp(builderOp{opcode: wire.OperateOpCONFIG, aux: policy, path: path, a: int64(capacity), byColName: byCol})
 }
 
 // Trim shrinks the table field at path to at most keep rows by policy (and,
 // for a *_COL policy, byCol), without changing the table's stored eviction
-// config (design doc §3.2). byCol may be "" when policy does not need one.
+// config (design doc §3.2). Unlike Config it is valid in BOTH modes: it is a
+// one-off shrink, not a change to the table's configuration, so it does not
+// collide with a schema-mode table's schema-declared eviction triple. byCol
+// may be "" when policy does not need one.
 func (ob *OperateBuilder) Trim(path Path, keep uint32, policy uint8, byCol string) *OperateBuilder {
 	return ob.addOp(builderOp{opcode: wire.OperateOpTRIM, aux: policy, path: path, a: int64(keep), byColName: byCol})
 }
@@ -435,12 +442,19 @@ func (ob *OperateBuilder) Trim(path Path, keep uint32, policy uint8, byCol strin
 // version in this atomic call, an append-only evolution or a dynamic-mode
 // freeze (design doc §2.8/§2.9). It must be the first op in the list.
 // dropExtra sets wire.OperateMigrateDropExtra, discarding dynamic fields s
-// does not declare rather than rejecting the call. A nil s is recorded and
-// returned by Args rather than panicking.
+// does not declare rather than rejecting the call. s is validated here, as
+// WithSchema validates its own; a nil s or a validation failure is recorded
+// and returned by Args rather than panicking.
 func (ob *OperateBuilder) Migrate(from int64, s *wire.Schema, dropExtra bool) *OperateBuilder {
 	if s == nil {
 		if ob.err == nil {
 			ob.err = fmt.Errorf("client: operate: Migrate requires a non-nil schema")
+		}
+		return ob
+	}
+	if err := s.Validate(); err != nil {
+		if ob.err == nil {
+			ob.err = err
 		}
 		return ob
 	}
@@ -513,6 +527,14 @@ func (ob *OperateBuilder) Args() (*wire.OperateArgs, error) {
 		args.Schema = ob.schema.Encode()
 	}
 	for _, op := range ob.ops {
+		if op.opcode == wire.OperateOpCONFIG && ob.schema != nil {
+			// The server answers wire.ErrOperateOpcode for a CONFIG against a
+			// schema-mode record (design doc §3.2: a schema-mode table's
+			// eviction triple comes from its schema and changes only via
+			// MIGRATE), so this call can only ever fail — say so here rather
+			// than after a round trip.
+			return nil, fmt.Errorf("client: operate: Config is dynamic-mode only; a schema-mode table's eviction triple changes via Migrate")
+		}
 		wop, err := ob.resolveOp(op)
 		if err != nil {
 			return nil, err

--- a/client/operate.go
+++ b/client/operate.go
@@ -20,8 +20,14 @@ import (
 // An error from wire.EncodeOperateArgs (a's op/ret list, key, or schema
 // blob exceeds a wire cap, or carries a structurally invalid field) is
 // returned unchanged, without a network round trip — build a's OperateArgs
-// with OperateBuilder to avoid ever hitting one by hand.
+// with OperateBuilder to avoid ever hitting one by hand. A nil a is
+// wire.ErrOperateArgs rather than a panic: it is the shape a caller lands on
+// by ignoring OperateBuilder.Args's error, which is exactly when a panic is
+// least welcome.
 func (c *Client) Operate(ctx context.Context, a *wire.OperateArgs) (*wire.OperateResult, error) {
+	if a == nil {
+		return nil, wire.ErrOperateArgs
+	}
 	args, err := wire.EncodeOperateArgs(a)
 	if err != nil {
 		return nil, err
@@ -39,9 +45,20 @@ func (c *Client) Operate(ctx context.Context, a *wire.OperateArgs) (*wire.Operat
 // wire.Cell{Type: wire.OperateTypeUnset} rather than an error, so a caller
 // can read res.Values[i] uniformly without special-casing "not present"
 // against a decode failure.
+//
+// The tagged cell must consume b exactly. A value that decodes and leaves
+// bytes over is not the value it claims to be — a table's or a row's
+// encoding read as a scalar, or a corrupt frame — and returning its first
+// cell would silently hand the caller a prefix of something else.
 func DecodeOperateValue(b []byte) (wire.Cell, error) {
-	c, _, err := wire.DecodeTaggedCell(b)
-	return c, err
+	c, n, err := wire.DecodeTaggedCell(b)
+	if err != nil {
+		return wire.Cell{}, err
+	}
+	if n != len(b) {
+		return wire.Cell{}, fmt.Errorf("client: operate: %d bytes left after the tagged cell: %w", len(b)-n, wire.ErrOperateArgs)
+	}
+	return c, nil
 }
 
 // Path addresses one node inside an operate record (design doc §2.4): the
@@ -143,15 +160,23 @@ type builderRet struct {
 // into a non-table field, a typed op whose type disagrees with the schema —
 // is recorded and returned by Args, so no intermediate call needs its own
 // error check.
+// schema and createSchema are deliberately two fields. createSchema is the
+// blob the CALL carries, which the server checks against the version the
+// record is stored at when it opens it — so it must stay the schema the
+// record has NOW, and only WithSchema sets it. schema is what Field/Col
+// names resolve against, which a MIGRATE moves forward: MIGRATE is the first
+// op, so every other op and every return spec runs against the record as the
+// migration leaves it, and must be resolved against the target schema.
 type OperateBuilder struct {
-	key     []byte
-	schema  *wire.Schema
-	create  uint8
-	ttl     time.Duration
-	ttlMode uint8
-	ops     []builderOp
-	rets    []builderRet
-	err     error
+	key          []byte
+	schema       *wire.Schema
+	createSchema *wire.Schema
+	create       uint8
+	ttl          time.Duration
+	ttlMode      uint8
+	ops          []builderOp
+	rets         []builderRet
+	err          error
 }
 
 // NewOperate starts building an operate call against key. The call defaults
@@ -190,7 +215,7 @@ func (ob *OperateBuilder) WithSchema(s *wire.Schema) *OperateBuilder {
 			return ob
 		}
 	}
-	ob.schema = s
+	ob.schema, ob.createSchema = s, s
 	ob.create = wire.OperateCreateSchema
 	return ob
 }
@@ -200,7 +225,7 @@ func (ob *OperateBuilder) WithSchema(s *wire.Schema) *OperateBuilder {
 // the ops that first touch it. It is exclusive with WithSchema, for the
 // reason given there.
 func (ob *OperateBuilder) Dynamic() *OperateBuilder {
-	if ob.create == wire.OperateCreateSchema || ob.schema != nil {
+	if ob.create == wire.OperateCreateSchema {
 		if ob.err == nil {
 			ob.err = fmt.Errorf("client: operate: builder is already in schema mode; Dynamic and WithSchema are exclusive")
 		}
@@ -460,11 +485,23 @@ func (ob *OperateBuilder) Trim(path Path, keep uint32, policy uint8, byCol strin
 // Migrate moves the record from its stored version (from, or
 // wire.OperateMigrateFromDynamic when the record is dynamic-mode) to s's
 // version in this atomic call, an append-only evolution or a dynamic-mode
-// freeze (design doc §2.8/§2.9). It must be the first op in the list.
-// dropExtra sets wire.OperateMigrateDropExtra, discarding dynamic fields s
-// does not declare rather than rejecting the call. s is validated here, as
-// WithSchema validates its own; a nil s or a validation failure is recorded
-// and returned by Args rather than panicking.
+// freeze (design doc §2.8/§2.9). dropExtra sets
+// wire.OperateMigrateDropExtra, discarding dynamic fields s does not declare
+// rather than rejecting the call. s is validated here, as WithSchema
+// validates its own; a nil s or a validation failure is recorded and
+// returned by Args rather than panicking.
+//
+// It must be the FIRST op: applyOps rejects a MIGRATE at any other index
+// with wire.ErrOperateOpcode (design doc §2.8), so calling it after another
+// op can only ever build a request the server refuses. That is recorded as a
+// builder error here instead.
+//
+// It also moves the builder's resolution schema to s, without touching the
+// call's `create` byte or the schema blob the call carries. Every op after
+// the MIGRATE — which is all of them — and every return spec runs against
+// the record as the migration leaves it, so their Field/Col names resolve
+// against the TARGET schema. The call still declares the version the record
+// is stored at, which is what the server checks when it opens it.
 func (ob *OperateBuilder) Migrate(from int64, s *wire.Schema, dropExtra bool) *OperateBuilder {
 	if s == nil {
 		if ob.err == nil {
@@ -478,10 +515,17 @@ func (ob *OperateBuilder) Migrate(from int64, s *wire.Schema, dropExtra bool) *O
 		}
 		return ob
 	}
+	if len(ob.ops) > 0 {
+		if ob.err == nil {
+			ob.err = fmt.Errorf("client: operate: Migrate must be the first op, but %d op(s) were added before it", len(ob.ops))
+		}
+		return ob
+	}
 	var aux uint8
 	if dropExtra {
 		aux = wire.OperateMigrateDropExtra
 	}
+	ob.schema = s
 	return ob.addOp(builderOp{opcode: wire.OperateOpMIGRATE, aux: aux, path: RecordPath(), a: from, bytes: s.Encode()})
 }
 
@@ -543,8 +587,8 @@ func (ob *OperateBuilder) Args() (*wire.OperateArgs, error) {
 		TTLMode: ob.ttlMode,
 		Create:  ob.create,
 	}
-	if ob.schema != nil {
-		args.Schema = ob.schema.Encode()
+	if ob.createSchema != nil {
+		args.Schema = ob.createSchema.Encode()
 	}
 	for _, op := range ob.ops {
 		if op.opcode == wire.OperateOpCONFIG && ob.schema != nil {
@@ -552,7 +596,9 @@ func (ob *OperateBuilder) Args() (*wire.OperateArgs, error) {
 			// schema-mode record (design doc §3.2: a schema-mode table's
 			// eviction triple comes from its schema and changes only via
 			// MIGRATE), so this call can only ever fail — say so here rather
-			// than after a round trip.
+			// than after a round trip. A schema installed by a MIGRATE counts:
+			// the record is in schema mode from the freeze onwards, and the
+			// MIGRATE is the first op, so every CONFIG in the list is after it.
 			return nil, fmt.Errorf("client: operate: Config is dynamic-mode only; a schema-mode table's eviction triple changes via Migrate")
 		}
 		wop, err := ob.resolveOp(op)

--- a/client/operate_test.go
+++ b/client/operate_test.go
@@ -193,10 +193,13 @@ func TestOperateEndToEnd(t *testing.T) {
 		if !reflect.DeepEqual(gotArgs, builderArgs) {
 			t.Fatalf("args on the wire:\n got %+v\nwant %+v", gotArgs, builderArgs)
 		}
-		payload := wire.EncodeOperateResult(&wire.OperateResult{
+		payload, eerr := wire.EncodeOperateResult(&wire.OperateResult{
 			Status: wire.OperateStatusOK,
 			Values: [][]byte{wire.AppendTaggedCell(nil, wire.Cell{Type: wire.OperateTypeU8, U: 9})},
 		})
+		if eerr != nil {
+			t.Fatalf("EncodeOperateResult: %v", eerr)
+		}
 		return StatusOK, payload
 	})
 	defer stop()
@@ -265,5 +268,64 @@ func TestOperateEncodeErrorNoNetworkCall(t *testing.T) {
 	}
 	if !errors.Is(err, wire.ErrOperateCap) {
 		t.Fatalf("err = %v, want wire.ErrOperateCap", err)
+	}
+}
+
+// TestOperateBuilderMigrateValidatesSchema covers Migrate's schema check.
+// WithSchema validates the schema it attaches, so Migrate — which ships a
+// second schema blob the server will store — must do the same, or an invalid
+// target schema only surfaces after a round trip.
+func TestOperateBuilderMigrateValidatesSchema(t *testing.T) {
+	bad := &wire.Schema{Version: 2, Fields: []wire.FieldDef{
+		{Name: "f", Type: wire.OperateTypeFixed, N: 0}, // FIXED(0) is not a width
+	}}
+	if err := bad.Validate(); err == nil {
+		t.Fatal("the fixture schema must be invalid for this test to mean anything")
+	}
+	_, err := NewOperate([]byte("k")).Dynamic().
+		Migrate(wire.OperateMigrateFromDynamic, bad, false).
+		Args()
+	if err == nil {
+		t.Fatal("Migrate accepted a schema that fails Validate")
+	}
+
+	good := &wire.Schema{Version: 2, Fields: []wire.FieldDef{{Name: "f", Type: wire.OperateTypeU64}}}
+	if _, err := NewOperate([]byte("k")).Dynamic().
+		Migrate(wire.OperateMigrateFromDynamic, good, false).Args(); err != nil {
+		t.Fatalf("a valid migration schema must build: %v", err)
+	}
+}
+
+// TestOperateBuilderConfigIsDynamicOnly covers the two mode rules the
+// builder can check for itself: CONFIG against a schema-mode record is
+// wire.ErrOperateOpcode on the server (design doc §3.2 — a schema-mode
+// table's eviction triple comes from its schema), so the call can only ever
+// fail; TRIM is valid in both modes and must keep building.
+func TestOperateBuilderConfigIsDynamicOnly(t *testing.T) {
+	s := &wire.Schema{Version: 1, Fields: []wire.FieldDef{
+		{Name: "ev", Type: wire.OperateTypeTable, Table: &wire.TableDef{
+			KeyType: wire.OperateTypeU64,
+			Cols:    []wire.ColumnDef{{Name: "hits", Type: wire.OperateTypeU32}},
+		}},
+	}}
+
+	if _, err := NewOperate([]byte("k")).WithSchema(s).
+		Config(F("ev"), 10, wire.OperatePolicyMinKey, "").Args(); err == nil {
+		t.Fatal("Config built a call against a schema-mode record")
+	}
+	// The same op is fine without a schema.
+	if _, err := NewOperate([]byte("k")).Dynamic().
+		Config(F("ev"), 10, wire.OperatePolicyMinKey, "").Args(); err != nil {
+		t.Fatalf("Config in dynamic mode: %v", err)
+	}
+
+	// TRIM builds in both modes.
+	if _, err := NewOperate([]byte("k")).WithSchema(s).
+		Trim(F("ev"), 5, wire.OperatePolicyMinCol, "hits").Args(); err != nil {
+		t.Fatalf("Trim in schema mode: %v", err)
+	}
+	if _, err := NewOperate([]byte("k")).Dynamic().
+		Trim(F("ev"), 5, wire.OperatePolicyMinCol, "hits").Args(); err != nil {
+		t.Fatalf("Trim in dynamic mode: %v", err)
 	}
 }

--- a/client/operate_test.go
+++ b/client/operate_test.go
@@ -3,6 +3,7 @@
 package client
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"reflect"
@@ -112,9 +113,15 @@ func TestOperateBuilderSchemaErrors(t *testing.T) {
 
 // TestOperateBuilderConfigTrimColPolicyGuard checks that Args rejects a
 // Config/Trim call whose policy is a *_COL policy (MIN_COL/MAX_COL) but
-// whose byCol is empty, both in dynamic mode (where the wire itself would
-// otherwise accept byColLen 0 and silently mean column 0) and in schema
-// mode (where an empty byCol would otherwise resolve nothing at all).
+// whose byCol is empty, in dynamic mode (where the wire itself would
+// otherwise accept byColLen 0 and silently mean column 0) and in schema mode
+// (where an empty byCol would otherwise resolve nothing at all).
+//
+// The schema-mode case uses Trim, not Config. Config in schema mode is
+// refused by the mode guard before the byCol rule is ever consulted, so a
+// Config sub-case here would pass for the wrong reason and keep passing if
+// the byCol rule were deleted; Trim is valid in both modes, so it reaches the
+// rule under test.
 func TestOperateBuilderConfigTrimColPolicyGuard(t *testing.T) {
 	if _, err := NewOperate([]byte("k")).Dynamic().
 		Config(F("t"), 1024, wire.OperatePolicyMinCol, "").Args(); err == nil {
@@ -126,9 +133,20 @@ func TestOperateBuilderConfigTrimColPolicyGuard(t *testing.T) {
 	}
 
 	s := sessionSchema()
+	_, err := NewOperate([]byte("k")).WithSchema(s).
+		Trim(F("b"), 10, wire.OperatePolicyMinCol, "").Args()
+	if err == nil {
+		t.Fatal("expected error for Trim with MinCol policy and empty byCol (schema mode)")
+	}
+	if !strings.Contains(err.Error(), "column name") {
+		t.Fatalf("err = %v, want the *_COL byCol rule, not some earlier guard", err)
+	}
+
+	// The same Trim with a real column name builds, so the case above is
+	// failing on the empty byCol and not on the path or the mode.
 	if _, err := NewOperate([]byte("k")).WithSchema(s).
-		Config(F("b"), 1024, wire.OperatePolicyMinCol, "").Args(); err == nil {
-		t.Fatal("expected error for Config with MinCol policy and empty byCol (schema mode)")
+		Trim(F("b"), 10, wire.OperatePolicyMinCol, "c").Args(); err != nil {
+		t.Fatalf("Trim with MinCol and a real byCol (schema mode): %v", err)
 	}
 
 	// A non-*_COL policy still needs no byCol.
@@ -398,5 +416,140 @@ func TestOperateBuilderColumnNeedsRowKey(t *testing.T) {
 	}
 	if args.Ops[0].Path.Kind != wire.OperatePathCol || args.Ops[0].Path.Col.Name != "c" {
 		t.Fatalf("path = %+v", args.Ops[0].Path)
+	}
+}
+
+// TestOperateNilArgs covers Client.Operate against a nil args pointer, which
+// is the shape a caller lands on by ignoring OperateBuilder.Args's error.
+// EncodeOperateArgs dereferences it, so this used to panic inside the client.
+func TestOperateNilArgs(t *testing.T) {
+	c, err := New(Config{Servers: []string{"127.0.0.1:1"}})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	defer func() { _ = c.Close() }()
+
+	res, err := c.Operate(context.Background(), nil)
+	if !errors.Is(err, wire.ErrOperateArgs) {
+		t.Fatalf("err = %v, want wire.ErrOperateArgs", err)
+	}
+	if res != nil {
+		t.Fatalf("res = %+v, want nil", res)
+	}
+}
+
+// TestDecodeOperateValueTrailingBytes covers the "one tagged cell, exactly"
+// rule. A value that decodes and leaves bytes over is not the value it claims
+// to be — a table's or a row's encoding read as a scalar, or a corrupt
+// frame — and returning its first cell would hand the caller a prefix of
+// something else.
+func TestDecodeOperateValueTrailingBytes(t *testing.T) {
+	one := wire.AppendTaggedCell(nil, wire.Cell{Type: wire.OperateTypeU16, U: 7})
+	if c, err := DecodeOperateValue(one); err != nil || c.U != 7 {
+		t.Fatalf("a single tagged cell must decode: %+v %v", c, err)
+	}
+	two := wire.AppendTaggedCell(append([]byte(nil), one...), wire.Cell{Type: wire.OperateTypeU8, U: 1})
+	if _, err := DecodeOperateValue(two); !errors.Is(err, wire.ErrOperateArgs) {
+		t.Fatalf("two cells: err = %v, want wire.ErrOperateArgs", err)
+	}
+	if _, err := DecodeOperateValue(append(append([]byte(nil), one...), 0)); err == nil {
+		t.Fatal("a single trailing byte was accepted")
+	}
+	// The absent-value convention is one byte and still decodes.
+	if c, err := DecodeOperateValue([]byte{wire.OperateTypeUnset}); err != nil || c.Type != wire.OperateTypeUnset {
+		t.Fatalf("UNSET: %+v %v", c, err)
+	}
+}
+
+// TestOperateBuilderMigrateMustBeFirst covers MIGRATE's position. applyOps
+// rejects a MIGRATE at any index but 0 with wire.ErrOperateOpcode (design doc
+// §2.8), so building one after another op can only ever produce a request the
+// server refuses.
+func TestOperateBuilderMigrateMustBeFirst(t *testing.T) {
+	s := &wire.Schema{Version: 2, Fields: []wire.FieldDef{{Name: "rc", Type: wire.OperateTypeU64}}}
+
+	_, err := NewOperate([]byte("k")).Dynamic().
+		AddT(F("rc"), wire.OperateTypeU64, 1).
+		Migrate(wire.OperateMigrateFromDynamic, s, false).
+		Args()
+	if err == nil {
+		t.Fatal("Migrate after another op built a call")
+	}
+	if !strings.Contains(err.Error(), "first op") {
+		t.Fatalf("err = %v, want it to name the position rule", err)
+	}
+
+	// Two MIGRATEs is the same rule: the second is not the first op.
+	if _, err := NewOperate([]byte("k")).Dynamic().
+		Migrate(wire.OperateMigrateFromDynamic, s, false).
+		Migrate(wire.OperateMigrateFromDynamic, s, false).Args(); err == nil {
+		t.Fatal("a second Migrate built a call")
+	}
+
+	// Migrate first is fine, and stays op 0.
+	args, err := NewOperate([]byte("k")).Dynamic().
+		Migrate(wire.OperateMigrateFromDynamic, s, false).
+		Add(F("rc"), 1).Args()
+	if err != nil {
+		t.Fatalf("Migrate first: %v", err)
+	}
+	if args.Ops[0].Opcode != wire.OperateOpMIGRATE {
+		t.Fatalf("op 0 = %d, want MIGRATE", args.Ops[0].Opcode)
+	}
+}
+
+// TestOperateBuilderMigrateInstallsResolutionSchema covers what a MIGRATE
+// does to name resolution. It is the first op, so every other op and every
+// return spec runs against the record as the migration leaves it, and their
+// Field/Col names must resolve against the TARGET schema — by position, with
+// Type OperateTypeFromSchema — not as dynamic name segments.
+func TestOperateBuilderMigrateInstallsResolutionSchema(t *testing.T) {
+	s := sessionSchema()
+	args, err := NewOperate([]byte("k")).Dynamic().
+		Migrate(wire.OperateMigrateFromDynamic, s, false).
+		Add(F("rc"), 1).
+		Count(F("b")).
+		Args()
+	if err != nil {
+		t.Fatalf("Args: %v", err)
+	}
+	if args.Create != wire.OperateCreateDynamic {
+		t.Fatalf("create = %d, want CreateDynamic; a freeze does not change the create mode", args.Create)
+	}
+	// The call's own schema blob stays empty: the server checks the blob
+	// against the version the record is stored at when it OPENS it, and this
+	// record is dynamic. The target schema rides on the MIGRATE op instead.
+	if len(args.Schema) != 0 {
+		t.Fatalf("args.Schema = %x, want empty for a dynamic-create call", args.Schema)
+	}
+	add := args.Ops[1]
+	if add.Path.Field.ByName || add.Path.Field.Pos != 0 {
+		t.Fatalf("Add path = %+v, want position 0 (rc) resolved against the target schema", add.Path.Field)
+	}
+	if add.Type != wire.OperateTypeFromSchema {
+		t.Fatalf("Add type = %d, want OperateTypeFromSchema", add.Type)
+	}
+	if ret := args.Rets[0]; ret.Path.Field.ByName || ret.Path.Field.Pos != 3 {
+		t.Fatalf("ret path = %+v, want position 3 (b)", ret.Path.Field)
+	}
+
+	// A schema-mode evolution keeps shipping the version the record is stored
+	// at while resolving later names against the target.
+	v1 := sessionSchema()
+	v2 := sessionSchema()
+	v2.Version = 2
+	v2.Fields = append(v2.Fields, wire.FieldDef{Name: "extra", Type: wire.OperateTypeU64})
+	args, err = NewOperate([]byte("k")).WithSchema(v1).
+		Migrate(1, v2, false).
+		Add(F("extra"), 1).
+		Args()
+	if err != nil {
+		t.Fatalf("schema-mode evolution: %v", err)
+	}
+	if !bytes.Equal(args.Schema, v1.Encode()) {
+		t.Fatal("the call's schema blob must stay the version the record is stored at")
+	}
+	if got := args.Ops[1].Path.Field.Pos; got != 4 {
+		t.Fatalf("Add path pos = %d, want 4 (the field only v2 declares)", got)
 	}
 }

--- a/client/operate_test.go
+++ b/client/operate_test.go
@@ -1,0 +1,241 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package client
+
+import (
+	"context"
+	"errors"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/rostamlabs/rostam/sdk/wire"
+)
+
+// sessionSchema mirrors sdk/wire/operate_schema_test.go's helper of the same
+// name (design doc §4's v1-session-record-in-v2 worked example), qualified
+// with wire. since this is a different package.
+func sessionSchema() *wire.Schema {
+	return &wire.Schema{Version: 1, Fields: []wire.FieldDef{
+		{Name: "rc", Type: wire.OperateTypeU8}, {Name: "bc", Type: wire.OperateTypeU8}, {Name: "hist", Type: wire.OperateTypeU32},
+		{Name: "b", Type: wire.OperateTypeTable, Table: &wire.TableDef{KeyType: wire.OperateTypeU64, Cols: []wire.ColumnDef{
+			{Name: "c", Type: wire.OperateTypeU16}, {Name: "hi", Type: wire.OperateTypeI64}, {Name: "t", Type: wire.OperateTypeU32}},
+			Cap: 1024, Policy: wire.OperatePolicyMinCol, ByCol: 2}},
+	}}
+}
+
+// TestOperateBuilderSchemaMode builds design doc §4's session-record worked
+// example through the builder and checks the resolved wire.OperateArgs
+// against a hand-written one: positions resolved from names, Type ==
+// OperateTypeFromSchema on every untyped scalar op, and a bare zero Type on
+// the control op (IF never declares one, design doc §2.4).
+func TestOperateBuilderSchemaMode(t *testing.T) {
+	s := sessionSchema()
+	key := []byte("session:42")
+	id := uint64(7)
+	rowKey := KeyU64(id)
+	const bid = int64(99)
+	const won = int64(1)
+
+	got, err := NewOperate(key).WithSchema(s).
+		TTL(90*time.Second, wire.OperateTTLCreateOnly).
+		If(F("rc"), wire.OperateCmpGE, 255, 2).
+		Shr(F("rc"), 1).
+		Shr(F("bc"), 1).
+		Add(F("rc"), 1).
+		Add(Col("b", rowKey, "c"), 1).
+		Max(Col("b", rowKey, "hi"), bid).
+		Stamp(Col("b", rowKey, "t"), wire.OperateStampS).
+		Shl(F("hist"), 1).
+		Or(F("hist"), won).
+		Return(F("rc")).
+		Return(Row("b", rowKey)).
+		Args()
+	if err != nil {
+		t.Fatalf("Args: %v", err)
+	}
+
+	want := &wire.OperateArgs{
+		Key:     key,
+		TTL:     90 * time.Second,
+		TTLMode: wire.OperateTTLCreateOnly,
+		Create:  wire.OperateCreateSchema,
+		Schema:  s.Encode(),
+		Ops: []wire.OperateOp{
+			{Opcode: wire.OperateOpIF, Aux: wire.OperateCmpGE,
+				Path: wire.OperatePath{Kind: wire.OperatePathField, Field: wire.OperateSeg{Pos: 0}}, A: 255, B: 2},
+			{Opcode: wire.OperateOpSHR, Type: wire.OperateTypeFromSchema,
+				Path: wire.OperatePath{Kind: wire.OperatePathField, Field: wire.OperateSeg{Pos: 0}}, A: 1},
+			{Opcode: wire.OperateOpSHR, Type: wire.OperateTypeFromSchema,
+				Path: wire.OperatePath{Kind: wire.OperatePathField, Field: wire.OperateSeg{Pos: 1}}, A: 1},
+			{Opcode: wire.OperateOpADD, Type: wire.OperateTypeFromSchema,
+				Path: wire.OperatePath{Kind: wire.OperatePathField, Field: wire.OperateSeg{Pos: 0}}, A: 1},
+			{Opcode: wire.OperateOpADD, Type: wire.OperateTypeFromSchema,
+				Path: wire.OperatePath{Kind: wire.OperatePathCol, Field: wire.OperateSeg{Pos: 3}, Key: rowKey, Col: wire.OperateSeg{Pos: 0}}, A: 1},
+			{Opcode: wire.OperateOpMAX, Type: wire.OperateTypeFromSchema,
+				Path: wire.OperatePath{Kind: wire.OperatePathCol, Field: wire.OperateSeg{Pos: 3}, Key: rowKey, Col: wire.OperateSeg{Pos: 1}}, A: bid},
+			{Opcode: wire.OperateOpSTAMP, Type: wire.OperateTypeFromSchema, Aux: wire.OperateStampS,
+				Path: wire.OperatePath{Kind: wire.OperatePathCol, Field: wire.OperateSeg{Pos: 3}, Key: rowKey, Col: wire.OperateSeg{Pos: 2}}},
+			{Opcode: wire.OperateOpSHL, Type: wire.OperateTypeFromSchema,
+				Path: wire.OperatePath{Kind: wire.OperatePathField, Field: wire.OperateSeg{Pos: 2}}, A: 1},
+			{Opcode: wire.OperateOpOR, Type: wire.OperateTypeFromSchema,
+				Path: wire.OperatePath{Kind: wire.OperatePathField, Field: wire.OperateSeg{Pos: 2}}, A: won},
+		},
+		Rets: []wire.OperateRet{
+			{Mode: wire.OperateRetValue, Path: wire.OperatePath{Kind: wire.OperatePathField, Field: wire.OperateSeg{Pos: 0}}},
+			{Mode: wire.OperateRetValue, Path: wire.OperatePath{Kind: wire.OperatePathRow, Field: wire.OperateSeg{Pos: 3}, Key: rowKey}},
+		},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("\n got %+v\nwant %+v", got, want)
+	}
+}
+
+// TestOperateBuilderSchemaErrors checks the three resolution failures Args
+// must report against a schema: an unknown field name, a row key of the
+// wrong width for the table's key type, and a column path targeting a
+// non-table field.
+func TestOperateBuilderSchemaErrors(t *testing.T) {
+	s := sessionSchema()
+
+	if _, err := NewOperate([]byte("k")).WithSchema(s).Return(F("nope")).Args(); err == nil {
+		t.Fatal("expected error for unknown field name")
+	}
+	if _, err := NewOperate([]byte("k")).WithSchema(s).Return(Row("b", []byte{1, 2, 3})).Args(); err == nil {
+		t.Fatal("expected error for wrong key width")
+	}
+	if _, err := NewOperate([]byte("k")).WithSchema(s).Return(Col("rc", []byte{0}, "x")).Args(); err == nil {
+		t.Fatal("expected error for a column path on a non-table field")
+	}
+}
+
+// TestOperateBuilderDynamicMode checks that without a schema, Field/Col
+// resolve to name segments, typed variants (AddT/SetBytesT) carry the given
+// type, and an untyped variant (Add) still emits OperateTypeFromSchema —
+// valid only against an existing target, per design doc §2.9.
+func TestOperateBuilderDynamicMode(t *testing.T) {
+	got, err := NewOperate([]byte("k")).Dynamic().
+		AddT(F("hits"), wire.OperateTypeI64, 5).
+		SetBytesT(F("name"), wire.OperateTypeBytes, []byte("v")).
+		Add(F("hits"), 1).
+		Args()
+	if err != nil {
+		t.Fatalf("Args: %v", err)
+	}
+	want := &wire.OperateArgs{
+		Key:    []byte("k"),
+		Create: wire.OperateCreateDynamic,
+		Ops: []wire.OperateOp{
+			{Opcode: wire.OperateOpADD, Type: wire.OperateTypeI64,
+				Path: wire.OperatePath{Kind: wire.OperatePathField, Field: wire.OperateSeg{ByName: true, Name: "hits"}}, A: 5},
+			{Opcode: wire.OperateOpSET, Type: wire.OperateTypeBytes,
+				Path: wire.OperatePath{Kind: wire.OperatePathField, Field: wire.OperateSeg{ByName: true, Name: "name"}}, Bytes: []byte("v")},
+			{Opcode: wire.OperateOpADD, Type: wire.OperateTypeFromSchema,
+				Path: wire.OperatePath{Kind: wire.OperatePathField, Field: wire.OperateSeg{ByName: true, Name: "hits"}}, A: 1},
+		},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("\n got %+v\nwant %+v", got, want)
+	}
+}
+
+// TestOperateEndToEnd runs a builder-built call through a fake server: the
+// server decodes the request frame's op name and args, asserts the args
+// DeepEqual what the builder produced, and replies with an OperateResult;
+// Client.Operate must decode that result, and DecodeOperateValue must read
+// the single returned scalar back out of it.
+func TestOperateEndToEnd(t *testing.T) {
+	builderArgs, err := NewOperate([]byte("k")).Dynamic().
+		AddT(F("hits"), wire.OperateTypeI64, 1).
+		Return(F("hits")).
+		Args()
+	if err != nil {
+		t.Fatalf("Args: %v", err)
+	}
+
+	addr, stop := startFakeServer(t, func(body []byte) (uint8, []byte) {
+		opName, argsBytes := decodeOpFrame(t, body)
+		if opName != "operate" {
+			t.Fatalf("op = %q, want operate", opName)
+		}
+		gotArgs, derr := wire.DecodeOperateArgs(argsBytes)
+		if derr != nil {
+			t.Fatalf("DecodeOperateArgs: %v", derr)
+		}
+		if !reflect.DeepEqual(gotArgs, builderArgs) {
+			t.Fatalf("args on the wire:\n got %+v\nwant %+v", gotArgs, builderArgs)
+		}
+		payload := wire.EncodeOperateResult(&wire.OperateResult{
+			Status: wire.OperateStatusOK,
+			Values: [][]byte{wire.AppendTaggedCell(nil, wire.Cell{Type: wire.OperateTypeU8, U: 9})},
+		})
+		return StatusOK, payload
+	})
+	defer stop()
+
+	c, err := New(Config{Servers: []string{addr}})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	defer func() { _ = c.Close() }()
+
+	res, err := c.Operate(context.Background(), builderArgs)
+	if err != nil {
+		t.Fatalf("Operate: %v", err)
+	}
+	if res.Status != wire.OperateStatusOK || len(res.Values) != 1 {
+		t.Fatalf("unexpected result: %+v", res)
+	}
+	cell, err := DecodeOperateValue(res.Values[0])
+	if err != nil {
+		t.Fatalf("DecodeOperateValue: %v", err)
+	}
+	if cell.Type != wire.OperateTypeU8 || cell.U != 9 {
+		t.Fatalf("cell = %+v, want U8(9)", cell)
+	}
+}
+
+// TestDecodeOperateValueAbsent checks the absent-value convention
+// DecodeOperateValue documents: a tagged UNSET byte decodes to a Cell whose
+// Type is OperateTypeUnset, not an error.
+func TestDecodeOperateValueAbsent(t *testing.T) {
+	c, err := DecodeOperateValue([]byte{wire.OperateTypeUnset})
+	if err != nil {
+		t.Fatalf("DecodeOperateValue: %v", err)
+	}
+	if c.Type != wire.OperateTypeUnset {
+		t.Fatalf("cell = %+v, want Unset", c)
+	}
+}
+
+// TestOperateNonReplayable checks that operate is registered as
+// non-replayable: it mutates counters non-idempotently, so a blind replay
+// after an ambiguous post-commit failure would apply every increment twice.
+func TestOperateNonReplayable(t *testing.T) {
+	if !nonReplayableOp("operate") {
+		t.Fatal("nonReplayableOp(\"operate\") = false, want true")
+	}
+}
+
+// TestOperateEncodeErrorNoNetworkCall checks that an OperateArgs which fails
+// wire.EncodeOperateArgs (here, too many ops) is rejected by Client.Operate
+// before any network call is attempted: the server address is a closed port
+// that a dial would fail loudly on, but since pools are created lazily
+// (New's MinConnsPerServer defaults to 0) the encode error must come back
+// without ever touching it.
+func TestOperateEncodeErrorNoNetworkCall(t *testing.T) {
+	c, err := New(Config{Servers: []string{"127.0.0.1:1"}})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	defer func() { _ = c.Close() }()
+
+	args := &wire.OperateArgs{Key: []byte("k"), Ops: make([]wire.OperateOp, wire.OperateMaxOps+1)}
+	_, err = c.Operate(context.Background(), args)
+	if err == nil {
+		t.Fatal("expected an encode error")
+	}
+	if !errors.Is(err, wire.ErrOperateCap) {
+		t.Fatalf("err = %v, want wire.ErrOperateCap", err)
+	}
+}

--- a/client/operate_test.go
+++ b/client/operate_test.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"errors"
 	"reflect"
+	"strings"
 	"testing"
 	"time"
 
@@ -327,5 +328,75 @@ func TestOperateBuilderConfigIsDynamicOnly(t *testing.T) {
 	if _, err := NewOperate([]byte("k")).Dynamic().
 		Trim(F("ev"), 5, wire.OperatePolicyMinCol, "hits").Args(); err != nil {
 		t.Fatalf("Trim in dynamic mode: %v", err)
+	}
+}
+
+// TestOperateBuilderModesAreExclusive covers the create-mode setters in both
+// orders. Before this guard, a builder that had been through both shipped a
+// DYNAMIC create byte alongside a schema blob and schema-position paths: the
+// wire decoder accepts that frame, so nothing rejected it until the dynamic
+// engine failed every path with wire.ErrOperatePath, a round trip later.
+func TestOperateBuilderModesAreExclusive(t *testing.T) {
+	s := &wire.Schema{Version: 1, Fields: []wire.FieldDef{{Name: "hits", Type: wire.OperateTypeU64}}}
+
+	got, err := NewOperate([]byte("k")).WithSchema(s).Dynamic().
+		Add(F("hits"), 1).Args()
+	if err == nil {
+		t.Fatalf("WithSchema().Dynamic() built a call: %+v", got)
+	}
+	if !strings.Contains(err.Error(), "schema mode") {
+		t.Fatalf("err = %v, want it to name the mode already set", err)
+	}
+
+	got, err = NewOperate([]byte("k")).Dynamic().WithSchema(s).
+		AddT(F("hits"), wire.OperateTypeU64, 1).Args()
+	if err == nil {
+		t.Fatalf("Dynamic().WithSchema() built a call: %+v", got)
+	}
+	if !strings.Contains(err.Error(), "dynamic mode") {
+		t.Fatalf("err = %v, want it to name the mode already set", err)
+	}
+
+	// Neither guard fires when only one of the two is used, nor when the same
+	// one is used twice.
+	if _, err := NewOperate([]byte("k")).WithSchema(s).WithSchema(s).
+		Add(F("hits"), 1).Args(); err != nil {
+		t.Fatalf("WithSchema twice: %v", err)
+	}
+	if _, err := NewOperate([]byte("k")).Dynamic().Dynamic().
+		AddT(F("hits"), wire.OperateTypeU64, 1).Args(); err != nil {
+		t.Fatalf("Dynamic twice: %v", err)
+	}
+}
+
+// TestOperateBuilderColumnNeedsRowKey covers a Path carrying a column but no
+// row key. A column belongs to a row (design doc §2.4), and the wire form
+// for such a path is OperatePathField, which DROPS the column and aims the
+// op at the field itself — in dynamic mode a SET meant for one column would
+// overwrite a scalar field of the same name.
+func TestOperateBuilderColumnNeedsRowKey(t *testing.T) {
+	orphan := Path{Field: "b", Col: "c", HasCol: true}
+
+	got, err := NewOperate([]byte("k")).Dynamic().SetT(orphan, wire.OperateTypeU64, 1).Args()
+	if err == nil {
+		t.Fatalf("a column path without a key built a call: %+v", got)
+	}
+	if !strings.Contains(err.Error(), `"c"`) || !strings.Contains(err.Error(), `"b"`) {
+		t.Fatalf("err = %v, want it to name the column and the field", err)
+	}
+
+	// A return spec goes through the same resolver, so it is caught too.
+	if _, err := NewOperate([]byte("k")).Dynamic().Return(orphan).Args(); err == nil {
+		t.Fatal("a column ret spec without a key built a call")
+	}
+
+	// The well-formed version of the same path still builds, as a Col path.
+	args, err := NewOperate([]byte("k")).Dynamic().
+		SetT(Col("b", []byte("r"), "c"), wire.OperateTypeU64, 1).Args()
+	if err != nil {
+		t.Fatalf("Col(field, key, col): %v", err)
+	}
+	if args.Ops[0].Path.Kind != wire.OperatePathCol || args.Ops[0].Path.Col.Name != "c" {
+		t.Fatalf("path = %+v", args.Ops[0].Path)
 	}
 }

--- a/client/operate_test.go
+++ b/client/operate_test.go
@@ -109,6 +109,34 @@ func TestOperateBuilderSchemaErrors(t *testing.T) {
 	}
 }
 
+// TestOperateBuilderConfigTrimColPolicyGuard checks that Args rejects a
+// Config/Trim call whose policy is a *_COL policy (MIN_COL/MAX_COL) but
+// whose byCol is empty, both in dynamic mode (where the wire itself would
+// otherwise accept byColLen 0 and silently mean column 0) and in schema
+// mode (where an empty byCol would otherwise resolve nothing at all).
+func TestOperateBuilderConfigTrimColPolicyGuard(t *testing.T) {
+	if _, err := NewOperate([]byte("k")).Dynamic().
+		Config(F("t"), 1024, wire.OperatePolicyMinCol, "").Args(); err == nil {
+		t.Fatal("expected error for Config with MinCol policy and empty byCol (dynamic mode)")
+	}
+	if _, err := NewOperate([]byte("k")).Dynamic().
+		Trim(F("t"), 10, wire.OperatePolicyMaxCol, "").Args(); err == nil {
+		t.Fatal("expected error for Trim with MaxCol policy and empty byCol (dynamic mode)")
+	}
+
+	s := sessionSchema()
+	if _, err := NewOperate([]byte("k")).WithSchema(s).
+		Config(F("b"), 1024, wire.OperatePolicyMinCol, "").Args(); err == nil {
+		t.Fatal("expected error for Config with MinCol policy and empty byCol (schema mode)")
+	}
+
+	// A non-*_COL policy still needs no byCol.
+	if _, err := NewOperate([]byte("k")).Dynamic().
+		Config(F("t"), 1024, wire.OperatePolicyNone, "").Args(); err != nil {
+		t.Fatalf("Config with OperatePolicyNone and empty byCol: unexpected error: %v", err)
+	}
+}
+
 // TestOperateBuilderDynamicMode checks that without a schema, Field/Col
 // resolve to name segments, typed variants (AddT/SetBytesT) carry the given
 // type, and an untyped variant (Add) still emits OperateTypeFromSchema —

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -5,6 +5,22 @@ Notable user-visible changes. Entries that alter existing behaviour are marked
 
 ## Unreleased
 
+- **`operate`: server-side atomic multi-field updates on a record.** A new
+  built-in op updates several fields of one record atomically, in one round
+  trip, against a hot key — the way you'd reach for a Redis hash command or
+  an Aerospike `Operate` call, without writing a custom Go op or a
+  client-side get-modify-put CAS loop. The record/table model is record →
+  table of keyed rows → columns, addressed by path and applied under the same
+  shard lock as every other read-write op. Two storage modes share one apply
+  engine: **schema** mode packs a client-defined, versioned layout with
+  nothing per value (fastest, smallest, for a known shape); **dynamic** mode
+  is schema-free, Redis-hash-ergonomic, and lets any op add a new name/type
+  at any time. A dynamic record can later be frozen into schema mode with
+  `MIGRATE`. Available on the Go client via `client.NewOperate`'s typed
+  op-list builder. See
+  [the KV overview](kv/overview.md#atomic-multi-field-updates-operate) for
+  the full path/type/op vocabulary, caps, and worked examples.
+
 - **New `-online-compaction` flag.** Opts every replicated mmap reject-writes
   shard into online relocating compaction, so a write/overwrite-heavy replicated
   shard reclaims dead ("ghost") bytes while the process runs instead of only at

--- a/docs/kv/custom-ops.md
+++ b/docs/kv/custom-ops.md
@@ -108,6 +108,20 @@ Inside a handler, `tx` gives you the shard-local store:
 | `tx.Cache()` | escape hatch to the underlying cache (stats, iteration) |
 | `tx.Vectors()` | the vector `CollectionStore` (nil if the dispatcher has none) |
 
+## Don't need custom Go? Use the built-in `operate`
+
+Most atomic multi-field updates don't need a custom op at all: the built-in
+[`operate`](overview.md#atomic-multi-field-updates-operate) op covers
+counters, guarded updates, capped/evicting tables (LRU, LFU, top-N, bounded
+FIFO), and server-side compare-and-swap on any field, driven entirely by a
+data-shaped op list built with the Go client's `OperateBuilder` — no Go code
+to register or ship.
+
+Reach for a custom Go op instead when the update isn't shaped as record +
+table + scalar ops — arbitrary nesting, cross-key logic, a format `operate`
+doesn't model (e.g. JSON in place), or logic you'd rather express directly in
+Go than as an op list.
+
 ## Native Go vs WASM
 
 A native Go op lives in the server process, so it works on `Direct` and

--- a/docs/kv/overview.md
+++ b/docs/kv/overview.md
@@ -75,6 +75,335 @@ shard's Raft log on `Embedded` (and under the shard lock on `Direct`). This is
 the extension point for [custom ops](custom-ops.md) and
 [WASM procedures](wasm.md).
 
+## Atomic multi-field updates: `operate`
+
+`operate` is a built-in op for updating several fields of one record
+atomically, in one round trip, against a hot key — the way you'd reach for a
+Redis hash command or an Aerospike `Operate` call, without writing a custom Go
+op and without a client-side get-modify-put CAS loop. The op list you send is
+data: a new counter, a new guard, or a new table is a different call, not a
+server rebuild. It runs under the same shard lock as every other read-write
+op (design doc `operate-v2-design.md`, §1).
+
+### The record and table model
+
+A record is a struct of scalar fields; a field may be a **table** of keyed
+rows of fixed-width columns. The shape is exactly record → table → row →
+column — no arbitrary nesting, and no table inside a row. Every record is
+stored in one of two encodings, chosen when the record is created:
+
+| Mode | Trade-off | Pick it when |
+|---|---|---|
+| **Schema** | Client-defined, versioned layout stored once; values packed with nothing per value; rows are fixed-width and binary-searchable. Smallest memory, fastest apply. | The shape is known and the record is hot or numerous (counters, per-key sub-records, rate limits). |
+| **Dynamic** | No schema: every field and column carries its own `[name][type]`; any name/type can be added by any op, at any time. Redis-hash ergonomics, ~40-60% more bytes per value, a scan instead of a binary search. | The shape is still changing, or you want `HINCRBY`/`HSET`-style ergonomics without declaring anything up front. |
+
+Both modes share the same paths, ops, returns, caps, and determinism — one
+apply engine over two byte layouts. A dynamic record can later be frozen into
+a schema mode record with `MIGRATE` (see below).
+
+A path into a record is one of:
+
+- `()` — the record itself (valid for `CHECK EXISTS`/`ABSENT`, `DEL`, and a whole-record return).
+- `(field)` — a record field.
+- `(field, rowKey)` — a whole row of the table at `field`.
+- `(field, rowKey, col)` — one column of one row.
+
+In schema mode a `field`/`col` is addressed by its **schema position**;
+dynamic mode addresses both by **name**. Writing to a path vivifies it (a
+missing row is created, evicting first if the table is full; a missing
+dynamic field/column is created with the op's declared type); reads never
+vivify, and an absent or `UNSET` scalar reads as zero for arithmetic and
+comparisons.
+
+### Scalar types
+
+| Tag | Type | Width | Allowed |
+|---|---|---|---|
+| 0-7 | `U8` `U16` `U32` `U64` `I8` `I16` `I32` `I64` | 1/2/4/8 B, little-endian; arithmetic saturates | record field or table column |
+| 8-9 | `F32` `F64` | 4/8 B, IEEE 754, canonical quiet NaN | record field or table column |
+| 10-11 | `UVARINT` `IVARINT` | 1-10 B, LEB128 (`IVARINT` zigzagged) | **record fields only**, never a table column |
+| 12 | `BYTES` | `[len uvarint][data]`, ≤ 65535 B | **record fields only** |
+| 13 | `FIXED(n)` | `n` raw bytes, 1-255 | record field, table column, or table row key |
+| 14 | `TABLE` | — | **record fields only** — a table cannot nest inside a row |
+| 15 | `UNSET` | 0 bytes | not a storable type — how an absent, declared slot reads back |
+
+A table's row key must be an unsigned fixed-width int (`U8`..`U64`, compared
+numerically) or `FIXED(n)` (compared bytewise); signed ints, floats, and every
+variable-length type are rejected as a key.
+
+### Schema lifecycle
+
+A schema (`wire.Schema`: a `Version` and an ordered `[]FieldDef`) is defined
+**client-side**, chosen by the app, and rides the call:
+
+- **Create.** A call may carry the schema blob (`WithSchema` in the Go
+  client). If the record is absent, it's created with that schema. If it
+  exists, the call's version must equal the stored version or the call fails
+  with `wire.ErrOperateSchemaVersion` before any op runs — only the version is
+  compared, not the blob's bytes.
+- **Evolve.** A `MIGRATE` op at the head of the list moves a record from its
+  stored version to a new one in the same atomic call: the new schema must be
+  an **append-only extension** (`Schema.Extends`) — every existing field and
+  table column keeps its position, type, and width (a stored name may not
+  change, though an unnamed one may gain a name); new fields/columns may only
+  be appended; a table's `Cap`/`Policy`/`ByCol` may change freely. Anything
+  else is rejected. New fields/columns zero-fill on migrate; a lowered `Cap`
+  evicts down to it during the same rewrite.
+- **Freeze.** `MIGRATE` with `from = wire.OperateMigrateFromDynamic` converts
+  a dynamic record into schema mode in one atomic rewrite: each schema field
+  and column is filled from the dynamic value of the same name (the target
+  schema must store names — a freeze matches by name), domains must match
+  (widths saturate), and a dynamic field the schema doesn't declare is an
+  error unless the migration's `dropExtra` flag is set. The reverse (thaw) is
+  not supported.
+- **Cache.** The server keeps a small cache keyed by schema bytes holding the
+  decoded layout (field offsets, row width, column offsets), so a repeat
+  schema resolves every path by arithmetic with no re-parsing.
+
+### Ops
+
+Every op is `(opcode, type, aux, path, a, b, bytes)`. `type` is the
+create/check type byte — in dynamic mode it's the type a new field/column is
+created with; in schema mode it must match the schema's type or be
+`wire.OperateTypeFromSchema` (`0xFF`, what the typed Go client sends). `a`
+carries an int operand, or the float64 bit pattern (`math.Float64bits`) of a
+float operand — `F32` fields included, storage rounds. `bytes` carries a
+`BYTES`/`FIXED` operand, a `CONFIG`/`TRIM` column name, or a `MIGRATE` schema
+blob.
+
+**Scalar ops** (record field or table column):
+
+| Op | Operand | Effect | Field types |
+|---|---|---|---|
+| `SET` | `a` or `bytes` | write `v` | all scalars |
+| `ADD` | `a` | `x += a`, saturating (int) / IEEE (float) | int, float |
+| `MUL` | `a` | `x *= a`, saturating (int) / IEEE (float) | int, float |
+| `MIN` / `MAX` | `a` or `bytes` | `x = min/max(x, v)` | int, float, bytes/fixed (bytewise) |
+| `AND` / `OR` / `XOR` | `a` | bitwise, masked to the field width | fixed-width int only |
+| `SHL` | `a` (0..64) | shift left, masked to the field width | fixed-width int only |
+| `SHR` | `a` (0..64) | shift right; arithmetic for signed, logical for unsigned | fixed-width int only |
+| `STAMP` | `aux` = unit (`wire.OperateStampMs`/`OperateStampS`) | `x = tx.applyStamp()` in that unit, saturating | int only |
+| `DEL` | — | see below | all |
+
+`DEL`'s effect depends on the path it's given: a record field becomes
+`UNSET` (schema mode) or is removed outright (dynamic mode); a row is
+removed from its table; a table field is emptied (all rows dropped); the
+record path (`()`) deletes the whole record. **`DEL ()` is terminal**: the
+op list stops there and every return sees an absent record, rather than
+running further ops against nothing. In dynamic mode, **deleting a record's
+last field deletes the record** (the `HDEL`-of-the-last-field precedent); a
+schema-mode record is never deleted implicitly — an all-zero record is a
+valid state.
+
+**Table ops** (path = the table field itself):
+
+| Op | Operand | Effect |
+|---|---|---|
+| `MIGRATE` | `a` = from version (or `wire.OperateMigrateFromDynamic`), `aux` = flags, `bytes` = new schema blob | must be the first op in the list; append-only evolution or a dynamic freeze |
+| `CONFIG` | `a` = cap, `aux` = policy, `bytes` = byCol name | **dynamic mode only** — sets the table's eviction triple, creating an empty table if absent; schema mode rejects it (`wire.ErrOperateOpcode`) since eviction there is part of the schema, changed via `MIGRATE` |
+| `TRIM` | `a` = keep, `aux` = policy, `bytes`/`b` = byCol | one-off shrink of the table to `keep` rows by the given policy, without changing the table's stored policy; a no-op against an absent table |
+
+**Control ops:**
+
+| Op | Operand | Effect |
+|---|---|---|
+| `IF` | `aux` = cmp, `a`/`bytes`, `b` = n | if `node(path) cmp v` is false, skip the next `n` ops |
+| `CHECK` | `aux` = cmp, `a`/`bytes` | if false, **abort the whole list** — record unchanged, result status `CHECK_FAILED` with this op's index |
+
+Comparators: `EQ NE LT LE GT GE EXISTS ABSENT`. A scalar compares in its
+domain (an absent numeric reads as 0; bytes compare bytewise); **a table
+compares by its row count**; **a row has no value of its own and compares as
+1 (present) / 0 (absent)**, making `EXISTS`/`ABSENT` the only comparators
+that mean anything on it. `IF`'s skip count `n` is bounded by the remaining
+op list and is validated whenever the `IF` runs — not only when the skip
+branch is taken — so a malformed op list is rejected regardless of what the
+record holds. On `CHECK_FAILED`, return specs are still evaluated, against
+the record as it was *before* the call, so the caller can see why it failed.
+
+### Returns
+
+Each return spec is `(mode, path)`, evaluated after every op has applied (or,
+on `CHECK_FAILED`, against the original record):
+
+- **`VALUE`** — the node's self-describing encoding: a scalar as
+  `[type u8][data]`; a row as `[mode][nCols]{[type][data]}*` in schema order
+  (schema mode) or `[mode][nCols]{[nlen][name][type][data]}*` (dynamic mode);
+  the record as its full stored encoding, mode byte and schema included, so
+  it's decodable stand-alone (`wire.DecodeRecord` reads a plain `get` of an
+  operate key the same way); a **table as `[mode][nRows]{rows}` exactly as
+  stored, without a schema blob** — the caller is expected to already hold
+  the schema. An absent path returns `[wire.OperateTypeUnset]`.
+- **`COUNT`** — a tagged `U64`: row count for a table, field count for the
+  record, `1`/`0` for a present/absent scalar or row. Absent is `0`.
+
+### TTL modes
+
+| Mode | Behavior |
+|---|---|
+| `KEEP` (default) | leave the existing expiry alone; no expiry on create |
+| `SET` | refresh to the call's TTL on every call, create or update alike; a TTL of `0` **clears** the expiry |
+| `CREATE_ONLY` | set the TTL only when this call creates the record (`incr_ex` semantics); an update preserves the existing deadline verbatim |
+
+### Eviction policies
+
+A table's `cap` (0 = unbounded, the default) and `policy` decide what's
+evicted when an insert would grow the table past its cap:
+
+| Policy | Victim |
+|---|---|
+| `MIN_KEY` | smallest row key |
+| `MAX_KEY` | largest row key |
+| `MIN_COL` | smallest value in the eviction column (`byCol`); ties go to the smallest key |
+| `MAX_COL` | largest value in the eviction column; ties go to the smallest key |
+| `NONE` | with `cap > 0` this still needs a deterministic victim — it evicts by `MIN_KEY` |
+
+Recipes:
+
+- **LRU** — `MIN_COL` on a column the app refreshes with `STAMP` on every
+  touch; the stalest row is evicted.
+- **LFU** — `MIN_COL` on a hit counter the app `ADD`s to on every touch; the
+  least-used row is evicted.
+- **Top-N by score** — `MIN_COL` on the score column: inserting a new, higher
+  score evicts the current lowest.
+- **Bounded FIFO / recent-N** — `MIN_KEY` (or `MAX_KEY`) with the app's own
+  sequence number or timestamp as the row key and `cap = N`; there's no
+  server-assigned auto-key, so the app supplies one it can reproduce
+  deterministically.
+
+The victim is a pure function of the row bytes, so every replica evicts the
+same row. In schema mode the eviction triple lives in the schema and changes
+via `MIGRATE`; in dynamic mode it's set per record with `CONFIG`. `TRIM` does
+a one-off shrink to a row count without touching the stored policy.
+
+### Determinism
+
+Stored bytes are a pure function of the record: rows sorted by key, fields in
+schema order (schema mode) or name order (dynamic mode) — Go map/slice
+iteration never leaks into the bytes. Integer math saturates rather than
+wraps; floats are canonicalized (`F32` rounded, NaN stored as the canonical
+quiet NaN). The **only** clock any op ever consults is the applying
+transaction's stamp (`tx.applyStamp()`), via `STAMP` — never a wall clock. On
+an unreplicated or otherwise unstamped apply that stamp is `0`, so an
+unstamped `STAMP` writes `0`: a `MIN_COL`/`MAX_COL` "LRU" table built on that
+column then degrades to evicting by ascending key, since every row ties on
+the stamp and `*_COL` ties resolve to the smallest key. A follower re-applying
+the same call against the same prior record, with the same stamp, always
+produces byte-identical stored bytes.
+
+### Caps and all-or-nothing
+
+| Cap | Value | Bounds |
+|---|---|---|
+| `maxFields`, `maxCols` | 65535 | fields per schema, columns per table |
+| `maxSchemaBytes` | 4096 B | encoded schema size |
+| `maxRows` | 1<<20 | rows per table |
+| `maxRowWidth` | 4096 B | key + columns of one row |
+| `maxKeyLen`, `maxNameLen` | 255 | row keys and (dynamic) field/column names |
+| `maxBytesLen` | 65535 B | a `BYTES` field's payload |
+| `maxNameBytes` | 4096 B | all names stored in one record |
+| `maxRecordBytes` | 16 MiB | the record's total encoded size after apply |
+| `maxOps`, `maxRet` | 4096 each | ops and return specs per call |
+
+Hitting any cap is an **error with the record left unchanged** — never an
+implicit eviction. Row and column growth is charged against these budgets
+before anything is allocated, and the stored-bytes decoder is hardened the
+same way a hostile `put` value would need to be handled: every count is
+bounded before it sizes an allocation, and every read is truncation-checked.
+
+### Example: schema mode
+
+The v1-session shape from the design doc — a per-key bidder counter, a bid
+history bitmask, and a capped, LRU-evicted table of recent bidders — built
+through the Go client's `OperateBuilder`:
+
+```go
+schema := &wire.Schema{Version: 1, Fields: []wire.FieldDef{
+    {Name: "rc", Type: wire.OperateTypeU8},
+    {Name: "bc", Type: wire.OperateTypeU8},
+    {Name: "hist", Type: wire.OperateTypeU32},
+    {Name: "b", Type: wire.OperateTypeTable, Table: &wire.TableDef{
+        KeyType: wire.OperateTypeU64,
+        Cols: []wire.ColumnDef{
+            {Name: "c", Type: wire.OperateTypeU16},
+            {Name: "hi", Type: wire.OperateTypeI64},
+            {Name: "t", Type: wire.OperateTypeU32},
+        },
+        Cap: 1024, Policy: wire.OperatePolicyMinCol, ByCol: 2, // LRU on "t"
+    }},
+}}
+
+rowKey := client.KeyU64(bidderID)
+args, err := client.NewOperate(sessionKey).WithSchema(schema).
+    TTL(90*time.Second, wire.OperateTTLCreateOnly).
+    If(client.F("rc"), wire.OperateCmpGE, 255, 2). // guard: halve before overflow
+    Shr(client.F("rc"), 1).
+    Shr(client.F("bc"), 1).
+    Add(client.F("rc"), 1).
+    Add(client.Col("b", rowKey, "c"), 1).       // this bidder's bid count
+    Max(client.Col("b", rowKey, "hi"), bidAmount).
+    Stamp(client.Col("b", rowKey, "t"), wire.OperateStampS). // keeps the row fresh for MIN_COL
+    Shl(client.F("hist"), 1).
+    Or(client.F("hist"), won).
+    Return(client.F("rc")).
+    Return(client.Row("b", rowKey)).
+    Args()
+if err != nil {
+    return err
+}
+res, err := c.Operate(ctx, args)
+```
+
+One round trip: guards the overflow, updates three fields and one table row
+(creating and, if the table is full, evicting a row as needed), and reads
+back the new bidder count and the touched row — no client-side read, no CAS
+retry.
+
+### Example: dynamic mode
+
+A `HINCRBY`/`HSET`-style counter with no schema declared up front:
+
+```go
+args, err := client.NewOperate([]byte("user:42")).Dynamic().
+    AddT(client.F("hits"), wire.OperateTypeI64, 1).
+    Return(client.F("hits")).
+    Args()
+if err != nil {
+    return err
+}
+res, err := c.Operate(ctx, args)
+hits, err := client.DecodeOperateValue(res.Values[0]) // wire.Cell{Type: I64, U: ...}
+```
+
+The first call creates the record in dynamic mode and the `hits` field with
+it; later calls (`Add`, without the `T` suffix) resolve it as an existing
+`I64` field. `SetBytesT(client.F("name"), wire.OperateTypeBytes, v)` adds a
+second, differently-typed field the same way. A plain `get` on the key
+decodes with `wire.DecodeRecord`.
+
+### Wire summary
+
+A call encodes as (`sdk/wire/operate.go`):
+
+```
+[keyLen u16][key][ttlMs u64][ttlMode u8][create u8][schemaLen u16][schema]?
+[nOps u16]{op}*[nRet u16]{ret}*
+```
+
+- **op**: `[opcode u8][type u8][aux u8][path][a i64][b i64][blen u16][bytes]`
+- **path**: `[kind u8]` then, per kind, `[fseg]`, `[fseg][kseg]`, or
+  `[fseg][kseg][cseg]`, where `fseg`/`cseg` is `[0][pos uvarint]` (schema
+  position) or `[1][len u8][name]` (name segment), and `kseg` is `[len
+  u8][key bytes]`
+- **ret**: `[mode u8][path]`
+- **result**: `[status u8][failedOp u16 iff CHECK_FAILED][nRet u16]{[vlen
+  u32][value]}*`
+
+Every multi-byte field in the call and result frames (lengths, `a`/`b`,
+`ttlMs`, `failedOp`, `vlen`) is **big-endian**, matching every other builtin's
+wire args. The stored **record and cell data themselves are little-endian**
+(fixed-width ints, table row keys) — the wire args format and the on-disk
+record format are independent conventions.
+
 ## TTL semantics
 
 TTLs are absolute deadlines computed at write time. Expiry is enforced lazily on

--- a/docs/kv/overview.md
+++ b/docs/kv/overview.md
@@ -293,7 +293,10 @@ unstamped `STAMP` writes `0`: a `MIN_COL`/`MAX_COL` "LRU" table built on that
 column then degrades to evicting by ascending key, since every row ties on
 the stamp and `*_COL` ties resolve to the smallest key. A follower re-applying
 the same call against the same prior record, with the same stamp, always
-produces byte-identical stored bytes.
+produces byte-identical stored bytes. On read, the schema-mode engine
+bounds-checks stored bytes but does not re-verify stored row ordering (valid
+in, valid out); the dynamic engine, which trusts nothing about its input
+until it has walked it, verifies ordering on read.
 
 ### Caps and all-or-nothing
 

--- a/docs/kv/overview.md
+++ b/docs/kv/overview.md
@@ -185,10 +185,15 @@ blob.
 | `STAMP` | `aux` = unit (`wire.OperateStampMs`/`OperateStampS`) | `x = tx.applyStamp()` in that unit, saturating | int only |
 | `DEL` | — | see below | all |
 
-`DEL`'s effect depends on the path it's given: a record field becomes
-`UNSET` (schema mode) or is removed outright (dynamic mode); a row is
-removed from its table; a table field is emptied (all rows dropped); the
-record path (`()`) deletes the whole record. **`DEL ()` is terminal**: the
+`DEL`'s effect depends on the path it's given: a record field is **always
+present in schema mode** — the schema declares it, so `DEL` cannot remove it
+or leave it `UNSET`; instead it **zeroes the field to its declared type's
+zero value**. A table column behaves the same way when its row exists;
+against a column of a row that doesn't exist, `DEL` never vivifies — it's a
+no-op, not a zero-write. In dynamic mode a field or column is **removed
+outright**. A row is removed from its table; a table field is emptied (all
+rows dropped); the record path (`()`) deletes the whole record. **`DEL ()`
+is terminal**: the
 op list stops there and every return sees an absent record, rather than
 running further ops against nothing. In dynamic mode, **deleting a record's
 last field deletes the record** (the `HDEL`-of-the-last-field precedent); a

--- a/docs/kv/overview.md
+++ b/docs/kv/overview.md
@@ -206,7 +206,7 @@ valid state.
 |---|---|---|
 | `MIGRATE` | `a` = from version (or `wire.OperateMigrateFromDynamic`), `aux` = flags, `bytes` = new schema blob | must be the first op in the list; append-only evolution or a dynamic freeze |
 | `CONFIG` | `a` = cap, `aux` = policy, `bytes` = byCol name | **dynamic mode only** — sets the table's eviction triple, creating an empty table if absent; schema mode rejects it (`wire.ErrOperateOpcode`) since eviction there is part of the schema, changed via `MIGRATE` |
-| `TRIM` | `a` = keep, `aux` = policy, `bytes`/`b` = byCol | one-off shrink of the table to `keep` rows by the given policy, without changing the table's stored policy; a no-op against an absent table |
+| `TRIM` | `a` = keep, `aux` = policy, `bytes`/`b` = byCol | valid in **both** modes — one-off shrink of the table to `keep` rows by the given policy, without changing the table's stored policy; a no-op against an absent table |
 
 **Control ops:**
 

--- a/ops/builtin.go
+++ b/ops/builtin.go
@@ -69,12 +69,12 @@ var builtinHandlers = map[string]Handler{
 	"persist": handlePersist,
 	"ttl":     handleTTL,
 	"incr_ex": handleIncrEx,
-	"caex":    handleCAEX,
-	"mget":    handleMGet,
 	// operate is a generic atomic multi-field read/check/write op against one
 	// stored record, addressed and typed by the call's schema (design doc
 	// operate-v2-design.md).
 	"operate": handleOperate,
+	"caex":    handleCAEX,
+	"mget":    handleMGet,
 	// flush wipes the ENTIRE KV keyspace (keyless, no args). The cluster path
 	// broadcasts it to every shard group; each group applies it here against its own
 	// cache. See handleFlush.

--- a/ops/builtin.go
+++ b/ops/builtin.go
@@ -71,6 +71,10 @@ var builtinHandlers = map[string]Handler{
 	"incr_ex": handleIncrEx,
 	"caex":    handleCAEX,
 	"mget":    handleMGet,
+	// operate is a generic atomic multi-field read/check/write op against one
+	// stored record, addressed and typed by the call's schema (design doc
+	// operate-v2-design.md).
+	"operate": handleOperate,
 	// flush wipes the ENTIRE KV keyspace (keyless, no args). The cluster path
 	// broadcasts it to every shard group; each group applies it here against its own
 	// cache. See handleFlush.
@@ -198,6 +202,7 @@ var builtinHandlers = map[string]Handler{
 //   - "incr_ex" (read-write) args: [keyLen u16][key][delta i64][ttlMs u64] → new value as i64 BE (TTL set on create only)
 //   - "caex"    (read-write) args: [keyLen u16][key][expLen u32][expected][ttlMs u64] → 1-byte 1=TTL refreshed/0=mismatch|absent
 //   - "mget"    (read-only)  args: [count u16]([keyLen u16][key])*         → [count u16]([found u8](+[valLen u32][val] if found))*
+//   - "operate" (read-write) args: see sdk/wire/operate.go → [status u8][failedOp u16?][nRet u16]{[vlen u32][value]}*
 //   - "flush"   (read-write) args: (ignored)                               → empty (wipes the ENTIRE keyspace; broadcast to every shard group in cluster mode)
 //   - "__ping__" (read-only) args: (ignored)                             → empty
 //

--- a/ops/hostile_decode_test.go
+++ b/ops/hostile_decode_test.go
@@ -140,6 +140,8 @@ var hostileDecoders = []struct {
 	{"DecodeNamedSearchArgsOpts", DecodeNamedSearchArgsOpts},
 	{"DecodeNamedSparseSearchArgs", DecodeNamedSparseSearchArgs},
 	{"DecodeNamedSparseSearchArgsOpts", DecodeNamedSparseSearchArgsOpts},
+	{"DecodeOperateArgs", DecodeOperateArgs},
+	{"DecodeOperateResult", DecodeOperateResult},
 	{"DecodePayloadResult", DecodePayloadResult},
 	{"DecodePutArgs", DecodePutArgs},
 	{"DecodePutBatchArgs", DecodePutBatchArgs},
@@ -150,6 +152,7 @@ var hostileDecoders = []struct {
 	{"DecodeQueryResultGroupedFanOut", DecodeQueryResultGroupedFanOut},
 	{"DecodeQuerySpecArgs", DecodeQuerySpecArgs},
 	{"DecodeQueryTreeLanes", DecodeQueryTreeLanes},
+	{"DecodeRecord", DecodeRecord},
 	{"DecodeReshardAbortArgs", DecodeReshardAbortArgs},
 	{"DecodeReshardArgs", DecodeReshardArgs},
 	{"DecodeResplitArgs", DecodeResplitArgs},
@@ -157,6 +160,7 @@ var hostileDecoders = []struct {
 	{"DecodeResplitCleanupResult", DecodeResplitCleanupResult},
 	{"DecodeScanVectorsArgs", DecodeScanVectorsArgs},
 	{"DecodeScanVectorsResult", DecodeScanVectorsResult},
+	{"DecodeSchema", DecodeSchema},
 	{"DecodeScrollArgs", DecodeScrollArgs},
 	{"DecodeScrollArgsCursor", DecodeScrollArgsCursor},
 	{"DecodeScrollArgsOpts", DecodeScrollArgsOpts},
@@ -246,7 +250,7 @@ func TestNoDecoderPanicsOnHostileBytes(t *testing.T) {
 	// A floor on the roster, because the failure mode of this sweep is silent:
 	// deleting entries makes it pass faster, not fail. Raise it when decoders are
 	// added; only lower it deliberately, when an op is genuinely removed.
-	const minDecoders = 144
+	const minDecoders = 148
 	if len(hostileDecoders) < minDecoders {
 		t.Fatalf("only %d decoders in the sweep (floor %d) — entries were removed, "+
 			"which narrows the coverage without failing anything", len(hostileDecoders), minDecoders)

--- a/ops/operate.go
+++ b/ops/operate.go
@@ -103,5 +103,5 @@ func handleOperate(tx *TxContext, args []byte) ([]byte, error) {
 		}
 	}
 
-	return wire.EncodeOperateResult(res), nil
+	return wire.EncodeOperateResult(res)
 }

--- a/ops/operate.go
+++ b/ops/operate.go
@@ -1,0 +1,107 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package ops
+
+import (
+	"errors"
+
+	"github.com/rostamlabs/rostam/cache"
+	"github.com/rostamlabs/rostam/sdk/wire"
+)
+
+// handleOperate is the server-side handler for the "operate" op (design doc
+// §3.5): one atomic, multi-field read/check/write call against a single
+// stored record, addressed and typed by the call's schema (or, in dynamic
+// mode, the stored field set). Every semantic rule — path resolution, op
+// dispatch, the record-size backstop, and what a call returns — lives in
+// applyRecordBytes (ops/operate_apply.go, ops/operate_engine.go); this
+// handler only wraps that pure function with the store's key lookup, the
+// TTL rules below, and the reply frame.
+//
+// All-or-nothing: applyRecordBytes either returns a complete replacement for
+// the stored bytes (out) or signals that nothing is to be stored (an error,
+// a failed CHECK, or a cap hit never partially apply — the record is left
+// exactly as it was). This handler performs exactly one store mutation per
+// call — a single Put/PutAbs, or a single Del on deletion — never more than
+// one, and never on an error or a failed CHECK.
+//
+// Determinism: the only clock this handler (and, through stampMs,
+// applyRecordBytes) ever consults is tx.applyStamp() — the leader-stamped
+// apply clock on a replicated apply, or the unstamped zero value otherwise —
+// never a wall clock. Two replicas applying the same call against the same
+// prior record, with the same stamp, therefore always produce identical
+// stored bytes and identical expiries.
+//
+// cur aliasing: tx.GetWithExpiry's returned value aliases the cache's page.
+// applyRecordBytes copies it before making any change (openRecord ->
+// copyRecord) and returns its own, freshly allocated out; this handler never
+// writes through cur and never touches it again once applyRecordBytes has
+// been called.
+func handleOperate(tx *TxContext, args []byte) ([]byte, error) {
+	a, err := wire.DecodeOperateArgs(args)
+	if err != nil {
+		return nil, err
+	}
+
+	cur, expiryMs, err := tx.GetWithExpiry(a.Key)
+	absent := errors.Is(err, cache.ErrNotFound)
+	if err != nil && !absent {
+		return nil, err
+	}
+	if absent {
+		cur = nil
+	}
+
+	stampMs, _ := tx.applyStamp()
+	out, deleted, res, err := applyRecordBytes(cur, a, stampMs)
+	if err != nil {
+		if errors.Is(err, errOperateAbsent) {
+			// design doc §3.5: create = NONE against an absent key is the
+			// store's own not-found error, not an operate-specific one.
+			return nil, cache.ErrNotFound
+		}
+		return nil, err
+	}
+
+	switch {
+	case res.Status == wire.OperateStatusCheckFailed:
+		// A no-op (design doc §3.3): the record is unchanged and its TTL is
+		// untouched. out is nil here (applyWithEngine never sets it on a
+		// failed CHECK), so there is nothing to write even if this case were
+		// skipped — but this way that invariant does not have to hold for
+		// correctness.
+	case deleted:
+		// design doc §2.5. Deleting a key that was already absent is a
+		// no-op: DEL () against nothing does not manufacture a tombstone.
+		if !absent {
+			if _, err := tx.Del(a.Key); err != nil {
+				return nil, err
+			}
+		}
+	default:
+		switch a.TTLMode {
+		case wire.OperateTTLSet:
+			// Refreshed on every call, create or update alike.
+			err = tx.Put(a.Key, out, a.TTL)
+		case wire.OperateTTLCreateOnly:
+			if absent {
+				err = tx.Put(a.Key, out, a.TTL)
+			} else {
+				// Preserve the existing deadline verbatim (PutAbs takes no
+				// stamp branch, so this is deterministic across replicas).
+				err = tx.PutAbs(a.Key, out, expiryMs)
+			}
+		default: // wire.OperateTTLKeep
+			if absent {
+				err = tx.Put(a.Key, out, 0)
+			} else {
+				err = tx.PutAbs(a.Key, out, expiryMs)
+			}
+		}
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return wire.EncodeOperateResult(res), nil
+}

--- a/ops/operate_apply.go
+++ b/ops/operate_apply.go
@@ -160,7 +160,11 @@ func openRecord(es engines, cur []byte, a *wire.OperateArgs) (modeEngine, error)
 		return nil, wire.ErrOperateArgs
 	}
 
-	e, err := openMode(es, copyRecord(cur), true)
+	buf, err := copyRecord(cur)
+	if err != nil {
+		return nil, err
+	}
+	e, err := openMode(es, buf, true)
 	if err != nil {
 		return nil, err
 	}
@@ -228,10 +232,21 @@ func openMode(es engines, buf []byte, existed bool) (modeEngine, error) {
 // copyRecord copies cur into a buffer the engine owns, with slack so a single
 // row insert usually does not reallocate. The stored value aliases the
 // store's cache page (design doc §2.6): it must never be written through.
-func copyRecord(cur []byte) []byte {
+//
+// The §2.7 record-size cap is checked BEFORE the copy, not after: the value
+// under the key is whatever a plain `put` left there, so it can be far larger
+// than any operate record may be, and copying it first would let one call
+// allocate an arbitrary multiple of the cap before the engine ever looked at
+// the bytes. A stored value that big cannot be a valid operate record, so it
+// is wire.ErrOperateRecord — a malformed stored record — rather than
+// wire.ErrOperateCap, which means "this call would grow the record too far".
+func copyRecord(cur []byte) ([]byte, error) {
+	if len(cur) > maxOperateRecordBytes {
+		return nil, wire.ErrOperateRecord
+	}
 	buf := make([]byte, len(cur), len(cur)+64)
 	copy(buf, cur)
-	return buf
+	return buf, nil
 }
 
 // retsBefore evaluates the return specs against the pre-call record after a
@@ -247,7 +262,11 @@ func retsBefore(es engines, cur []byte, rets []wire.OperateRet) ([][]byte, error
 	// Re-opening the pre-call bytes reuses the same pooled engines: the
 	// working copy they were pointing at is discarded whole by a failed
 	// CHECK, so nothing in it is still needed.
-	e, err := openMode(es, copyRecord(cur), true)
+	buf, err := copyRecord(cur)
+	if err != nil {
+		return nil, err
+	}
+	e, err := openMode(es, buf, true)
 	if err != nil {
 		return nil, err
 	}

--- a/ops/operate_apply.go
+++ b/ops/operate_apply.go
@@ -23,13 +23,16 @@ var schemaEnginePool = sync.Pool{New: func() any { return new(schemaEngine) }}
 
 // applyRecordBytes applies one operate call to a stored record.
 //
-// cur is the record's stored bytes, or nil when the key is absent; it is
-// never mutated — the engine works on a private copy. On success out is the
-// record to store (deleted == true means "delete the key instead", design doc
-// §2.5). On a failed CHECK the call is a no-op: out is cur unchanged and the
-// result carries OperateStatusCheckFailed plus the return specs evaluated
-// against the pre-call record (design doc §3.3). On error nothing is
-// returned but the error, and the stored record is unchanged by definition.
+// cur is the record's stored bytes, or nil when the key is absent; it is never
+// mutated — the engine works on a private copy.
+//
+// out is what the caller should store, and it is nil whenever the call stores
+// nothing: on a failed CHECK (a no-op, whose result still carries
+// OperateStatusCheckFailed and the return specs evaluated against the pre-call
+// record, design doc §3.3), on any error, and when deleted is true — which
+// means "delete the key" rather than "store nothing" (design doc §2.5). out is
+// never an alias of cur: the caller can write it back without thinking about
+// the store's own page.
 func applyRecordBytes(cur []byte, a *wire.OperateArgs, stampMs int64) ([]byte, bool, *wire.OperateResult, error) {
 	if len(a.Ops) > wire.OperateMaxOps || len(a.Rets) > wire.OperateMaxRet {
 		return nil, false, nil, wire.ErrOperateCap
@@ -58,7 +61,7 @@ func applyWithEngine(se *schemaEngine, cur []byte, a *wire.OperateArgs, stampMs 
 		if verr != nil {
 			return nil, false, nil, verr
 		}
-		return cur, false, &wire.OperateResult{Status: status, FailedOp: failedOp, Values: vals}, nil
+		return nil, false, &wire.OperateResult{Status: status, FailedOp: failedOp, Values: vals}, nil
 	}
 
 	if e.empty() {

--- a/ops/operate_apply.go
+++ b/ops/operate_apply.go
@@ -1,0 +1,230 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package ops
+
+// applyRecordBytes is the pure core of the operate op: stored record bytes in,
+// stored record bytes out, with no store, no clock, and no lock of its own.
+// The handler (design doc §3.5) wraps it with the key lookup, the TTL rules
+// and the reply frame; everything below is a deterministic function of
+// (cur, args, stampMs), which is what makes an operate call replayable on
+// every replica.
+
+import (
+	"sync"
+
+	"github.com/rostamlabs/rostam/sdk/wire"
+)
+
+// schemaEnginePool keeps schema engines (and, with them, their tail index and
+// cell scratch) alive between calls: the design doc's §2.6 budget for the
+// in-place path is one allocation for the record copy, which leaves no room
+// for a fresh engine per call on a hot key.
+var schemaEnginePool = sync.Pool{New: func() any { return new(schemaEngine) }}
+
+// applyRecordBytes applies one operate call to a stored record.
+//
+// cur is the record's stored bytes, or nil when the key is absent; it is
+// never mutated — the engine works on a private copy. On success out is the
+// record to store (deleted == true means "delete the key instead", design doc
+// §2.5). On a failed CHECK the call is a no-op: out is cur unchanged and the
+// result carries OperateStatusCheckFailed plus the return specs evaluated
+// against the pre-call record (design doc §3.3). On error nothing is
+// returned but the error, and the stored record is unchanged by definition.
+func applyRecordBytes(cur []byte, a *wire.OperateArgs, stampMs int64) ([]byte, bool, *wire.OperateResult, error) {
+	if len(a.Ops) > wire.OperateMaxOps || len(a.Rets) > wire.OperateMaxRet {
+		return nil, false, nil, wire.ErrOperateCap
+	}
+	se := schemaEnginePool.Get().(*schemaEngine) //nolint:errcheck,forcetypeassert // the pool's New returns exactly this
+	out, deleted, res, err := applyWithEngine(se, cur, a, stampMs)
+	se.clear()
+	schemaEnginePool.Put(se)
+	return out, deleted, res, err
+}
+
+func applyWithEngine(se *schemaEngine, cur []byte, a *wire.OperateArgs, stampMs int64) ([]byte, bool, *wire.OperateResult, error) {
+	e, err := openRecord(se, cur, a)
+	if err != nil {
+		return nil, false, nil, err
+	}
+
+	status, failedOp, err := applyOps(e, a.Ops, stampMs)
+	if err != nil {
+		return nil, false, nil, err
+	}
+	if status == wire.OperateStatusCheckFailed {
+		// The op list aborts with the record unchanged, and the returns are
+		// evaluated against that unchanged record.
+		vals, verr := retsBefore(se, cur, a.Rets)
+		if verr != nil {
+			return nil, false, nil, verr
+		}
+		return cur, false, &wire.OperateResult{Status: status, FailedOp: failedOp, Values: vals}, nil
+	}
+
+	if e.empty() {
+		// The record is gone, so every return is absent (oracle ruling): there
+		// is nothing left to resolve a path against.
+		vals, verr := absentRets(a.Rets)
+		if verr != nil {
+			return nil, false, nil, verr
+		}
+		return nil, true, &wire.OperateResult{Status: wire.OperateStatusOK, Values: vals}, nil
+	}
+
+	out := e.bytes()
+	// §2.7's backstop, checked on the finished record: a call that would store
+	// an over-large record fails with the record unchanged.
+	if len(out) > maxOperateRecordBytes {
+		return nil, false, nil, wire.ErrOperateCap
+	}
+	// The returns see the record as it now is, so a record path is present
+	// even when this call created it — ref.present is "existed before the
+	// call" only for the op list's own EXISTS/ABSENT (the oracle evaluates
+	// its success-path returns with existed = true for the same reason).
+	se.existed = true
+	vals, verr := evalRets(e, a.Rets)
+	if verr != nil {
+		return nil, false, nil, verr
+	}
+	return out, false, &wire.OperateResult{Status: wire.OperateStatusOK, Values: vals}, nil
+}
+
+// openRecord resolves the call's `create` parameter against the stored record
+// (design doc §3.5) and returns an engine over a private, patchable copy of
+// the bytes to apply the ops to.
+func openRecord(se *schemaEngine, cur []byte, a *wire.OperateArgs) (engine, error) {
+	if cur == nil {
+		return createRecord(se, a)
+	}
+	if len(cur) < 1 {
+		return nil, wire.ErrOperateRecord
+	}
+	mode := cur[0]
+
+	var callSchema *wire.Schema
+	switch a.Create {
+	case wire.OperateCreateNone:
+		// Ruling (the oracle's): a create = NONE call carries no schema blob,
+		// so one that arrives anyway is ignored rather than checked.
+	case wire.OperateCreateSchema:
+		if len(a.Schema) == 0 {
+			return nil, wire.ErrOperateSchema
+		}
+		s, _, err := operateSchemas.get(a.Schema)
+		if err != nil {
+			return nil, err
+		}
+		callSchema = s
+		if mode != wire.OperateModeSchema {
+			return nil, wire.ErrOperateMode
+		}
+	case wire.OperateCreateDynamic:
+		if mode != wire.OperateModeDynamic {
+			return nil, wire.ErrOperateMode
+		}
+	default:
+		return nil, wire.ErrOperateArgs
+	}
+
+	e, err := openMode(se, copyRecord(cur), true)
+	if err != nil {
+		return nil, err
+	}
+	if callSchema != nil {
+		// Ruling (the oracle's): §2.8 compares versions, not blobs. The stored
+		// schema stays authoritative for the record; the call's blob only has
+		// to agree on the version, so a differently encoded blob of the same
+		// version is accepted and changes nothing.
+		if se.schema.Version != callSchema.Version {
+			return nil, wire.ErrOperateSchemaVersion
+		}
+	}
+	return e, nil
+}
+
+// createRecord builds the record a call creates when the key is absent
+// (design doc §3.5).
+func createRecord(se *schemaEngine, a *wire.OperateArgs) (engine, error) {
+	switch a.Create {
+	case wire.OperateCreateNone:
+		return nil, errOperateAbsent
+	case wire.OperateCreateSchema:
+		buf, err := newSchemaRecord(a.Schema, operateSchemas)
+		if err != nil {
+			return nil, err
+		}
+		return openMode(se, buf, false)
+	case wire.OperateCreateDynamic:
+		return openMode(se, []byte{wire.OperateModeDynamic, 0}, false)
+	default:
+		return nil, wire.ErrOperateArgs
+	}
+}
+
+// openMode builds the engine for a record's stored mode byte. The dynamic
+// engine lands in a later task; until then a dynamic record is a mode this
+// build cannot apply to.
+func openMode(se *schemaEngine, buf []byte, existed bool) (engine, error) {
+	if len(buf) < 1 {
+		return nil, wire.ErrOperateRecord
+	}
+	switch buf[0] {
+	case wire.OperateModeSchema:
+		if err := se.reset(buf, operateSchemas); err != nil {
+			return nil, err
+		}
+		se.existed = existed
+		return se, nil
+	case wire.OperateModeDynamic:
+		return nil, wire.ErrOperateMode
+	default:
+		return nil, wire.ErrOperateRecord
+	}
+}
+
+// copyRecord copies cur into a buffer the engine owns, with slack so a single
+// row insert usually does not reallocate. The stored value aliases the
+// store's cache page (design doc §2.6): it must never be written through.
+func copyRecord(cur []byte) []byte {
+	buf := make([]byte, len(cur), len(cur)+64)
+	copy(buf, cur)
+	return buf
+}
+
+// retsBefore evaluates the return specs against the pre-call record after a
+// failed CHECK. Against a record that did not exist before the call every
+// return is absent, without resolving anything (oracle ruling).
+func retsBefore(se *schemaEngine, cur []byte, rets []wire.OperateRet) ([][]byte, error) {
+	if len(rets) == 0 {
+		return nil, nil
+	}
+	if cur == nil {
+		return absentRets(rets)
+	}
+	e, err := openMode(se, copyRecord(cur), true)
+	if err != nil {
+		return nil, err
+	}
+	return evalRets(e, rets)
+}
+
+// absentRets is what every return spec evaluates to when there is no record
+// to resolve against: UNSET for a VALUE, a tagged zero for a COUNT (design
+// doc §2.4/§3.4).
+func absentRets(rets []wire.OperateRet) ([][]byte, error) {
+	if len(rets) == 0 {
+		return nil, nil
+	}
+	out := make([][]byte, 0, len(rets))
+	for i := range rets {
+		switch rets[i].Mode {
+		case wire.OperateRetCount:
+			out = append(out, appendCountValue(0))
+		case wire.OperateRetValue:
+			out = append(out, []byte{wire.OperateTypeUnset})
+		default:
+			return nil, wire.ErrOperateArgs
+		}
+	}
+	return out, nil
+}

--- a/ops/operate_apply.go
+++ b/ops/operate_apply.go
@@ -21,6 +21,32 @@ import (
 // for a fresh engine per call on a hot key.
 var schemaEnginePool = sync.Pool{New: func() any { return new(schemaEngine) }}
 
+// dynamicEnginePool does the same for dynamic-mode records (design doc §2.9),
+// whose engine carries a field index and an encode scratch buffer worth
+// keeping between calls for the same reason.
+var dynamicEnginePool = sync.Pool{New: func() any { return new(dynamicEngine) }}
+
+// modeEngine is the engine of one stored record plus the one thing
+// applyWithEngine needs that the engine interface does not carry: the
+// "did this record exist before the call" flag a record-path EXISTS/ABSENT
+// compares (design doc §2.4), which the returns see as true once the call
+// has stored something.
+type modeEngine interface {
+	engine
+	setExisted(v bool)
+}
+
+// setExisted implements modeEngine for the schema engine.
+func (e *schemaEngine) setExisted(v bool) { e.existed = v }
+
+// engines is the pair of pooled engines one call borrows: which of the two
+// runs is decided by the stored record's mode byte, and the other costs
+// nothing but a pool round trip.
+type engines struct {
+	se *schemaEngine
+	de *dynamicEngine
+}
+
 // applyRecordBytes applies one operate call to a stored record.
 //
 // cur is the record's stored bytes, or nil when the key is absent; it is never
@@ -37,15 +63,20 @@ func applyRecordBytes(cur []byte, a *wire.OperateArgs, stampMs int64) ([]byte, b
 	if len(a.Ops) > wire.OperateMaxOps || len(a.Rets) > wire.OperateMaxRet {
 		return nil, false, nil, wire.ErrOperateCap
 	}
-	se := schemaEnginePool.Get().(*schemaEngine) //nolint:errcheck,forcetypeassert // the pool's New returns exactly this
-	out, deleted, res, err := applyWithEngine(se, cur, a, stampMs)
-	se.clear()
-	schemaEnginePool.Put(se)
+	es := engines{
+		se: schemaEnginePool.Get().(*schemaEngine),   //nolint:errcheck,forcetypeassert // the pool's New returns exactly this
+		de: dynamicEnginePool.Get().(*dynamicEngine), //nolint:errcheck,forcetypeassert // the pool's New returns exactly this
+	}
+	out, deleted, res, err := applyWithEngine(es, cur, a, stampMs)
+	es.se.clear()
+	es.de.clear()
+	schemaEnginePool.Put(es.se)
+	dynamicEnginePool.Put(es.de)
 	return out, deleted, res, err
 }
 
-func applyWithEngine(se *schemaEngine, cur []byte, a *wire.OperateArgs, stampMs int64) ([]byte, bool, *wire.OperateResult, error) {
-	e, err := openRecord(se, cur, a)
+func applyWithEngine(es engines, cur []byte, a *wire.OperateArgs, stampMs int64) ([]byte, bool, *wire.OperateResult, error) {
+	e, err := openRecord(es, cur, a)
 	if err != nil {
 		return nil, false, nil, err
 	}
@@ -57,7 +88,7 @@ func applyWithEngine(se *schemaEngine, cur []byte, a *wire.OperateArgs, stampMs 
 	if status == wire.OperateStatusCheckFailed {
 		// The op list aborts with the record unchanged, and the returns are
 		// evaluated against that unchanged record.
-		vals, verr := retsBefore(se, cur, a.Rets)
+		vals, verr := retsBefore(es, cur, a.Rets)
 		if verr != nil {
 			return nil, false, nil, verr
 		}
@@ -84,7 +115,7 @@ func applyWithEngine(se *schemaEngine, cur []byte, a *wire.OperateArgs, stampMs 
 	// even when this call created it — ref.present is "existed before the
 	// call" only for the op list's own EXISTS/ABSENT (the oracle evaluates
 	// its success-path returns with existed = true for the same reason).
-	se.existed = true
+	e.setExisted(true)
 	vals, verr := evalRets(e, a.Rets)
 	if verr != nil {
 		return nil, false, nil, verr
@@ -95,9 +126,9 @@ func applyWithEngine(se *schemaEngine, cur []byte, a *wire.OperateArgs, stampMs 
 // openRecord resolves the call's `create` parameter against the stored record
 // (design doc §3.5) and returns an engine over a private, patchable copy of
 // the bytes to apply the ops to.
-func openRecord(se *schemaEngine, cur []byte, a *wire.OperateArgs) (engine, error) {
+func openRecord(es engines, cur []byte, a *wire.OperateArgs) (modeEngine, error) {
 	if cur == nil {
-		return createRecord(se, a)
+		return createRecord(es, a)
 	}
 	if len(cur) < 1 {
 		return nil, wire.ErrOperateRecord
@@ -129,7 +160,7 @@ func openRecord(se *schemaEngine, cur []byte, a *wire.OperateArgs) (engine, erro
 		return nil, wire.ErrOperateArgs
 	}
 
-	e, err := openMode(se, copyRecord(cur), true)
+	e, err := openMode(es, copyRecord(cur), true)
 	if err != nil {
 		return nil, err
 	}
@@ -138,7 +169,7 @@ func openRecord(se *schemaEngine, cur []byte, a *wire.OperateArgs) (engine, erro
 		// schema stays authoritative for the record; the call's blob only has
 		// to agree on the version, so a differently encoded blob of the same
 		// version is accepted and changes nothing.
-		if se.schema.Version != callSchema.Version {
+		if es.se.schema.Version != callSchema.Version {
 			return nil, wire.ErrOperateSchemaVersion
 		}
 	}
@@ -147,7 +178,7 @@ func openRecord(se *schemaEngine, cur []byte, a *wire.OperateArgs) (engine, erro
 
 // createRecord builds the record a call creates when the key is absent
 // (design doc §3.5).
-func createRecord(se *schemaEngine, a *wire.OperateArgs) (engine, error) {
+func createRecord(es engines, a *wire.OperateArgs) (modeEngine, error) {
 	switch a.Create {
 	case wire.OperateCreateNone:
 		return nil, errOperateAbsent
@@ -156,30 +187,39 @@ func createRecord(se *schemaEngine, a *wire.OperateArgs) (engine, error) {
 		if err != nil {
 			return nil, err
 		}
-		return openMode(se, buf, false)
+		return openMode(es, buf, false)
 	case wire.OperateCreateDynamic:
-		return openMode(se, []byte{wire.OperateModeDynamic, 0}, false)
+		// An empty dynamic record: the mode byte and a field count of zero
+		// (design doc §2.9). The slack is what a first field's splice grows
+		// into without reallocating.
+		buf := append(make([]byte, 0, 64), wire.OperateModeDynamic, 0)
+		return openMode(es, buf, false)
 	default:
 		return nil, wire.ErrOperateArgs
 	}
 }
 
-// openMode builds the engine for a record's stored mode byte. The dynamic
-// engine lands in a later task; until then a dynamic record is a mode this
-// build cannot apply to.
-func openMode(se *schemaEngine, buf []byte, existed bool) (engine, error) {
+// openMode builds the engine for a record's stored mode byte: the stored
+// bytes, not the call, decide which of the two engines runs (design doc
+// §2.9, "the mode byte on the record and the create byte on the call are the
+// whole contract").
+func openMode(es engines, buf []byte, existed bool) (modeEngine, error) {
 	if len(buf) < 1 {
 		return nil, wire.ErrOperateRecord
 	}
 	switch buf[0] {
 	case wire.OperateModeSchema:
-		if err := se.reset(buf, operateSchemas); err != nil {
+		if err := es.se.reset(buf, operateSchemas); err != nil {
 			return nil, err
 		}
-		se.existed = existed
-		return se, nil
+		es.se.existed = existed
+		return es.se, nil
 	case wire.OperateModeDynamic:
-		return nil, wire.ErrOperateMode
+		if err := es.de.reset(buf, operateSchemas); err != nil {
+			return nil, err
+		}
+		es.de.existed = existed
+		return es.de, nil
 	default:
 		return nil, wire.ErrOperateRecord
 	}
@@ -197,14 +237,17 @@ func copyRecord(cur []byte) []byte {
 // retsBefore evaluates the return specs against the pre-call record after a
 // failed CHECK. Against a record that did not exist before the call every
 // return is absent, without resolving anything (oracle ruling).
-func retsBefore(se *schemaEngine, cur []byte, rets []wire.OperateRet) ([][]byte, error) {
+func retsBefore(es engines, cur []byte, rets []wire.OperateRet) ([][]byte, error) {
 	if len(rets) == 0 {
 		return nil, nil
 	}
 	if cur == nil {
 		return absentRets(rets)
 	}
-	e, err := openMode(se, copyRecord(cur), true)
+	// Re-opening the pre-call bytes reuses the same pooled engines: the
+	// working copy they were pointing at is discarded whole by a failed
+	// CHECK, so nothing in it is still needed.
+	e, err := openMode(es, copyRecord(cur), true)
 	if err != nil {
 		return nil, err
 	}

--- a/ops/operate_bench_test.go
+++ b/ops/operate_bench_test.go
@@ -1,0 +1,162 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package ops
+
+// Benchmarks for the design doc's §2.6 in-place byte-patching claim: applying
+// a small op list to an existing record should cost one allocation for the
+// record copy and one for the result frame, independent of how many rows the
+// record holds. These measure that against the tree oracle, which rebuilds
+// the whole record on every call, to quantify the win the byte engines exist
+// for.
+//
+// benchBigSessionRecord and benchBigDynamicRecord mirror bigSessionRecord
+// (operate_schema_engine_test.go) and bigDynamicRecord
+// (operate_dynamic_engine_test.go) exactly, but take a *testing.B: the
+// existing helpers are typed *testing.T and a benchmark cannot supply one.
+// sessionArgsFor, dynamicArgsFor, applyTree, applyRecordBytes, and the path
+// helpers (keyU64, fieldPath, colPath, opFromSchema) are reused unchanged —
+// none of those need a *testing.T.
+
+import (
+	"testing"
+
+	"github.com/rostamlabs/rostam/sdk/wire"
+)
+
+func benchBigSessionRecord(b *testing.B, n int) []byte {
+	b.Helper()
+	s := sessionSchema()
+	a := &wire.OperateArgs{Create: wire.OperateCreateSchema, Schema: s.Encode()}
+	for k := 0; k < n; k++ {
+		a.Ops = append(a.Ops, wire.OperateOp{Opcode: wire.OperateOpADD, Type: opFromSchema,
+			Path: colPath(3, keyU64(uint64(k)), 0), A: 1})
+	}
+	out, _, _, err := applyRecordBytes(nil, a, 1)
+	if err != nil {
+		b.Fatal(err)
+	}
+	if _, derr := wire.DecodeRecord(out); derr != nil {
+		b.Fatal(derr)
+	}
+	return out
+}
+
+func benchBigDynamicRecord(b *testing.B, n int) []byte {
+	b.Helper()
+	a := &wire.OperateArgs{Create: wire.OperateCreateDynamic, Ops: []wire.OperateOp{
+		{Opcode: wire.OperateOpSET, Type: wire.OperateTypeU8, Path: namePath("rc"), A: 1},
+		{Opcode: wire.OperateOpSET, Type: wire.OperateTypeU8, Path: namePath("bc"), A: 1},
+		{Opcode: wire.OperateOpSET, Type: wire.OperateTypeU32, Path: namePath("hist"), A: 1},
+	}}
+	for k := 0; k < n; k++ {
+		a.Ops = append(a.Ops, wire.OperateOp{Opcode: wire.OperateOpADD, Type: wire.OperateTypeU16,
+			Path: nameColPath("b", keyU64(uint64(k)), "c"), A: 1})
+	}
+	out, _, _, err := applyRecordBytes(nil, a, 1)
+	if err != nil {
+		b.Fatal(err)
+	}
+	if _, derr := wire.DecodeRecord(out); derr != nil {
+		b.Fatal(derr)
+	}
+	return out
+}
+
+// BenchmarkOperateSchemaExistingRow is the design doc's §2.6 headline number:
+// the 6-op session op-list against an existing row in a 1024-row schema-mode
+// record, through the in-place byte engine. applyRecordBytes returns a new
+// buffer rather than mutating cur, so feeding it the same original bytes on
+// every iteration keeps this on the in-place (found, no resize) path for the
+// whole run.
+func BenchmarkOperateSchemaExistingRow(b *testing.B) {
+	rec := benchBigSessionRecord(b, 1024)
+	a := sessionArgsFor(keyU64(512))
+	a.Rets = nil
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if _, _, _, err := applyRecordBytes(rec, a, 1); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+// BenchmarkOperateSchemaExistingRowWithReturns is the same call with the
+// worked example's two Rets entries attached, informational: it shows the
+// cost of populating a result frame on top of the in-place patch.
+func BenchmarkOperateSchemaExistingRowWithReturns(b *testing.B) {
+	rec := benchBigSessionRecord(b, 1024)
+	key := keyU64(512)
+	a := sessionArgsFor(key)
+	a.Rets = []wire.OperateRet{
+		{Mode: wire.OperateRetValue, Path: fieldPath(0)},
+		{Mode: wire.OperateRetValue, Path: rowPath(3, key)},
+	}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if _, _, _, err := applyRecordBytes(rec, a, 1); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+// BenchmarkOperateSchemaNewRowEvict is the other end of §2.6: the table is
+// already at its cap of 1024 rows, and every call targets a key the table
+// does not hold, so every call inserts a row and evicts one to stay at cap.
+// applyRecordBytes never mutates cur, so the base record — full at cap — is
+// the same on every iteration; a single sentinel key that is never one of
+// the base record's 1024 keys therefore takes the insert+evict path on every
+// call without needing to build a fresh args value (and a fresh key) inside
+// the timed loop.
+func BenchmarkOperateSchemaNewRowEvict(b *testing.B) {
+	rec := benchBigSessionRecord(b, 1024) // keys 0..1023, table cap 1024: full
+	newKey := keyU64(1 << 32)             // never a key in the base record
+	a := sessionArgsFor(newKey)
+	a.Rets = nil
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if _, _, _, err := applyRecordBytes(rec, a, 1); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+// BenchmarkOperateDynamicExistingRow is BenchmarkOperateSchemaExistingRow's
+// dynamic-mode counterpart: the same 6-op shape (by name instead of by
+// position) against an existing row in a 1024-row dynamic-mode record.
+func BenchmarkOperateDynamicExistingRow(b *testing.B) {
+	rec := benchBigDynamicRecord(b, 1024)
+	a := dynamicArgsFor(keyU64(512))
+	a.Rets = nil
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if _, _, _, err := applyRecordBytes(rec, a, 1); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+// BenchmarkOperateTreeOracle runs the identical 6-op session call through the
+// tree oracle instead of the byte engine: the comparison point for §2.6's
+// claim that byte-patching avoids the oracle's per-call decode/rebuild/encode
+// cost. applyTree copies its input before mutating it, so the decoded tree
+// built once outside the loop stays valid input for every iteration.
+func BenchmarkOperateTreeOracle(b *testing.B) {
+	recBytes := benchBigSessionRecord(b, 1024)
+	tree, err := wire.DecodeRecord(recBytes)
+	if err != nil {
+		b.Fatal(err)
+	}
+	a := sessionArgsFor(keyU64(512))
+	a.Rets = nil
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if _, _, err := applyTree(tree, a, 1); err != nil {
+			b.Fatal(err)
+		}
+	}
+}

--- a/ops/operate_dynamic_engine.go
+++ b/ops/operate_dynamic_engine.go
@@ -1,0 +1,1966 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package ops
+
+// The dynamic-mode byte engine (design doc §2.9): it navigates and patches a
+// self-describing record's bytes directly, never building a tree. A field is
+// a binary search over the name-sorted field index, a row is a walk with
+// O(1) rowLen skips that stops early (rows are key-sorted), and a column is
+// a walk within the row. Every edit that changes a width is a splice, and
+// each enclosing length prefix (nCols, rowLen, nRows, byteLen, nFields) is
+// rewritten from the inside out, so a prefix that changes width never
+// invalidates an offset the same edit still has to use.
+//
+// The tree oracle (operate_oracle_test.go) is the definition of what this
+// file must do; TestDynamicEngineMatchesOracle compares them byte for byte,
+// and TestCrossModeEquivalence checks it against the schema engine.
+//
+// Stored bytes are untrusted — a plain `put` can store anything under the
+// key — so newDynamicEngine validates the whole frame with a bounds-checked
+// walk before any offset here is trusted, and every method below is written
+// to be unable to panic on input that passed that walk.
+
+import (
+	"bytes"
+	"encoding/binary"
+	"math"
+	"sort"
+
+	"github.com/rostamlabs/rostam/sdk/wire"
+)
+
+// --- index -----------------------------------------------------------------
+
+// inlineDynFields is the number of field-index entries that ride inside the
+// engine struct. Dynamic records in practice hold a handful of fields; a
+// wider one falls back to a heap slice, which a pooled engine then keeps.
+const inlineDynFields = 8
+
+// dynField is one stored record field: the offsets of its parts within the
+// engine's buffer, in stored (name-sorted) order.
+//
+//	[off: nlen u8][nameOff: name][typOff: type u8][n u8 iff FIXED][valOff: value][end
+type dynField struct {
+	off     int
+	nameOff int
+	nameLen int
+	typOff  int
+	valOff  int
+	end     int
+	typ     uint8
+	n       uint8
+}
+
+// dynTable is one table field's header, parsed from its value area:
+//
+//	[lenOff: byteLen][capOff: cap][policyOff: policy][byColOff: byColLen][byColName]
+//	[nRowsOff: nRows][rowsOff: rows…][end
+type dynTable struct {
+	lenOff, lenLen     int
+	byteLen            int
+	capOff, capLen     int
+	policyOff          int
+	byColOff, byColLen int // byColOff is the byColLen byte; byColLen the name's length
+	nRowsOff, nRowsLen int
+	rowsOff            int
+	end                int
+	nRows              int
+	capV               uint32
+	policy             uint8
+}
+
+// dynRow is one row of a dynamic table:
+//
+//	[off: rowLen][bodyOff/keyLenOff: klen][keyOff: key][nColsOff: nCols][colsOff: cols…][end
+type dynRow struct {
+	off                int
+	lenLen             int
+	bodyOff            int
+	bodyLen            int
+	keyOff, keyLen     int
+	nColsOff, nColsLen int
+	colsOff            int
+	end                int
+	nCols              int
+}
+
+// dynCol is one column of a dynamic row:
+//
+//	[off: nlen u8][nameOff: name][typOff: type u8][n u8 iff FIXED][valOff: data][end
+type dynCol struct {
+	off     int
+	nameOff int
+	nameLen int
+	typOff  int
+	valOff  int
+	end     int
+	typ     uint8
+	n       uint8
+}
+
+// --- construction and structural validation --------------------------------
+
+// dynamicEngine implements engine over a dynamic-mode record's stored bytes.
+// buf is the engine's own copy, which it patches in place and splices as
+// needed; fields is the name-sorted field index, rebuilt after every splice.
+//
+// inner is non-nil once MIGRATE has frozen the record into schema mode
+// (design doc §2.9): the bytes are no longer dynamic, so every method
+// delegates to a schema engine over the frozen buffer for the rest of the
+// call — later ops and the return specs must see the frozen record.
+type dynamicEngine struct {
+	buf     []byte
+	cache   *schemaCache
+	fields  []dynField
+	nOff    int // offset of the nFields uvarint (always 1)
+	nLen    int
+	existed bool
+	deleted bool
+	inner   *schemaEngine
+
+	fieldsArr [inlineDynFields]dynField
+	// enc builds one entry (a tagged cell, a fresh field, a row) before it is
+	// spliced in. It is kept between calls so the splice paths do not
+	// allocate on a warm engine.
+	enc []byte
+	// scratch encodes one fixed-width cell's data for the in-place path,
+	// which is the only path the §2.6 allocation budget applies to.
+	scratch [256]byte
+}
+
+// newDynamicEngine builds an engine over buf, which becomes the engine's
+// private buffer (it is patched in place). buf is untrusted: the whole frame
+// — mode byte, field entries, and every table's rows and columns — is
+// validated here by a bounds-checked walk that must land exactly on the end
+// of the buffer, and anything that does not fit is wire.ErrOperateRecord.
+func newDynamicEngine(buf []byte) (*dynamicEngine, error) {
+	e := &dynamicEngine{}
+	if err := e.reset(buf, operateSchemas); err != nil {
+		return nil, err
+	}
+	return e, nil
+}
+
+// reset re-points an engine at buf, so a pooled engine can be reused without
+// re-allocating its field index. It performs the same validation as
+// newDynamicEngine. cache is used only by a freeze, which needs the target
+// schema's layout.
+func (e *dynamicEngine) reset(buf []byte, cache *schemaCache) error {
+	e.clear()
+	e.cache = cache
+	if len(buf) < 1 || buf[0] != wire.OperateModeDynamic {
+		return wire.ErrOperateRecord
+	}
+	e.buf = buf
+	if cap(e.fields) == 0 {
+		e.fields = e.fieldsArr[:0]
+	}
+	return e.walk(true)
+}
+
+// clear drops the engine's references so a pooled engine does not pin a
+// record buffer between calls. The field index keeps its capacity: it holds
+// no pointers, so a large record's index is reused rather than re-allocated.
+func (e *dynamicEngine) clear() {
+	e.buf, e.cache, e.inner = nil, nil, nil
+	e.fields = e.fields[:0]
+	e.enc = e.enc[:0]
+	e.nOff, e.nLen, e.existed, e.deleted = 0, 0, false, false
+}
+
+// setExisted records whether the record existed before this call, which is
+// what a record-path EXISTS/ABSENT compares (design doc §2.4). A frozen
+// record answers from its inner engine, so the flag travels there too.
+func (e *dynamicEngine) setExisted(v bool) {
+	e.existed = v
+	if e.inner != nil {
+		e.inner.existed = v
+	}
+}
+
+// walk rebuilds the field index from the buffer, checking that the walk lands
+// exactly on the end of it. With deep set it also validates every table's
+// rows and columns — the untrusted-input pass newDynamicEngine/reset make
+// once; a re-walk after a splice only needs the field level, since the bytes
+// it is re-reading are ones this engine just wrote.
+func (e *dynamicEngine) walk(deep bool) error {
+	buf := e.buf
+	nFields, m, err := readUvarint(buf[1:])
+	if err != nil {
+		return wire.ErrOperateRecord
+	}
+	if nFields > wire.OperateMaxFields {
+		return wire.ErrOperateRecord
+	}
+	e.nOff, e.nLen = 1, m
+	off := 1 + m
+	if !wire.CountFitsIn(int(nFields), len(buf)-off, 3) { //nolint:gosec // bounded by OperateMaxFields above
+		return wire.ErrOperateRecord
+	}
+	// Every field, row and column decoded anywhere in the record is charged
+	// against one budget, exactly as wire.DecodeRecord does, so the two agree
+	// on which records exist at all.
+	budget := int(nFields) //nolint:gosec // bounded by OperateMaxFields above
+
+	e.fields = e.fields[:0]
+	if int(nFields) > cap(e.fields) { //nolint:gosec // bounded above
+		e.fields = make([]dynField, 0, nFields)
+	}
+	prevOff, prevLen := 0, -1
+	for i := 0; i < int(nFields); i++ { //nolint:gosec // bounded above
+		var f dynField
+		f.off = off
+		if len(buf)-off < 1 {
+			return wire.ErrOperateRecord
+		}
+		f.nameLen = int(buf[off])
+		off++
+		if len(buf)-off < f.nameLen {
+			return wire.ErrOperateRecord
+		}
+		f.nameOff = off
+		off += f.nameLen
+		if prevLen >= 0 && bytes.Compare(buf[prevOff:prevOff+prevLen], buf[f.nameOff:off]) >= 0 {
+			// Strictly ascending by name, the invariant the encoder produces
+			// and the record decoder enforces.
+			return wire.ErrOperateRecord
+		}
+		prevOff, prevLen = f.nameOff, f.nameLen
+
+		if len(buf)-off < 1 {
+			return wire.ErrOperateRecord
+		}
+		f.typOff = off
+		f.typ = buf[off]
+		off++
+
+		if f.typ == wire.OperateTypeTable {
+			f.valOff = off
+			ln, terr := e.tableSpan(off, deep, &budget)
+			if terr != nil {
+				return terr
+			}
+			off += ln
+		} else {
+			if f.typ == wire.OperateTypeFixed {
+				if len(buf)-off < 1 {
+					return wire.ErrOperateRecord
+				}
+				f.n = buf[off]
+				off++
+			}
+			f.valOff = off
+			ln, cerr := cellDataLen(f.typ, f.n, buf[off:])
+			if cerr != nil {
+				return cerr
+			}
+			off += ln
+		}
+		f.end = off
+		e.fields = append(e.fields, f)
+	}
+	if off != len(buf) {
+		return wire.ErrOperateRecord
+	}
+	return nil
+}
+
+// tableSpan returns the stored length of the table value at off ([byteLen]
+// plus the bytes it covers), validating the rows and columns inside it when
+// deep is set.
+func (e *dynamicEngine) tableSpan(off int, deep bool, budget *int) (int, error) {
+	byteLen, m, err := readUvarint(e.buf[off:])
+	if err != nil {
+		return 0, wire.ErrOperateRecord
+	}
+	if !lenFits(byteLen, len(e.buf)-off-m) {
+		return 0, wire.ErrOperateRecord
+	}
+	total := m + int(byteLen) //nolint:gosec // bounded by lenFits above
+	if deep {
+		if err := e.validateTable(off, off+m, int(byteLen), budget); err != nil { //nolint:gosec // bounded above
+			return 0, err
+		}
+	}
+	return total, nil
+}
+
+// validateTable walks a table's inner bytes (everything byteLen covers),
+// checking the header, every row's exact extent, and that the rows arrive
+// strictly ascending by key.
+func (e *dynamicEngine) validateTable(lenOff, innerOff, innerLen int, budget *int) error {
+	t, err := e.parseTableAt(lenOff, innerOff, innerLen)
+	if err != nil {
+		return err
+	}
+	if !wire.CountFitsIn(t.nRows, t.end-t.rowsOff, 3) {
+		return wire.ErrOperateRecord
+	}
+	*budget += t.nRows
+	if *budget > wire.OperateMaxRows {
+		return wire.ErrOperateRecord
+	}
+
+	off := t.rowsOff
+	prevOff, prevLen := 0, -1
+	for i := 0; i < t.nRows; i++ {
+		r, rerr := e.rowAt(off, t.end)
+		if rerr != nil {
+			return rerr
+		}
+		if err := e.validateRow(r, budget); err != nil {
+			return err
+		}
+		if prevLen >= 0 && bytes.Compare(e.buf[prevOff:prevOff+prevLen], e.buf[r.keyOff:r.keyOff+r.keyLen]) >= 0 {
+			return wire.ErrOperateRecord
+		}
+		prevOff, prevLen = r.keyOff, r.keyLen
+		off = r.end
+	}
+	if off != t.end {
+		return wire.ErrOperateRecord
+	}
+	return nil
+}
+
+// validateRow walks one row's columns, checking each cell's extent and that
+// the columns arrive strictly ascending by name.
+func (e *dynamicEngine) validateRow(r dynRow, budget *int) error {
+	if !wire.CountFitsIn(r.nCols, r.end-r.colsOff, 3) {
+		return wire.ErrOperateRecord
+	}
+	*budget += r.nCols
+	if *budget > wire.OperateMaxRows {
+		return wire.ErrOperateRecord
+	}
+	off := r.colsOff
+	prevOff, prevLen := 0, -1
+	for i := 0; i < r.nCols; i++ {
+		c, err := e.colAt(off, r.end)
+		if err != nil {
+			return err
+		}
+		if prevLen >= 0 && bytes.Compare(e.buf[prevOff:prevOff+prevLen], e.buf[c.nameOff:c.nameOff+c.nameLen]) >= 0 {
+			return wire.ErrOperateRecord
+		}
+		prevOff, prevLen = c.nameOff, c.nameLen
+		off = c.end
+	}
+	if off != r.end {
+		return wire.ErrOperateRecord
+	}
+	return nil
+}
+
+// lenFits reports whether a decoded byte length fits within remaining bytes
+// without narrowing it to int first: a stored length is an arbitrary uvarint
+// up to 2^64-1, and converting before comparing would wrap on a 32-bit int.
+func lenFits(n uint64, remaining int) bool {
+	if remaining < 0 {
+		return false
+	}
+	return n <= uint64(remaining) //nolint:gosec // remaining >= 0 checked above
+}
+
+// cellDataLen returns the stored length of one cell's data of type typ (and,
+// for FIXED, width n) at the front of b, rejecting anything the record codec
+// would reject: a truncated value, a non-canonical varint or BYTES length, an
+// over-long BYTES payload, an F32 bit pattern that does not survive the
+// codec's float64 round trip, and any type byte that is not cell data at all
+// (TABLE, or a tag past the last known type). It never allocates, which is
+// what lets the structural walk stay off the heap.
+func cellDataLen(typ, n uint8, b []byte) (int, error) {
+	switch typ {
+	case wire.OperateTypeUnset:
+		return 0, nil
+	case wire.OperateTypeU8, wire.OperateTypeI8,
+		wire.OperateTypeU16, wire.OperateTypeI16,
+		wire.OperateTypeU32, wire.OperateTypeI32,
+		wire.OperateTypeU64, wire.OperateTypeI64, wire.OperateTypeF64:
+		w := wire.CellWidth(typ, n)
+		if len(b) < w {
+			return 0, wire.ErrOperateRecord
+		}
+		return w, nil
+	case wire.OperateTypeF32:
+		if len(b) < 4 {
+			return 0, wire.ErrOperateRecord
+		}
+		// The codec stores an F32 through a float64 (Cell.F), so a bit
+		// pattern that does not come back identically — a signaling NaN on
+		// hardware that quiets it — decodes fine yet re-encodes differently.
+		// wire.DecodeRecord rejects those; so must this walk, or the two
+		// would disagree on which records exist.
+		v := binary.LittleEndian.Uint32(b[:4])
+		if math.Float32bits(float32(float64(math.Float32frombits(v)))) != v {
+			return 0, wire.ErrOperateRecord
+		}
+		return 4, nil
+	case wire.OperateTypeUVarint, wire.OperateTypeIVarint:
+		_, m, err := readUvarint(b)
+		if err != nil {
+			return 0, wire.ErrOperateRecord
+		}
+		return m, nil
+	case wire.OperateTypeBytes:
+		ln, m, err := readUvarint(b)
+		if err != nil {
+			return 0, wire.ErrOperateRecord
+		}
+		if ln > wire.OperateMaxBytesLen {
+			return 0, wire.ErrOperateRecord
+		}
+		if !wire.CountFitsIn(int(ln), len(b)-m, 1) { //nolint:gosec // bounded above
+			return 0, wire.ErrOperateRecord
+		}
+		return m + int(ln), nil //nolint:gosec // bounded above
+	case wire.OperateTypeFixed:
+		if !wire.CountFitsIn(int(n), len(b), 1) {
+			return 0, wire.ErrOperateRecord
+		}
+		return int(n), nil
+	default: // TABLE (never a cell) and every unknown tag
+		return 0, wire.ErrOperateRecord
+	}
+}
+
+// --- parsing helpers -------------------------------------------------------
+
+// table parses the header of the table field at index fi.
+func (e *dynamicEngine) table(fi int) (dynTable, error) {
+	if fi < 0 || fi >= len(e.fields) || e.fields[fi].typ != wire.OperateTypeTable {
+		return dynTable{}, wire.ErrOperatePath
+	}
+	f := &e.fields[fi]
+	byteLen, m, err := readUvarint(e.buf[f.valOff:])
+	if err != nil {
+		return dynTable{}, wire.ErrOperateRecord
+	}
+	if !lenFits(byteLen, len(e.buf)-f.valOff-m) {
+		return dynTable{}, wire.ErrOperateRecord
+	}
+	return e.parseTableAt(f.valOff, f.valOff+m, int(byteLen)) //nolint:gosec // bounded by lenFits above
+}
+
+// parseTableAt reads a table's header. lenOff is the byteLen prefix, innerOff
+// the first byte it covers, and innerLen how many.
+func (e *dynamicEngine) parseTableAt(lenOff, innerOff, innerLen int) (dynTable, error) {
+	buf := e.buf
+	t := dynTable{lenOff: lenOff, lenLen: innerOff - lenOff, byteLen: innerLen, end: innerOff + innerLen}
+	if lenOff < 0 || innerOff < lenOff || t.end > len(buf) {
+		return dynTable{}, wire.ErrOperateRecord
+	}
+	inner := buf[innerOff:t.end]
+
+	capV, m, err := readUvarint(inner)
+	if err != nil {
+		return dynTable{}, wire.ErrOperateRecord
+	}
+	if capV > wire.OperateMaxRows {
+		return dynTable{}, wire.ErrOperateRecord
+	}
+	t.capOff, t.capLen, t.capV = innerOff, m, uint32(capV) //nolint:gosec // bounded by OperateMaxRows above
+	off := innerOff + m
+
+	if t.end-off < 1 {
+		return dynTable{}, wire.ErrOperateRecord
+	}
+	t.policyOff, t.policy = off, buf[off]
+	off++
+	if t.policy > wire.OperatePolicyMaxCol {
+		return dynTable{}, wire.ErrOperateRecord
+	}
+
+	if t.end-off < 1 {
+		return dynTable{}, wire.ErrOperateRecord
+	}
+	t.byColOff = off
+	t.byColLen = int(buf[off])
+	off++
+	if t.end-off < t.byColLen {
+		return dynTable{}, wire.ErrOperateRecord
+	}
+	off += t.byColLen
+
+	nRows, m2, err := readUvarint(buf[off:t.end])
+	if err != nil {
+		return dynTable{}, wire.ErrOperateRecord
+	}
+	if nRows > wire.OperateMaxRows {
+		return dynTable{}, wire.ErrOperateRecord
+	}
+	t.nRowsOff, t.nRowsLen, t.nRows = off, m2, int(nRows) //nolint:gosec // bounded by OperateMaxRows above
+	t.rowsOff = off + m2
+	return t, nil
+}
+
+// byColName is the table's eviction column name, as stored.
+func (e *dynamicEngine) byColName(t dynTable) []byte {
+	return e.buf[t.byColOff+1 : t.byColOff+1+t.byColLen]
+}
+
+// rowAt parses the row whose rowLen prefix starts at off; end bounds the
+// table it lives in.
+func (e *dynamicEngine) rowAt(off, end int) (dynRow, error) {
+	buf := e.buf
+	if off < 0 || off > end || end > len(buf) {
+		return dynRow{}, wire.ErrOperateRecord
+	}
+	bodyLen, m, err := readUvarint(buf[off:end])
+	if err != nil {
+		return dynRow{}, wire.ErrOperateRecord
+	}
+	if !lenFits(bodyLen, end-off-m) {
+		return dynRow{}, wire.ErrOperateRecord
+	}
+	r := dynRow{off: off, lenLen: m, bodyOff: off + m, bodyLen: int(bodyLen)} //nolint:gosec // bounded by lenFits above
+	r.end = r.bodyOff + r.bodyLen
+
+	if r.end-r.bodyOff < 1 {
+		return dynRow{}, wire.ErrOperateRecord
+	}
+	r.keyLen = int(buf[r.bodyOff])
+	r.keyOff = r.bodyOff + 1
+	// A row key is 1-255 bytes (design doc §2.4): a zero-length key would
+	// make two distinct rows compare equal and is rejected by the codec.
+	if r.keyLen < 1 || r.end-r.keyOff < r.keyLen {
+		return dynRow{}, wire.ErrOperateRecord
+	}
+	off2 := r.keyOff + r.keyLen
+
+	nCols, m2, err := readUvarint(buf[off2:r.end])
+	if err != nil {
+		return dynRow{}, wire.ErrOperateRecord
+	}
+	if nCols > wire.OperateMaxCols {
+		return dynRow{}, wire.ErrOperateRecord
+	}
+	r.nColsOff, r.nColsLen, r.nCols = off2, m2, int(nCols) //nolint:gosec // bounded by OperateMaxCols above
+	r.colsOff = off2 + m2
+	return r, nil
+}
+
+// colAt parses the column entry starting at off; end bounds the row.
+func (e *dynamicEngine) colAt(off, end int) (dynCol, error) {
+	buf := e.buf
+	c := dynCol{off: off}
+	if off < 0 || end > len(buf) || end-off < 1 {
+		return dynCol{}, wire.ErrOperateRecord
+	}
+	c.nameLen = int(buf[off])
+	c.nameOff = off + 1
+	if end-c.nameOff < c.nameLen {
+		return dynCol{}, wire.ErrOperateRecord
+	}
+	off = c.nameOff + c.nameLen
+	if end-off < 1 {
+		return dynCol{}, wire.ErrOperateRecord
+	}
+	c.typOff, c.typ = off, buf[off]
+	off++
+	if c.typ == wire.OperateTypeFixed {
+		if end-off < 1 {
+			return dynCol{}, wire.ErrOperateRecord
+		}
+		c.n = buf[off]
+		off++
+	}
+	c.valOff = off
+	ln, err := cellDataLen(c.typ, c.n, buf[off:end])
+	if err != nil {
+		return dynCol{}, err
+	}
+	c.end = off + ln
+	return c, nil
+}
+
+// --- lookup ----------------------------------------------------------------
+
+// compareBytesString orders stored bytes against a path segment's name
+// without converting either: a []byte(name) conversion in the hot lookup
+// would allocate once per resolve.
+func compareBytesString(b []byte, s string) int {
+	n := len(b)
+	if len(s) < n {
+		n = len(s)
+	}
+	for i := 0; i < n; i++ {
+		switch {
+		case b[i] < s[i]:
+			return -1
+		case b[i] > s[i]:
+			return 1
+		}
+	}
+	switch {
+	case len(b) < len(s):
+		return -1
+	case len(b) > len(s):
+		return 1
+	default:
+		return 0
+	}
+}
+
+// findField binary-searches the name-sorted field index, returning the index
+// and whether it matched; when it did not, the index is where a field with
+// that name would be inserted.
+func (e *dynamicEngine) findField(name string) (int, bool) {
+	lo, hi := 0, len(e.fields)
+	for lo < hi {
+		mid := int(uint(lo+hi) >> 1)
+		f := &e.fields[mid]
+		if compareBytesString(e.buf[f.nameOff:f.nameOff+f.nameLen], name) < 0 {
+			lo = mid + 1
+		} else {
+			hi = mid
+		}
+	}
+	if lo < len(e.fields) {
+		f := &e.fields[lo]
+		if compareBytesString(e.buf[f.nameOff:f.nameOff+f.nameLen], name) == 0 {
+			return lo, true
+		}
+	}
+	return lo, false
+}
+
+// findRow walks the table's rows for key, stopping as soon as it passes where
+// the key would be (rows are sorted by key, compared bytewise in dynamic
+// mode). On a miss the returned row's off is the insertion offset.
+func (e *dynamicEngine) findRow(t dynTable, key []byte) (dynRow, int, bool, error) {
+	off := t.rowsOff
+	for i := 0; i < t.nRows; i++ {
+		r, err := e.rowAt(off, t.end)
+		if err != nil {
+			return dynRow{}, 0, false, err
+		}
+		switch bytes.Compare(e.buf[r.keyOff:r.keyOff+r.keyLen], key) {
+		case 0:
+			return r, i, true, nil
+		case 1:
+			return dynRow{off: off}, i, false, nil
+		}
+		off = r.end
+	}
+	return dynRow{off: off}, t.nRows, false, nil
+}
+
+// rowByIndex walks to row ri of the table field at fi.
+func (e *dynamicEngine) rowByIndex(fi, ri int) (dynTable, dynRow, error) {
+	t, err := e.table(fi)
+	if err != nil {
+		return dynTable{}, dynRow{}, err
+	}
+	if ri < 0 || ri >= t.nRows {
+		return dynTable{}, dynRow{}, wire.ErrOperatePath
+	}
+	off := t.rowsOff
+	for i := 0; ; i++ {
+		r, rerr := e.rowAt(off, t.end)
+		if rerr != nil {
+			return dynTable{}, dynRow{}, rerr
+		}
+		if i == ri {
+			return t, r, nil
+		}
+		off = r.end
+	}
+}
+
+// findCol walks the row's columns for name (they are sorted by name), and on
+// a miss reports the insertion offset in the returned column's off.
+func (e *dynamicEngine) findCol(r dynRow, name string) (dynCol, int, bool, error) {
+	off := r.colsOff
+	for i := 0; i < r.nCols; i++ {
+		c, err := e.colAt(off, r.end)
+		if err != nil {
+			return dynCol{}, 0, false, err
+		}
+		switch compareBytesString(e.buf[c.nameOff:c.nameOff+c.nameLen], name) {
+		case 0:
+			return c, i, true, nil
+		case 1:
+			return dynCol{off: off}, i, false, nil
+		}
+		off = c.end
+	}
+	return dynCol{off: off}, r.nCols, false, nil
+}
+
+// colByIndex walks to column ci of a row.
+func (e *dynamicEngine) colByIndex(r dynRow, ci int) (dynCol, error) {
+	if ci < 0 || ci >= r.nCols {
+		return dynCol{}, wire.ErrOperatePath
+	}
+	off := r.colsOff
+	for i := 0; ; i++ {
+		c, err := e.colAt(off, r.end)
+		if err != nil {
+			return dynCol{}, err
+		}
+		if i == ci {
+			return c, nil
+		}
+		off = c.end
+	}
+}
+
+// --- type rules (design doc §2.4/§2.9) -------------------------------------
+
+// validDynScalarType reports whether t names a type a dynamic value can have.
+func validDynScalarType(t uint8) bool {
+	return t < wire.OperateTypeCount && t != wire.OperateTypeTable && t != wire.OperateTypeUnset
+}
+
+// dynDomain groups types the way §2.4's "the domain must match" rule does,
+// and ranks them (int < float < bytes) for the cross-type ordering an
+// eviction column needs when two rows store different types under one name.
+func dynDomain(t uint8) int {
+	switch {
+	case wire.TypeIsInt(t):
+		return 0
+	case wire.TypeIsFloat(t):
+		return 1
+	case wire.TypeIsBytes(t):
+		return 2
+	default:
+		return -1
+	}
+}
+
+// createType is the type a missing dynamic field or column is created with
+// (the oracle's treeCreateType): the op's own type byte, never "from schema"
+// — there is no schema to take one from. n arrives from applyOps' fixedN.
+func createType(typ, n uint8) (uint8, uint8, error) {
+	if typ == wire.OperateTypeFromSchema || !validDynScalarType(typ) {
+		return 0, 0, wire.ErrOperateType
+	}
+	if typ == wire.OperateTypeFixed && n < 1 {
+		return 0, 0, wire.ErrOperateType
+	}
+	return typ, n, nil
+}
+
+// zeroType sanitizes the type an absent target reads as. applyOps hands it
+// through resolve already sanitized (zeroTypeFor), so this only guards the
+// callers that pass a bare 0.
+func zeroType(typ, n uint8) (uint8, uint8) {
+	if !validDynScalarType(typ) {
+		return wire.OperateTypeU8, 0
+	}
+	if typ == wire.OperateTypeFixed && n < 1 {
+		return wire.OperateTypeU8, 0
+	}
+	return typ, n
+}
+
+// dynTargetType is §2.4/§2.9's rule for an EXISTING dynamic scalar: a control op
+// (create=false) never checks anything, 0xFF takes the stored type, SET
+// replaces the type outright, and every other op must agree with the stored
+// type's domain. It returns the type the op's value is computed and stored
+// in (the oracle's treeCheckDynType + treeRetype).
+func dynTargetType(create bool, opcode, typ, n, storedTyp, storedN uint8) (uint8, uint8, error) {
+	if !create || typ == wire.OperateTypeFromSchema {
+		return storedTyp, storedN, nil
+	}
+	if !validDynScalarType(typ) {
+		return 0, 0, wire.ErrOperateType
+	}
+	if opcode == wire.OperateOpSET {
+		if typ == wire.OperateTypeFixed && n < 1 {
+			// A FIXED operand with no usable width cannot retype anything, so
+			// the stored type stands (the oracle's treeRetype returns ok =
+			// false here). applyOps rejects such an op before resolve, so
+			// this only keeps the function total.
+			return storedTyp, storedN, nil
+		}
+		return typ, n, nil
+	}
+	if dynDomain(typ) != dynDomain(storedTyp) {
+		return 0, 0, wire.ErrOperateType
+	}
+	return storedTyp, storedN, nil
+}
+
+// --- resolve ---------------------------------------------------------------
+
+// resolve implements engine.resolve for dynamic mode: fields are addressed by
+// name only (positions are unstable, since fields are kept sorted by name),
+// and create vivifies a field, a row, and a column as the path needs.
+func (e *dynamicEngine) resolve(p wire.OperatePath, create bool, opcode, typ, n uint8) (ref, error) {
+	if e.inner != nil {
+		return e.inner.resolve(p, create, opcode, typ, n)
+	}
+	if p.Kind > wire.OperatePathCol {
+		return ref{}, wire.ErrOperatePath
+	}
+	if p.Kind == wire.OperatePathRecord {
+		// Presence of the record is whether it existed before this call
+		// (oracle ruling): CHECK((), ABSENT) means "this call created it".
+		return ref{kind: refKindRecord, field: -1, row: -1, col: -1, off: -1, present: e.existed}, nil
+	}
+	if !p.Field.ByName {
+		return ref{}, wire.ErrOperatePath
+	}
+	if len(p.Field.Name) > wire.OperateMaxNameLen {
+		return ref{}, wire.ErrOperateCap
+	}
+	if p.Kind != wire.OperatePathField {
+		if len(p.Key) == 0 {
+			return ref{}, wire.ErrOperatePath
+		}
+		if len(p.Key) > wire.OperateMaxKeyLen {
+			return ref{}, wire.ErrOperateCap
+		}
+	}
+	if p.Kind == wire.OperatePathCol {
+		if !p.Col.ByName {
+			return ref{}, wire.ErrOperatePath
+		}
+		if len(p.Col.Name) > wire.OperateMaxNameLen {
+			return ref{}, wire.ErrOperateCap
+		}
+	}
+
+	fi, found := e.findField(p.Field.Name)
+	if p.Kind == wire.OperatePathField {
+		return e.resolveField(p, create, opcode, typ, n, fi, found)
+	}
+	return e.resolveRowCol(p, create, opcode, typ, n, fi, found)
+}
+
+// resolveField resolves a field path, vivifying the field when create is set:
+// an empty table for CONFIG (whose target is a table's eviction config), the
+// op's own type's zero for anything else.
+func (e *dynamicEngine) resolveField(p wire.OperatePath, create bool, opcode, typ, n uint8, fi int, found bool) (ref, error) {
+	if !found {
+		if !create {
+			zt, zn := zeroType(typ, n)
+			return ref{kind: refKindScalar, field: -1, row: -1, col: -1, off: -1, typ: zt, n: zn}, nil
+		}
+		if opcode == wire.OperateOpCONFIG {
+			if err := e.insertTableField(fi, p.Field.Name); err != nil {
+				return ref{}, err
+			}
+			idx, _ := e.findField(p.Field.Name)
+			return ref{kind: refKindTable, field: idx, row: -1, col: -1, off: -1}, nil
+		}
+		ctyp, cn, err := createType(typ, n)
+		if err != nil {
+			return ref{}, err
+		}
+		if err := e.insertScalarField(fi, p.Field.Name, ctyp, cn); err != nil {
+			return ref{}, err
+		}
+		idx, _ := e.findField(p.Field.Name)
+		return ref{kind: refKindScalar, field: idx, row: -1, col: -1, off: e.fields[idx].typOff,
+			typ: ctyp, n: cn}, nil
+	}
+
+	f := &e.fields[fi]
+	if f.typ == wire.OperateTypeTable {
+		return ref{kind: refKindTable, field: fi, row: -1, col: -1, off: -1, present: true}, nil
+	}
+	if create && opcode == wire.OperateOpCONFIG {
+		// A scalar field cannot take a table's eviction config: it would have
+		// to become a table, which only DEL then a row write can do (oracle
+		// ruling, design doc §2.9).
+		return ref{}, wire.ErrOperatePath
+	}
+	rtyp, rn, err := dynTargetType(create, opcode, typ, n, f.typ, f.n)
+	if err != nil {
+		return ref{}, err
+	}
+	return ref{kind: refKindScalar, field: fi, row: -1, col: -1, off: f.typOff,
+		typ: rtyp, n: rn, present: true}, nil
+}
+
+// resolveRowCol resolves a row or column path, vivifying the table field, the
+// row (evicting first if the table is at its cap) and the column as create
+// requires.
+func (e *dynamicEngine) resolveRowCol(p wire.OperatePath, create bool, opcode, typ, n uint8, fi int, found bool) (ref, error) { //nolint:gocognit // one vivification step per path segment, mirroring the oracle
+	kind := refKindRow
+	if p.Kind == wire.OperatePathCol {
+		kind = refKindScalar
+	}
+	if !found {
+		if !create {
+			zt, zn := zeroType(typ, n)
+			return ref{kind: kind, field: -1, row: -1, col: -1, off: -1, typ: zt, n: zn}, nil
+		}
+		if err := e.insertTableField(fi, p.Field.Name); err != nil {
+			return ref{}, err
+		}
+		fi, _ = e.findField(p.Field.Name)
+	} else if e.fields[fi].typ != wire.OperateTypeTable {
+		return ref{}, wire.ErrOperatePath // a row path into a scalar field
+	}
+
+	t, err := e.table(fi)
+	if err != nil {
+		return ref{}, err
+	}
+	row, ri, rowFound, err := e.findRow(t, p.Key)
+	if err != nil {
+		return ref{}, err
+	}
+	if !rowFound {
+		if !create {
+			zt, zn := zeroType(typ, n)
+			return ref{kind: kind, field: fi, row: -1, col: -1, off: -1, typ: zt, n: zn}, nil
+		}
+		if t.capV > 0 && uint32(t.nRows) >= t.capV { //nolint:gosec // nRows bounded by OperateMaxRows
+			if err := e.evictOne(fi, t.policy, e.byColName(t)); err != nil {
+				return ref{}, err
+			}
+			if t, err = e.table(fi); err != nil {
+				return ref{}, err
+			}
+			if row, ri, rowFound, err = e.findRow(t, p.Key); err != nil {
+				return ref{}, err
+			}
+		}
+		if !rowFound {
+			if t.nRows+1 > wire.OperateMaxRows {
+				return ref{}, wire.ErrOperateCap
+			}
+			if err := e.insertRow(fi, t, row.off, p.Key); err != nil {
+				return ref{}, err
+			}
+			if t, err = e.table(fi); err != nil {
+				return ref{}, err
+			}
+			if row, ri, _, err = e.findRow(t, p.Key); err != nil {
+				return ref{}, err
+			}
+		}
+	}
+	if p.Kind == wire.OperatePathRow {
+		return ref{kind: refKindRow, field: fi, row: ri, col: -1, off: -1, present: rowFound}, nil
+	}
+
+	col, ci, colFound, err := e.findCol(row, p.Col.Name)
+	if err != nil {
+		return ref{}, err
+	}
+	if !colFound {
+		if !create {
+			zt, zn := zeroType(typ, n)
+			return ref{kind: refKindScalar, field: fi, row: ri, col: -1, off: -1, typ: zt, n: zn}, nil
+		}
+		ctyp, cn, cerr := createType(typ, n)
+		if cerr != nil {
+			return ref{}, cerr
+		}
+		if row.nCols+1 > wire.OperateMaxCols {
+			return ref{}, wire.ErrOperateCap
+		}
+		if err := e.insertCol(fi, ri, col.off, p.Col.Name, ctyp, cn); err != nil {
+			return ref{}, err
+		}
+		_, row, err = e.rowByIndex(fi, ri)
+		if err != nil {
+			return ref{}, err
+		}
+		if col, ci, _, err = e.findCol(row, p.Col.Name); err != nil {
+			return ref{}, err
+		}
+		return ref{kind: refKindScalar, field: fi, row: ri, col: ci, off: col.typOff, typ: ctyp, n: cn}, nil
+	}
+	rtyp, rn, err := dynTargetType(create, opcode, typ, n, col.typ, col.n)
+	if err != nil {
+		return ref{}, err
+	}
+	return ref{kind: refKindScalar, field: fi, row: ri, col: ci, off: col.typOff,
+		typ: rtyp, n: rn, present: true}, nil
+}
+
+// --- get and set -----------------------------------------------------------
+
+// get implements engine.get: the scalar at r, or its type's zero when the
+// target is absent — or when a SET is about to replace the stored type, since
+// the new type's zero is what the operand applies to (design doc §2.9).
+func (e *dynamicEngine) get(r ref) (wire.Cell, error) {
+	if e.inner != nil {
+		return e.inner.get(r)
+	}
+	if r.kind != refKindScalar {
+		return wire.Cell{}, wire.ErrOperatePath
+	}
+	if r.off < 0 {
+		return wire.ZeroCell(r.typ, r.n), nil
+	}
+	storedTyp, storedN, dataOff, err := e.taggedAt(r.off)
+	if err != nil {
+		return wire.Cell{}, err
+	}
+	if storedTyp != r.typ || storedN != r.n {
+		return wire.ZeroCell(r.typ, r.n), nil
+	}
+	c, _, err := wire.DecodeCellData(r.typ, r.n, e.buf[dataOff:])
+	if err != nil {
+		return wire.Cell{}, err
+	}
+	return c, nil
+}
+
+// taggedAt reads the [type][n iff FIXED] header a field or column stores in
+// front of its data, returning the type, the width, and the data's offset.
+func (e *dynamicEngine) taggedAt(off int) (uint8, uint8, int, error) {
+	if off < 0 || off >= len(e.buf) {
+		return 0, 0, 0, wire.ErrOperateRecord
+	}
+	typ := e.buf[off]
+	off++
+	var n uint8
+	if typ == wire.OperateTypeFixed {
+		if off >= len(e.buf) {
+			return 0, 0, 0, wire.ErrOperateRecord
+		}
+		n = e.buf[off]
+		off++
+	}
+	return typ, n, off, nil
+}
+
+// taggedEnd is one past the last byte of the [type][n?][data] entry at off.
+func (e *dynamicEngine) taggedEnd(off int) (int, error) {
+	typ, n, dataOff, err := e.taggedAt(off)
+	if err != nil {
+		return 0, err
+	}
+	ln, err := cellDataLen(typ, n, e.buf[dataOff:])
+	if err != nil {
+		return 0, err
+	}
+	return dataOff + ln, nil
+}
+
+// set implements engine.set: a cell whose stored width does not change is
+// overwritten in place — the whole point of the byte engine — and anything
+// else (a new type, a varint that grew, a BYTES value) is spliced, with every
+// enclosing length prefix rewritten.
+func (e *dynamicEngine) set(r ref, c wire.Cell) error {
+	if e.inner != nil {
+		return e.inner.set(r, c)
+	}
+	if r.kind != refKindScalar || r.off < 0 {
+		return wire.ErrOperatePath
+	}
+	storedTyp, storedN, dataOff, err := e.taggedAt(r.off)
+	if err != nil {
+		return err
+	}
+	if c.Type == wire.OperateTypeFixed && len(c.B) != int(c.N) {
+		return wire.ErrOperateType
+	}
+	if c.Type == wire.OperateTypeBytes && len(c.B) > wire.OperateMaxBytesLen {
+		return wire.ErrOperateCap
+	}
+	if storedTyp == c.Type && storedN == c.N {
+		if w := wire.CellWidth(c.Type, c.N); w >= 0 {
+			if len(e.buf)-dataOff < w {
+				return wire.ErrOperateRecord
+			}
+			copy(e.buf[dataOff:dataOff+w], wire.AppendCellData(e.scratch[:0], c))
+			return nil
+		}
+	}
+	end, err := e.taggedEnd(r.off)
+	if err != nil {
+		return err
+	}
+	e.enc = wire.AppendTaggedCell(e.enc[:0], c)
+	return e.spliceValue(r, r.off, end-r.off, e.enc)
+}
+
+// spliceValue replaces the entry at [off, off+oldLen) with repl and rewrites
+// the enclosing lengths: nothing for a record field (its bytes are the
+// record's own), rowLen and the table's byteLen for a column.
+func (e *dynamicEngine) spliceValue(r ref, off, oldLen int, repl []byte) error {
+	delta := len(repl) - oldLen
+	if r.row < 0 {
+		if err := e.charge(delta); err != nil {
+			return err
+		}
+		e.buf = splice(e.buf, off, oldLen, repl)
+		return e.reindex()
+	}
+	// The row's and the table's length prefixes can widen along with the value
+	// they cover, so their worst case is charged before the first splice too.
+	if err := e.charge(delta + 2*binary.MaxVarintLen64); err != nil {
+		return err
+	}
+	t, row, err := e.rowByIndex(r.field, r.row)
+	if err != nil {
+		return err
+	}
+	e.buf = splice(e.buf, off, oldLen, repl)
+	if err := e.patchRowLen(t, row, delta); err != nil {
+		return err
+	}
+	return e.reindex()
+}
+
+// patchRowLen rewrites a row's length prefix and then the table's byteLen,
+// from the inside out: the row's prefix sits after the table's, so rewriting
+// it (and changing its width) cannot move the table's own offset. bodyDelta
+// is how much the row's body grew or shrank.
+func (e *dynamicEngine) patchRowLen(t dynTable, row dynRow, bodyDelta int) error {
+	newBody := row.bodyLen + bodyDelta
+	if newBody < 0 {
+		return wire.ErrOperateRecord
+	}
+	buf, m := spliceUvarint(e.buf, row.off, row.lenLen, uint64(newBody)) //nolint:gosec // checked non-negative above
+	e.buf = buf
+	return e.patchTableLen(t, bodyDelta+m-row.lenLen)
+}
+
+// patchTableLen rewrites just the table's byteLen after an edit inside it.
+func (e *dynamicEngine) patchTableLen(t dynTable, delta int) error {
+	newByteLen := t.byteLen + delta
+	if newByteLen < 0 {
+		return wire.ErrOperateRecord
+	}
+	e.buf, _ = spliceUvarint(e.buf, t.lenOff, t.lenLen, uint64(newByteLen)) //nolint:gosec // checked non-negative above
+	return nil
+}
+
+// charge rejects a growth that would take the record past the §2.7
+// record-size cap before the splice allocates for it.
+func (e *dynamicEngine) charge(delta int) error {
+	if delta > 0 && len(e.buf)+delta > maxOperateRecordBytes {
+		return wire.ErrOperateCap
+	}
+	return nil
+}
+
+// reindex re-walks the field level after a splice.
+func (e *dynamicEngine) reindex() error { return e.walk(false) }
+
+// --- splice paths: fields, rows, columns -----------------------------------
+
+// insertScalarField splices a fresh field, holding its type's zero, in at its
+// sorted position idx.
+func (e *dynamicEngine) insertScalarField(idx int, name string, typ, n uint8) error {
+	e.enc = appendDynName(e.enc[:0], name)
+	e.enc = wire.AppendTaggedCell(e.enc, wire.ZeroCell(typ, n))
+	return e.insertField(idx, e.enc)
+}
+
+// insertTableField splices an empty table field — no rows and no eviction
+// config — in at its sorted position idx.
+func (e *dynamicEngine) insertTableField(idx int, name string) error {
+	e.enc = appendDynName(e.enc[:0], name)
+	e.enc = append(e.enc, wire.OperateTypeTable)
+	// [cap 0][policy 0][byColLen 0][nRows 0], and the byteLen that covers it.
+	e.enc = binary.AppendUvarint(e.enc, 4)
+	e.enc = append(e.enc, 0, 0, 0, 0)
+	return e.insertField(idx, e.enc)
+}
+
+// insertField splices one encoded field entry in at sorted position idx and
+// rewrites nFields.
+func (e *dynamicEngine) insertField(idx int, entry []byte) error {
+	if len(e.fields)+1 > wire.OperateMaxFields {
+		return wire.ErrOperateCap
+	}
+	at := len(e.buf)
+	if idx < len(e.fields) {
+		at = e.fields[idx].off
+	}
+	if err := e.charge(len(entry) + binary.MaxVarintLen64); err != nil {
+		return err
+	}
+	e.buf = splice(e.buf, at, 0, entry)
+	e.buf, _ = spliceUvarint(e.buf, e.nOff, e.nLen, uint64(len(e.fields)+1))
+	return e.reindex()
+}
+
+// removeField splices field fi out entirely and rewrites nFields. A dynamic
+// field is removed, not zeroed: there is no schema declaring it (design doc
+// §2.5), which is also why losing the last one deletes the record.
+func (e *dynamicEngine) removeField(fi int) error {
+	if fi < 0 || fi >= len(e.fields) {
+		return nil
+	}
+	f := e.fields[fi]
+	e.buf = splice(e.buf, f.off, f.end-f.off, nil)
+	e.buf, _ = spliceUvarint(e.buf, e.nOff, e.nLen, uint64(len(e.fields)-1))
+	return e.reindex()
+}
+
+// insertRow splices an empty row (key, no columns) in at its sorted offset
+// and rewrites nRows and the table's byteLen.
+func (e *dynamicEngine) insertRow(fi int, t dynTable, at int, key []byte) error {
+	body := append(e.enc[:0], byte(len(key))) //nolint:gosec // key length bounded by OperateMaxKeyLen in resolve
+	body = append(body, key...)
+	body = append(body, 0) // nCols = 0
+	e.enc = body
+	var hdr [binary.MaxVarintLen64]byte
+	m := binary.PutUvarint(hdr[:], uint64(len(body)))
+	if err := e.charge(m + len(body) + binary.MaxVarintLen64); err != nil {
+		return err
+	}
+	e.buf = splice(e.buf, at, 0, hdr[:m])
+	e.buf = splice(e.buf, at+m, 0, body)
+
+	rowBytes := m + len(body)
+	buf, m2 := spliceUvarint(e.buf, t.nRowsOff, t.nRowsLen, uint64(t.nRows+1)) //nolint:gosec // nRows >= 0
+	e.buf = buf
+	if err := e.patchTableLen(t, rowBytes+m2-t.nRowsLen); err != nil {
+		return err
+	}
+	return e.reindex()
+}
+
+// removeRow splices row ri out of the table field at fi and rewrites nRows
+// and byteLen.
+func (e *dynamicEngine) removeRow(fi, ri int) error {
+	t, row, err := e.rowByIndex(fi, ri)
+	if err != nil {
+		return err
+	}
+	removed := row.end - row.off
+	e.buf = splice(e.buf, row.off, removed, nil)
+	buf, m := spliceUvarint(e.buf, t.nRowsOff, t.nRowsLen, uint64(t.nRows-1)) //nolint:gosec // ri < nRows, so nRows >= 1
+	e.buf = buf
+	if err := e.patchTableLen(t, m-t.nRowsLen-removed); err != nil {
+		return err
+	}
+	return e.reindex()
+}
+
+// insertCol splices a fresh column, holding its type's zero, into row ri at
+// its sorted offset, and rewrites nCols, rowLen and byteLen.
+func (e *dynamicEngine) insertCol(fi, ri, at int, name string, typ, n uint8) error {
+	e.enc = appendDynName(e.enc[:0], name)
+	e.enc = wire.AppendTaggedCell(e.enc, wire.ZeroCell(typ, n))
+	entry := e.enc
+	if err := e.charge(len(entry) + 2*binary.MaxVarintLen64); err != nil {
+		return err
+	}
+	t, row, err := e.rowByIndex(fi, ri)
+	if err != nil {
+		return err
+	}
+	e.buf = splice(e.buf, at, 0, entry)
+	buf, m := spliceUvarint(e.buf, row.nColsOff, row.nColsLen, uint64(row.nCols+1)) //nolint:gosec // nCols >= 0
+	e.buf = buf
+	if err := e.patchRowLen(t, row, len(entry)+m-row.nColsLen); err != nil {
+		return err
+	}
+	return e.reindex()
+}
+
+// removeCol splices column ci out of row ri and rewrites nCols, rowLen and
+// byteLen. Ruling (the oracle's): the row survives losing its last column — a
+// row is a keyed entity, and an empty column list encodes fine.
+func (e *dynamicEngine) removeCol(fi, ri, ci int) error {
+	t, row, err := e.rowByIndex(fi, ri)
+	if err != nil {
+		return err
+	}
+	c, err := e.colByIndex(row, ci)
+	if err != nil {
+		return err
+	}
+	removed := c.end - c.off
+	e.buf = splice(e.buf, c.off, removed, nil)
+	buf, m := spliceUvarint(e.buf, row.nColsOff, row.nColsLen, uint64(row.nCols-1)) //nolint:gosec // ci < nCols, so nCols >= 1
+	e.buf = buf
+	if err := e.patchRowLen(t, row, m-row.nColsLen-removed); err != nil {
+		return err
+	}
+	return e.reindex()
+}
+
+// appendDynName appends a stored [nlen u8][name] pair. The caller has already
+// bounded the name at OperateMaxNameLen.
+func appendDynName(dst []byte, name string) []byte {
+	dst = append(dst, byte(len(name))) //nolint:gosec // bounded by OperateMaxNameLen in resolve
+	return append(dst, name...)
+}
+
+// --- del, count ------------------------------------------------------------
+
+// del implements engine.del (design doc §3.1/§2.5): the record is marked
+// deleted, and a dynamic field, row or column is removed outright rather than
+// zeroed. Deleting something absent is a no-op.
+func (e *dynamicEngine) del(r ref) error {
+	if e.inner != nil {
+		return e.inner.del(r)
+	}
+	switch r.kind {
+	case refKindRecord:
+		e.deleted = true
+		return nil
+	case refKindTable:
+		// Ruling (the oracle's): in dynamic mode DEL of a field removes the
+		// field whatever it holds — unlike schema mode, where a table field
+		// is declared by the schema and can only be emptied.
+		return e.removeField(r.field)
+	case refKindRow:
+		if !r.present {
+			return nil
+		}
+		return e.removeRow(r.field, r.row)
+	default: // refKindScalar: a field or a column
+		if !r.present {
+			return nil
+		}
+		if r.row < 0 {
+			return e.removeField(r.field)
+		}
+		return e.removeCol(r.field, r.row, r.col)
+	}
+}
+
+// count implements engine.count (design doc §3.3/§3.4): fields for the
+// record, rows for a table, and presence as 1/0 for a row or a scalar.
+func (e *dynamicEngine) count(r ref) (uint64, error) {
+	if e.inner != nil {
+		return e.inner.count(r)
+	}
+	switch r.kind {
+	case refKindRecord:
+		return uint64(len(e.fields)), nil //nolint:gosec // bounded by OperateMaxFields
+	case refKindTable:
+		t, err := e.table(r.field)
+		if err != nil {
+			return 0, err
+		}
+		return uint64(t.nRows), nil //nolint:gosec // nRows >= 0
+	default:
+		if r.present {
+			return 1, nil
+		}
+		return 0, nil
+	}
+}
+
+// --- eviction, TRIM and CONFIG ---------------------------------------------
+
+// evictOne removes the victim the policy names (design doc §2.3): the
+// smallest or largest key (the ends of the sorted table), or the smallest or
+// largest value in the eviction column, ties going to the smallest key.
+//
+// Ruling (mirrors the oracle): a cap above 0 with PolicyNone still needs a
+// deterministic victim — it evicts by MIN_KEY, as does any unknown policy.
+func (e *dynamicEngine) evictOne(fi int, policy uint8, byColName []byte) error {
+	t, err := e.table(fi)
+	if err != nil {
+		return err
+	}
+	if t.nRows == 0 {
+		return nil
+	}
+	victim := 0
+	switch policy {
+	case wire.OperatePolicyMaxKey:
+		victim = t.nRows - 1
+	case wire.OperatePolicyMinCol, wire.OperatePolicyMaxCol:
+		if victim, err = e.colVictim(t, policy == wire.OperatePolicyMaxCol, byColName); err != nil {
+			return err
+		}
+	default:
+		victim = 0
+	}
+	return e.removeRow(fi, victim)
+}
+
+// colVictim scans the table once for the row with the smallest (or largest)
+// value in the eviction column; a row that does not carry the column reads as
+// zero (design doc §2.4), and ties go to the first row in stored order, which
+// is the smallest key.
+func (e *dynamicEngine) colVictim(t dynTable, wantMax bool, byColName []byte) (int, error) {
+	best := 0
+	var bestCell wire.Cell
+	off := t.rowsOff
+	for i := 0; i < t.nRows; i++ {
+		row, err := e.rowAt(off, t.end)
+		if err != nil {
+			return 0, err
+		}
+		c, err := e.evictCell(row, byColName)
+		if err != nil {
+			return 0, err
+		}
+		if i == 0 {
+			bestCell = c
+		} else if ord := compareDynCells(c, bestCell); (wantMax && ord > 0) || (!wantMax && ord < 0) {
+			best, bestCell = i, c
+		}
+		off = row.end
+	}
+	return best, nil
+}
+
+// evictCell reads a row's eviction column, or the integer zero when the row
+// does not carry it.
+func (e *dynamicEngine) evictCell(row dynRow, byColName []byte) (wire.Cell, error) {
+	off := row.colsOff
+	for i := 0; i < row.nCols; i++ {
+		c, err := e.colAt(off, row.end)
+		if err != nil {
+			return wire.Cell{}, err
+		}
+		switch bytes.Compare(e.buf[c.nameOff:c.nameOff+c.nameLen], byColName) {
+		case 0:
+			cell, _, derr := wire.DecodeCellData(c.typ, c.n, e.buf[c.valOff:c.end])
+			if derr != nil {
+				return wire.Cell{}, derr
+			}
+			return cell, nil
+		case 1:
+			return wire.Cell{Type: wire.OperateTypeU8}, nil // sorted by name: past it
+		}
+		off = c.end
+	}
+	return wire.Cell{Type: wire.OperateTypeU8}, nil
+}
+
+// compareDynCells orders two cells deterministically (the oracle's
+// treeCompareCells). Within a domain the comparison is the natural one;
+// across domains — reachable in dynamic mode, where two rows may store
+// different types under one column name — the domain rank (int < float <
+// bytes) orders them, so the victim stays a pure function of the bytes.
+func compareDynCells(a, b wire.Cell) int {
+	da, db := dynDomain(a.Type), dynDomain(b.Type)
+	if da != db {
+		if da < db {
+			return -1
+		}
+		return 1
+	}
+	switch da {
+	case 1:
+		switch {
+		case a.F < b.F:
+			return -1
+		case a.F > b.F:
+			return 1
+		default:
+			return 0
+		}
+	case 2:
+		return bytes.Compare(a.B, b.B)
+	case 0:
+		return compareDynInts(a, b)
+	default:
+		return 0
+	}
+}
+
+// compareDynInts orders two integer cells exactly, including a signed cell
+// against an unsigned one (a negative value is below every unsigned value).
+func compareDynInts(a, b wire.Cell) int {
+	au, bu := wire.TypeIsUnsigned(a.Type), wire.TypeIsUnsigned(b.Type)
+	switch {
+	case au && bu:
+		switch {
+		case a.U < b.U:
+			return -1
+		case a.U > b.U:
+			return 1
+		default:
+			return 0
+		}
+	case !au && !bu:
+		x, y := int64(a.U), int64(b.U) //nolint:gosec // reinterpret the stored signed bits
+		switch {
+		case x < y:
+			return -1
+		case x > y:
+			return 1
+		default:
+			return 0
+		}
+	case au:
+		return -compareDynMixed(b, a)
+	default:
+		return compareDynMixed(a, b)
+	}
+}
+
+func compareDynMixed(signed, unsigned wire.Cell) int {
+	s := int64(signed.U) //nolint:gosec // reinterpret the stored signed bits
+	if s < 0 {
+		return -1
+	}
+	switch {
+	case uint64(s) < unsigned.U:
+		return -1
+	case uint64(s) > unsigned.U:
+		return 1
+	default:
+		return 0
+	}
+}
+
+// trim implements engine.trim (design doc §3.2): a one-off shrink to keep
+// rows by the op's own policy, leaving the table's stored eviction config
+// alone. It is a shrink, not a write, so an absent field is a no-op.
+func (e *dynamicEngine) trim(r ref, keep uint32, policy uint8, byCol uint16, byColName string) error {
+	_ = byCol // dynamic mode addresses the eviction column by name
+	if e.inner != nil {
+		return e.inner.trim(r, keep, policy, byCol, byColName)
+	}
+	if policy > wire.OperatePolicyMaxCol {
+		return wire.ErrOperateSchema
+	}
+	if r.kind != refKindTable {
+		if r.kind == refKindScalar && !r.present {
+			return nil // an absent dynamic table field: nothing to shrink
+		}
+		return wire.ErrOperatePath
+	}
+	if policy == wire.OperatePolicyMinCol || policy == wire.OperatePolicyMaxCol {
+		if byColName == "" {
+			// Mirrors Schema.Validate's "ByCol must name a real column" rule
+			// for a *_COL policy (oracle ruling).
+			return wire.ErrOperatePath
+		}
+	}
+	name := []byte(byColName)
+	for {
+		t, err := e.table(r.field)
+		if err != nil {
+			return err
+		}
+		if uint64(t.nRows) <= uint64(keep) { //nolint:gosec // nRows >= 0
+			return nil
+		}
+		if err := e.evictOne(r.field, policy, name); err != nil {
+			return err
+		}
+	}
+}
+
+// config implements engine.config (design doc §3.2): it writes the table's
+// eviction triple into the stored header and evicts down to the new cap.
+func (e *dynamicEngine) config(r ref, capN uint32, policy uint8, byColName string) error {
+	if e.inner != nil {
+		return e.inner.config(r, capN, policy, byColName)
+	}
+	// The name-length bound comes first because applyOps cannot check it: it
+	// is a cap on the op's operand, and the oracle reports it before it looks
+	// at the policy byte.
+	if len(byColName) > wire.OperateMaxNameLen {
+		return wire.ErrOperateCap
+	}
+	if policy > wire.OperatePolicyMaxCol {
+		// An unknown policy byte is a schema-shaped error, the same one
+		// Schema.Validate returns for a table declaring it (oracle ruling).
+		return wire.ErrOperateSchema
+	}
+	if (policy == wire.OperatePolicyMinCol || policy == wire.OperatePolicyMaxCol) && byColName == "" {
+		return wire.ErrOperatePath
+	}
+	if r.kind != refKindTable {
+		return wire.ErrOperatePath
+	}
+	t, err := e.table(r.field)
+	if err != nil {
+		return err
+	}
+	hdr := binary.AppendUvarint(e.enc[:0], uint64(capN))
+	hdr = append(hdr, policy)
+	hdr = appendDynName(hdr, byColName)
+	e.enc = hdr
+	oldLen := t.nRowsOff - t.capOff
+	if err := e.charge(len(hdr) - oldLen); err != nil {
+		return err
+	}
+	e.buf = splice(e.buf, t.capOff, oldLen, hdr)
+	if err := e.patchTableLen(t, len(hdr)-oldLen); err != nil {
+		return err
+	}
+	if err := e.reindex(); err != nil {
+		return err
+	}
+
+	name := []byte(byColName)
+	for capN > 0 {
+		t, err := e.table(r.field)
+		if err != nil {
+			return err
+		}
+		if uint32(t.nRows) <= capN { //nolint:gosec // nRows bounded by OperateMaxRows
+			break
+		}
+		if err := e.evictOne(r.field, policy, name); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// --- migrate (the freeze) --------------------------------------------------
+
+// migrate implements engine.migrate for dynamic mode (design doc §2.9): the
+// only migration a dynamic record accepts is a freeze into schema mode. The
+// schema blob is decoded (and its layout resolved) first, so a malformed blob
+// is reported as such whatever the from-version says — the oracle's order.
+func (e *dynamicEngine) migrate(from int64, flags uint8, schemaBlob []byte) error {
+	if e.inner != nil {
+		return e.inner.migrate(from, flags, schemaBlob)
+	}
+	ent, err := e.cache.lookupCall(schemaBlob)
+	if err != nil {
+		return err
+	}
+	if from != wire.OperateMigrateFromDynamic {
+		// An append-only evolution (§2.8) needs a schema-mode record to
+		// extend; this one has no schema to extend from.
+		return wire.ErrOperateMode
+	}
+	if !ent.schema.StoreNames {
+		// A freeze matches dynamic fields and columns by name, so the target
+		// schema has to carry them.
+		return wire.ErrOperateSchema
+	}
+	return e.freeze(ent, flags&wire.OperateMigrateDropExtra != 0)
+}
+
+// freeze rewrites the record in schema mode: every schema field and column is
+// filled from the dynamic value of the same name (domains must match, widths
+// saturate), rows are packed fixed-width in the schema's key order and
+// evicted down to the schema's cap, and a dynamic field or column the schema
+// does not have is an error unless dropExtra is set.
+func (e *dynamicEngine) freeze(ent *schemaEntry, dropExtra bool) error {
+	s, layout := ent.schema, ent.layout
+	cells := make([]wire.Cell, len(s.Fields))
+	tables := make([][]byte, len(s.Fields))
+	rowCounts := make([]int, len(s.Fields))
+	matched := 0
+
+	for i := range s.Fields {
+		fd := &s.Fields[i]
+		if fd.Name == "" {
+			return wire.ErrOperateSchema
+		}
+		fi, found := e.findField(fd.Name)
+		if found {
+			matched++
+		}
+
+		if fd.Type != wire.OperateTypeTable {
+			var src wire.Cell
+			if found {
+				f := &e.fields[fi]
+				if f.typ == wire.OperateTypeTable {
+					return wire.ErrOperateType
+				}
+				c, _, err := wire.DecodeCellData(f.typ, f.n, e.buf[f.valOff:f.end])
+				if err != nil {
+					return err
+				}
+				src = c
+			}
+			c, err := convertCell(src, found, fd.Type, fd.N)
+			if err != nil {
+				return err
+			}
+			cells[i] = c
+			continue
+		}
+
+		packed, rows, err := e.freezeTable(fi, found, fd, layout.Tables[i], dropExtra)
+		if err != nil {
+			return err
+		}
+		cells[i] = wire.Cell{Type: wire.OperateTypeTable}
+		tables[i], rowCounts[i] = packed, rows
+	}
+
+	if !dropExtra && matched != len(e.fields) {
+		return wire.ErrOperateSchema
+	}
+	return e.installFrozen(ent, cells, tables, rowCounts)
+}
+
+// freezeTable packs one dynamic table into the schema's fixed-width row
+// layout, sorted by the schema's key comparison and evicted down to its cap.
+func (e *dynamicEngine) freezeTable(fi int, found bool, fd *wire.FieldDef, tl *wire.TableLayout, dropExtra bool) ([]byte, int, error) {
+	td := fd.Table
+	if !found {
+		return nil, 0, nil
+	}
+	f := &e.fields[fi]
+	if f.typ != wire.OperateTypeTable {
+		return nil, 0, wire.ErrOperateType
+	}
+	t, err := e.table(fi)
+	if err != nil {
+		return nil, 0, err
+	}
+	// rows x the NEW row width can reach 2^20 x 4096, which wraps a 32-bit
+	// int: the projection is charged in uint64 before anything is allocated.
+	if tableBytes(t.nRows, tl.RowWidth) > uint64(maxOperateRecordBytes) { //nolint:gosec // maxOperateRecordBytes > 0
+		return nil, 0, wire.ErrOperateCap
+	}
+
+	packed := make([]byte, 0, t.nRows*tl.RowWidth)
+	off := t.rowsOff
+	for i := 0; i < t.nRows; i++ {
+		row, rerr := e.rowAt(off, t.end)
+		if rerr != nil {
+			return nil, 0, rerr
+		}
+		// Ruling (the oracle's): a schema-mode row key is exactly the table's
+		// key width, so a dynamic key of any other length cannot be packed.
+		if row.keyLen != tl.KeyWidth {
+			return nil, 0, wire.ErrOperateSchema
+		}
+		packed = append(packed, e.buf[row.keyOff:row.keyOff+row.keyLen]...)
+		hits := 0
+		for c := range td.Cols {
+			cd := &td.Cols[c]
+			if cd.Name == "" {
+				return nil, 0, wire.ErrOperateSchema
+			}
+			col, _, colFound, cerr := e.findCol(row, cd.Name)
+			if cerr != nil {
+				return nil, 0, cerr
+			}
+			var src wire.Cell
+			if colFound {
+				hits++
+				cell, _, derr := wire.DecodeCellData(col.typ, col.n, e.buf[col.valOff:col.end])
+				if derr != nil {
+					return nil, 0, derr
+				}
+				src = cell
+			}
+			cell, cerr2 := convertCell(src, colFound, cd.Type, cd.N)
+			if cerr2 != nil {
+				return nil, 0, cerr2
+			}
+			packed = wire.AppendCellData(packed, cell)
+		}
+		if hits != row.nCols && !dropExtra {
+			return nil, 0, wire.ErrOperateSchema
+		}
+		off = row.end
+	}
+
+	rows := t.nRows
+	packed = sortPackedRows(packed, rows, tl, td.KeyType)
+	for td.Cap > 0 && uint32(rows) > td.Cap { //nolint:gosec // rows bounded by OperateMaxRows
+		packed, rows = evictPackedRow(packed, rows, tl, td)
+	}
+	return packed, rows, nil
+}
+
+// sortPackedRows reorders fixed-width packed rows into the schema's key
+// order: numeric keys compare as little-endian integers, FIXED keys
+// bytewise. The rows arrive in the dynamic record's bytewise key order, which
+// already is the schema's order for a FIXED key, so only a numeric key can
+// need the reorder — and even then only when the two orders differ.
+func sortPackedRows(packed []byte, rows int, tl *wire.TableLayout, keyType uint8) []byte {
+	if rows < 2 || keyType == wire.OperateTypeFixed {
+		return packed
+	}
+	w := tl.RowWidth
+	key := func(i int) []byte { return packed[i*w : i*w+tl.KeyWidth] }
+	idx := make([]int, rows)
+	for i := range idx {
+		idx[i] = i
+	}
+	sort.Slice(idx, func(a, b int) bool {
+		return compareRowKey(key(idx[a]), key(idx[b]), keyType) < 0
+	})
+	moved := false
+	for i := range idx {
+		if idx[i] != i {
+			moved = true
+			break
+		}
+	}
+	if !moved {
+		return packed
+	}
+	out := make([]byte, rows*w)
+	for i, src := range idx {
+		copy(out[i*w:(i+1)*w], packed[src*w:(src+1)*w])
+	}
+	return out
+}
+
+// evictPackedRow removes the victim the schema's policy names from packed
+// rows, returning the shortened buffer and row count.
+func evictPackedRow(packed []byte, rows int, tl *wire.TableLayout, td *wire.TableDef) ([]byte, int) {
+	if rows == 0 {
+		return packed, 0
+	}
+	w := tl.RowWidth
+	victim := 0
+	switch td.Policy {
+	case wire.OperatePolicyMaxKey:
+		victim = rows - 1
+	case wire.OperatePolicyMinCol, wire.OperatePolicyMaxCol:
+		byCol := int(td.ByCol)
+		if byCol >= 0 && byCol < len(td.Cols) {
+			typ, n := td.Cols[byCol].Type, td.Cols[byCol].N
+			width := wire.CellWidth(typ, n)
+			at := tl.ColOff[byCol]
+			wantMax := td.Policy == wire.OperatePolicyMaxCol
+			bestAt := at
+			for i := 1; i < rows; i++ {
+				cur := i*w + at
+				ord := compareCellBytes(packed[cur:cur+width], packed[bestAt:bestAt+width], typ)
+				if (wantMax && ord > 0) || (!wantMax && ord < 0) {
+					victim, bestAt = i, cur
+				}
+			}
+		}
+	default:
+		victim = 0
+	}
+	copy(packed[victim*w:], packed[(victim+1)*w:rows*w])
+	return packed[:(rows-1)*w], rows - 1
+}
+
+// convertCell re-types src as (typ, n) for a freeze (design doc §2.9): the
+// domains must match and widths saturate, which is exactly a SET of the
+// source value into a zero cell of the target type.
+func convertCell(src wire.Cell, present bool, typ, n uint8) (wire.Cell, error) {
+	dst := wire.ZeroCell(typ, n)
+	if !present {
+		return dst, nil
+	}
+	if dynDomain(src.Type) != dynDomain(typ) || dynDomain(typ) < 0 {
+		return wire.Cell{}, wire.ErrOperateType
+	}
+	var op wire.Operand
+	switch dynDomain(typ) {
+	case 0:
+		op.A = intOperand(src)
+	case 1:
+		op.A = int64(math.Float64bits(src.F)) //nolint:gosec // a float operand travels as its bit pattern
+	default:
+		op.Bytes = src.B
+	}
+	return wire.ApplyScalar(wire.OperateOpSET, dst, false, op)
+}
+
+// intOperand renders an integer cell as the int64 operand a SET carries,
+// saturating an unsigned value that does not fit.
+func intOperand(c wire.Cell) int64 {
+	if wire.TypeIsUnsigned(c.Type) && c.U > math.MaxInt64 {
+		return math.MaxInt64
+	}
+	return int64(c.U) //nolint:gosec // reinterpret the stored bits
+}
+
+// installFrozen writes the schema-mode record the freeze produced and hands
+// the engine over to a schema engine on it: every later op in this call, and
+// every return spec, must see the frozen record.
+func (e *dynamicEngine) installFrozen(ent *schemaEntry, cells []wire.Cell, tables [][]byte, rowCounts []int) error {
+	s, layout := ent.schema, ent.layout
+	size := uint64(1) + uint64(len(ent.blob)) + uint64(layout.FixedLen)
+	for _, i := range layout.VarTail {
+		if s.Fields[i].Type == wire.OperateTypeTable {
+			size += uint64(uvarintLen(uint64(rowCounts[i]))) + uint64(len(tables[i])) //nolint:gosec // rowCounts >= 0
+			continue
+		}
+		size += uint64(len(wire.AppendCellData(nil, cells[i])))
+	}
+	if size > uint64(maxOperateRecordBytes) { //nolint:gosec // maxOperateRecordBytes > 0
+		return wire.ErrOperateCap
+	}
+
+	out := make([]byte, 0, size+64)
+	out = append(out, wire.OperateModeSchema)
+	out = append(out, ent.blob...)
+	for i := range s.Fields {
+		if layout.FixedOff[i] < 0 {
+			continue
+		}
+		out = wire.AppendCellData(out, cells[i])
+	}
+	for _, i := range layout.VarTail {
+		if s.Fields[i].Type == wire.OperateTypeTable {
+			out = binary.AppendUvarint(out, uint64(rowCounts[i])) //nolint:gosec // rowCounts >= 0
+			out = append(out, tables[i]...)
+			continue
+		}
+		out = wire.AppendCellData(out, cells[i])
+	}
+
+	inner, err := newSchemaEngine(out, e.cache)
+	if err != nil {
+		return err
+	}
+	inner.existed = e.existed
+	inner.deleted = e.deleted
+	e.inner = inner
+	e.buf = out
+	e.fields = e.fields[:0]
+	return nil
+}
+
+// --- value, bytes, empty ---------------------------------------------------
+
+// value implements engine.value (design doc §3.4): the whole record, the
+// table's stored value behind the mode byte, a row's named columns as tagged
+// cells, or one tagged scalar.
+func (e *dynamicEngine) value(r ref) ([]byte, error) {
+	if e.inner != nil {
+		return e.inner.value(r)
+	}
+	switch r.kind {
+	case refKindRecord:
+		return append([]byte(nil), e.buf...), nil
+	case refKindTable:
+		// Ruling (the oracle's): no names ride along for the table itself —
+		// the mode byte says which of the two table layouts follows, and the
+		// bytes are exactly the ones the record encoder emits for the field.
+		if r.field < 0 || r.field >= len(e.fields) {
+			return nil, wire.ErrOperatePath
+		}
+		f := &e.fields[r.field]
+		out := make([]byte, 0, 1+f.end-f.valOff)
+		out = append(out, wire.OperateModeDynamic)
+		return append(out, e.buf[f.valOff:f.end]...), nil
+	case refKindRow:
+		_, row, err := e.rowByIndex(r.field, r.row)
+		if err != nil {
+			return nil, err
+		}
+		// [mode][nCols]{[nlen][name] tagged}: a stored column entry is
+		// already [nlen][name][type][n?][data], so the row's own bytes are
+		// the answer.
+		out := make([]byte, 0, 1+row.end-row.nColsOff)
+		out = append(out, wire.OperateModeDynamic)
+		return append(out, e.buf[row.nColsOff:row.end]...), nil
+	default:
+		end, err := e.taggedEnd(r.off)
+		if err != nil {
+			return nil, err
+		}
+		return append([]byte(nil), e.buf[r.off:end]...), nil
+	}
+}
+
+// bytes implements engine.bytes: the record's current encoded form, which is
+// the engine's working buffer itself.
+func (e *dynamicEngine) bytes() []byte {
+	if e.inner != nil {
+		return e.inner.bytes()
+	}
+	return e.buf
+}
+
+// empty implements engine.empty: a dynamic record that lost its last field is
+// deleted (design doc §2.5) — there is no schema declaring an empty shell, so
+// an empty dynamic record has no meaning. A frozen record answers as the
+// schema record it now is.
+func (e *dynamicEngine) empty() bool {
+	if e.inner != nil {
+		return e.inner.empty()
+	}
+	return e.deleted || len(e.fields) == 0
+}

--- a/ops/operate_dynamic_engine.go
+++ b/ops/operate_dynamic_engine.go
@@ -58,7 +58,7 @@ type dynField struct {
 type dynTable struct {
 	lenOff, lenLen     int
 	byteLen            int
-	capOff, capLen     int
+	capOff             int
 	policyOff          int
 	byColOff, byColLen int // byColOff is the byColLen byte; byColLen the name's length
 	nRowsOff, nRowsLen int
@@ -480,7 +480,7 @@ func (e *dynamicEngine) parseTableAt(lenOff, innerOff, innerLen int) (dynTable, 
 	if capV > wire.OperateMaxRows {
 		return dynTable{}, wire.ErrOperateRecord
 	}
-	t.capOff, t.capLen, t.capV = innerOff, m, uint32(capV) //nolint:gosec // bounded by OperateMaxRows above
+	t.capOff, t.capV = innerOff, uint32(capV) //nolint:gosec // bounded by OperateMaxRows above
 	off := innerOff + m
 
 	if t.end-off < 1 {
@@ -502,6 +502,14 @@ func (e *dynamicEngine) parseTableAt(lenOff, innerOff, innerLen int) (dynTable, 
 		return dynTable{}, wire.ErrOperateRecord
 	}
 	off += t.byColLen
+	// A MIN_COL/MAX_COL policy evicts by a named column, so it is meaningless
+	// without the name (design doc §3.2). wire.DecodeRecord rejects the
+	// pairing; so must this parse, or the two would disagree on which records
+	// exist. config() refuses to write it in the first place, so no edit this
+	// engine makes can produce a table the check then rejects.
+	if (t.policy == wire.OperatePolicyMinCol || t.policy == wire.OperatePolicyMaxCol) && t.byColLen == 0 {
+		return dynTable{}, wire.ErrOperateRecord
+	}
 
 	nRows, m2, err := readUvarint(buf[off:t.end])
 	if err != nil {

--- a/ops/operate_dynamic_engine.go
+++ b/ops/operate_dynamic_engine.go
@@ -768,14 +768,13 @@ func dynTargetType(create bool, opcode, typ, n, storedTyp, storedN uint8) (uint8
 		return 0, 0, wire.ErrOperateType
 	}
 	if opcode == wire.OperateOpSET {
-		if typ == wire.OperateTypeFixed && n < 1 {
-			// A FIXED operand with no usable width cannot retype anything, so
-			// the stored type stands (the oracle's treeRetype returns ok =
-			// false here). applyOps rejects such an op before resolve, so
-			// this only keeps the function total.
-			return storedTyp, storedN, nil
-		}
-		return typ, n, nil
+		// SET replaces the scalar including its type (design doc §2.9), so it
+		// names a type exactly as it would on a missing target — including a
+		// FIXED operand that cannot form a cell, which is wire.ErrOperateType
+		// either way. There is no stored type left for such a SET to fall
+		// back on, and §2.4 leaves no room for reinterpreting the op against
+		// one.
+		return createType(typ, n)
 	}
 	if dynDomain(typ) != dynDomain(storedTyp) {
 		return 0, 0, wire.ErrOperateType
@@ -793,6 +792,13 @@ func (e *dynamicEngine) resolve(p wire.OperatePath, create bool, opcode, typ, n 
 		return e.inner.resolve(p, create, opcode, typ, n)
 	}
 	if p.Kind > wire.OperatePathCol {
+		return ref{}, wire.ErrOperatePath
+	}
+	if opcode == wire.OperateOpCONFIG && p.Kind != wire.OperatePathField {
+		// A table's eviction config lives on the field itself (design doc
+		// §3.2), so a record, row or column path is malformed — checked
+		// before the record path's early return below, since the oracle
+		// rejects a CONFIG at () too.
 		return ref{}, wire.ErrOperatePath
 	}
 	if p.Kind == wire.OperatePathRecord {
@@ -862,11 +868,15 @@ func (e *dynamicEngine) resolveField(p wire.OperatePath, create bool, opcode, ty
 	if f.typ == wire.OperateTypeTable {
 		return ref{kind: refKindTable, field: fi, row: -1, col: -1, off: -1, present: true}, nil
 	}
-	if create && opcode == wire.OperateOpCONFIG {
-		// A scalar field cannot take a table's eviction config: it would have
-		// to become a table, which only DEL then a row write can do (oracle
-		// ruling, design doc §2.9).
-		return ref{}, wire.ErrOperatePath
+	if opcode == wire.OperateOpCONFIG {
+		// A scalar field cannot take a table's eviction config — it would
+		// have to become a table, which only DEL then a row write can do
+		// (design doc §2.9) — but that is config's rejection to make, after
+		// the operand checks, which is the order the oracle rejects it in.
+		// The op's TABLE type byte is not a scalar type and is not checked
+		// against the stored one here for the same reason.
+		return ref{kind: refKindScalar, field: fi, row: -1, col: -1, off: f.typOff,
+			typ: f.typ, n: f.n, present: true}, nil
 	}
 	rtyp, rn, err := dynTargetType(create, opcode, typ, n, f.typ, f.n)
 	if err != nil {
@@ -1200,7 +1210,9 @@ func (e *dynamicEngine) insertRow(fi int, t dynTable, at int, key []byte) error 
 	e.enc = body
 	var hdr [binary.MaxVarintLen64]byte
 	m := binary.PutUvarint(hdr[:], uint64(len(body)))
-	if err := e.charge(m + len(body) + binary.MaxVarintLen64); err != nil {
+	// The row's bytes plus the worst case of the two prefixes that cover it
+	// widening: the table's nRows and its byteLen.
+	if err := e.charge(m + len(body) + 2*binary.MaxVarintLen64); err != nil {
 		return err
 	}
 	e.buf = splice(e.buf, at, 0, hdr[:m])
@@ -1238,7 +1250,9 @@ func (e *dynamicEngine) insertCol(fi, ri, at int, name string, typ, n uint8) err
 	e.enc = appendDynName(e.enc[:0], name)
 	e.enc = wire.AppendTaggedCell(e.enc, wire.ZeroCell(typ, n))
 	entry := e.enc
-	if err := e.charge(len(entry) + 2*binary.MaxVarintLen64); err != nil {
+	// The column's bytes plus the worst case of the three prefixes that cover
+	// it widening: the row's nCols and rowLen, and the table's byteLen.
+	if err := e.charge(len(entry) + 3*binary.MaxVarintLen64); err != nil {
 		return err
 	}
 	t, row, err := e.rowByIndex(fi, ri)
@@ -1544,17 +1558,9 @@ func (e *dynamicEngine) config(r ref, capN uint32, policy uint8, byColName strin
 	if e.inner != nil {
 		return e.inner.config(r, capN, policy, byColName)
 	}
-	// The name-length bound comes first because applyOps cannot check it: it
-	// is a cap on the op's operand, and the oracle reports it before it looks
-	// at the policy byte.
-	if len(byColName) > wire.OperateMaxNameLen {
-		return wire.ErrOperateCap
-	}
-	if policy > wire.OperatePolicyMaxCol {
-		// An unknown policy byte is a schema-shaped error, the same one
-		// Schema.Validate returns for a table declaring it (oracle ruling).
-		return wire.ErrOperateSchema
-	}
+	// applyOps has already bounded byColName's length and rejected an unknown
+	// policy byte, in that order (see its CONFIG branch); what is left is the
+	// pair of rules the loop cannot state, both of them wire.ErrOperatePath.
 	if (policy == wire.OperatePolicyMinCol || policy == wire.OperatePolicyMaxCol) && byColName == "" {
 		return wire.ErrOperatePath
 	}

--- a/ops/operate_dynamic_engine.go
+++ b/ops/operate_dynamic_engine.go
@@ -368,10 +368,10 @@ func lenFits(n uint64, remaining int) bool {
 // cellDataLen returns the stored length of one cell's data of type typ (and,
 // for FIXED, width n) at the front of b, rejecting anything the record codec
 // would reject: a truncated value, a non-canonical varint or BYTES length, an
-// over-long BYTES payload, an F32 bit pattern that does not survive the
-// codec's float64 round trip, and any type byte that is not cell data at all
-// (TABLE, or a tag past the last known type). It never allocates, which is
-// what lets the structural walk stay off the heap.
+// over-long BYTES payload, a FIXED width of 0, a float bit pattern that does
+// not survive the codec's canonicalizing round trip, and any type byte that
+// is not cell data at all (TABLE, or a tag past the last known type). It
+// never allocates, which is what lets the structural walk stay off the heap.
 func cellDataLen(typ, n uint8, b []byte) (int, error) {
 	switch typ {
 	case wire.OperateTypeUnset:
@@ -379,7 +379,7 @@ func cellDataLen(typ, n uint8, b []byte) (int, error) {
 	case wire.OperateTypeU8, wire.OperateTypeI8,
 		wire.OperateTypeU16, wire.OperateTypeI16,
 		wire.OperateTypeU32, wire.OperateTypeI32,
-		wire.OperateTypeU64, wire.OperateTypeI64, wire.OperateTypeF64:
+		wire.OperateTypeU64, wire.OperateTypeI64:
 		w := wire.CellWidth(typ, n)
 		if len(b) < w {
 			return 0, wire.ErrOperateRecord
@@ -389,16 +389,29 @@ func cellDataLen(typ, n uint8, b []byte) (int, error) {
 		if len(b) < 4 {
 			return 0, wire.ErrOperateRecord
 		}
-		// The codec stores an F32 through a float64 (Cell.F), so a bit
-		// pattern that does not come back identically — a signaling NaN on
-		// hardware that quiets it — decodes fine yet re-encodes differently.
+		// The codec canonicalizes every NaN on the way out (wire.CanonFloat,
+		// design doc §2.5) and stores an F32 through a float64 (Cell.F), so a
+		// bit pattern that does not come back identically — any NaN but the
+		// canonical quiet one — decodes fine yet re-encodes differently.
 		// wire.DecodeRecord rejects those; so must this walk, or the two
 		// would disagree on which records exist.
 		v := binary.LittleEndian.Uint32(b[:4])
-		if math.Float32bits(float32(float64(math.Float32frombits(v)))) != v {
+		f := wire.CanonFloat(wire.OperateTypeF32, float64(math.Float32frombits(v)))
+		if math.Float32bits(float32(f)) != v {
 			return 0, wire.ErrOperateRecord
 		}
 		return 4, nil
+	case wire.OperateTypeF64:
+		if len(b) < 8 {
+			return 0, wire.ErrOperateRecord
+		}
+		// Same rule one width up: only the canonical quiet NaN re-encodes to
+		// itself, every other NaN spelling is a malformed record.
+		v := binary.LittleEndian.Uint64(b[:8])
+		if math.Float64bits(wire.CanonFloat(wire.OperateTypeF64, math.Float64frombits(v))) != v {
+			return 0, wire.ErrOperateRecord
+		}
+		return 8, nil
 	case wire.OperateTypeUVarint, wire.OperateTypeIVarint:
 		_, m, err := readUvarint(b)
 		if err != nil {
@@ -418,6 +431,11 @@ func cellDataLen(typ, n uint8, b []byte) (int, error) {
 		}
 		return m + int(ln), nil //nolint:gosec // bounded above
 	case wire.OperateTypeFixed:
+		// FIXED's declared width is 1-255 (design doc §2.1): a stored 0 is a
+		// malformed record, which is what wire.DecodeRecord calls it too.
+		if n == 0 {
+			return 0, wire.ErrOperateRecord
+		}
 		if !wire.CountFitsIn(int(n), len(b), 1) {
 			return 0, wire.ErrOperateRecord
 		}
@@ -1112,13 +1130,17 @@ func (e *dynamicEngine) spliceValue(r ref, off, oldLen int, repl []byte) error {
 		e.buf = splice(e.buf, off, oldLen, repl)
 		return e.reindex()
 	}
-	// The row's and the table's length prefixes can widen along with the value
-	// they cover, so their worst case is charged before the first splice too.
-	if err := e.charge(delta + 2*binary.MaxVarintLen64); err != nil {
-		return err
-	}
 	t, row, err := e.rowByIndex(r.field, r.row)
 	if err != nil {
+		return err
+	}
+	// The row's and the table's length prefixes can widen along with the
+	// value they cover, so they are charged before the first splice too — at
+	// their ACTUAL width change, computed from the inside out, not at the
+	// worst case of two maximum-width varints (see prefixDelta).
+	rowDelta := prefixDelta(int64(row.bodyLen)+int64(delta), row.lenLen)
+	tblDelta := prefixDelta(int64(t.byteLen)+int64(delta)+int64(rowDelta), t.lenLen)
+	if err := e.charge(delta + rowDelta + tblDelta); err != nil {
 		return err
 	}
 	e.buf = splice(e.buf, off, oldLen, repl)
@@ -1153,12 +1175,37 @@ func (e *dynamicEngine) patchTableLen(t dynTable, delta int) error {
 }
 
 // charge rejects a growth that would take the record past the §2.7
-// record-size cap before the splice allocates for it.
+// record-size cap before the splice allocates for it. The sum is taken in
+// 64-bit so a hostile delta can never wrap a 32-bit int into a small
+// positive size.
 func (e *dynamicEngine) charge(delta int) error {
-	if delta > 0 && len(e.buf)+delta > maxOperateRecordBytes {
+	if delta > 0 && int64(len(e.buf))+int64(delta) > int64(maxOperateRecordBytes) {
 		return wire.ErrOperateCap
 	}
 	return nil
+}
+
+// prefixDelta is how many bytes a uvarint length prefix currently oldLen
+// bytes wide grows (or shrinks) by when it comes to hold newVal.
+//
+// Every charge uses this rather than binary.MaxVarintLen64 per prefix: an
+// edit inside a table is covered by up to three prefixes (nCols, rowLen,
+// byteLen), and charging each of them a maximum-width varint over-charges by
+// as much as 27 bytes. The oracle checks only the size of the FINISHED
+// record, so a call whose result lands a few bytes under maxRecordBytes must
+// be accepted — over-charging would reject it and diverge. Real prefixes
+// grow by at most one byte per edit, and the exact figure is cheap to
+// compute, so there is no reason to guess.
+//
+// newVal is taken as an int64 so the caller's arithmetic cannot wrap on a
+// 32-bit int; a negative one cannot arise from a well-formed edit and is
+// reported as no change, leaving the splice's own structural checks to
+// reject the record.
+func prefixDelta(newVal int64, oldLen int) int {
+	if newVal < 0 {
+		return 0
+	}
+	return uvarintLen(uint64(newVal)) - oldLen
 }
 
 // reindex re-walks the field level after a splice.
@@ -1195,7 +1242,9 @@ func (e *dynamicEngine) insertField(idx int, entry []byte) error {
 	if idx < len(e.fields) {
 		at = e.fields[idx].off
 	}
-	if err := e.charge(len(entry) + binary.MaxVarintLen64); err != nil {
+	// The entry's bytes plus the actual width change of the one prefix that
+	// covers it: the record's own nFields.
+	if err := e.charge(len(entry) + prefixDelta(int64(len(e.fields))+1, e.nLen)); err != nil {
 		return err
 	}
 	e.buf = splice(e.buf, at, 0, entry)
@@ -1225,15 +1274,17 @@ func (e *dynamicEngine) insertRow(fi int, t dynTable, at int, key []byte) error 
 	e.enc = body
 	var hdr [binary.MaxVarintLen64]byte
 	m := binary.PutUvarint(hdr[:], uint64(len(body)))
-	// The row's bytes plus the worst case of the two prefixes that cover it
-	// widening: the table's nRows and its byteLen.
-	if err := e.charge(m + len(body) + 2*binary.MaxVarintLen64); err != nil {
+	rowBytes := m + len(body)
+	// The row's bytes plus the actual width change of the two prefixes that
+	// cover it: the table's nRows and, around that, its byteLen.
+	nRowsDelta := prefixDelta(int64(t.nRows)+1, t.nRowsLen)
+	tblDelta := prefixDelta(int64(t.byteLen)+int64(rowBytes)+int64(nRowsDelta), t.lenLen)
+	if err := e.charge(rowBytes + nRowsDelta + tblDelta); err != nil {
 		return err
 	}
 	e.buf = splice(e.buf, at, 0, hdr[:m])
 	e.buf = splice(e.buf, at+m, 0, body)
 
-	rowBytes := m + len(body)
 	buf, m2 := spliceUvarint(e.buf, t.nRowsOff, t.nRowsLen, uint64(t.nRows+1)) //nolint:gosec // nRows >= 0
 	e.buf = buf
 	if err := e.patchTableLen(t, rowBytes+m2-t.nRowsLen); err != nil {
@@ -1265,13 +1316,17 @@ func (e *dynamicEngine) insertCol(fi, ri, at int, name string, typ, n uint8) err
 	e.enc = appendDynName(e.enc[:0], name)
 	e.enc = wire.AppendTaggedCell(e.enc, wire.ZeroCell(typ, n))
 	entry := e.enc
-	// The column's bytes plus the worst case of the three prefixes that cover
-	// it widening: the row's nCols and rowLen, and the table's byteLen.
-	if err := e.charge(len(entry) + 3*binary.MaxVarintLen64); err != nil {
-		return err
-	}
 	t, row, err := e.rowByIndex(fi, ri)
 	if err != nil {
+		return err
+	}
+	// The column's bytes plus the actual width change of the three prefixes
+	// that cover it, from the inside out: the row's nCols, then its rowLen,
+	// then the table's byteLen.
+	nColsDelta := prefixDelta(int64(row.nCols)+1, row.nColsLen)
+	rowDelta := prefixDelta(int64(row.bodyLen)+int64(len(entry))+int64(nColsDelta), row.lenLen)
+	tblDelta := prefixDelta(int64(t.byteLen)+int64(len(entry))+int64(nColsDelta)+int64(rowDelta), t.lenLen)
+	if err := e.charge(len(entry) + nColsDelta + rowDelta + tblDelta); err != nil {
 		return err
 	}
 	e.buf = splice(e.buf, at, 0, entry)
@@ -1591,7 +1646,10 @@ func (e *dynamicEngine) config(r ref, capN uint32, policy uint8, byColName strin
 	hdr = appendDynName(hdr, byColName)
 	e.enc = hdr
 	oldLen := t.nRowsOff - t.capOff
-	if err := e.charge(len(hdr) - oldLen); err != nil {
+	hdrDelta := len(hdr) - oldLen
+	// The table's byteLen covers the header being rewritten, so it moves with
+	// it; charge its actual width change alongside the header's own.
+	if err := e.charge(hdrDelta + prefixDelta(int64(t.byteLen)+int64(hdrDelta), t.lenLen)); err != nil {
 		return err
 	}
 	e.buf = splice(e.buf, t.capOff, oldLen, hdr)

--- a/ops/operate_dynamic_engine.go
+++ b/ops/operate_dynamic_engine.go
@@ -215,6 +215,9 @@ func (e *dynamicEngine) walk(deep bool) error {
 		}
 		f.nameLen = int(buf[off])
 		off++
+		if f.nameLen == 0 {
+			return wire.ErrOperateRecord
+		}
 		if len(buf)-off < f.nameLen {
 			return wire.ErrOperateRecord
 		}
@@ -549,6 +552,9 @@ func (e *dynamicEngine) colAt(off, end int) (dynCol, error) {
 	}
 	c.nameLen = int(buf[off])
 	c.nameOff = off + 1
+	if c.nameLen == 0 {
+		return dynCol{}, wire.ErrOperateRecord
+	}
 	if end-c.nameOff < c.nameLen {
 		return dynCol{}, wire.ErrOperateRecord
 	}
@@ -812,6 +818,12 @@ func (e *dynamicEngine) resolve(p wire.OperatePath, create bool, opcode, typ, n 
 	if len(p.Field.Name) > wire.OperateMaxNameLen {
 		return ref{}, wire.ErrOperateCap
 	}
+	if create && p.Field.Name == "" {
+		// Names are 1-255 bytes, like row keys (design doc §2.4): a create
+		// that would vivify a field with an empty name is rejected here,
+		// before insertTableField ever runs, matching the oracle.
+		return ref{}, wire.ErrOperatePath
+	}
 	if p.Kind != wire.OperatePathField {
 		if len(p.Key) == 0 {
 			return ref{}, wire.ErrOperatePath
@@ -826,6 +838,9 @@ func (e *dynamicEngine) resolve(p wire.OperatePath, create bool, opcode, typ, n 
 		}
 		if len(p.Col.Name) > wire.OperateMaxNameLen {
 			return ref{}, wire.ErrOperateCap
+		}
+		if create && p.Col.Name == "" {
+			return ref{}, wire.ErrOperatePath
 		}
 	}
 

--- a/ops/operate_dynamic_engine_test.go
+++ b/ops/operate_dynamic_engine_test.go
@@ -469,6 +469,9 @@ func TestNewDynamicEngineValidates(t *testing.T) {
 			0, 0, 0},
 		"zero-length row key": {wire.OperateModeDynamic, 1, 1, 'a', wire.OperateTypeTable, 6,
 			0, 0, 0, 1, 2, 0, 0},
+		"zero-length field name": {wire.OperateModeDynamic, 1, 0},
+		"zero-length column name": {wire.OperateModeDynamic, 1, 1, 'a', wire.OperateTypeTable, 9,
+			0, 0, 0, 1, 4, 1, 'k', 1, 0},
 	}
 	for name, in := range bad {
 		if _, err := newDynamicEngine(append([]byte(nil), in...)); !errors.Is(err, wire.ErrOperateRecord) {

--- a/ops/operate_dynamic_engine_test.go
+++ b/ops/operate_dynamic_engine_test.go
@@ -44,9 +44,9 @@ func TestDynamicEngineMatchesOracle(t *testing.T) {
 			a := randomDynamicArgs(sub)
 			o, ores, oerr := applyTree(oracle, a, int64(iter))
 			e, eres, eerr := bytesApply(byteRec, a, int64(iter))
-			if (oerr == nil) != (eerr == nil) {
-				t.Fatalf("seed %d call %d: oracle err %v, engine err %v\nargs %+v",
-					seed, call, oerr, eerr, a)
+			if operateErrName(oerr) != operateErrName(eerr) {
+				t.Fatalf("seed %d call %d: oracle err %q, engine err %q\nargs %+v",
+					seed, call, operateErrName(oerr), operateErrName(eerr), a)
 			}
 			if oerr != nil {
 				continue

--- a/ops/operate_dynamic_engine_test.go
+++ b/ops/operate_dynamic_engine_test.go
@@ -271,9 +271,12 @@ func dynamicArgsFor(key []byte) *wire.OperateArgs {
 }
 
 // TestDynamicEngineAllocs pins the §2.6 budget for dynamic mode's in-place
-// path: the record copy and the result frame, and nothing per op. A
-// regression here means a lookup or a patch started building something —
-// exactly the cost the byte engine exists to avoid.
+// path: the record copy and the result frame, and nothing per op — two
+// allocations, which is what the budget is quoted as and what this measures.
+// A regression here means a lookup or a patch started building something —
+// exactly the cost the byte engine exists to avoid. The bound is the measured
+// figure, not a round number above it: slack here is coverage given away,
+// since a new per-call allocation would slip in under it unnoticed.
 func TestDynamicEngineAllocs(t *testing.T) {
 	rec := bigDynamicRecord(t, 1024)
 	a := dynamicArgsFor(keyU64(512))
@@ -283,8 +286,8 @@ func TestDynamicEngineAllocs(t *testing.T) {
 			t.Fatal(err)
 		}
 	})
-	if allocs > 3 {
-		t.Fatalf("%v allocations per apply, want at most 3", allocs)
+	if allocs > 2 {
+		t.Fatalf("%v allocations per apply, want at most 2 (the record copy and the result frame)", allocs)
 	}
 	t.Logf("allocations per apply: %v", allocs)
 }
@@ -484,6 +487,12 @@ func TestNewDynamicEngineValidates(t *testing.T) {
 			0x01, 0, 0, 0, 0, 0, 0xF8, 0x7F},
 		"non-canonical F32 NaN": {wire.OperateModeDynamic, 1, 1, 'a', wire.OperateTypeF32,
 			0x01, 0, 0xC0, 0x7F},
+		// A MIN_COL/MAX_COL policy with no eviction column name: the codec
+		// rejects the pairing, so the walk must too.
+		"MIN_COL policy with no byCol": {wire.OperateModeDynamic, 1, 1, 't', wire.OperateTypeTable, 4,
+			0, wire.OperatePolicyMinCol, 0, 0},
+		"MAX_COL policy with no byCol": {wire.OperateModeDynamic, 1, 1, 't', wire.OperateTypeTable, 4,
+			0, wire.OperatePolicyMaxCol, 0, 0},
 	}
 	for name, in := range bad {
 		if _, err := newDynamicEngine(append([]byte(nil), in...)); !errors.Is(err, wire.ErrOperateRecord) {
@@ -678,5 +687,34 @@ func TestDynamicChargeIsExactAtTheCap(t *testing.T) {
 	}
 	if _, _, oerr = applyTree(treeClone(rec), insert, 0); !errors.Is(oerr, wire.ErrOperateCap) {
 		t.Fatalf("cap = finished size - 1: oracle err = %v, want ErrOperateCap", oerr)
+	}
+}
+
+// TestDynamicEngineAcceptsColPolicyWithColumn is the positive half of the two
+// *_COL cases in TestNewDynamicEngineValidates: a table that DOES name its
+// eviction column must still open, and so must every policy that does not
+// evict by one. Without this the rejections above would pass just as well if
+// the walk refused every *_COL table.
+func TestDynamicEngineAcceptsColPolicyWithColumn(t *testing.T) {
+	build := func(policy uint8, byCol string) []byte {
+		inner := []byte{0, policy, byte(len(byCol))}
+		inner = append(inner, byCol...)
+		inner = append(inner, 0) // nRows
+		b := []byte{wire.OperateModeDynamic, 1, 1, 't', wire.OperateTypeTable, byte(len(inner))}
+		return append(b, inner...)
+	}
+	cases := map[string][]byte{
+		"MIN_COL with a column": build(wire.OperatePolicyMinCol, "c"),
+		"MAX_COL with a column": build(wire.OperatePolicyMaxCol, "c"),
+		"MIN_KEY, no column":    build(wire.OperatePolicyMinKey, ""),
+		"NONE, no column":       build(wire.OperatePolicyNone, ""),
+	}
+	for name, buf := range cases {
+		if _, err := wire.DecodeRecord(buf); err != nil {
+			t.Fatalf("%s: the codec rejected the fixture: %v", name, err)
+		}
+		if _, err := newDynamicEngine(append([]byte(nil), buf...)); err != nil {
+			t.Fatalf("%s: engine rejected a record the codec accepts: %v", name, err)
+		}
 	}
 }

--- a/ops/operate_dynamic_engine_test.go
+++ b/ops/operate_dynamic_engine_test.go
@@ -472,6 +472,18 @@ func TestNewDynamicEngineValidates(t *testing.T) {
 		"zero-length field name": {wire.OperateModeDynamic, 1, 0},
 		"zero-length column name": {wire.OperateModeDynamic, 1, 1, 'a', wire.OperateTypeTable, 9,
 			0, 0, 0, 1, 4, 1, 'k', 1, 0},
+		// FIXED(0) is not a width (design doc §2.1: 1-255). The codec
+		// rejects it in a field header and in a column header, so the walk
+		// must too, or the two disagree on which records exist.
+		"zero-width FIXED field": {wire.OperateModeDynamic, 1, 1, 'a', wire.OperateTypeFixed, 0},
+		"zero-width FIXED column": {wire.OperateModeDynamic, 1, 1, 't', wire.OperateTypeTable, 12,
+			0, 0, 0, 1, 7, 1, 'k', 1, 1, 'c', wire.OperateTypeFixed, 0},
+		// Only the canonical quiet NaN re-encodes to itself now that
+		// AppendCellData canonicalizes on the way out, in either float width.
+		"non-canonical F64 NaN": {wire.OperateModeDynamic, 1, 1, 'a', wire.OperateTypeF64,
+			0x01, 0, 0, 0, 0, 0, 0xF8, 0x7F},
+		"non-canonical F32 NaN": {wire.OperateModeDynamic, 1, 1, 'a', wire.OperateTypeF32,
+			0x01, 0, 0xC0, 0x7F},
 	}
 	for name, in := range bad {
 		if _, err := newDynamicEngine(append([]byte(nil), in...)); !errors.Is(err, wire.ErrOperateRecord) {
@@ -574,4 +586,97 @@ func TestDynamicEngineAcceptsExactlyTheCodec(t *testing.T) {
 		t.Fatalf("only %d corpus entries were valid records — the comparison is vacuous", agreed)
 	}
 	t.Logf("%d corpus entries, %d of them valid records", len(corpus), agreed)
+}
+
+// TestDynamicEngineAcceptsCanonicalFloats is the positive half of the two
+// float cases in TestNewDynamicEngineValidates: the canonical quiet NaN, and
+// every ordinary finite value, must still open. Without this the rejections
+// above would pass just as well if the walk refused all NaNs, or all floats.
+func TestDynamicEngineAcceptsCanonicalFloats(t *testing.T) {
+	negZero := math.Copysign(0, -1)
+	for _, f := range []float64{math.NaN(), 0, negZero, 1.5, math.Inf(-1)} {
+		for _, typ := range []uint8{wire.OperateTypeF32, wire.OperateTypeF64} {
+			rec := &wire.Record{Mode: wire.OperateModeDynamic, Fields: []wire.Field{
+				{Name: "a", Cell: wire.Cell{Type: typ, F: f}}}}
+			buf := rec.Encode()
+			if _, err := wire.DecodeRecord(buf); err != nil {
+				t.Fatalf("codec rejected its own encoding of %v (%d): %v", f, typ, err)
+			}
+			if _, err := newDynamicEngine(append([]byte(nil), buf...)); err != nil {
+				t.Fatalf("engine rejected %v (%d) which the codec accepts: %v", f, typ, err)
+			}
+		}
+	}
+}
+
+// TestDynamicChargeIsExactAtTheCap covers the §2.7 charge accounting at the
+// boundary. An edit inside a table row is covered by three length prefixes
+// (nCols, rowLen, byteLen); charging each of them a maximum-width varint
+// over-charges by up to 27 bytes, which would refuse a call whose FINISHED
+// record fits — and the oracle, which checks only the finished size, would
+// accept it. So the two are compared at exactly the cap and one byte under.
+func TestDynamicChargeIsExactAtTheCap(t *testing.T) {
+	base, _, _, err := applyRecordBytes(nil, &wire.OperateArgs{Create: wire.OperateCreateDynamic,
+		Ops: []wire.OperateOp{
+			{Opcode: wire.OperateOpSET, Type: wire.OperateTypeU64,
+				Path: nameColPath("t", []byte("k"), "a"), A: 1},
+			{Opcode: wire.OperateOpSET, Type: wire.OperateTypeBytes,
+				Path: namePath("pad"), Bytes: bytes.Repeat([]byte{9}, 200)},
+		}}, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// The op under test inserts a second column into that row, growing the
+	// record by the column's bytes and nothing else (no prefix widens).
+	insert := &wire.OperateArgs{Create: wire.OperateCreateDynamic, Ops: []wire.OperateOp{
+		{Opcode: wire.OperateOpSET, Type: wire.OperateTypeU64,
+			Path: nameColPath("t", []byte("k"), "b"), A: 2}}}
+
+	restore := maxOperateRecordBytes
+	t.Cleanup(func() { maxOperateRecordBytes = restore })
+
+	out, _, _, err := applyRecordBytes(append([]byte(nil), base...), insert, 0)
+	if err != nil {
+		t.Fatalf("the insert must apply under the default cap: %v", err)
+	}
+	final := len(out)
+	if final <= len(base) {
+		t.Fatalf("the insert did not grow the record: %d -> %d", len(base), final)
+	}
+
+	rec, err := wire.DecodeRecord(base)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Exactly at the cap: both the engine and the oracle must accept.
+	maxOperateRecordBytes = final
+	got, _, _, err := applyRecordBytes(append([]byte(nil), base...), insert, 0)
+	if err != nil {
+		t.Fatalf("cap = the finished size (%d): engine refused with %v", final, err)
+	}
+	if len(got) != final {
+		t.Fatalf("record is %d bytes at the cap, want %d", len(got), final)
+	}
+	oracleOut, _, oerr := applyTree(treeClone(rec), insert, 0)
+	if oerr != nil {
+		t.Fatalf("cap = the finished size: oracle refused with %v", oerr)
+	}
+	if !bytes.Equal(oracleOut.Encode(), got) {
+		t.Fatalf("engine and oracle disagree at the cap:\n engine %x\n oracle %x", got, oracleOut.Encode())
+	}
+
+	// One byte under: both must refuse, with the same error.
+	maxOperateRecordBytes = final - 1
+	got, _, _, err = applyRecordBytes(append([]byte(nil), base...), insert, 0)
+	if !errors.Is(err, wire.ErrOperateCap) {
+		t.Fatalf("cap = finished size - 1: engine err = %v, want ErrOperateCap", err)
+	}
+	if got != nil {
+		t.Fatalf("a cap hit stored %x", got)
+	}
+	if _, _, oerr = applyTree(treeClone(rec), insert, 0); !errors.Is(oerr, wire.ErrOperateCap) {
+		t.Fatalf("cap = finished size - 1: oracle err = %v, want ErrOperateCap", oerr)
+	}
 }

--- a/ops/operate_dynamic_engine_test.go
+++ b/ops/operate_dynamic_engine_test.go
@@ -1,0 +1,574 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package ops
+
+// Tests for the dynamic-mode byte engine (design doc §2.9). As with the
+// schema engine, the tree oracle in operate_oracle_test.go is the definition
+// of correctness: the semantics suite runs against both, and the property
+// test below compares them call after call, down to the stored bytes.
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"math"
+	"math/rand"
+	"reflect"
+	"testing"
+
+	"github.com/rostamlabs/rostam/sdk/wire"
+)
+
+// TestDynamicEngineSemantics runs the whole semantics suite against the byte
+// engines with dynamic mode enabled: every "dynamic:" sub-test the schema
+// engine skips must hold here.
+func TestDynamicEngineSemantics(t *testing.T) {
+	runSemantics(t, bytesApply)
+}
+
+// TestDynamicEngineMatchesOracle is the equivalence property for dynamic
+// mode: for random op lists drawn from the whole vocabulary — including
+// CONFIG/TRIM, the control ops, deliberately invalid paths and the occasional
+// MIGRATE freeze — the byte engine and the tree oracle must agree on whether
+// the call errors, on the result frame, and on the stored bytes, call after
+// call, so a divergence that only shows up on an already-diverged record is
+// caught too.
+func TestDynamicEngineMatchesOracle(t *testing.T) {
+	const iters = 2000
+	rng := rand.New(rand.NewSource(11)) //nolint:gosec // deterministic test input, not cryptography
+	for iter := 0; iter < iters; iter++ {
+		seed := rng.Int63()
+		sub := rand.New(rand.NewSource(seed)) //nolint:gosec // deterministic test input
+		var oracle, byteRec *wire.Record
+		for call := 0; call < 5; call++ {
+			a := randomDynamicArgs(sub)
+			o, ores, oerr := applyTree(oracle, a, int64(iter))
+			e, eres, eerr := bytesApply(byteRec, a, int64(iter))
+			if (oerr == nil) != (eerr == nil) {
+				t.Fatalf("seed %d call %d: oracle err %v, engine err %v\nargs %+v",
+					seed, call, oerr, eerr, a)
+			}
+			if oerr != nil {
+				continue
+			}
+			if !reflect.DeepEqual(ores, eres) {
+				t.Fatalf("seed %d call %d: results differ\noracle %+v\nengine %+v\nargs %+v",
+					seed, call, ores, eres, a)
+			}
+			if (o == nil) != (e == nil) {
+				t.Fatalf("seed %d call %d: oracle nil=%v engine nil=%v\nargs %+v",
+					seed, call, o == nil, e == nil, a)
+			}
+			if o != nil && !bytes.Equal(o.Encode(), e.Encode()) {
+				t.Fatalf("seed %d call %d: bytes differ\noracle %x\nengine %x\nargs %+v",
+					seed, call, o.Encode(), e.Encode(), a)
+			}
+			oracle, byteRec = o, e
+		}
+	}
+}
+
+// --- cross-mode equivalence -------------------------------------------------
+
+// crossOp is one logical op in both spellings: addressed by position against
+// a schema record, and by name (with the type the schema declares) against a
+// dynamic one.
+type crossOp struct {
+	schema wire.OperateOp
+	dyn    wire.OperateOp
+}
+
+// crossModeOps builds a batch of logically identical ops for both modes. It
+// draws only ops whose meaning does not depend on which mode stores the
+// record: writes to a scalar field or a table column, and DEL of a row or a
+// column. (DEL of a FIELD does differ by design — schema mode zeroes it,
+// dynamic mode removes it and, with the last one, the record — and the
+// semantics suite covers that rule directly.)
+func crossModeOps(rng *rand.Rand, s *wire.Schema) []crossOp {
+	pool := []uint8{wire.OperateOpSET, wire.OperateOpADD, wire.OperateOpMUL, wire.OperateOpMIN,
+		wire.OperateOpMAX, wire.OperateOpAND, wire.OperateOpOR, wire.OperateOpXOR,
+		wire.OperateOpSHL, wire.OperateOpSHR, wire.OperateOpSTAMP}
+	ops := make([]crossOp, 0, 6)
+	for i := 0; i < 1+rng.Intn(6); i++ {
+		opcode := pool[rng.Intn(len(pool))]
+		a := int64(rng.Intn(300)) - 20
+		if opcode == wire.OperateOpSHL || opcode == wire.OperateOpSHR {
+			a = int64(rng.Intn(65)) // a shift operand outside [0,64] is an error in both modes
+		}
+		key := keyU64(uint64(rng.Intn(8)))
+		aux := uint8(0)
+		if opcode == wire.OperateOpSTAMP {
+			aux = uint8(rng.Intn(2))
+		}
+		switch pick := rng.Intn(10); {
+		case pick < 3: // a scalar record field
+			pos := rng.Intn(3)
+			fd := &s.Fields[pos]
+			ops = append(ops, crossOp{
+				schema: wire.OperateOp{Opcode: opcode, Type: opFromSchema, Aux: aux, Path: fieldPath(uint32(pos)), A: a},
+				dyn:    wire.OperateOp{Opcode: opcode, Type: fd.Type, Aux: aux, Path: namePath(fd.Name), A: a},
+			})
+		case pick < 8: // a table column
+			col := rng.Intn(len(s.Fields[3].Table.Cols))
+			cd := &s.Fields[3].Table.Cols[col]
+			ops = append(ops, crossOp{
+				schema: wire.OperateOp{Opcode: opcode, Type: opFromSchema, Aux: aux,
+					Path: colPath(3, key, uint32(col)), A: a},
+				dyn: wire.OperateOp{Opcode: opcode, Type: cd.Type, Aux: aux,
+					Path: nameColPath(s.Fields[3].Name, key, cd.Name), A: a},
+			})
+		case pick == 8: // DEL of one column
+			col := rng.Intn(len(s.Fields[3].Table.Cols))
+			cd := &s.Fields[3].Table.Cols[col]
+			ops = append(ops, crossOp{
+				schema: wire.OperateOp{Opcode: wire.OperateOpDEL, Type: opFromSchema, Path: colPath(3, key, uint32(col))},
+				dyn: wire.OperateOp{Opcode: wire.OperateOpDEL, Type: opFromSchema,
+					Path: nameColPath(s.Fields[3].Name, key, cd.Name)},
+			})
+		default: // DEL of one row
+			ops = append(ops, crossOp{
+				schema: wire.OperateOp{Opcode: wire.OperateOpDEL, Type: opFromSchema, Path: rowPath(3, key)},
+				dyn: wire.OperateOp{Opcode: wire.OperateOpDEL, Type: opFromSchema,
+					Path: nameRowPath(s.Fields[3].Name, key)},
+			})
+		}
+	}
+	return ops
+}
+
+// TestCrossModeEquivalence is design doc §5.13's cross-mode property: the
+// same logical op list, applied by position to a schema record and by name to
+// a dynamic one, must leave the same logical values behind — the same field
+// values, the same rows under the same keys, and the same column values,
+// even though the two records store none of it the same way.
+func TestCrossModeEquivalence(t *testing.T) {
+	s := sessionSchema()
+	rng := rand.New(rand.NewSource(7)) //nolint:gosec // deterministic test input
+	var schemaRec, dynRec *wire.Record
+	for call := 0; call < 50; call++ {
+		batch := crossModeOps(rng, s)
+		sa := &wire.OperateArgs{Create: wire.OperateCreateSchema, Schema: s.Encode()}
+		da := &wire.OperateArgs{Create: wire.OperateCreateDynamic}
+		for _, c := range batch {
+			sa.Ops = append(sa.Ops, c.schema)
+			da.Ops = append(da.Ops, c.dyn)
+		}
+		sr, _, serr := bytesApply(schemaRec, sa, int64(call)*1000)
+		if serr != nil {
+			t.Fatalf("call %d schema mode: %v\nops %+v", call, serr, sa.Ops)
+		}
+		dr, _, derr := bytesApply(dynRec, da, int64(call)*1000)
+		if derr != nil {
+			t.Fatalf("call %d dynamic mode: %v\nops %+v", call, derr, da.Ops)
+		}
+		schemaRec, dynRec = sr, dr
+		if schemaRec == nil || dynRec == nil {
+			t.Fatalf("call %d: a record disappeared (schema nil=%v dynamic nil=%v)", call, sr == nil, dr == nil)
+		}
+	}
+
+	for i := range s.Fields {
+		fd := &s.Fields[i]
+		if fd.Type != wire.OperateTypeTable {
+			want := schemaRec.Fields[i].Cell
+			got := dynCellByName(dynRec.Fields, fd.Name, fd.Type, fd.N)
+			if !cellEqual(want, got) {
+				t.Fatalf("field %q: schema %+v, dynamic %+v", fd.Name, want, got)
+			}
+			continue
+		}
+		stbl := schemaRec.Fields[i].Table
+		dfi := treeFindField(dynRec.Fields, fd.Name)
+		if dfi < 0 || dynRec.Fields[dfi].Table == nil {
+			t.Fatalf("table %q missing from the dynamic record: %+v", fd.Name, dynRec.Fields)
+		}
+		dtbl := dynRec.Fields[dfi].Table
+		if len(stbl.Rows) != len(dtbl.Rows) {
+			t.Fatalf("table %q: %d schema rows, %d dynamic rows", fd.Name, len(stbl.Rows), len(dtbl.Rows))
+		}
+		for r := range stbl.Rows {
+			row := &stbl.Rows[r]
+			dri, found := treeFindRow(dtbl.Rows, row.Key, 0, true)
+			if !found {
+				t.Fatalf("table %q: row %x missing from the dynamic record", fd.Name, row.Key)
+			}
+			for c := range fd.Table.Cols {
+				cd := &fd.Table.Cols[c]
+				want := row.Cols[c].Cell
+				got := dynColByName(dtbl.Rows[dri].Cols, cd.Name, cd.Type, cd.N)
+				if !cellEqual(want, got) {
+					t.Fatalf("table %q row %x column %q: schema %+v, dynamic %+v",
+						fd.Name, row.Key, cd.Name, want, got)
+				}
+			}
+		}
+	}
+}
+
+// dynCellByName is the dynamic record's value for a schema field, or that
+// field's zero when the dynamic record never had it written (design doc §2.4,
+// "absent is zero" — which is exactly what an untouched schema field holds).
+func dynCellByName(fields []wire.Field, name string, typ, n uint8) wire.Cell {
+	if i := treeFindField(fields, name); i >= 0 {
+		return fields[i].Cell
+	}
+	return wire.ZeroCell(typ, n)
+}
+
+func dynColByName(cols []wire.Col, name string, typ, n uint8) wire.Cell {
+	if i := treeFindCol(cols, name); i >= 0 {
+		return cols[i].Cell
+	}
+	return wire.ZeroCell(typ, n)
+}
+
+// cellEqual compares two cells by value: floats by bit pattern (so a
+// canonical NaN equals itself) and bytes by content, since an empty payload
+// is spelled both nil and []byte{}.
+func cellEqual(a, b wire.Cell) bool {
+	return a.Type == b.Type && a.N == b.N && a.U == b.U &&
+		math.Float64bits(a.F) == math.Float64bits(b.F) && bytes.Equal(a.B, b.B)
+}
+
+// --- allocations ------------------------------------------------------------
+
+// bigDynamicRecord builds the design doc's §4 session shape as a dynamic
+// record with n rows in its table: the same worked example the schema
+// engine's allocation budget is quoted against, self-describing instead.
+func bigDynamicRecord(t *testing.T, n int) []byte {
+	t.Helper()
+	a := &wire.OperateArgs{Create: wire.OperateCreateDynamic, Ops: []wire.OperateOp{
+		{Opcode: wire.OperateOpSET, Type: wire.OperateTypeU8, Path: namePath("rc"), A: 1},
+		{Opcode: wire.OperateOpSET, Type: wire.OperateTypeU8, Path: namePath("bc"), A: 1},
+		{Opcode: wire.OperateOpSET, Type: wire.OperateTypeU32, Path: namePath("hist"), A: 1},
+	}}
+	for k := 0; k < n; k++ {
+		a.Ops = append(a.Ops, wire.OperateOp{Opcode: wire.OperateOpADD, Type: wire.OperateTypeU16,
+			Path: nameColPath("b", keyU64(uint64(k)), "c"), A: 1})
+	}
+	out, _, _, err := applyRecordBytes(nil, a, 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, derr := wire.DecodeRecord(out); derr != nil {
+		t.Fatal(derr)
+	}
+	return out
+}
+
+// dynamicArgsFor is the worked example's per-request op list against one
+// existing row: six ops that all patch fixed-width cells in place.
+func dynamicArgsFor(key []byte) *wire.OperateArgs {
+	return &wire.OperateArgs{Create: wire.OperateCreateDynamic, Ops: []wire.OperateOp{
+		{Opcode: wire.OperateOpADD, Type: wire.OperateTypeU8, Path: namePath("rc"), A: 1},
+		{Opcode: wire.OperateOpADD, Type: wire.OperateTypeU8, Path: namePath("bc"), A: 1},
+		{Opcode: wire.OperateOpOR, Type: wire.OperateTypeU32, Path: namePath("hist"), A: 4},
+		{Opcode: wire.OperateOpADD, Type: wire.OperateTypeU16, Path: nameColPath("b", key, "c"), A: 1},
+		{Opcode: wire.OperateOpMAX, Type: wire.OperateTypeI64, Path: nameColPath("b", key, "hi"), A: 500},
+		{Opcode: wire.OperateOpSTAMP, Type: wire.OperateTypeU32, Aux: wire.OperateStampS,
+			Path: nameColPath("b", key, "t")},
+	}}
+}
+
+// TestDynamicEngineAllocs pins the §2.6 budget for dynamic mode's in-place
+// path: the record copy and the result frame, and nothing per op. A
+// regression here means a lookup or a patch started building something —
+// exactly the cost the byte engine exists to avoid.
+func TestDynamicEngineAllocs(t *testing.T) {
+	rec := bigDynamicRecord(t, 1024)
+	a := dynamicArgsFor(keyU64(512))
+	a.Rets = nil
+	allocs := testing.AllocsPerRun(50, func() {
+		if _, _, _, err := applyRecordBytes(rec, a, 1); err != nil {
+			t.Fatal(err)
+		}
+	})
+	if allocs > 3 {
+		t.Fatalf("%v allocations per apply, want at most 3", allocs)
+	}
+	t.Logf("allocations per apply: %v", allocs)
+}
+
+// --- freeze -----------------------------------------------------------------
+
+// TestDynamicFreezeThenSchemaCallsWork covers the handover a freeze makes
+// (design doc §2.9): once MIGRATE has rewritten the record in schema mode,
+// the rest of the same call and every later call must see a schema record —
+// including the create parameter, which now has to say SCHEMA.
+func TestDynamicFreezeThenSchemaCallsWork(t *testing.T) {
+	base, _, _, err := applyRecordBytes(nil, &wire.OperateArgs{Create: wire.OperateCreateDynamic,
+		Ops: []wire.OperateOp{
+			{Opcode: wire.OperateOpSET, Type: wire.OperateTypeU32, Path: namePath("hits"), A: 7},
+			{Opcode: wire.OperateOpSET, Type: wire.OperateTypeBytes, Path: namePath("name"), Bytes: []byte("ab")},
+			{Opcode: wire.OperateOpSET, Type: wire.OperateTypeU16, Path: nameColPath("b", keyU64(9), "c"), A: 3},
+		}}, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	fs := frozenSchema()
+	// The ops after the MIGRATE run against the frozen record: by position,
+	// which a dynamic record rejects outright.
+	frozen, _, res, err := applyRecordBytes(base, &wire.OperateArgs{Create: wire.OperateCreateNone,
+		Ops: []wire.OperateOp{
+			{Opcode: wire.OperateOpMIGRATE, Type: opFromSchema, Path: recPath(),
+				A: wire.OperateMigrateFromDynamic, Bytes: fs.Encode()},
+			{Opcode: wire.OperateOpADD, Type: opFromSchema, Path: fieldPath(0), A: 5},
+		},
+		Rets: []wire.OperateRet{
+			{Mode: wire.OperateRetValue, Path: fieldPath(0)},
+			{Mode: wire.OperateRetCount, Path: fieldPath(2)},
+		}}, 0)
+	if err != nil {
+		t.Fatalf("freeze: %v", err)
+	}
+	if len(frozen) == 0 || frozen[0] != wire.OperateModeSchema {
+		t.Fatalf("record is not in schema mode: %x", frozen)
+	}
+	if c, _, derr := wire.DecodeTaggedCell(res.Values[0]); derr != nil || c.U != 12 {
+		t.Fatalf("the op after the MIGRATE did not see the frozen record: %+v %v", c, derr)
+	}
+	if c, _, derr := wire.DecodeTaggedCell(res.Values[1]); derr != nil || c.U != 1 {
+		t.Fatalf("row COUNT after the freeze: %+v %v", c, derr)
+	}
+
+	// A later call must speak schema mode, at the frozen version.
+	after, _, _, err := applyRecordBytes(frozen, &wire.OperateArgs{Create: wire.OperateCreateSchema,
+		Schema: fs.Encode(),
+		Ops:    []wire.OperateOp{{Opcode: wire.OperateOpADD, Type: opFromSchema, Path: fieldPath(0), A: 1}}}, 0)
+	if err != nil {
+		t.Fatalf("schema-mode call on a frozen record: %v", err)
+	}
+	rec, err := wire.DecodeRecord(after)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if rec.Fields[0].Cell.U != 13 || string(rec.Fields[1].Cell.B) != "ab" {
+		t.Fatalf("frozen values not carried: %+v", rec.Fields)
+	}
+	if _, _, _, err := applyRecordBytes(frozen, &wire.OperateArgs{Create: wire.OperateCreateDynamic,
+		Ops: []wire.OperateOp{{Opcode: wire.OperateOpADD, Type: wire.OperateTypeU8, Path: namePath("hits"), A: 1}}},
+		0); !errors.Is(err, wire.ErrOperateMode) {
+		t.Fatalf("a dynamic call on a frozen record: err = %v, want ErrOperateMode", err)
+	}
+}
+
+// TestDynamicMigrateRejectsSchemaEvolution pins the other half of §2.9's
+// migrate rule: only a freeze can migrate a dynamic record, since there is no
+// stored schema for an append-only extension to extend.
+func TestDynamicMigrateRejectsSchemaEvolution(t *testing.T) {
+	base, _, _, err := applyRecordBytes(nil, &wire.OperateArgs{Create: wire.OperateCreateDynamic,
+		Ops: []wire.OperateOp{{Opcode: wire.OperateOpSET, Type: wire.OperateTypeU8, Path: namePath("a"), A: 1}}}, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	fs := frozenSchema()
+	if _, _, _, err := applyRecordBytes(base, &wire.OperateArgs{Create: wire.OperateCreateNone,
+		Ops: []wire.OperateOp{{Opcode: wire.OperateOpMIGRATE, Type: opFromSchema, Path: recPath(),
+			A: 3, Bytes: fs.Encode()}}}, 0); !errors.Is(err, wire.ErrOperateMode) {
+		t.Fatalf("err = %v, want ErrOperateMode", err)
+	}
+	// A malformed blob is reported as such whatever the from-version says.
+	if _, _, _, err := applyRecordBytes(base, &wire.OperateArgs{Create: wire.OperateCreateNone,
+		Ops: []wire.OperateOp{{Opcode: wire.OperateOpMIGRATE, Type: opFromSchema, Path: recPath(),
+			A: wire.OperateMigrateFromDynamic, Bytes: []byte{9, 9}}}}, 0); !errors.Is(err, wire.ErrShortArgs) {
+		t.Fatalf("err = %v, want ErrShortArgs", err)
+	}
+}
+
+// --- hostile input ----------------------------------------------------------
+
+// TestDynamicEngineNeverPanics feeds applyRecordBytes dynamic-mode bytes it
+// must treat as hostile: a plain `put` can store anything under an operate
+// key, so every offset in the engine comes from a bounds-checked walk.
+// Truncated records, single-byte mutations and the shared hostile frames must
+// all come back as an error with no output, never a panic — and a record the
+// codec accepts must still be one after the call.
+func TestDynamicEngineNeverPanics(t *testing.T) {
+	valid := bigDynamicRecord(t, 4)
+	a := dynamicArgsFor(keyU64(2))
+	a.Rets = []wire.OperateRet{
+		{Mode: wire.OperateRetValue, Path: recPath()},
+		{Mode: wire.OperateRetValue, Path: namePath("b")},
+		{Mode: wire.OperateRetValue, Path: nameRowPath("b", keyU64(2))},
+		{Mode: wire.OperateRetCount, Path: namePath("b")},
+	}
+	del := &wire.OperateArgs{Create: wire.OperateCreateNone, Ops: []wire.OperateOp{
+		{Opcode: wire.OperateOpDEL, Type: opFromSchema, Path: nameRowPath("b", keyU64(1))},
+		{Opcode: wire.OperateOpDEL, Type: opFromSchema, Path: nameColPath("b", keyU64(3), "c")},
+		{Opcode: wire.OperateOpTRIM, Type: opFromSchema, Path: namePath("b"), A: 1,
+			Aux: wire.OperatePolicyMinCol, Bytes: []byte("c")},
+	}}
+	cfg := &wire.OperateArgs{Create: wire.OperateCreateDynamic, Ops: []wire.OperateOp{
+		{Opcode: wire.OperateOpCONFIG, Type: opFromSchema, Path: namePath("b"), A: 2,
+			Aux: wire.OperatePolicyMaxCol, Bytes: []byte("hi")},
+		{Opcode: wire.OperateOpSET, Type: wire.OperateTypeBytes, Path: namePath("zz"), Bytes: []byte("xy")},
+		{Opcode: wire.OperateOpMIGRATE, Type: opFromSchema, Path: recPath(),
+			A: wire.OperateMigrateFromDynamic, Bytes: frozenSchema().Encode()},
+	}}
+
+	var corpus [][]byte
+	for i := 0; i <= len(valid); i++ { // every prefix, including the empty one
+		corpus = append(corpus, append([]byte(nil), valid[:i]...))
+	}
+	for i := range valid { // every single-byte mutation
+		for _, delta := range []byte{1, 0x80, 0xFF} {
+			m := append([]byte(nil), valid...)
+			m[i] += delta
+			corpus = append(corpus, m)
+		}
+	}
+	for _, body := range hostileBodies() { // the shared hostile frames, as dynamic records
+		corpus = append(corpus, append([]byte{wire.OperateModeDynamic}, body...))
+	}
+
+	for _, args := range []*wire.OperateArgs{a, del, cfg} {
+		for _, in := range corpus {
+			before := append([]byte(nil), in...)
+			out, deleted, res, err := safeApply(in, args)
+			if err != nil {
+				if out != nil || deleted || res != nil {
+					t.Fatalf("error path returned output for %x: out=%x deleted=%v res=%+v", in, out, deleted, res)
+				}
+			} else if out != nil {
+				if _, derr := wire.DecodeRecord(in); derr != nil {
+					// The engine's guarantee is valid in, valid out: bytes the
+					// codec itself rejects are not held to it.
+					continue
+				}
+				if _, derr := wire.DecodeRecord(out); derr != nil {
+					t.Fatalf("accepted valid %x and produced undecodable %x: %v", in, out, derr)
+				}
+			}
+			if !bytes.Equal(in, before) {
+				t.Fatalf("input mutated: %x -> %x", before, in)
+			}
+		}
+	}
+}
+
+// TestNewDynamicEngineValidates pins the structural walk: a frame that does
+// not describe itself exactly is a malformed record, not something to patch.
+func TestNewDynamicEngineValidates(t *testing.T) {
+	valid := bigDynamicRecord(t, 2)
+	if _, err := newDynamicEngine(append([]byte(nil), valid...)); err != nil {
+		t.Fatalf("a valid record must open: %v", err)
+	}
+	bad := map[string][]byte{
+		"empty":            {},
+		"schema mode byte": {wire.OperateModeSchema, 0},
+		"unknown mode":     {7, 0},
+		"no field count":   {wire.OperateModeDynamic},
+		"count overshoots": {wire.OperateModeDynamic, 4},
+		"trailing garbage": append(append([]byte(nil), valid...), 0),
+		"non-canonical count": append([]byte{wire.OperateModeDynamic, 0x80, 0x00},
+			valid[2:]...),
+		"names out of order": {wire.OperateModeDynamic, 2, 1, 'b', wire.OperateTypeU8, 0, 1, 'a', wire.OperateTypeU8, 0},
+		"duplicate names":    {wire.OperateModeDynamic, 2, 1, 'a', wire.OperateTypeU8, 0, 1, 'a', wire.OperateTypeU8, 0},
+		"table type as a cell": {wire.OperateModeDynamic, 1, 1, 'a', wire.OperateTypeTable, 3,
+			0, 0, 0},
+		"zero-length row key": {wire.OperateModeDynamic, 1, 1, 'a', wire.OperateTypeTable, 6,
+			0, 0, 0, 1, 2, 0, 0},
+	}
+	for name, in := range bad {
+		if _, err := newDynamicEngine(append([]byte(nil), in...)); !errors.Is(err, wire.ErrOperateRecord) {
+			t.Errorf("%s: err=%v, want ErrOperateRecord", name, err)
+		}
+	}
+}
+
+// TestDynamicRecordSizeCap covers §2.7's record-size backstop in dynamic
+// mode: growth is charged before the splice allocates for it, so a call that
+// would store an over-large record fails with the record unchanged.
+func TestDynamicRecordSizeCap(t *testing.T) {
+	restore := maxOperateRecordBytes
+	maxOperateRecordBytes = 512
+	t.Cleanup(func() { maxOperateRecordBytes = restore })
+
+	small, _, _, err := applyRecordBytes(nil, &wire.OperateArgs{Create: wire.OperateCreateDynamic,
+		Ops: []wire.OperateOp{{Opcode: wire.OperateOpSET, Type: wire.OperateTypeBytes,
+			Path: namePath("b"), Bytes: bytes.Repeat([]byte{7}, 64)}}}, 0)
+	if err != nil {
+		t.Fatalf("a record under the bound must still apply: %v", err)
+	}
+	before := append([]byte(nil), small...)
+	out, _, _, err := applyRecordBytes(small, &wire.OperateArgs{Create: wire.OperateCreateDynamic,
+		Ops: []wire.OperateOp{{Opcode: wire.OperateOpSET, Type: wire.OperateTypeBytes,
+			Path: namePath("b"), Bytes: bytes.Repeat([]byte{7}, 1024)}}}, 0)
+	if !errors.Is(err, wire.ErrOperateCap) {
+		t.Fatalf("err=%v, want ErrOperateCap", err)
+	}
+	if out != nil {
+		t.Fatalf("a cap hit stored %x", out)
+	}
+	if !bytes.Equal(small, before) {
+		t.Fatal("record changed by a call that hit the record-size cap")
+	}
+}
+
+// TestDynamicEngineIndexGrows covers the field index's fallback off the
+// inline array: a record with more fields than inlineDynFields must index,
+// patch and re-index exactly as a small one does.
+func TestDynamicEngineIndexGrows(t *testing.T) {
+	a := &wire.OperateArgs{Create: wire.OperateCreateDynamic}
+	const n = inlineDynFields * 3
+	for i := 0; i < n; i++ {
+		a.Ops = append(a.Ops, wire.OperateOp{Opcode: wire.OperateOpSET, Type: wire.OperateTypeU32,
+			Path: namePath(fmt.Sprintf("f%02d", i)), A: int64(i)})
+	}
+	out, _, _, err := applyRecordBytes(nil, a, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	rec, err := wire.DecodeRecord(out)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(rec.Fields) != n {
+		t.Fatalf("%d fields, want %d", len(rec.Fields), n)
+	}
+	for i := range rec.Fields {
+		if rec.Fields[i].Name != fmt.Sprintf("f%02d", i) || rec.Fields[i].Cell.U != uint64(i) {
+			t.Fatalf("field %d: %+v", i, rec.Fields[i])
+		}
+	}
+}
+
+// TestDynamicEngineAcceptsExactlyTheCodec pins the engine's structural walk
+// against wire.DecodeRecord: the two must agree, byte stream for byte stream,
+// on which dynamic records exist at all. If the engine were the more
+// permissive of the two it could patch a frame the codec cannot read back;
+// if it were the stricter one it would reject records a follower stored.
+func TestDynamicEngineAcceptsExactlyTheCodec(t *testing.T) {
+	valid := bigDynamicRecord(t, 3)
+	var corpus [][]byte
+	for i := 0; i <= len(valid); i++ {
+		corpus = append(corpus, append([]byte(nil), valid[:i]...))
+	}
+	for i := range valid {
+		for _, delta := range []byte{1, 2, 0x7F, 0x80, 0xFF} {
+			m := append([]byte(nil), valid...)
+			m[i] += delta
+			corpus = append(corpus, m)
+		}
+	}
+	for _, body := range hostileBodies() {
+		corpus = append(corpus, append([]byte{wire.OperateModeDynamic}, body...))
+	}
+
+	agreed := 0
+	for _, in := range corpus {
+		_, cerr := wire.DecodeRecord(append([]byte(nil), in...))
+		_, eerr := newDynamicEngine(append([]byte(nil), in...))
+		if (cerr == nil) != (eerr == nil) {
+			t.Fatalf("codec err=%v, engine err=%v for %x", cerr, eerr, in)
+		}
+		if cerr == nil {
+			agreed++
+		}
+	}
+	if agreed < 2 {
+		t.Fatalf("only %d corpus entries were valid records — the comparison is vacuous", agreed)
+	}
+	t.Logf("%d corpus entries, %d of them valid records", len(corpus), agreed)
+}

--- a/ops/operate_engine.go
+++ b/ops/operate_engine.go
@@ -189,19 +189,29 @@ func trimByCol(b int64) uint16 {
 // might create a FIXED-typed dynamic-mode target: a FIXED cell's width is
 // the length of its operand bytes (design doc §2.1, "FIXED(n): n raw bytes
 // (1-255)"), never a declared width, since there is no schema to declare
-// one. Every other type creates with n=0. Mirrors the oracle's
-// treeCreateType FIXED branch; an out-of-[1,255] length is
-// wire.ErrOperateType, the same error a real too-wide/empty FIXED value
-// gets from wire.ApplyScalar/AppendTaggedCell elsewhere.
-func fixedN(o *wire.OperateOp) (uint8, error) {
+// one. Every other type creates with n=0.
+//
+// An operand that cannot form a FIXED(1-255) cell yields 0, which every
+// engine rejects as wire.ErrOperateType where the width would actually be
+// used (the oracle's treeCreateType). It is deliberately NOT rejected here:
+// the loop must resolve the path first, so that such an op aimed at a table
+// field or a row reports the path error the oracle reports, rather than a
+// type error about a width nothing was going to use.
+func fixedN(o *wire.OperateOp) uint8 {
 	if o.Type != wire.OperateTypeFixed {
-		return 0, nil
+		return 0
 	}
 	if len(o.Bytes) < 1 || len(o.Bytes) > wire.OperateMaxKeyLen {
-		return 0, wire.ErrOperateType
+		return 0
 	}
-	return uint8(len(o.Bytes)), nil //nolint:gosec // bounded to [1,255] above
+	return uint8(len(o.Bytes)) //nolint:gosec // bounded to [1,255] above
 }
+
+// opcodeInspect is the pseudo-opcode a create=false resolve runs under when
+// no op is driving it (evalRets). It is not a wire opcode — 0 is not one —
+// and no engine consults the opcode for a create=false resolve, where a
+// stored type is never checked or replaced.
+const opcodeInspect uint8 = 0
 
 // zeroTypeFor is the type an ABSENT dynamic-mode target reads as for an op
 // that only inspects it (design doc §2.4, "absent is zero"; the oracle's
@@ -320,19 +330,35 @@ func applyOps(e engine, ops []wire.OperateOp, stampMs int64) (uint8, uint16, err
 			}
 
 		case wire.OperateOpCONFIG:
-			// config() takes no path (only the ref it resolves to), so this
-			// is the only place that can reject CONFIG at a row/col/record
-			// path — a table's eviction config lives on the field itself
-			// (oracle ruling).
-			if o.Path.Kind != wire.OperatePathField {
-				return 0, 0, wire.ErrOperatePath
+			// Order matters here, because every one of these checks can fail
+			// with a different error and the oracle fixes which one wins
+			// (design doc §3.2 says what CONFIG means; the oracle's config
+			// says in what order it says no):
+			//
+			//	mode -> path kind -> path name -> name lengths -> cap ->
+			//	policy -> a *_COL policy's column name -> the field's kind
+			//
+			// The first three belong to resolve, which is the only thing
+			// that knows the record's mode: a schema-mode record answers
+			// wire.ErrOperateOpcode there, before it looks at the path at
+			// all, because a schema-mode table's eviction triple comes from
+			// its schema and cannot be set per record. The last two belong
+			// to config. Only the operand checks in the middle are the
+			// loop's, and they run AFTER resolve has vivified the table
+			// field, which costs nothing: an error discards the whole
+			// working copy anyway.
+			r, err := e.resolve(o.Path, true, o.Opcode, wire.OperateTypeTable, 0)
+			if err != nil {
+				return 0, 0, err
+			}
+			if len(o.Bytes) > wire.OperateMaxNameLen {
+				return 0, 0, wire.ErrOperateCap
 			}
 			if err := checkRowCap(o.A); err != nil {
 				return 0, 0, err
 			}
-			r, err := e.resolve(o.Path, true, o.Opcode, wire.OperateTypeTable, 0)
-			if err != nil {
-				return 0, 0, err
+			if o.Aux > wire.OperatePolicyMaxCol {
+				return 0, 0, wire.ErrOperateSchema
 			}
 			if err := e.config(r, uint32(o.A), o.Aux, string(o.Bytes)); err != nil { //nolint:gosec // o.A bounded above
 				return 0, 0, err
@@ -365,11 +391,7 @@ func applyOps(e engine, ops []wire.OperateOp, stampMs int64) (uint8, uint16, err
 		default: // the scalar ops (SET/ADD/MUL/MIN/MAX/AND/OR/XOR/SHL/SHR/STAMP);
 			// wire.ApplyScalar itself rejects anything else with
 			// wire.ErrOperateOpcode.
-			n, err := fixedN(o)
-			if err != nil {
-				return 0, 0, err
-			}
-			r, err := e.resolve(o.Path, true, o.Opcode, o.Type, n)
+			r, err := e.resolve(o.Path, true, o.Opcode, o.Type, fixedN(o))
 			if err != nil {
 				return 0, 0, err
 			}
@@ -423,7 +445,7 @@ func evalRets(e engine, rets []wire.OperateRet) ([][]byte, error) {
 		// control op: no type check on what it finds, and an absent dynamic
 		// target's zero type is irrelevant (evalRets substitutes UNSET / a
 		// zero count itself rather than reading it).
-		nd, err := e.resolve(r.Path, false, wire.OperateOpIF, 0, 0)
+		nd, err := e.resolve(r.Path, false, opcodeInspect, 0, 0)
 		if err != nil {
 			return nil, err
 		}

--- a/ops/operate_engine.go
+++ b/ops/operate_engine.go
@@ -3,6 +3,7 @@
 package ops
 
 import (
+	"encoding/binary"
 	"errors"
 
 	"github.com/rostamlabs/rostam/sdk/wire"
@@ -394,4 +395,50 @@ func evalRets(e engine, rets []wire.OperateRet) ([][]byte, error) {
 // §3.4).
 func appendCountValue(n uint64) []byte {
 	return wire.AppendTaggedCell(nil, wire.Cell{Type: wire.OperateTypeU64, U: n})
+}
+
+// --- shared byte helpers ---------------------------------------------------
+//
+// Both byte-level engines patch a record by replacing one span of it with
+// another, so the two primitives live here rather than in either engine.
+
+// splice replaces buf[off:off+oldLen] with repl and returns the resulting
+// buffer, reusing buf's storage whenever its capacity can absorb the growth
+// (the initial record copy reserves slack precisely so a row insert usually
+// can). The caller is responsible for charging the growth against the
+// record-size cap first: splice itself allocates whatever it is asked to.
+func splice(buf []byte, off, oldLen int, repl []byte) []byte {
+	delta := len(repl) - oldLen
+	switch {
+	case delta == 0:
+		copy(buf[off:], repl)
+		return buf
+	case delta > 0 && cap(buf)-len(buf) < delta:
+		out := make([]byte, len(buf)+delta, len(buf)+delta+64)
+		copy(out, buf[:off])
+		copy(out[off:], repl)
+		copy(out[off+len(repl):], buf[off+oldLen:])
+		return out
+	case delta > 0:
+		old := len(buf)
+		buf = buf[:old+delta]
+		// copy is a memmove: the tail may overlap its destination.
+		copy(buf[off+len(repl):], buf[off+oldLen:old])
+		copy(buf[off:], repl)
+		return buf
+	default:
+		copy(buf[off:], repl)
+		copy(buf[off+len(repl):], buf[off+oldLen:])
+		return buf[:len(buf)+delta]
+	}
+}
+
+// spliceUvarint replaces buf[off:off+oldLen] with the canonical uvarint
+// encoding of v, returning the buffer and the new encoding's length. It is
+// how a row count or a length prefix is rewritten in place when the value's
+// encoded width may change.
+func spliceUvarint(buf []byte, off, oldLen int, v uint64) ([]byte, int) {
+	var tmp [binary.MaxVarintLen64]byte
+	n := binary.PutUvarint(tmp[:], v)
+	return splice(buf, off, oldLen, tmp[:n]), n
 }

--- a/ops/operate_engine.go
+++ b/ops/operate_engine.go
@@ -315,6 +315,13 @@ func applyOps(e engine, ops []wire.OperateOp, stampMs int64) (uint8, uint16, err
 			if err != nil {
 				return 0, 0, err
 			}
+			// resolve reports what it found, not whether it fits a scalar
+			// op: a path can resolve straight to the record, a table, or a
+			// row (e.g. a stray Col-shaped op against a plain field). Only
+			// refKindScalar is a valid scalar-op target (oracle ruling).
+			if r.kind != refKindScalar {
+				return 0, 0, wire.ErrOperatePath
+			}
 			cur, err := e.get(r)
 			if err != nil {
 				return 0, 0, err

--- a/ops/operate_engine.go
+++ b/ops/operate_engine.go
@@ -94,8 +94,19 @@ type engine interface {
 	// with (schema mode ignores them, since the schema is authoritative);
 	// applyOps computes n as len(o.Bytes) for a FIXED target it is about to
 	// create (see fixedN) and 0 otherwise, matching the wire encoding of a
-	// freshly created FIXED cell.
-	resolve(p wire.OperatePath, create bool, typ, n uint8) (ref, error)
+	// freshly created FIXED cell. For a create=false resolve, typ/n are
+	// instead the type an ABSENT dynamic target reads as (see zeroTypeFor),
+	// and no type check is performed on a target that does exist — every
+	// create=false caller is a control op, whose type byte the design doc
+	// §2.4 rules never check against a stored type.
+	//
+	// opcode is the op resolve is running for. Only dynamic mode consults
+	// it, and only for a create=true resolve, where design doc §2.9's
+	// "SET replaces the scalar including its type" makes SET the one op
+	// whose declared type may differ from the stored one without being a
+	// domain error (the oracle's treeCheckDynType/treeRetype pair). Schema
+	// mode ignores it: a schema-mode field's type is never replaced.
+	resolve(p wire.OperatePath, create bool, opcode, typ, n uint8) (ref, error)
 	// get returns r's current scalar value. If !r.present this is the
 	// type's zero cell (design doc §2.4, "absent reads as zero") — callers
 	// pass r.present alongside it to whatever needs to distinguish the two.
@@ -192,12 +203,39 @@ func fixedN(o *wire.OperateOp) (uint8, error) {
 	return uint8(len(o.Bytes)), nil //nolint:gosec // bounded to [1,255] above
 }
 
+// zeroTypeFor is the type an ABSENT dynamic-mode target reads as for an op
+// that only inspects it (design doc §2.4, "absent is zero"; the oracle's
+// treeZeroTypeFor). The op's own type byte picks the zero's domain — so a
+// comparison against an absent BYTES-typed target compares bytewise (empty
+// against the operand) rather than as an integer — and an integer zero is
+// the fallback for 0xFF and for any byte that is not a value type at all.
+// A FIXED zero is as wide as the operand it is compared against, since
+// there is no schema to declare a width.
+//
+// Schema mode never needs it (the schema is authoritative for every field's
+// type), and it is only meaningful where the target is absent: a stored
+// value's own type always wins over the op's byte.
+func zeroTypeFor(o *wire.OperateOp) (uint8, uint8) {
+	if o.Type < wire.OperateTypeCount && o.Type != wire.OperateTypeTable && o.Type != wire.OperateTypeUnset {
+		if o.Type != wire.OperateTypeFixed {
+			return o.Type, 0
+		}
+		if len(o.Bytes) >= 1 && len(o.Bytes) <= wire.OperateMaxKeyLen {
+			return o.Type, uint8(len(o.Bytes)) //nolint:gosec // bounded to [1,255] above
+		}
+	}
+	return wire.OperateTypeU8, 0
+}
+
 // evalCond evaluates one IF/CHECK op's comparator against the node its path
 // addresses (design doc §3.3). It never vivifies (resolve's create=false).
-// The comparator travels in o.Aux (control ops otherwise ignore the type
-// byte — o.Type is never consulted here, matching resolve's typ=0/n=0).
+// The comparator travels in o.Aux; the type byte is not checked against a
+// stored type (a control op never declares one, §2.4) but does pick the
+// domain an absent dynamic target compares in, which is what zeroTypeFor
+// hands to resolve.
 func evalCond(e engine, o *wire.OperateOp) (bool, error) {
-	r, err := e.resolve(o.Path, false, 0, 0)
+	zeroTyp, zeroN := zeroTypeFor(o)
+	r, err := e.resolve(o.Path, false, o.Opcode, zeroTyp, zeroN)
 	if err != nil {
 		return false, err
 	}
@@ -267,7 +305,7 @@ func applyOps(e engine, ops []wire.OperateOp, stampMs int64) (uint8, uint16, err
 			}
 
 		case wire.OperateOpDEL:
-			r, err := e.resolve(o.Path, false, 0, 0)
+			r, err := e.resolve(o.Path, false, o.Opcode, 0, 0)
 			if err != nil {
 				return 0, 0, err
 			}
@@ -292,7 +330,7 @@ func applyOps(e engine, ops []wire.OperateOp, stampMs int64) (uint8, uint16, err
 			if err := checkRowCap(o.A); err != nil {
 				return 0, 0, err
 			}
-			r, err := e.resolve(o.Path, true, wire.OperateTypeTable, 0)
+			r, err := e.resolve(o.Path, true, o.Opcode, wire.OperateTypeTable, 0)
 			if err != nil {
 				return 0, 0, err
 			}
@@ -316,7 +354,7 @@ func applyOps(e engine, ops []wire.OperateOp, stampMs int64) (uint8, uint16, err
 			if o.Aux > wire.OperatePolicyMaxCol {
 				return 0, 0, wire.ErrOperateSchema
 			}
-			r, err := e.resolve(o.Path, false, 0, 0)
+			r, err := e.resolve(o.Path, false, o.Opcode, 0, 0)
 			if err != nil {
 				return 0, 0, err
 			}
@@ -331,7 +369,7 @@ func applyOps(e engine, ops []wire.OperateOp, stampMs int64) (uint8, uint16, err
 			if err != nil {
 				return 0, 0, err
 			}
-			r, err := e.resolve(o.Path, true, o.Type, n)
+			r, err := e.resolve(o.Path, true, o.Opcode, o.Type, n)
 			if err != nil {
 				return 0, 0, err
 			}
@@ -381,7 +419,11 @@ func evalRets(e engine, rets []wire.OperateRet) ([][]byte, error) {
 		if r.Mode != wire.OperateRetValue && r.Mode != wire.OperateRetCount {
 			return nil, wire.ErrOperateArgs
 		}
-		nd, err := e.resolve(r.Path, false, 0, 0)
+		// A return spec inspects but never writes, so it resolves like a
+		// control op: no type check on what it finds, and an absent dynamic
+		// target's zero type is irrelevant (evalRets substitutes UNSET / a
+		// zero count itself rather than reading it).
+		nd, err := e.resolve(r.Path, false, wire.OperateOpIF, 0, 0)
 		if err != nil {
 			return nil, err
 		}

--- a/ops/operate_engine.go
+++ b/ops/operate_engine.go
@@ -223,6 +223,12 @@ func applyOps(e engine, ops []wire.OperateOp, stampMs int64) (uint8, uint16, err
 			if i != 0 {
 				return 0, 0, wire.ErrOperateOpcode
 			}
+			// migrate() takes no path (it always addresses the whole
+			// record), so this is the only place that can reject a
+			// MIGRATE aimed at a field/row/col (oracle ruling).
+			if o.Path.Kind != wire.OperatePathRecord {
+				return 0, 0, wire.ErrOperatePath
+			}
 			if err := e.migrate(o.A, o.Aux, o.Bytes); err != nil {
 				return 0, 0, err
 			}
@@ -262,6 +268,13 @@ func applyOps(e engine, ops []wire.OperateOp, stampMs int64) (uint8, uint16, err
 			}
 
 		case wire.OperateOpCONFIG:
+			// config() takes no path (only the ref it resolves to), so this
+			// is the only place that can reject CONFIG at a row/col/record
+			// path — a table's eviction config lives on the field itself
+			// (oracle ruling).
+			if o.Path.Kind != wire.OperatePathField {
+				return 0, 0, wire.ErrOperatePath
+			}
 			if err := checkRowCap(o.A); err != nil {
 				return 0, 0, err
 			}
@@ -274,6 +287,12 @@ func applyOps(e engine, ops []wire.OperateOp, stampMs int64) (uint8, uint16, err
 			}
 
 		case wire.OperateOpTRIM:
+			// trim() takes no path either, and unlike CONFIG it does not
+			// even create — a row/col/record path is rejected here before
+			// resolve gets a chance to no-op it as merely absent.
+			if o.Path.Kind != wire.OperatePathField {
+				return 0, 0, wire.ErrOperatePath
+			}
 			if err := checkRowCap(o.A); err != nil {
 				return 0, 0, err
 			}

--- a/ops/operate_engine.go
+++ b/ops/operate_engine.go
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package ops
+
+import "errors"
+
+// maxOperateRecordBytes is the design doc §2.7 backstop on a stored operate
+// record: after a call's ops apply, the encoded record must still fit, or the
+// call fails with wire.ErrOperateCap and the record is left unchanged (a cap
+// hit is never an implicit eviction). It is a var rather than a const so a
+// test can lower it and exercise the bound without building 16 MiB of record.
+var maxOperateRecordBytes = 16 << 20
+
+var (
+	// errOperateAbsent is the "create = NONE and the key does not exist"
+	// error of design doc §3.5. The handler maps it to the store's
+	// not-found error.
+	errOperateAbsent = errors.New("ops: operate record absent")
+	// errOperateIfRange marks an IF whose skip count is negative or reaches
+	// past the end of the op list (design doc §3.3, "n bounded by the
+	// remaining list"). The bound is checked whenever the IF executes, not
+	// only when the branch is taken, so a malformed op list is rejected the
+	// same way regardless of the data it runs against.
+	errOperateIfRange = errors.New("ops: operate IF skip count out of range")
+)

--- a/ops/operate_engine.go
+++ b/ops/operate_engine.go
@@ -2,7 +2,11 @@
 
 package ops
 
-import "errors"
+import (
+	"errors"
+
+	"github.com/rostamlabs/rostam/sdk/wire"
+)
 
 // maxOperateRecordBytes is the design doc §2.7 backstop on a stored operate
 // record: after a call's ops apply, the encoded record must still fit, or the
@@ -23,3 +27,345 @@ var (
 	// same way regardless of the data it runs against.
 	errOperateIfRange = errors.New("ops: operate IF skip count out of range")
 )
+
+// ref addresses one node inside a record for one op: the record itself, a
+// scalar field or column, a table field, or one row of a table. It is the
+// engine's own bookkeeping — field, row, col, off, typ, and n are filled in
+// (and read back) however a given engine needs, and applyOps never looks at
+// them. applyOps reads exactly two of ref's members:
+//
+//   - kind: one of the refKind* constants below, so evalCond (and nothing
+//     else in the loop) can tell a count-shaped target (the record, a table
+//     field, or a table row — design doc §3.3, "a table compares by its row
+//     count") from a scalar one without otherwise interpreting the ref.
+//   - present: whether the path resolved to something that already existed
+//     before this call (design doc §2.4/§2.5). For OperatePathRecord this is
+//     "did the record exist before the call", not "does it exist now" (the
+//     oracle's ruling: CHECK((), ABSENT) means "this call created it").
+//
+// resolve is the only place a ref is produced; every other engine method
+// takes one back exactly as resolve returned it.
+type ref struct {
+	kind uint8
+	//nolint:unused // reserved for the byte-level engines (Tasks 8/10); applyOps never reads it
+	field int
+	//nolint:unused // reserved for the byte-level engines (Tasks 8/10); applyOps never reads it
+	row int
+	//nolint:unused // reserved for the byte-level engines (Tasks 8/10); applyOps never reads it
+	col     int
+	off     int
+	typ, n  uint8
+	present bool
+}
+
+// refKind* are the values an engine's resolve stores in ref.kind (see ref's
+// doc comment). They are this file's own vocabulary — not part of the wire
+// protocol — shared with every engine that implements engine below.
+const (
+	// refKindScalar is a record field or table column holding one Cell:
+	// compared with wire.CompareCell, applied with wire.ApplyScalar.
+	refKindScalar uint8 = iota
+	// refKindRecord is the record itself (o.Path.Kind == wire.OperatePathRecord):
+	// compared by field count via count().
+	refKindRecord
+	// refKindTable is a table field: compared by row count via count().
+	refKindTable
+	// refKindRow is one row of a table: compared by presence, which count()
+	// reports as 1 (present) or 0 (absent) — the oracle's ruling that a row
+	// has no value of its own, so EXISTS/ABSENT are the only comparators
+	// with a useful meaning on it.
+	refKindRow
+)
+
+// engine is what applyOps and evalRets need from a stored operate record to
+// run one call's op and return specs (design doc §3). Two implementations
+// exist: a schema-mode engine and a dynamic-mode engine, each patching its
+// own stored byte layout in place; applyOps is the one place that knows op
+// dispatch semantics, so neither engine needs to duplicate it.
+//
+// Every method's error is returned verbatim by applyOps/evalRets — engines
+// return the wire.ErrOperate* sentinels, never a wrapped or engine-private
+// error, so callers (and tests comparing against the oracle) can compare by
+// errors.Is.
+type engine interface {
+	// resolve looks up path and returns a ref to it. create=false never
+	// vivifies anything (used by DEL, TRIM, IF/CHECK, and evalRets); create
+	// =true vivifies what a write needs — rows in both modes, fields/columns
+	// in dynamic mode (schema-mode fields always exist, design doc §2.5).
+	// typ/n are the type to create an absent DYNAMIC-mode scalar target
+	// with (schema mode ignores them, since the schema is authoritative);
+	// applyOps computes n as len(o.Bytes) for a FIXED target it is about to
+	// create (see fixedN) and 0 otherwise, matching the wire encoding of a
+	// freshly created FIXED cell.
+	resolve(p wire.OperatePath, create bool, typ, n uint8) (ref, error)
+	// get returns r's current scalar value. If !r.present this is the
+	// type's zero cell (design doc §2.4, "absent reads as zero") — callers
+	// pass r.present alongside it to whatever needs to distinguish the two.
+	get(r ref) (wire.Cell, error)
+	// set writes c to r's scalar target, vivifying it if resolve did not
+	// already (create was true).
+	set(r ref, c wire.Cell) error
+	// del implements DEL for r's kind (design doc §3.1/§2.5): the record ->
+	// deleted; a field -> UNSET (schema mode) or removed (dynamic mode); a
+	// table -> emptied; a row/col -> removed. It never vivifies: deleting
+	// something r.present == false reports is a no-op, not an error.
+	del(r ref) error
+	// count reports r's count for a compare (evalCond) or a RetCount
+	// (evalRets; design doc §3.3/§3.4): field count for refKindRecord, row
+	// count for refKindTable, and presence as 1 (present) or 0 (absent) for
+	// refKindRow and refKindScalar alike (the oracle's ruling: a plain
+	// scalar's "count" is only ever meaningful as exists/absent, the same
+	// convention as a row). evalCond never calls it for refKindScalar — it
+	// uses CompareCell there instead — but evalRets' RetCount does not
+	// special-case any kind, so an engine must still answer for a scalar
+	// ref.
+	count(r ref) (uint64, error)
+	// trim shrinks the table field at r to at most keep rows by policy (and,
+	// for a *_COL policy, byCol in schema mode or byColName in dynamic
+	// mode), leaving the table's stored eviction config untouched (design
+	// doc §3.2). It is a shrink, not a write: an absent table (r.present ==
+	// false) is a no-op.
+	trim(r ref, keep uint32, policy uint8, byCol uint16, byColName string) error
+	// config sets the table field at r's eviction triple (cap, policy,
+	// byColName), creating an empty table if absent, and evicts down to the
+	// new cap (design doc §3.2). Dynamic mode only.
+	config(r ref, capN uint32, policy uint8, byColName string) error
+	// migrate implements MIGRATE (design doc §2.8/§2.9): append-only schema
+	// evolution (from >= 0) or a dynamic-mode freeze (from ==
+	// wire.OperateMigrateFromDynamic). applyOps guarantees it is only ever
+	// called for ops[0].
+	migrate(from int64, flags uint8, schemaBlob []byte) error
+	// value returns r's tagged encoding for a RetValue (design doc §3.4):
+	// AppendTaggedCell's output for a scalar, the table's own encoding for
+	// refKindTable, and (design doc §2.4) the row's encoding for refKindRow.
+	// It is never called when r.present is false — evalRets substitutes
+	// []byte{wire.OperateTypeUnset} itself in that case.
+	value(r ref) ([]byte, error)
+	// bytes returns the record's current encoded form.
+	bytes() []byte
+	// empty reports whether the record should be deleted as a side effect
+	// of the ops that ran (design doc §2.5: a dynamic-mode record that lost
+	// its last field). applyOps does not call this itself — it is read by
+	// the caller once applyOps returns OK.
+	empty() bool
+}
+
+// checkRowCap bounds a CONFIG/TRIM cap operand to [0, wire.OperateMaxRows]
+// (design doc §2.7): negative or oversized is wire.ErrOperateCap, checked
+// before resolve so a hostile cap never even vivifies the table field.
+func checkRowCap(a int64) error {
+	if a < 0 || a > int64(wire.OperateMaxRows) {
+		return wire.ErrOperateCap
+	}
+	return nil
+}
+
+// fixedN computes the n (width) applyOps passes to resolve when a scalar op
+// might create a FIXED-typed dynamic-mode target: a FIXED cell's width is
+// the length of its operand bytes (design doc §2.1, "FIXED(n): n raw bytes
+// (1-255)"), never a declared width, since there is no schema to declare
+// one. Every other type creates with n=0. Mirrors the oracle's
+// treeCreateType FIXED branch; an out-of-[1,255] length is
+// wire.ErrOperateType, the same error a real too-wide/empty FIXED value
+// gets from wire.ApplyScalar/AppendTaggedCell elsewhere.
+func fixedN(o *wire.OperateOp) (uint8, error) {
+	if o.Type != wire.OperateTypeFixed {
+		return 0, nil
+	}
+	if len(o.Bytes) < 1 || len(o.Bytes) > wire.OperateMaxKeyLen {
+		return 0, wire.ErrOperateType
+	}
+	return uint8(len(o.Bytes)), nil //nolint:gosec // bounded to [1,255] above
+}
+
+// evalCond evaluates one IF/CHECK op's comparator against the node its path
+// addresses (design doc §3.3). It never vivifies (resolve's create=false).
+// The comparator travels in o.Aux (control ops otherwise ignore the type
+// byte — o.Type is never consulted here, matching resolve's typ=0/n=0).
+func evalCond(e engine, o *wire.OperateOp) (bool, error) {
+	r, err := e.resolve(o.Path, false, 0, 0)
+	if err != nil {
+		return false, err
+	}
+	op := wire.Operand{A: o.A, Bytes: o.Bytes}
+	if r.kind == refKindScalar {
+		c, err := e.get(r)
+		if err != nil {
+			return false, err
+		}
+		return wire.CompareCell(o.Aux, c, r.present, op)
+	}
+	// refKindRecord, refKindTable, refKindRow: all three compare by count
+	// (design doc §3.3) — a row's count() is defined as 1/0 by presence.
+	n, err := e.count(r)
+	if err != nil {
+		return false, err
+	}
+	return wire.CompareCount(o.Aux, n, r.present, op)
+}
+
+// applyOps runs a call's op list against e in order (design doc §3.1-§3.3),
+// returning the result status, the failing op's index on
+// wire.OperateStatusCheckFailed, or a non-nil error. On any error the loop
+// stops immediately — it never continues to a later op, so nothing beyond
+// what e's own methods already touched is applied; the caller is expected to
+// hold e's changes in a copy that is discarded whole on error (the engine
+// owns atomicity of that buffer, applyOps only owns not making it worse by
+// running further ops after a failure).
+func applyOps(e engine, ops []wire.OperateOp, stampMs int64) (uint8, uint16, error) {
+	for i := 0; i < len(ops); i++ {
+		o := &ops[i]
+		switch o.Opcode {
+		case wire.OperateOpMIGRATE:
+			// MIGRATE must be the first op (design doc §2.8); the caller
+			// enforces it can only ever be Ops[0] by construction, but a
+			// hostile/malformed op list might still carry one later.
+			if i != 0 {
+				return 0, 0, wire.ErrOperateOpcode
+			}
+			if err := e.migrate(o.A, o.Aux, o.Bytes); err != nil {
+				return 0, 0, err
+			}
+
+		case wire.OperateOpIF, wire.OperateOpCHECK:
+			// IF's skip count is validated whenever the op runs, not only
+			// when the branch not-taken path would use it: a malformed op
+			// list is malformed regardless of what the record holds (design
+			// doc §3.3, oracle ruling).
+			if o.Opcode == wire.OperateOpIF && (o.B < 0 || o.B > int64(len(ops)-1-i)) {
+				return 0, 0, errOperateIfRange
+			}
+			ok, err := evalCond(e, o)
+			if err != nil {
+				return 0, 0, err
+			}
+			if !ok {
+				if o.Opcode == wire.OperateOpCHECK {
+					return wire.OperateStatusCheckFailed, uint16(i), nil //nolint:gosec // i bounded by wire.OperateMaxOps
+				}
+				i += int(o.B)
+			}
+
+		case wire.OperateOpDEL:
+			r, err := e.resolve(o.Path, false, 0, 0)
+			if err != nil {
+				return 0, 0, err
+			}
+			if err := e.del(r); err != nil {
+				return 0, 0, err
+			}
+			// DEL () is terminal (oracle ruling): the record is gone, so
+			// the list ends here rather than running further ops against
+			// nothing (design doc §3.1).
+			if o.Path.Kind == wire.OperatePathRecord {
+				return wire.OperateStatusOK, 0, nil
+			}
+
+		case wire.OperateOpCONFIG:
+			if err := checkRowCap(o.A); err != nil {
+				return 0, 0, err
+			}
+			r, err := e.resolve(o.Path, true, wire.OperateTypeTable, 0)
+			if err != nil {
+				return 0, 0, err
+			}
+			if err := e.config(r, uint32(o.A), o.Aux, string(o.Bytes)); err != nil { //nolint:gosec // o.A bounded above
+				return 0, 0, err
+			}
+
+		case wire.OperateOpTRIM:
+			if err := checkRowCap(o.A); err != nil {
+				return 0, 0, err
+			}
+			r, err := e.resolve(o.Path, false, 0, 0)
+			if err != nil {
+				return 0, 0, err
+			}
+			if err := e.trim(r, uint32(o.A), o.Aux, uint16(o.B), string(o.Bytes)); err != nil { //nolint:gosec // o.A bounded above; o.B is a column position, not attacker-scaled
+				return 0, 0, err
+			}
+
+		default: // the scalar ops (SET/ADD/MUL/MIN/MAX/AND/OR/XOR/SHL/SHR/STAMP);
+			// wire.ApplyScalar itself rejects anything else with
+			// wire.ErrOperateOpcode.
+			n, err := fixedN(o)
+			if err != nil {
+				return 0, 0, err
+			}
+			r, err := e.resolve(o.Path, true, o.Type, n)
+			if err != nil {
+				return 0, 0, err
+			}
+			cur, err := e.get(r)
+			if err != nil {
+				return 0, 0, err
+			}
+			next, err := wire.ApplyScalar(o.Opcode, cur, r.present,
+				wire.Operand{A: o.A, Aux: o.Aux, Bytes: o.Bytes, StampMs: stampMs})
+			if err != nil {
+				return 0, 0, err
+			}
+			if err := e.set(r, next); err != nil {
+				return 0, 0, err
+			}
+		}
+	}
+	return wire.OperateStatusOK, 0, nil
+}
+
+// evalRets evaluates every return spec after applyOps returns (or, on
+// wire.OperateStatusCheckFailed, against the pre-call record — the caller
+// picks which engine instance to pass; evalRets itself is agnostic to that,
+// design doc §3.4). It never vivifies (resolve's create=false).
+//
+// Absent-path mechanism: a ret whose path resolves with ref.present == false
+// never calls value()/count() at all — evalRets substitutes
+// []byte{wire.OperateTypeUnset} for RetValue and a tagged zero for RetCount
+// itself. This is the "absent reads as zero/unset" rule (design doc §2.4)
+// applied uniformly across scalar, row, table, and record paths, and it is
+// the only absent-path mechanism an engine needs to support: value() and
+// count() are never asked to report absence themselves.
+func evalRets(e engine, rets []wire.OperateRet) ([][]byte, error) {
+	if len(rets) == 0 {
+		return nil, nil
+	}
+	out := make([][]byte, 0, len(rets))
+	for i := range rets {
+		r := &rets[i]
+		if r.Mode != wire.OperateRetValue && r.Mode != wire.OperateRetCount {
+			return nil, wire.ErrOperateArgs
+		}
+		nd, err := e.resolve(r.Path, false, 0, 0)
+		if err != nil {
+			return nil, err
+		}
+		if !nd.present {
+			if r.Mode == wire.OperateRetCount {
+				out = append(out, appendCountValue(0))
+			} else {
+				out = append(out, []byte{wire.OperateTypeUnset})
+			}
+			continue
+		}
+		if r.Mode == wire.OperateRetCount {
+			n, err := e.count(nd)
+			if err != nil {
+				return nil, err
+			}
+			out = append(out, appendCountValue(n))
+			continue
+		}
+		v, err := e.value(nd)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, v)
+	}
+	return out, nil
+}
+
+// appendCountValue encodes a RetCount result as a tagged U64 (design doc
+// §3.4).
+func appendCountValue(n uint64) []byte {
+	return wire.AppendTaggedCell(nil, wire.Cell{Type: wire.OperateTypeU64, U: n})
+}

--- a/ops/operate_engine.go
+++ b/ops/operate_engine.go
@@ -47,12 +47,9 @@ var (
 // resolve is the only place a ref is produced; every other engine method
 // takes one back exactly as resolve returned it.
 type ref struct {
-	kind uint8
-	//nolint:unused // reserved for the byte-level engines (Tasks 8/10); applyOps never reads it
-	field int
-	//nolint:unused // reserved for the byte-level engines (Tasks 8/10); applyOps never reads it
-	row int
-	//nolint:unused // reserved for the byte-level engines (Tasks 8/10); applyOps never reads it
+	kind    uint8
+	field   int
+	row     int
 	col     int
 	off     int
 	typ, n  uint8
@@ -159,6 +156,22 @@ func checkRowCap(a int64) error {
 		return wire.ErrOperateCap
 	}
 	return nil
+}
+
+// trimByCol narrows a TRIM's eviction-column operand to the uint16 the engines
+// address columns with, without letting a hostile value alias a real column: an
+// int64 outside [0, OperateMaxCols) becomes OperateMaxCols, which is one past
+// the highest addressable position (a schema's ByCol must be < len(Cols), and
+// len(Cols) <= OperateMaxCols), so a schema-mode engine rejects it with
+// wire.ErrOperatePath exactly as the oracle rejects the original out-of-range
+// value. Dynamic mode addresses the eviction column by name and ignores this
+// entirely. Without the clamp, o.B = 65536 (or -65536) would silently trim by
+// column 0.
+func trimByCol(b int64) uint16 {
+	if b < 0 || b >= int64(wire.OperateMaxCols) {
+		return wire.OperateMaxCols
+	}
+	return uint16(b) //nolint:gosec // bounded to [0, OperateMaxCols) above
 }
 
 // fixedN computes the n (width) applyOps passes to resolve when a scalar op
@@ -297,11 +310,17 @@ func applyOps(e engine, ops []wire.OperateOp, stampMs int64) (uint8, uint16, err
 			if err := checkRowCap(o.A); err != nil {
 				return 0, 0, err
 			}
+			// The policy byte is validated before resolve, not inside the
+			// engine: an unknown policy is a malformed op whatever the
+			// record holds (the oracle checks it in the same place).
+			if o.Aux > wire.OperatePolicyMaxCol {
+				return 0, 0, wire.ErrOperateSchema
+			}
 			r, err := e.resolve(o.Path, false, 0, 0)
 			if err != nil {
 				return 0, 0, err
 			}
-			if err := e.trim(r, uint32(o.A), o.Aux, uint16(o.B), string(o.Bytes)); err != nil { //nolint:gosec // o.A bounded above; o.B is a column position, not attacker-scaled
+			if err := e.trim(r, uint32(o.A), o.Aux, trimByCol(o.B), string(o.Bytes)); err != nil { //nolint:gosec // o.A bounded by checkRowCap above
 				return 0, 0, err
 			}
 

--- a/ops/operate_engine_test.go
+++ b/ops/operate_engine_test.go
@@ -390,6 +390,53 @@ func TestApplyOpsMigrate(t *testing.T) {
 	if len(f2.migrated) != 0 {
 		t.Fatalf("migrate must not have been called: %v", f2.migrated)
 	}
+
+	// MIGRATE at index 0 but not addressing the record -> wire.ErrOperatePath,
+	// and e.migrate must never be called (migrate() has no path of its own
+	// to reject it with).
+	f3 := newFakeEngine()
+	ops3 := []wire.OperateOp{
+		{Opcode: wire.OperateOpMIGRATE, A: 3, Path: fakeFieldPath("x")},
+	}
+	_, _, err = applyOps(f3, ops3, 0)
+	if !errors.Is(err, wire.ErrOperatePath) {
+		t.Fatalf("applyOps (MIGRATE not at record path): err=%v, want wire.ErrOperatePath", err)
+	}
+	if len(f3.migrated) != 0 {
+		t.Fatalf("migrate must not have been called: %v", f3.migrated)
+	}
+}
+
+// CONFIG/TRIM at a row, col, or record path -> wire.ErrOperatePath, without
+// ever calling resolve (config()/trim() have no path of their own to reject
+// it with, so the loop must).
+func TestApplyOpsConfigTrimPathKind(t *testing.T) {
+	cases := []struct {
+		name string
+		op   wire.OperateOp
+	}{
+		{"config-row", wire.OperateOp{Opcode: wire.OperateOpCONFIG, Path: fakeRowPath("b", "k1"), A: 1}},
+		{"config-record", wire.OperateOp{Opcode: wire.OperateOpCONFIG, Path: fakeRecordPath(), A: 1}},
+		{"trim-row", wire.OperateOp{Opcode: wire.OperateOpTRIM, Path: fakeRowPath("b", "k1"), A: 1}},
+		{"trim-record", wire.OperateOp{Opcode: wire.OperateOpTRIM, Path: fakeRecordPath(), A: 1}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			f := newFakeEngine()
+			_, _, err := applyOps(f, []wire.OperateOp{tc.op}, 0)
+			if !errors.Is(err, wire.ErrOperatePath) {
+				t.Fatalf("%s: err=%v, want wire.ErrOperatePath", tc.name, err)
+			}
+			for _, call := range f.calls {
+				if len(call) >= len("resolve:") && call[:len("resolve:")] == "resolve:" {
+					t.Fatalf("%s: resolve was called before the path-kind check rejected the op: %v", tc.name, f.calls)
+				}
+			}
+			if len(f.configured) != 0 || len(f.trimmed) != 0 {
+				t.Fatalf("%s: config/trim must not have been called", tc.name)
+			}
+		})
+	}
 }
 
 // (e)/(f) evalRets maps RetCount to a tagged U64 and RetValue to e.value();

--- a/ops/operate_engine_test.go
+++ b/ops/operate_engine_test.go
@@ -659,6 +659,37 @@ func TestApplyOpsTableComparesByCount(t *testing.T) {
 	}
 }
 
+// A scalar op whose path resolves to the record, a table, or a row (not a
+// scalar) is rejected, even though resolve() itself succeeded.
+func TestApplyOpsScalarRejectsNonScalarTarget(t *testing.T) {
+	cases := []struct {
+		name string
+		path wire.OperatePath
+	}{
+		{"record", fakeRecordPath()},
+		{"table", fakeFieldPath("b")},
+		{"row", fakeRowPath("b", "k1")},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			f := newFakeEngine()
+			f.tables[pathKey(fakeFieldPath("b"))] = 0
+			ops := []wire.OperateOp{
+				{Opcode: wire.OperateOpSET, Type: wire.OperateTypeU32, Path: tc.path, A: 1},
+			}
+			_, _, err := applyOps(f, ops, 0)
+			if !errors.Is(err, wire.ErrOperatePath) {
+				t.Fatalf("%s: err=%v, want wire.ErrOperatePath", tc.name, err)
+			}
+			for _, call := range f.calls {
+				if call == "get" || call == "set" {
+					t.Fatalf("%s: get/set must not run against a non-scalar ref: %v", tc.name, f.calls)
+				}
+			}
+		})
+	}
+}
+
 // fixedN: SET creating a FIXED dynamic target passes n=len(o.Bytes); an
 // out-of-range FIXED length is rejected before resolve is called.
 func TestFixedN(t *testing.T) {

--- a/ops/operate_engine_test.go
+++ b/ops/operate_engine_test.go
@@ -711,3 +711,27 @@ func TestFixedN(t *testing.T) {
 		t.Fatalf("fixedN(FIXED, too long) = %v, want wire.ErrOperateType", err)
 	}
 }
+
+// bytesApply adapts applyRecordBytes to the semantics suite's applier type:
+// it encodes the tree the suite hands it, applies the call to those bytes,
+// and decodes the result back into a tree. Every byte-level engine is tested
+// through this adapter, so a divergence from the oracle shows up as either a
+// different tree or bytes the record codec refuses.
+func bytesApply(rec *wire.Record, a *wire.OperateArgs, stampMs int64) (*wire.Record, *wire.OperateResult, error) {
+	var cur []byte
+	if rec != nil {
+		cur = rec.Encode()
+	}
+	out, deleted, res, err := applyRecordBytes(cur, a, stampMs)
+	if err != nil {
+		return nil, nil, err
+	}
+	if deleted || len(out) == 0 {
+		return nil, res, nil
+	}
+	got, derr := wire.DecodeRecord(out)
+	if derr != nil {
+		return nil, nil, fmt.Errorf("engine produced undecodable bytes %x: %w", out, derr)
+	}
+	return got, res, nil
+}

--- a/ops/operate_engine_test.go
+++ b/ops/operate_engine_test.go
@@ -105,7 +105,8 @@ func segKey(s wire.OperateSeg) string {
 	return fmt.Sprintf("pos=%d", s.Pos)
 }
 
-func (f *fakeEngine) resolve(p wire.OperatePath, create bool, typ, n uint8) (ref, error) {
+func (f *fakeEngine) resolve(p wire.OperatePath, create bool, opcode, typ, n uint8) (ref, error) {
+	_ = opcode // the fake never retypes a stored cell, so the opcode is noise here
 	key := pathKey(p)
 	f.calls = append(f.calls, "resolve:"+key)
 	if err, ok := f.forceResolveErr[key]; ok {

--- a/ops/operate_engine_test.go
+++ b/ops/operate_engine_test.go
@@ -1,0 +1,635 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package ops
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/rostamlabs/rostam/sdk/wire"
+)
+
+// --- fakeEngine --------------------------------------------------------
+//
+// fakeEngine is a minimal engine backed by maps keyed by the textual form of
+// an OperatePath (pathKey below), used only to exercise applyOps/evalRets'
+// dispatch decisions in isolation from any real byte layout. It records
+// every call it receives (in order) so a test can assert what did, and did
+// not, run.
+
+type fakeEngine struct {
+	// cells holds present scalar values (refKindScalar), keyed by pathKey.
+	cells map[string]wire.Cell
+	// tables holds present table fields (refKindTable) -> row count, keyed
+	// by pathKey of the field path.
+	tables map[string]uint64
+	// rows holds present rows (refKindRow), keyed by pathKey of the row
+	// path.
+	rows map[string]bool
+	// recordPresent is the ref for OperatePathRecord's present (whether the
+	// record existed before this call).
+	recordPresent bool
+	// recordFieldCount is refKindRecord's count().
+	recordFieldCount uint64
+
+	// values overrides the tagged bytes value() returns for a pathKey; a
+	// missing entry falls back to AppendTaggedCell of the cell/a placeholder.
+	values map[string][]byte
+
+	// forceResolveErr, keyed by pathKey, makes resolve fail for that path.
+	forceResolveErr map[string]error
+
+	calls []string
+
+	migrateErr error
+	migrated   []migrateCall
+	configured []configCall
+	trimmed    []trimCall
+	deleted    []string
+
+	isEmpty bool
+}
+
+type migrateCall struct {
+	from   int64
+	flags  uint8
+	schema []byte
+}
+
+type configCall struct {
+	capN      uint32
+	policy    uint8
+	byColName string
+}
+
+type trimCall struct {
+	keep      uint32
+	policy    uint8
+	byCol     uint16
+	byColName string
+}
+
+func newFakeEngine() *fakeEngine {
+	return &fakeEngine{
+		cells:           map[string]wire.Cell{},
+		tables:          map[string]uint64{},
+		rows:            map[string]bool{},
+		values:          map[string][]byte{},
+		forceResolveErr: map[string]error{},
+	}
+}
+
+// pathKey renders an OperatePath as a stable string so the fake can key its
+// maps by it. It is test-only plumbing, not a wire format.
+func pathKey(p wire.OperatePath) string {
+	switch p.Kind {
+	case wire.OperatePathRecord:
+		return "record"
+	case wire.OperatePathField:
+		return "field:" + segKey(p.Field)
+	case wire.OperatePathRow:
+		return "field:" + segKey(p.Field) + "/row:" + string(p.Key)
+	case wire.OperatePathCol:
+		return "field:" + segKey(p.Field) + "/row:" + string(p.Key) + "/col:" + segKey(p.Col)
+	default:
+		return fmt.Sprintf("invalid:%d", p.Kind)
+	}
+}
+
+func segKey(s wire.OperateSeg) string {
+	if s.ByName {
+		return "name=" + s.Name
+	}
+	return fmt.Sprintf("pos=%d", s.Pos)
+}
+
+func (f *fakeEngine) resolve(p wire.OperatePath, create bool, typ, n uint8) (ref, error) {
+	key := pathKey(p)
+	f.calls = append(f.calls, "resolve:"+key)
+	if err, ok := f.forceResolveErr[key]; ok {
+		return ref{}, err
+	}
+	switch p.Kind {
+	case wire.OperatePathRecord:
+		return ref{kind: refKindRecord, present: f.recordPresent}, nil
+	case wire.OperatePathRow:
+		present := f.rows[key]
+		if !present && create {
+			f.rows[key] = true
+			present = true
+		}
+		return ref{kind: refKindRow, off: hashKey(key), present: present}, nil
+	default: // Field or Col: a table field, or a scalar
+		if _, ok := f.tables[key]; ok {
+			return ref{kind: refKindTable, off: hashKey(key), present: true}, nil
+		}
+		c, present := f.cells[key]
+		if !present {
+			if create {
+				c = wire.ZeroCell(typ, n)
+				f.cells[key] = c
+				present = true
+			} else {
+				c = wire.ZeroCell(typ, n)
+			}
+		}
+		return ref{kind: refKindScalar, off: hashKey(key), typ: c.Type, n: c.N, present: present}, nil
+	}
+}
+
+func hashKey(s string) int {
+	h := 0
+	for i := 0; i < len(s); i++ {
+		h = h*31 + int(s[i])
+	}
+	return h
+}
+
+func (f *fakeEngine) get(r ref) (wire.Cell, error) {
+	f.calls = append(f.calls, "get")
+	for key, c := range f.cells {
+		if hashKey(key) == r.off {
+			return c, nil
+		}
+	}
+	return wire.ZeroCell(r.typ, r.n), nil
+}
+
+func (f *fakeEngine) set(r ref, c wire.Cell) error {
+	f.calls = append(f.calls, "set")
+	for key := range f.cells {
+		if hashKey(key) == r.off {
+			f.cells[key] = c
+			return nil
+		}
+	}
+	return errors.New("fakeEngine: set on unknown ref")
+}
+
+func (f *fakeEngine) del(r ref) error {
+	f.calls = append(f.calls, "del")
+	switch r.kind {
+	case refKindRecord:
+		f.deleted = append(f.deleted, "record")
+	default:
+		for key := range f.cells {
+			if hashKey(key) == r.off {
+				delete(f.cells, key)
+				f.deleted = append(f.deleted, key)
+				return nil
+			}
+		}
+	}
+	return nil
+}
+
+func (f *fakeEngine) count(r ref) (uint64, error) {
+	f.calls = append(f.calls, "count")
+	switch r.kind {
+	case refKindRecord:
+		return f.recordFieldCount, nil
+	case refKindTable:
+		for key, n := range f.tables {
+			if hashKey(key) == r.off {
+				return n, nil
+			}
+		}
+		return 0, nil
+	default: // refKindRow, refKindScalar: presence as 1/0 (design doc's
+		// "a plain scalar's count is only exists/absent" ruling, same as a
+		// row).
+		if r.present {
+			return 1, nil
+		}
+		return 0, nil
+	}
+}
+
+func (f *fakeEngine) trim(r ref, keep uint32, policy uint8, byCol uint16, byColName string) error {
+	f.calls = append(f.calls, "trim")
+	f.trimmed = append(f.trimmed, trimCall{keep: keep, policy: policy, byCol: byCol, byColName: byColName})
+	return nil
+}
+
+func (f *fakeEngine) config(r ref, capN uint32, policy uint8, byColName string) error {
+	f.calls = append(f.calls, "config")
+	f.configured = append(f.configured, configCall{capN: capN, policy: policy, byColName: byColName})
+	return nil
+}
+
+func (f *fakeEngine) migrate(from int64, flags uint8, schemaBlob []byte) error {
+	f.calls = append(f.calls, "migrate")
+	if f.migrateErr != nil {
+		return f.migrateErr
+	}
+	f.migrated = append(f.migrated, migrateCall{from: from, flags: flags, schema: schemaBlob})
+	return nil
+}
+
+func (f *fakeEngine) value(r ref) ([]byte, error) {
+	f.calls = append(f.calls, "value")
+	for key := range f.cells {
+		if hashKey(key) == r.off {
+			if v, ok := f.values[key]; ok {
+				return v, nil
+			}
+			return wire.AppendTaggedCell(nil, f.cells[key]), nil
+		}
+	}
+	return []byte{wire.OperateTypeUnset}, nil
+}
+
+func (f *fakeEngine) bytes() []byte { return nil }
+func (f *fakeEngine) empty() bool   { return f.isEmpty }
+
+// --- helpers -------------------------------------------------------------
+
+func fakeFieldPath(name string) wire.OperatePath {
+	return wire.OperatePath{Kind: wire.OperatePathField, Field: wire.OperateSeg{ByName: true, Name: name}}
+}
+
+func fakeRowPath(field, key string) wire.OperatePath {
+	return wire.OperatePath{Kind: wire.OperatePathRow, Field: wire.OperateSeg{ByName: true, Name: field}, Key: []byte(key)}
+}
+
+func fakeRecordPath() wire.OperatePath {
+	return wire.OperatePath{Kind: wire.OperatePathRecord}
+}
+
+func (f *fakeEngine) setScalar(path string, c wire.Cell) {
+	f.cells[path] = c
+}
+
+// --- tests -----------------------------------------------------------------
+
+// (a) IF false skips exactly B ops; B beyond the end is errOperateIfRange
+// even when the condition is true.
+func TestApplyOpsIfSkip(t *testing.T) {
+	f := newFakeEngine()
+	f.setScalar(pathKey(fakeFieldPath("x")), wire.Cell{Type: wire.OperateTypeU32, U: 1})
+
+	// IF x == 0 is FALSE (x is 1) -> skip the next 1 op: the SET (index 1)
+	// is skipped, ADD at index 2 runs against the original x.
+	ops := []wire.OperateOp{
+		{Opcode: wire.OperateOpIF, Type: wire.OperateTypeU32, Aux: wire.OperateCmpEQ, Path: fakeFieldPath("x"), A: 0, B: 1},
+		{Opcode: wire.OperateOpSET, Type: wire.OperateTypeU32, Path: fakeFieldPath("x"), A: 999},
+		{Opcode: wire.OperateOpADD, Type: wire.OperateTypeU32, Path: fakeFieldPath("x"), A: 5},
+	}
+	status, failed, err := applyOps(f, ops, 0)
+	if err != nil || status != wire.OperateStatusOK || failed != 0 {
+		t.Fatalf("applyOps: status=%d failed=%d err=%v", status, failed, err)
+	}
+	c := f.cells[pathKey(fakeFieldPath("x"))]
+	if c.U != 6 {
+		t.Fatalf("x = %d, want 6 (1+5; SET at index 1 must have been skipped)", c.U)
+	}
+
+	// IF false: condition false, skip count reaches past the end ->
+	// errOperateIfRange regardless.
+	f2 := newFakeEngine()
+	f2.setScalar(pathKey(fakeFieldPath("x")), wire.Cell{Type: wire.OperateTypeU32, U: 1})
+	ops2 := []wire.OperateOp{
+		{Opcode: wire.OperateOpIF, Type: wire.OperateTypeU32, Aux: wire.OperateCmpEQ, Path: fakeFieldPath("x"), A: 0, B: 5},
+	}
+	_, _, err = applyOps(f2, ops2, 0)
+	if !errors.Is(err, errOperateIfRange) {
+		t.Fatalf("applyOps: err=%v, want errOperateIfRange", err)
+	}
+
+	// Condition true (so the branch is NOT taken) but B still reaches past
+	// the end -> validated eagerly regardless of branch outcome.
+	f3 := newFakeEngine()
+	f3.setScalar(pathKey(fakeFieldPath("x")), wire.Cell{Type: wire.OperateTypeU32, U: 0})
+	ops3 := []wire.OperateOp{
+		{Opcode: wire.OperateOpIF, Type: wire.OperateTypeU32, Aux: wire.OperateCmpEQ, Path: fakeFieldPath("x"), A: 0, B: 5},
+	}
+	_, _, err = applyOps(f3, ops3, 0)
+	if !errors.Is(err, errOperateIfRange) {
+		t.Fatalf("applyOps (condition true): err=%v, want errOperateIfRange", err)
+	}
+
+	// Negative B is also out of range.
+	f4 := newFakeEngine()
+	f4.setScalar(pathKey(fakeFieldPath("x")), wire.Cell{Type: wire.OperateTypeU32, U: 0})
+	ops4 := []wire.OperateOp{
+		{Opcode: wire.OperateOpIF, Type: wire.OperateTypeU32, Aux: wire.OperateCmpEQ, Path: fakeFieldPath("x"), A: 0, B: -1},
+	}
+	_, _, err = applyOps(f4, ops4, 0)
+	if !errors.Is(err, errOperateIfRange) {
+		t.Fatalf("applyOps (negative B): err=%v, want errOperateIfRange", err)
+	}
+}
+
+// (b) CHECK false returns (CheckFailed, idx, nil) and no `set` runs after.
+func TestApplyOpsCheckFailedStopsBeforeSet(t *testing.T) {
+	f := newFakeEngine()
+	f.setScalar(pathKey(fakeFieldPath("x")), wire.Cell{Type: wire.OperateTypeU32, U: 7})
+
+	ops := []wire.OperateOp{
+		{Opcode: wire.OperateOpCHECK, Type: wire.OperateTypeU32, Aux: wire.OperateCmpEQ, Path: fakeFieldPath("x"), A: 0}, // false: 7 != 0
+		{Opcode: wire.OperateOpSET, Type: wire.OperateTypeU32, Path: fakeFieldPath("x"), A: 999},
+	}
+	status, failed, err := applyOps(f, ops, 0)
+	if err != nil {
+		t.Fatalf("applyOps: unexpected err %v", err)
+	}
+	if status != wire.OperateStatusCheckFailed || failed != 0 {
+		t.Fatalf("applyOps: status=%d failed=%d, want CheckFailed at 0", status, failed)
+	}
+	for _, call := range f.calls {
+		if call == "set" {
+			t.Fatalf("set was called after CHECK failed: calls=%v", f.calls)
+		}
+	}
+	if f.cells[pathKey(fakeFieldPath("x"))].U != 7 {
+		t.Fatalf("x mutated despite CHECK failure")
+	}
+}
+
+// (c) unknown opcode -> wire.ErrOperateOpcode.
+func TestApplyOpsUnknownOpcode(t *testing.T) {
+	f := newFakeEngine()
+	ops := []wire.OperateOp{
+		{Opcode: 250, Type: wire.OperateTypeU32, Path: fakeFieldPath("x"), A: 1},
+	}
+	_, _, err := applyOps(f, ops, 0)
+	if !errors.Is(err, wire.ErrOperateOpcode) {
+		t.Fatalf("applyOps: err=%v, want wire.ErrOperateOpcode", err)
+	}
+}
+
+// (d) MIGRATE at index > 0 -> error; MIGRATE at index 0 forwards (A, Aux,
+// Bytes) to e.migrate.
+func TestApplyOpsMigrate(t *testing.T) {
+	f := newFakeEngine()
+	ops := []wire.OperateOp{
+		{Opcode: wire.OperateOpMIGRATE, A: 3, Aux: wire.OperateMigrateDropExtra, Bytes: []byte("schema-blob"), Path: fakeRecordPath()},
+	}
+	status, _, err := applyOps(f, ops, 0)
+	if err != nil || status != wire.OperateStatusOK {
+		t.Fatalf("applyOps: status=%d err=%v", status, err)
+	}
+	if len(f.migrated) != 1 {
+		t.Fatalf("migrate was not called: %v", f.calls)
+	}
+	got := f.migrated[0]
+	if got.from != 3 || got.flags != wire.OperateMigrateDropExtra || string(got.schema) != "schema-blob" {
+		t.Fatalf("migrate called with %+v, want {3 %d schema-blob}", got, wire.OperateMigrateDropExtra)
+	}
+
+	f2 := newFakeEngine()
+	ops2 := []wire.OperateOp{
+		{Opcode: wire.OperateOpSET, Type: wire.OperateTypeU32, Path: fakeFieldPath("x"), A: 1},
+		{Opcode: wire.OperateOpMIGRATE, A: 3, Path: fakeRecordPath()},
+	}
+	_, _, err = applyOps(f2, ops2, 0)
+	if !errors.Is(err, wire.ErrOperateOpcode) {
+		t.Fatalf("applyOps (MIGRATE not at 0): err=%v, want wire.ErrOperateOpcode", err)
+	}
+	if len(f2.migrated) != 0 {
+		t.Fatalf("migrate must not have been called: %v", f2.migrated)
+	}
+}
+
+// (e)/(f) evalRets maps RetCount to a tagged U64 and RetValue to e.value();
+// absent -> [Unset] for VALUE and a tagged 0 for COUNT.
+func TestEvalRets(t *testing.T) {
+	f := newFakeEngine()
+	f.setScalar(pathKey(fakeFieldPath("present")), wire.Cell{Type: wire.OperateTypeU32, U: 42})
+
+	rets := []wire.OperateRet{
+		{Mode: wire.OperateRetValue, Path: fakeFieldPath("present")},
+		{Mode: wire.OperateRetCount, Path: fakeFieldPath("present")},
+		{Mode: wire.OperateRetValue, Path: fakeFieldPath("absent")},
+		{Mode: wire.OperateRetCount, Path: fakeFieldPath("absent")},
+	}
+	vals, err := evalRets(f, rets)
+	if err != nil {
+		t.Fatalf("evalRets: %v", err)
+	}
+	if len(vals) != 4 {
+		t.Fatalf("evalRets: got %d values, want 4", len(vals))
+	}
+	wantValue := wire.AppendTaggedCell(nil, wire.Cell{Type: wire.OperateTypeU32, U: 42})
+	if string(vals[0]) != string(wantValue) {
+		t.Fatalf("VALUE(present) = %v, want %v", vals[0], wantValue)
+	}
+	wantCount := wire.AppendTaggedCell(nil, wire.Cell{Type: wire.OperateTypeU64, U: 1})
+	if string(vals[1]) != string(wantCount) {
+		t.Fatalf("COUNT(present) = %v, want %v", vals[1], wantCount)
+	}
+	if len(vals[2]) != 1 || vals[2][0] != wire.OperateTypeUnset {
+		t.Fatalf("VALUE(absent) = %v, want [Unset]", vals[2])
+	}
+	wantZero := wire.AppendTaggedCell(nil, wire.Cell{Type: wire.OperateTypeU64, U: 0})
+	if string(vals[3]) != string(wantZero) {
+		t.Fatalf("COUNT(absent) = %v, want %v", vals[3], wantZero)
+	}
+
+	// Absent path must not call value()/count() at all: exactly one of each
+	// ran, for the two *present* rets above, and nothing extra from the two
+	// absent ones.
+	nValue, nCount := 0, 0
+	for _, call := range f.calls {
+		switch call {
+		case "value":
+			nValue++
+		case "count":
+			nCount++
+		}
+	}
+	if nValue != 1 || nCount != 1 {
+		t.Fatalf("value()/count() called %d/%d times, want 1/1 (absent rets must skip them)", nValue, nCount)
+	}
+
+	// Unknown ret mode -> wire.ErrOperateArgs.
+	_, err = evalRets(f, []wire.OperateRet{{Mode: 250, Path: fakeFieldPath("present")}})
+	if !errors.Is(err, wire.ErrOperateArgs) {
+		t.Fatalf("evalRets(bad mode): err=%v, want wire.ErrOperateArgs", err)
+	}
+}
+
+// (f) a scalar op forwards `present` from the ref into ApplyScalar (absent
+// -> arithmetic on zero).
+func TestApplyOpsScalarPresentForwarded(t *testing.T) {
+	f := newFakeEngine()
+	// "y" is absent: ADD 10 against a zero-valued, absent cell must land on
+	// 10 (present is irrelevant to ADD's arithmetic itself, but resolve
+	// must vivify with the right zero and get() must report it).
+	ops := []wire.OperateOp{
+		{Opcode: wire.OperateOpADD, Type: wire.OperateTypeU32, Path: fakeFieldPath("y"), A: 10},
+	}
+	status, _, err := applyOps(f, ops, 0)
+	if err != nil || status != wire.OperateStatusOK {
+		t.Fatalf("applyOps: status=%d err=%v", status, err)
+	}
+	c, ok := f.cells[pathKey(fakeFieldPath("y"))]
+	if !ok || c.U != 10 {
+		t.Fatalf("y = %+v (present=%v), want U=10", c, ok)
+	}
+
+	// CompareCell also receives r.present: EXISTS on an absent scalar
+	// path is false even though get() returns a defined zero cell.
+	f2 := newFakeEngine()
+	ops2 := []wire.OperateOp{
+		{Opcode: wire.OperateOpCHECK, Type: wire.OperateTypeU32, Aux: wire.OperateCmpExists, Path: fakeFieldPath("z")},
+	}
+	status2, failed2, err := applyOps(f2, ops2, 0)
+	if err != nil {
+		t.Fatalf("applyOps: %v", err)
+	}
+	if status2 != wire.OperateStatusCheckFailed || failed2 != 0 {
+		t.Fatalf("CHECK(EXISTS) on absent scalar: status=%d failed=%d, want CheckFailed@0", status2, failed2)
+	}
+}
+
+// (g) CONFIG/TRIM A bounds: negative or over wire.OperateMaxRows ->
+// wire.ErrOperateCap, checked before resolve vivifies anything.
+func TestApplyOpsConfigTrimCap(t *testing.T) {
+	cases := []struct {
+		name string
+		op   uint8
+		a    int64
+	}{
+		{"config-negative", wire.OperateOpCONFIG, -1},
+		{"config-over", wire.OperateOpCONFIG, int64(wire.OperateMaxRows) + 1},
+		{"trim-negative", wire.OperateOpTRIM, -1},
+		{"trim-over", wire.OperateOpTRIM, int64(wire.OperateMaxRows) + 1},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			f := newFakeEngine()
+			ops := []wire.OperateOp{
+				{Opcode: tc.op, Path: fakeFieldPath("tbl"), A: tc.a, Bytes: []byte("col")},
+			}
+			_, _, err := applyOps(f, ops, 0)
+			if !errors.Is(err, wire.ErrOperateCap) {
+				t.Fatalf("%s: err=%v, want wire.ErrOperateCap", tc.name, err)
+			}
+			for _, call := range f.calls {
+				if call == "resolve:"+pathKey(fakeFieldPath("tbl")) {
+					t.Fatalf("%s: resolve was called before the cap check rejected the op", tc.name)
+				}
+			}
+		})
+	}
+
+	// In-bounds CONFIG/TRIM forward exactly (A, Aux, Bytes) as documented.
+	f := newFakeEngine()
+	ops := []wire.OperateOp{
+		{Opcode: wire.OperateOpCONFIG, Path: fakeFieldPath("tbl"), A: 100, Aux: wire.OperatePolicyMinCol, Bytes: []byte("hi")},
+	}
+	status, _, err := applyOps(f, ops, 0)
+	if err != nil || status != wire.OperateStatusOK {
+		t.Fatalf("CONFIG in-bounds: status=%d err=%v", status, err)
+	}
+	if len(f.configured) != 1 || f.configured[0].capN != 100 || f.configured[0].policy != wire.OperatePolicyMinCol || f.configured[0].byColName != "hi" {
+		t.Fatalf("config called with %+v", f.configured)
+	}
+
+	f2 := newFakeEngine()
+	ops2 := []wire.OperateOp{
+		{Opcode: wire.OperateOpTRIM, Path: fakeFieldPath("tbl"), A: 5, Aux: wire.OperatePolicyMinKey, B: 2, Bytes: []byte("bc")},
+	}
+	status2, _, err := applyOps(f2, ops2, 0)
+	if err != nil || status2 != wire.OperateStatusOK {
+		t.Fatalf("TRIM in-bounds: status=%d err=%v", status2, err)
+	}
+	if len(f2.trimmed) != 1 || f2.trimmed[0].keep != 5 || f2.trimmed[0].policy != wire.OperatePolicyMinKey || f2.trimmed[0].byCol != 2 || f2.trimmed[0].byColName != "bc" {
+		t.Fatalf("trim called with %+v", f2.trimmed)
+	}
+}
+
+// DEL () (record path) is terminal: OK immediately, no further ops run.
+func TestApplyOpsDelRecordTerminal(t *testing.T) {
+	f := newFakeEngine()
+	f.recordPresent = true
+	ops := []wire.OperateOp{
+		{Opcode: wire.OperateOpDEL, Path: fakeRecordPath()},
+		{Opcode: wire.OperateOpSET, Type: wire.OperateTypeU32, Path: fakeFieldPath("x"), A: 999},
+	}
+	status, _, err := applyOps(f, ops, 0)
+	if err != nil || status != wire.OperateStatusOK {
+		t.Fatalf("applyOps: status=%d err=%v", status, err)
+	}
+	if len(f.deleted) != 1 || f.deleted[0] != "record" {
+		t.Fatalf("del(record) not recorded: %v", f.deleted)
+	}
+	if _, ok := f.cells[pathKey(fakeFieldPath("x"))]; ok {
+		t.Fatalf("SET ran after a terminal record DEL")
+	}
+}
+
+// A row ref compares by presence (count 1/0), via CompareCount.
+func TestApplyOpsRowComparesByPresence(t *testing.T) {
+	f := newFakeEngine()
+	// Row absent: CHECK ABSENT should pass (true), so status stays OK.
+	ops := []wire.OperateOp{
+		{Opcode: wire.OperateOpCHECK, Aux: wire.OperateCmpAbsent, Path: fakeRowPath("b", "k1")},
+	}
+	status, _, err := applyOps(f, ops, 0)
+	if err != nil || status != wire.OperateStatusOK {
+		t.Fatalf("CHECK ABSENT on absent row: status=%d err=%v", status, err)
+	}
+
+	// Now the same row is present: CHECK ABSENT should fail.
+	f2 := newFakeEngine()
+	f2.rows[pathKey(fakeRowPath("b", "k1"))] = true
+	ops2 := []wire.OperateOp{
+		{Opcode: wire.OperateOpCHECK, Aux: wire.OperateCmpAbsent, Path: fakeRowPath("b", "k1")},
+	}
+	status2, failed2, err := applyOps(f2, ops2, 0)
+	if err != nil {
+		t.Fatalf("applyOps: %v", err)
+	}
+	if status2 != wire.OperateStatusCheckFailed || failed2 != 0 {
+		t.Fatalf("CHECK ABSENT on present row: status=%d failed=%d, want CheckFailed@0", status2, failed2)
+	}
+}
+
+// A table ref compares by row count, via CompareCount.
+func TestApplyOpsTableComparesByCount(t *testing.T) {
+	f := newFakeEngine()
+	f.tables[pathKey(fakeFieldPath("b"))] = 3
+	ops := []wire.OperateOp{
+		{Opcode: wire.OperateOpCHECK, Aux: wire.OperateCmpGE, Path: fakeFieldPath("b"), A: 3},
+	}
+	status, _, err := applyOps(f, ops, 0)
+	if err != nil || status != wire.OperateStatusOK {
+		t.Fatalf("CHECK count>=3 on a 3-row table: status=%d err=%v", status, err)
+	}
+
+	ops2 := []wire.OperateOp{
+		{Opcode: wire.OperateOpCHECK, Aux: wire.OperateCmpGE, Path: fakeFieldPath("b"), A: 4},
+	}
+	status2, failed2, err := applyOps(f, ops2, 0)
+	if err != nil {
+		t.Fatalf("applyOps: %v", err)
+	}
+	if status2 != wire.OperateStatusCheckFailed || failed2 != 0 {
+		t.Fatalf("CHECK count>=4 on a 3-row table: status=%d failed=%d, want CheckFailed@0", status2, failed2)
+	}
+}
+
+// fixedN: SET creating a FIXED dynamic target passes n=len(o.Bytes); an
+// out-of-range FIXED length is rejected before resolve is called.
+func TestFixedN(t *testing.T) {
+	n, err := fixedN(&wire.OperateOp{Type: wire.OperateTypeFixed, Bytes: []byte("abc")})
+	if err != nil || n != 3 {
+		t.Fatalf("fixedN(FIXED,3 bytes) = (%d,%v), want (3,nil)", n, err)
+	}
+	n, err = fixedN(&wire.OperateOp{Type: wire.OperateTypeU32, Bytes: []byte("abc")})
+	if err != nil || n != 0 {
+		t.Fatalf("fixedN(U32) = (%d,%v), want (0,nil)", n, err)
+	}
+	_, err = fixedN(&wire.OperateOp{Type: wire.OperateTypeFixed, Bytes: nil})
+	if !errors.Is(err, wire.ErrOperateType) {
+		t.Fatalf("fixedN(FIXED, empty) = %v, want wire.ErrOperateType", err)
+	}
+	big := make([]byte, wire.OperateMaxKeyLen+1)
+	_, err = fixedN(&wire.OperateOp{Type: wire.OperateTypeFixed, Bytes: big})
+	if !errors.Is(err, wire.ErrOperateType) {
+		t.Fatalf("fixedN(FIXED, too long) = %v, want wire.ErrOperateType", err)
+	}
+}

--- a/ops/operate_engine_test.go
+++ b/ops/operate_engine_test.go
@@ -409,16 +409,16 @@ func TestApplyOpsMigrate(t *testing.T) {
 	}
 }
 
-// CONFIG/TRIM at a row, col, or record path -> wire.ErrOperatePath, without
-// ever calling resolve (config()/trim() have no path of their own to reject
-// it with, so the loop must).
+// TRIM at a row, col, or record path -> wire.ErrOperatePath, without ever
+// calling resolve (trim() has no path of its own to reject it with, so the
+// loop must). CONFIG's path-kind check is NOT here: it moved into resolve,
+// which is the only thing that knows whether the record's mode has an
+// eviction config at all — see TestApplyOpsConfigChecksRunAfterResolve.
 func TestApplyOpsConfigTrimPathKind(t *testing.T) {
 	cases := []struct {
 		name string
 		op   wire.OperateOp
 	}{
-		{"config-row", wire.OperateOp{Opcode: wire.OperateOpCONFIG, Path: fakeRowPath("b", "k1"), A: 1}},
-		{"config-record", wire.OperateOp{Opcode: wire.OperateOpCONFIG, Path: fakeRecordPath(), A: 1}},
 		{"trim-row", wire.OperateOp{Opcode: wire.OperateOpTRIM, Path: fakeRowPath("b", "k1"), A: 1}},
 		{"trim-record", wire.OperateOp{Opcode: wire.OperateOpTRIM, Path: fakeRecordPath(), A: 1}},
 	}
@@ -534,15 +534,15 @@ func TestApplyOpsScalarPresentForwarded(t *testing.T) {
 }
 
 // (g) CONFIG/TRIM A bounds: negative or over wire.OperateMaxRows ->
-// wire.ErrOperateCap, checked before resolve vivifies anything.
+// wire.ErrOperateCap, checked before resolve vivifies anything. (CONFIG's cap
+// check runs after resolve instead, because the record's mode and the path
+// come first — TestApplyOpsConfigChecksRunAfterResolve covers it.)
 func TestApplyOpsConfigTrimCap(t *testing.T) {
 	cases := []struct {
 		name string
 		op   uint8
 		a    int64
 	}{
-		{"config-negative", wire.OperateOpCONFIG, -1},
-		{"config-over", wire.OperateOpCONFIG, int64(wire.OperateMaxRows) + 1},
 		{"trim-negative", wire.OperateOpTRIM, -1},
 		{"trim-over", wire.OperateOpTRIM, int64(wire.OperateMaxRows) + 1},
 	}
@@ -587,6 +587,54 @@ func TestApplyOpsConfigTrimCap(t *testing.T) {
 	}
 	if len(f2.trimmed) != 1 || f2.trimmed[0].keep != 5 || f2.trimmed[0].policy != wire.OperatePolicyMinKey || f2.trimmed[0].byCol != 2 || f2.trimmed[0].byColName != "bc" {
 		t.Fatalf("trim called with %+v", f2.trimmed)
+	}
+}
+
+// CONFIG's checks run in the order the oracle rejects them in (design doc
+// §3.2): the engine first (its resolve knows the record's mode and the path),
+// then the loop's operand checks — the eviction column name's length, the cap,
+// and the policy byte — and only then config(). Each case below is malformed
+// in an operand that config() itself would accept, so it can only report the
+// right error if the loop got there first; the last one proves resolve still
+// goes first, by failing while the cap is out of range too.
+func TestApplyOpsConfigChecksRunAfterResolve(t *testing.T) {
+	longName := make([]byte, wire.OperateMaxNameLen+1)
+	cases := []struct {
+		name string
+		op   wire.OperateOp
+		want error
+	}{
+		{"byColName too long", wire.OperateOp{Opcode: wire.OperateOpCONFIG,
+			Path: fakeFieldPath("tbl"), A: 1, Bytes: longName}, wire.ErrOperateCap},
+		{"cap out of range", wire.OperateOp{Opcode: wire.OperateOpCONFIG,
+			Path: fakeFieldPath("tbl"), A: -1}, wire.ErrOperateCap},
+		{"unknown policy", wire.OperateOp{Opcode: wire.OperateOpCONFIG,
+			Path: fakeFieldPath("tbl"), A: 1, Aux: wire.OperatePolicyMaxCol + 1}, wire.ErrOperateSchema},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			f := newFakeEngine()
+			_, _, err := applyOps(f, []wire.OperateOp{tc.op}, 0)
+			if !errors.Is(err, tc.want) {
+				t.Fatalf("err=%v, want %v", err, tc.want)
+			}
+			if len(f.calls) == 0 || f.calls[0] != "resolve:"+pathKey(fakeFieldPath("tbl")) {
+				t.Fatalf("resolve must run before the operand checks: %v", f.calls)
+			}
+			if len(f.configured) != 0 {
+				t.Fatalf("config must not have been called: %+v", f.configured)
+			}
+		})
+	}
+
+	// resolve's own rejection — for a schema-mode record, the mode gate that
+	// answers wire.ErrOperateOpcode — wins over an out-of-range cap.
+	f := newFakeEngine()
+	f.forceResolveErr[pathKey(fakeFieldPath("tbl"))] = wire.ErrOperateOpcode
+	_, _, err := applyOps(f, []wire.OperateOp{{Opcode: wire.OperateOpCONFIG,
+		Path: fakeFieldPath("tbl"), A: -1}}, 0)
+	if !errors.Is(err, wire.ErrOperateOpcode) {
+		t.Fatalf("err=%v, want the resolve error wire.ErrOperateOpcode", err)
 	}
 }
 
@@ -692,25 +740,25 @@ func TestApplyOpsScalarRejectsNonScalarTarget(t *testing.T) {
 	}
 }
 
-// fixedN: SET creating a FIXED dynamic target passes n=len(o.Bytes); an
-// out-of-range FIXED length is rejected before resolve is called.
+// fixedN: SET creating a FIXED dynamic target passes n=len(o.Bytes). An
+// operand that cannot form a FIXED(1-255) cell yields 0 rather than an error
+// — the width is not the loop's to reject, because the same op aimed at a
+// table field or a row is a PATH error, and only resolve knows which. The
+// engines turn the 0 into wire.ErrOperateType where a width is actually
+// needed (TestDynamicSetFixedWidthIsAType covers the end-to-end rule).
 func TestFixedN(t *testing.T) {
-	n, err := fixedN(&wire.OperateOp{Type: wire.OperateTypeFixed, Bytes: []byte("abc")})
-	if err != nil || n != 3 {
-		t.Fatalf("fixedN(FIXED,3 bytes) = (%d,%v), want (3,nil)", n, err)
+	if n := fixedN(&wire.OperateOp{Type: wire.OperateTypeFixed, Bytes: []byte("abc")}); n != 3 {
+		t.Fatalf("fixedN(FIXED, 3 bytes) = %d, want 3", n)
 	}
-	n, err = fixedN(&wire.OperateOp{Type: wire.OperateTypeU32, Bytes: []byte("abc")})
-	if err != nil || n != 0 {
-		t.Fatalf("fixedN(U32) = (%d,%v), want (0,nil)", n, err)
+	if n := fixedN(&wire.OperateOp{Type: wire.OperateTypeU32, Bytes: []byte("abc")}); n != 0 {
+		t.Fatalf("fixedN(U32) = %d, want 0", n)
 	}
-	_, err = fixedN(&wire.OperateOp{Type: wire.OperateTypeFixed, Bytes: nil})
-	if !errors.Is(err, wire.ErrOperateType) {
-		t.Fatalf("fixedN(FIXED, empty) = %v, want wire.ErrOperateType", err)
+	if n := fixedN(&wire.OperateOp{Type: wire.OperateTypeFixed, Bytes: nil}); n != 0 {
+		t.Fatalf("fixedN(FIXED, empty) = %d, want 0", n)
 	}
 	big := make([]byte, wire.OperateMaxKeyLen+1)
-	_, err = fixedN(&wire.OperateOp{Type: wire.OperateTypeFixed, Bytes: big})
-	if !errors.Is(err, wire.ErrOperateType) {
-		t.Fatalf("fixedN(FIXED, too long) = %v, want wire.ErrOperateType", err)
+	if n := fixedN(&wire.OperateOp{Type: wire.OperateTypeFixed, Bytes: big}); n != 0 {
+		t.Fatalf("fixedN(FIXED, too long) = %d, want 0", n)
 	}
 }
 

--- a/ops/operate_engine_test.go
+++ b/ops/operate_engine_test.go
@@ -5,6 +5,7 @@ package ops
 import (
 	"errors"
 	"fmt"
+	"math"
 	"testing"
 
 	"github.com/rostamlabs/rostam/sdk/wire"
@@ -726,6 +727,11 @@ func bytesApply(rec *wire.Record, a *wire.OperateArgs, stampMs int64) (*wire.Rec
 	if err != nil {
 		return nil, nil, err
 	}
+	if res != nil && res.Status == wire.OperateStatusCheckFailed {
+		// A no-op: nothing is stored, and the record the suite sees is the
+		// one it passed in.
+		return rec, res, nil
+	}
 	if deleted || len(out) == 0 {
 		return nil, res, nil
 	}
@@ -734,4 +740,65 @@ func bytesApply(rec *wire.Record, a *wire.OperateArgs, stampMs int64) (*wire.Rec
 		return nil, nil, fmt.Errorf("engine produced undecodable bytes %x: %w", out, derr)
 	}
 	return got, res, nil
+}
+
+// TestApplyOpsTrimByCol pins the narrowing of TRIM's eviction-column operand.
+// It travels as an int64 and the engines address columns as a uint16, so a
+// plain conversion would let 1<<16 alias column 0 and -65536 alias it too —
+// silently trimming by a real column where the tree oracle rejects the op.
+// Anything outside [0, OperateMaxCols) must arrive as OperateMaxCols, which no
+// schema can have a column at.
+func TestApplyOpsTrimByCol(t *testing.T) {
+	cases := []struct {
+		name string
+		b    int64
+		want uint16
+	}{
+		{"zero", 0, 0},
+		{"in range", 7, 7},
+		{"highest addressable", int64(wire.OperateMaxCols) - 1, wire.OperateMaxCols - 1},
+		{"negative", -1, wire.OperateMaxCols},
+		{"negative aliasing zero", -65536, wire.OperateMaxCols},
+		{"one past the top", int64(wire.OperateMaxCols), wire.OperateMaxCols},
+		{"aliasing zero", 1 << 16, wire.OperateMaxCols},
+		{"aliasing column two", 1<<16 + 2, wire.OperateMaxCols},
+		{"max", math.MaxInt64, wire.OperateMaxCols},
+		{"min", math.MinInt64, wire.OperateMaxCols},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := trimByCol(tc.b); got != tc.want {
+				t.Fatalf("trimByCol(%d)=%d, want %d", tc.b, got, tc.want)
+			}
+			f := newFakeEngine()
+			ops := []wire.OperateOp{{Opcode: wire.OperateOpTRIM, Path: fakeFieldPath("tbl"),
+				A: 1, Aux: wire.OperatePolicyMinCol, B: tc.b}}
+			if _, _, err := applyOps(f, ops, 0); err != nil {
+				t.Fatalf("applyOps: %v", err)
+			}
+			if len(f.trimmed) != 1 || f.trimmed[0].byCol != tc.want {
+				t.Fatalf("trim called with %+v, want byCol %d", f.trimmed, tc.want)
+			}
+		})
+	}
+}
+
+// TestApplyOpsTrimPolicy: an unknown eviction policy is rejected before
+// resolve, the way the oracle rejects it — a malformed op is malformed
+// whatever the record holds.
+func TestApplyOpsTrimPolicy(t *testing.T) {
+	f := newFakeEngine()
+	ops := []wire.OperateOp{{Opcode: wire.OperateOpTRIM, Path: fakeFieldPath("tbl"), A: 1,
+		Aux: wire.OperatePolicyMaxCol + 1}}
+	if _, _, err := applyOps(f, ops, 0); !errors.Is(err, wire.ErrOperateSchema) {
+		t.Fatalf("err=%v, want wire.ErrOperateSchema", err)
+	}
+	for _, call := range f.calls {
+		if call == "resolve:"+pathKey(fakeFieldPath("tbl")) {
+			t.Fatal("resolve ran before the policy check rejected the op")
+		}
+	}
+	if len(f.trimmed) != 0 {
+		t.Fatalf("trim ran: %+v", f.trimmed)
+	}
 }

--- a/ops/operate_oracle_test.go
+++ b/ops/operate_oracle_test.go
@@ -17,11 +17,13 @@ package ops
 import (
 	"bytes"
 	"encoding/binary"
+	"errors"
 	"fmt"
 	"math"
 	"math/rand"
 	"sort"
 
+	"github.com/rostamlabs/rostam/cache"
 	"github.com/rostamlabs/rostam/sdk/wire"
 )
 
@@ -899,7 +901,11 @@ func (st *treeState) resolveDynamic(nd *treeNode, p wire.OperatePath, o wire.Ope
 		if err := treeCheckDynType(o, f.Cell.Type); err != nil {
 			return nil, err
 		}
-		if typ, n, ok := treeRetype(o); ok {
+		typ, n, ok, err := treeRetype(o)
+		if err != nil {
+			return nil, err
+		}
+		if ok {
 			nd.typ, nd.n, nd.retype = typ, n, true
 		}
 		return nd, nil
@@ -973,8 +979,12 @@ func (st *treeState) resolveDynamic(nd *treeNode, p wire.OperatePath, o wire.Ope
 	if err := treeCheckDynType(o, c.Type); err != nil {
 		return nil, err
 	}
-	if typ, n, ok := treeRetype(o); ok {
-		nd.typ, nd.n, nd.retype = typ, n, true
+	rtyp, rn, ok, err := treeRetype(o)
+	if err != nil {
+		return nil, err
+	}
+	if ok {
+		nd.typ, nd.n, nd.retype = rtyp, rn, true
 	}
 	return nd, nil
 }
@@ -1076,15 +1086,25 @@ func treeCreateType(o wire.OperateOp) (uint8, uint8, error) {
 }
 
 // treeRetype reports the new type of a dynamic SET that names one.
-func treeRetype(o wire.OperateOp) (uint8, uint8, bool) {
+//
+// Ruling (adjudicated against the design doc after the first version of this
+// oracle got it wrong): a SET that declares FIXED but carries an operand
+// that cannot form a FIXED(1-255) cell is wire.ErrOperateType on an existing
+// target exactly as on a missing one. §2.9 makes SET replace the scalar
+// INCLUDING its type, so there is no stored type left for such a SET to fall
+// back on, and §2.4's "an op that cannot apply to the field's type is an
+// error" leaves no room for the v1-style silent reinterpretation the earlier
+// code did (it kept the stored type and applied the op against it, which for
+// a stored integer meant writing o.A instead of the bytes the caller sent).
+func treeRetype(o wire.OperateOp) (uint8, uint8, bool, error) {
 	if o.Opcode != wire.OperateOpSET || o.Type == wire.OperateTypeFromSchema {
-		return 0, 0, false
+		return 0, 0, false, nil
 	}
 	typ, n, err := treeCreateType(o)
 	if err != nil {
-		return 0, 0, false
+		return 0, 0, false, err
 	}
-	return typ, n, true
+	return typ, n, true, nil
 }
 
 // treeZeroTypeFor is the type an absent dynamic target reads as. Ruling: the
@@ -2135,6 +2155,19 @@ func randomDynamicOp(rng *rand.Rand) wire.OperateOp {
 			o.Bytes = []byte(dynNames[rng.Intn(len(dynNames))])
 		}
 	}
+	if o.Type == wire.OperateTypeFixed && o.Opcode != wire.OperateOpTRIM && o.Opcode != wire.OperateOpCONFIG {
+		// An operand that cannot form a FIXED(1-255) cell. The type byte
+		// still says FIXED, so there is no width to create or replace with —
+		// wire.ErrOperateType wherever a width is needed, and a PATH error
+		// where the target turns out to be a table or a row, which is the
+		// distinction the loop's fixedN must not pre-empt.
+		switch rng.Intn(12) {
+		case 0:
+			o.Bytes = nil
+		case 1:
+			o.Bytes = make([]byte, wire.OperateMaxKeyLen+1)
+		}
+	}
 	if rng.Intn(8) == 0 {
 		o.Type = wire.OperateTypeFromSchema // "whatever is stored", which a missing target has none of
 	}
@@ -2235,4 +2268,35 @@ func randomFreezeTableDef(rng *rand.Rand) *wire.TableDef {
 		td.ByCol = uint16(rng.Intn(len(td.Cols))) //nolint:gosec // bounded by the column count
 	}
 	return td
+}
+
+// --- error identity --------------------------------------------------------
+
+// operateErrSentinels is every error an operate apply is allowed to return.
+// Which one comes out is part of the contract, not an implementation detail:
+// the client turns it into a status the caller branches on, so an engine that
+// says "bad type" where the oracle says "bad path" is a divergence even
+// though both reject the call. The equivalence property tests compare through
+// operateErrName rather than on nil-ness alone.
+var operateErrSentinels = []error{
+	wire.ErrOperateType, wire.ErrOperatePath, wire.ErrOperateOpcode, wire.ErrOperateCmp,
+	wire.ErrOperateSchema, wire.ErrOperateSchemaVersion, wire.ErrOperateMode,
+	wire.ErrOperateCap, wire.ErrOperateRecord, wire.ErrOperateArgs, wire.ErrShortArgs,
+	errOperateAbsent, errOperateIfRange, cache.ErrNotFound,
+}
+
+// operateErrName names err by the sentinel it wraps, so a property failure
+// reports which two errors disagreed. An error outside the roster is named in
+// full and can never compare equal to a sentinel, which is what makes an
+// engine-private error a test failure rather than a silent pass.
+func operateErrName(err error) string {
+	if err == nil {
+		return "<nil>"
+	}
+	for _, s := range operateErrSentinels {
+		if errors.Is(err, s) {
+			return s.Error()
+		}
+	}
+	return "unrostered error: " + err.Error()
 }

--- a/ops/operate_oracle_test.go
+++ b/ops/operate_oracle_test.go
@@ -1,0 +1,1616 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package ops
+
+// The operate v2 tree oracle.
+//
+// applyTree is the deliberately simple decode → apply → encode implementation
+// the design doc keeps as the reference semantics (§2.6, decision 10): it
+// copies the record tree, mutates it, re-sorts, and re-encodes. It is never
+// used by the handler — the shipped engines patch stored bytes in place — but
+// it is the executable definition of what those engines must do, and
+// operate_semantics_test.go runs the same suite against both.
+//
+// Everything here is test-only. errOperateAbsent moves to the apply engine
+// when that lands; the other helpers stay in the test files.
+
+import (
+	"bytes"
+	"encoding/binary"
+	"errors"
+	"math"
+	"sort"
+
+	"github.com/rostamlabs/rostam/sdk/wire"
+)
+
+var (
+	// errOperateAbsent is the "create = NONE and the key does not exist"
+	// error of design doc §3.5. The handler maps it to the store's
+	// not-found error.
+	errOperateAbsent = errors.New("ops: operate record absent")
+	// errOperateIfRange marks an IF whose skip count is negative or reaches
+	// past the end of the op list (design doc §3.3, "n bounded by the
+	// remaining list").
+	errOperateIfRange = errors.New("ops: operate IF skip count out of range")
+)
+
+// --- shared test helpers ---------------------------------------------------
+
+// sessionSchema is the design doc's §4 worked example, copied from
+// sdk/wire/operate_schema_test.go (package ops cannot see that helper):
+// three scalar counters and a bidder table with an LRU on its stamp column.
+func sessionSchema() *wire.Schema {
+	return &wire.Schema{Version: 1, Fields: []wire.FieldDef{
+		{Name: "rc", Type: wire.OperateTypeU8}, {Name: "bc", Type: wire.OperateTypeU8}, {Name: "hist", Type: wire.OperateTypeU32},
+		{Name: "b", Type: wire.OperateTypeTable, Table: &wire.TableDef{KeyType: wire.OperateTypeU64, Cols: []wire.ColumnDef{
+			{Name: "c", Type: wire.OperateTypeU16}, {Name: "hi", Type: wire.OperateTypeI64}, {Name: "t", Type: wire.OperateTypeU32}},
+			Cap: 1024, Policy: wire.OperatePolicyMinCol, ByCol: 2}},
+	}}
+}
+
+// frozenSchema is the target of a dynamic-mode freeze (design doc §2.9): it
+// stores names, because a freeze matches dynamic fields and columns by name.
+func frozenSchema() *wire.Schema {
+	return &wire.Schema{Version: 3, StoreNames: true, Fields: []wire.FieldDef{
+		{Name: "hits", Type: wire.OperateTypeU32},
+		{Name: "name", Type: wire.OperateTypeBytes},
+		{Name: "b", Type: wire.OperateTypeTable, Table: &wire.TableDef{KeyType: wire.OperateTypeU64,
+			Cols: []wire.ColumnDef{{Name: "c", Type: wire.OperateTypeU16}}}},
+	}}
+}
+
+// floatSchema exercises the parts of §2.2 sessionSchema does not: the float
+// types and the whole variable-length tail (BYTES, FIXED, UVARINT), which sit
+// after the fixed-width fields and are the ones a reader has to walk.
+func floatSchema() *wire.Schema {
+	return &wire.Schema{Version: 7, Fields: []wire.FieldDef{
+		{Name: "f32", Type: wire.OperateTypeF32},
+		{Name: "f64", Type: wire.OperateTypeF64},
+		{Name: "blob", Type: wire.OperateTypeBytes},
+		{Name: "cc", Type: wire.OperateTypeFixed, N: 2},
+		{Name: "v", Type: wire.OperateTypeUVarint},
+	}}
+}
+
+// widenedSchema is a version bump that is not an append-only extension: it
+// widens an existing field, which Schema.Extends rejects (design doc §2.8).
+func widenedSchema() *wire.Schema {
+	s := sessionSchema()
+	s.Version = 2
+	s.Fields[0].Type = wire.OperateTypeU16
+	return s
+}
+
+// su64 reinterprets a signed value as the bits Cell.U stores for it. Go
+// rejects uint64(int64(-5)) as a constant expression, so tests need the
+// conversion to happen in a function.
+func su64(i int64) uint64 { return uint64(i) }
+
+// f64 is a float operand as it travels on the wire: the IEEE bit pattern of a
+// float64, for F32 fields too (design doc §3).
+func f64(x float64) int64 { return int64(math.Float64bits(x)) }
+
+// keyU64 encodes a U64 row key the way a row stores it: little-endian, 8
+// bytes (design doc §2.3).
+func keyU64(k uint64) []byte {
+	return binary.LittleEndian.AppendUint64(nil, k)
+}
+
+func recPath() wire.OperatePath { return wire.OperatePath{Kind: wire.OperatePathRecord} }
+
+func fieldPath(pos uint32) wire.OperatePath {
+	return wire.OperatePath{Kind: wire.OperatePathField, Field: wire.OperateSeg{Pos: pos}}
+}
+
+func rowPath(pos uint32, key []byte) wire.OperatePath {
+	return wire.OperatePath{Kind: wire.OperatePathRow, Field: wire.OperateSeg{Pos: pos}, Key: key}
+}
+
+func colPath(pos uint32, key []byte, col uint32) wire.OperatePath {
+	return wire.OperatePath{Kind: wire.OperatePathCol, Field: wire.OperateSeg{Pos: pos}, Key: key,
+		Col: wire.OperateSeg{Pos: col}}
+}
+
+func namePath(name string) wire.OperatePath {
+	return wire.OperatePath{Kind: wire.OperatePathField, Field: wire.OperateSeg{ByName: true, Name: name}}
+}
+
+func nameRowPath(field string, key []byte) wire.OperatePath {
+	return wire.OperatePath{Kind: wire.OperatePathRow, Field: wire.OperateSeg{ByName: true, Name: field}, Key: key}
+}
+
+func nameColPath(field string, key []byte, col string) wire.OperatePath {
+	return wire.OperatePath{Kind: wire.OperatePathCol, Field: wire.OperateSeg{ByName: true, Name: field}, Key: key,
+		Col: wire.OperateSeg{ByName: true, Name: col}}
+}
+
+// rowKeys returns a table's row keys, in stored order, decoded as
+// little-endian u64s — the shape every test in the suite uses for keys.
+func rowKeys(t *wire.Table) []uint64 {
+	out := make([]uint64, 0, len(t.Rows))
+	for _, r := range t.Rows {
+		var v uint64
+		for i := len(r.Key) - 1; i >= 0; i-- {
+			v = v<<8 | uint64(r.Key[i])
+		}
+		out = append(out, v)
+	}
+	return out
+}
+
+// oper is a wire.OperateOp under construction: op() fills the fields every op
+// carries and the with* methods add the optional operands, so an op list in a
+// test reads like the design doc's worked examples (§4).
+type oper wire.OperateOp
+
+func op(opcode, typ uint8, p wire.OperatePath, a int64) oper {
+	return oper{Opcode: opcode, Type: typ, Path: p, A: a}
+}
+
+func (o oper) withAux(aux uint8) oper  { o.Aux = aux; return o }
+func (o oper) withB(b int64) oper      { o.B = b; return o }
+func (o oper) withBytes(b []byte) oper { o.Bytes = b; return o }
+func toOps(ops []oper) []wire.OperateOp {
+	out := make([]wire.OperateOp, len(ops))
+	for i := range ops {
+		out[i] = wire.OperateOp(ops[i])
+	}
+	return out
+}
+
+// schemaArgs, dynArgs and noneArgs build a call with each of the three
+// `create` modes (design doc §3.5).
+func schemaArgs(s *wire.Schema, ops ...oper) *wire.OperateArgs {
+	return &wire.OperateArgs{Create: wire.OperateCreateSchema, Schema: s.Encode(), Ops: toOps(ops)}
+}
+
+func dynArgs(ops ...oper) *wire.OperateArgs {
+	return &wire.OperateArgs{Create: wire.OperateCreateDynamic, Ops: toOps(ops)}
+}
+
+func noneArgs(ops ...oper) *wire.OperateArgs {
+	return &wire.OperateArgs{Create: wire.OperateCreateNone, Ops: toOps(ops)}
+}
+
+// withRet and withCount append VALUE / COUNT return specs (design doc §3.4).
+func withRet(a *wire.OperateArgs, paths ...wire.OperatePath) *wire.OperateArgs {
+	for _, p := range paths {
+		a.Rets = append(a.Rets, wire.OperateRet{Mode: wire.OperateRetValue, Path: p})
+	}
+	return a
+}
+
+func withCount(a *wire.OperateArgs, paths ...wire.OperatePath) *wire.OperateArgs {
+	for _, p := range paths {
+		a.Rets = append(a.Rets, wire.OperateRet{Mode: wire.OperateRetCount, Path: p})
+	}
+	return a
+}
+
+// --- the oracle ------------------------------------------------------------
+
+// applyTree applies a's op list to rec and returns the new record, the result
+// frame, and an error. rec == nil means the key is absent; a nil returned
+// record means the key is deleted (design doc §2.5). rec is never mutated: the
+// oracle works on a deep copy, so a CHECK failure — and any error — returns
+// the caller's original tree untouched (design doc §2.7: a cap hit is an
+// error with the record unchanged, never a partial write).
+//
+// Rulings this implementation makes where the design doc is silent are marked
+// "Ruling:" in the comments below.
+func applyTree(rec *wire.Record, a *wire.OperateArgs, stampMs int64) (*wire.Record, *wire.OperateResult, error) {
+	if len(a.Ops) > wire.OperateMaxOps || len(a.Rets) > wire.OperateMaxRet {
+		return rec, nil, wire.ErrOperateCap
+	}
+	cur, err := treeOpen(rec, a)
+	if err != nil {
+		return rec, nil, err
+	}
+	st := &treeState{rec: cur, existed: rec != nil, stampMs: stampMs}
+
+	status, failedOp, err := st.run(a.Ops)
+	if err != nil {
+		return rec, nil, err
+	}
+	if status == wire.OperateStatusCheckFailed {
+		// The whole list aborts with the record unchanged, and the return
+		// specs are evaluated against that unchanged record (design doc §3.3).
+		vals, verr := treeRets(rec, rec != nil, a.Rets)
+		if verr != nil {
+			return rec, nil, verr
+		}
+		return rec, &wire.OperateResult{Status: status, FailedOp: failedOp, Values: vals}, nil
+	}
+
+	out := st.rec
+	if st.deleted || (out.Mode == wire.OperateModeDynamic && len(out.Fields) == 0) {
+		out = nil
+	}
+	if out != nil {
+		treeNormalize(out)
+	}
+	vals, verr := treeRets(out, true, a.Rets)
+	if verr != nil {
+		return rec, nil, verr
+	}
+	return out, &wire.OperateResult{Status: wire.OperateStatusOK, Values: vals}, nil
+}
+
+// treeState is one in-flight apply: the working copy of the record, whether
+// that record existed before the call (record-path EXISTS/ABSENT), the
+// transaction stamp, and whether DEL () deleted it.
+type treeState struct {
+	rec     *wire.Record
+	existed bool
+	stampMs int64
+	deleted bool
+}
+
+// treeOpen resolves the call's `create` parameter against the stored record
+// (design doc §3.5) and returns the working copy to apply ops to.
+func treeOpen(rec *wire.Record, a *wire.OperateArgs) (*wire.Record, error) {
+	cur := treeClone(rec)
+	switch a.Create {
+	case wire.OperateCreateNone:
+		// Ruling: with create = NONE the call carries no schema blob, so a
+		// blob that arrives anyway is ignored rather than checked — there is
+		// nothing in §3.5 for it to be checked against.
+		if cur == nil {
+			return nil, errOperateAbsent
+		}
+	case wire.OperateCreateSchema:
+		if len(a.Schema) == 0 {
+			return nil, wire.ErrOperateSchema
+		}
+		s, n, err := wire.DecodeSchema(a.Schema)
+		if err != nil {
+			return nil, err
+		}
+		if n != len(a.Schema) {
+			return nil, wire.ErrOperateSchema
+		}
+		if cur == nil {
+			cur = treeNewSchemaRecord(s)
+			break
+		}
+		if cur.Mode != wire.OperateModeSchema {
+			return nil, wire.ErrOperateMode
+		}
+		// Ruling: §2.8 compares versions, not blobs. The stored schema stays
+		// authoritative for the record; the call's blob only has to agree on
+		// the version.
+		if cur.Schema.Version != s.Version {
+			return nil, wire.ErrOperateSchemaVersion
+		}
+	case wire.OperateCreateDynamic:
+		if cur == nil {
+			cur = &wire.Record{Mode: wire.OperateModeDynamic}
+			break
+		}
+		if cur.Mode != wire.OperateModeDynamic {
+			return nil, wire.ErrOperateMode
+		}
+	default:
+		return nil, wire.ErrOperateArgs
+	}
+	treeNormalize(cur)
+	return cur, nil
+}
+
+// run walks the op list (design doc §3.1-§3.3), returning the result status
+// and, on CHECK_FAILED, the failing op's index.
+func (st *treeState) run(ops []wire.OperateOp) (uint8, uint16, error) {
+	for i := 0; i < len(ops); i++ {
+		o := ops[i]
+		if o.Opcode == wire.OperateOpMIGRATE {
+			if i != 0 {
+				return 0, 0, wire.ErrOperateOpcode
+			}
+			if err := st.migrate(o); err != nil {
+				return 0, 0, err
+			}
+			continue
+		}
+		switch o.Opcode {
+		case wire.OperateOpIF:
+			ok, err := st.compare(o)
+			if err != nil {
+				return 0, 0, err
+			}
+			if !ok {
+				if o.B < 0 || o.B > int64(len(ops)-i-1) {
+					return 0, 0, errOperateIfRange
+				}
+				i += int(o.B)
+			}
+		case wire.OperateOpCHECK:
+			ok, err := st.compare(o)
+			if err != nil {
+				return 0, 0, err
+			}
+			if !ok {
+				return wire.OperateStatusCheckFailed, uint16(i), nil
+			}
+		case wire.OperateOpDEL:
+			if err := st.del(o); err != nil {
+				return 0, 0, err
+			}
+			// Ruling: DEL () is terminal. §3.1 says the record is deleted;
+			// rather than invent semantics for ops that would run against a
+			// deleted record, the list ends here and the return specs see an
+			// absent record.
+			if st.deleted {
+				return wire.OperateStatusOK, 0, nil
+			}
+		case wire.OperateOpCONFIG:
+			if err := st.config(o); err != nil {
+				return 0, 0, err
+			}
+		case wire.OperateOpTRIM:
+			if err := st.trim(o); err != nil {
+				return 0, 0, err
+			}
+		default:
+			if err := st.scalar(o); err != nil {
+				return 0, 0, err
+			}
+		}
+	}
+	return wire.OperateStatusOK, 0, nil
+}
+
+// scalar applies one §3.1 op to the scalar the path addresses, vivifying
+// what the write needs on the way (design doc §2.4, "writes vivify").
+func (st *treeState) scalar(o wire.OperateOp) error {
+	nd, err := st.resolve(o.Path, o, true)
+	if err != nil {
+		return err
+	}
+	if nd.kind == wire.OperatePathRecord || nd.kind == wire.OperatePathRow || nd.isTable {
+		return wire.ErrOperatePath
+	}
+	cell := treeCellAt(st.rec, nd)
+	out, err := wire.ApplyScalar(o.Opcode, cell, nd.present,
+		wire.Operand{A: o.A, Aux: o.Aux, Bytes: o.Bytes, StampMs: st.stampMs})
+	if err != nil {
+		return err
+	}
+	treeSetCell(st.rec, nd, out)
+	return nil
+}
+
+// compare evaluates an IF/CHECK comparator against the node the path
+// addresses (design doc §3.3). It never vivifies.
+func (st *treeState) compare(o wire.OperateOp) (bool, error) {
+	nd, err := st.resolve(o.Path, o, false)
+	if err != nil {
+		return false, err
+	}
+	opnd := wire.Operand{A: o.A, Aux: o.Aux, Bytes: o.Bytes, StampMs: st.stampMs}
+	switch {
+	case nd.kind == wire.OperatePathRecord:
+		return wire.CompareCount(o.Aux, uint64(st.fieldCount()), nd.present, opnd)
+	case nd.isTable:
+		var n uint64
+		if nd.tbl != nil {
+			n = uint64(len(nd.tbl.Rows))
+		}
+		return wire.CompareCount(o.Aux, n, nd.present, opnd)
+	case nd.kind == wire.OperatePathRow:
+		// Ruling: a row has no value of its own, so it compares as a count of
+		// 1 (present) or 0 (absent) — which makes EXISTS/ABSENT the only
+		// comparators with a useful meaning on it.
+		var n uint64
+		if nd.present {
+			n = 1
+		}
+		return wire.CompareCount(o.Aux, n, nd.present, opnd)
+	default:
+		return wire.CompareCell(o.Aux, treeCellAt(st.rec, nd), nd.present, opnd)
+	}
+}
+
+// del implements DEL for every path kind (design doc §3.1/§2.5). It never
+// vivifies: deleting something absent is a no-op, not an error.
+func (st *treeState) del(o wire.OperateOp) error {
+	nd, err := st.resolve(o.Path, o, false)
+	if err != nil {
+		return err
+	}
+	switch nd.kind {
+	case wire.OperatePathRecord:
+		st.deleted = true
+	case wire.OperatePathField:
+		if nd.fi < 0 {
+			return nil
+		}
+		if st.rec.Mode == wire.OperateModeDynamic {
+			st.rec.Fields = append(st.rec.Fields[:nd.fi], st.rec.Fields[nd.fi+1:]...)
+			return nil
+		}
+		if nd.isTable {
+			nd.tbl.Rows = nil
+			return nil
+		}
+		st.rec.Fields[nd.fi].Cell = wire.ZeroCell(nd.typ, nd.n)
+	case wire.OperatePathRow:
+		if !nd.present || nd.ri < 0 {
+			return nil
+		}
+		nd.tbl.Rows = append(nd.tbl.Rows[:nd.ri], nd.tbl.Rows[nd.ri+1:]...)
+	case wire.OperatePathCol:
+		if nd.ri < 0 || nd.ci < 0 || !nd.present {
+			return nil
+		}
+		row := &nd.tbl.Rows[nd.ri]
+		if st.rec.Mode == wire.OperateModeDynamic {
+			// Ruling: a dynamic row survives losing its last column; a row is
+			// a keyed entity, and an empty column list encodes fine.
+			row.Cols = append(row.Cols[:nd.ci], row.Cols[nd.ci+1:]...)
+			return nil
+		}
+		row.Cols[nd.ci].Cell = wire.ZeroCell(nd.typ, nd.n)
+	}
+	return nil
+}
+
+// config implements CONFIG (design doc §3.2): dynamic mode only, it sets the
+// eviction triple on the table at path, creating an empty table if absent,
+// and evicts down to the new cap.
+func (st *treeState) config(o wire.OperateOp) error {
+	if st.rec.Mode != wire.OperateModeDynamic {
+		return wire.ErrOperateOpcode
+	}
+	if o.Path.Kind != wire.OperatePathField {
+		return wire.ErrOperatePath
+	}
+	if !o.Path.Field.ByName {
+		return wire.ErrOperatePath
+	}
+	if len(o.Path.Field.Name) > wire.OperateMaxNameLen || len(o.Bytes) > wire.OperateMaxNameLen {
+		return wire.ErrOperateCap
+	}
+	if o.A < 0 || o.A > int64(wire.OperateMaxRows) {
+		return wire.ErrOperateCap
+	}
+	// Ruling: an unknown policy byte is a schema-shaped error, the same one
+	// Schema.Validate returns for a table declaring it.
+	if o.Aux > wire.OperatePolicyMaxCol {
+		return wire.ErrOperateSchema
+	}
+	byColName := string(o.Bytes)
+	if (o.Aux == wire.OperatePolicyMinCol || o.Aux == wire.OperatePolicyMaxCol) && byColName == "" {
+		// Ruling: mirrors Schema.Validate's "ByCol must name a real column"
+		// rule for a *_COL policy.
+		return wire.ErrOperatePath
+	}
+
+	fi := treeFindField(st.rec.Fields, o.Path.Field.Name)
+	if fi < 0 {
+		if len(st.rec.Fields)+1 > wire.OperateMaxFields {
+			return wire.ErrOperateCap
+		}
+		st.rec.Fields = append(st.rec.Fields, wire.Field{Name: o.Path.Field.Name,
+			Cell: wire.Cell{Type: wire.OperateTypeTable}, Table: &wire.Table{}})
+		treeSortFields(st.rec)
+		fi = treeFindField(st.rec.Fields, o.Path.Field.Name)
+	} else if st.rec.Fields[fi].Cell.Type != wire.OperateTypeTable {
+		return wire.ErrOperatePath
+	}
+	tbl := st.rec.Fields[fi].Table
+	tbl.Cap = uint32(o.A)
+	tbl.Policy = o.Aux
+	tbl.ByColName = byColName
+	for tbl.Cap > 0 && uint32(len(tbl.Rows)) > tbl.Cap {
+		treeEvictOne(tbl, tbl.Policy, int(tbl.ByCol), tbl.ByColName, true)
+	}
+	return nil
+}
+
+// trim implements TRIM (design doc §3.2): a one-off shrink of the table at
+// path to `keep` rows by the op's policy, leaving the stored policy alone.
+func (st *treeState) trim(o wire.OperateOp) error {
+	if o.Path.Kind != wire.OperatePathField {
+		return wire.ErrOperatePath
+	}
+	if o.A < 0 || o.A > int64(wire.OperateMaxRows) {
+		return wire.ErrOperateCap
+	}
+	if o.Aux > wire.OperatePolicyMaxCol {
+		return wire.ErrOperateSchema
+	}
+	nd, err := st.resolve(o.Path, o, false)
+	if err != nil {
+		return err
+	}
+	if nd.fi < 0 {
+		// Ruling: TRIM is a shrink, not a write, so an absent dynamic table
+		// field is a no-op rather than a vivification.
+		return nil
+	}
+	if !nd.isTable || nd.tbl == nil {
+		return wire.ErrOperatePath
+	}
+
+	dynamic := st.rec.Mode == wire.OperateModeDynamic
+	byCol := int(o.B)
+	byColName := string(o.Bytes)
+	if o.Aux == wire.OperatePolicyMinCol || o.Aux == wire.OperatePolicyMaxCol {
+		if dynamic {
+			if byColName == "" {
+				return wire.ErrOperatePath
+			}
+		} else if byCol < 0 || byCol >= len(st.rec.Schema.Fields[nd.fi].Table.Cols) {
+			return wire.ErrOperatePath
+		}
+	}
+	for len(nd.tbl.Rows) > int(o.A) {
+		treeEvictOne(nd.tbl, o.Aux, byCol, byColName, dynamic)
+	}
+	return nil
+}
+
+// migrate implements MIGRATE (design doc §2.8/§2.9). It must be Ops[0]; the
+// caller enforces that.
+func (st *treeState) migrate(o wire.OperateOp) error {
+	if o.Path.Kind != wire.OperatePathRecord {
+		return wire.ErrOperatePath
+	}
+	ns, n, err := wire.DecodeSchema(o.Bytes)
+	if err != nil {
+		return err
+	}
+	if n != len(o.Bytes) {
+		return wire.ErrOperateSchema
+	}
+	if o.A == wire.OperateMigrateFromDynamic {
+		return st.freeze(ns, o.Aux)
+	}
+	if st.rec.Mode != wire.OperateModeSchema {
+		return wire.ErrOperateMode
+	}
+	if o.A < 0 || o.A > math.MaxUint16 || uint16(o.A) != st.rec.Schema.Version {
+		return wire.ErrOperateSchemaVersion
+	}
+	if err := st.rec.Schema.Extends(ns); err != nil {
+		return err
+	}
+
+	old := st.rec
+	fields := make([]wire.Field, len(ns.Fields))
+	for i := range ns.Fields {
+		fd := &ns.Fields[i]
+		if fd.Type != wire.OperateTypeTable {
+			c := wire.ZeroCell(fd.Type, fd.N)
+			if i < len(old.Fields) {
+				c = treeSchemaCell(old.Fields[i].Cell, fd.Type, fd.N)
+			}
+			fields[i] = wire.Field{Name: fd.Name, Cell: c}
+			continue
+		}
+		tbl := &wire.Table{Cap: fd.Table.Cap, Policy: fd.Table.Policy, ByCol: fd.Table.ByCol}
+		if i < len(old.Fields) && old.Fields[i].Table != nil {
+			for _, r := range old.Fields[i].Table.Rows {
+				row := wire.Row{Key: append([]byte(nil), r.Key...), Cols: make([]wire.Col, len(fd.Table.Cols))}
+				for c := range fd.Table.Cols {
+					cd := &fd.Table.Cols[c]
+					if c < len(r.Cols) {
+						row.Cols[c] = wire.Col{Cell: treeSchemaCell(r.Cols[c].Cell, cd.Type, cd.N)}
+						continue
+					}
+					row.Cols[c] = wire.Col{Cell: wire.ZeroCell(cd.Type, cd.N)}
+				}
+				tbl.Rows = append(tbl.Rows, row)
+			}
+		}
+		treeSortRows(tbl, fd.Table.KeyType, false)
+		for tbl.Cap > 0 && uint32(len(tbl.Rows)) > tbl.Cap {
+			treeEvictOne(tbl, tbl.Policy, int(tbl.ByCol), "", false)
+		}
+		fields[i] = wire.Field{Name: fd.Name, Cell: wire.Cell{Type: wire.OperateTypeTable}, Table: tbl}
+	}
+	st.rec = &wire.Record{Mode: wire.OperateModeSchema, Schema: ns, Fields: fields}
+	treeNormalize(st.rec)
+	return nil
+}
+
+// freeze converts a dynamic record into schema mode (design doc §2.9): each
+// schema field and column is filled from the dynamic value of the same name,
+// widths saturate, rows are packed, and a dynamic field or column the schema
+// does not have is an error unless DROP_EXTRA is set.
+func (st *treeState) freeze(ns *wire.Schema, flags uint8) error {
+	if st.rec.Mode != wire.OperateModeDynamic {
+		return wire.ErrOperateMode
+	}
+	if !ns.StoreNames {
+		return wire.ErrOperateSchema
+	}
+	dropExtra := flags&wire.OperateMigrateDropExtra != 0
+
+	used := make(map[string]bool, len(ns.Fields))
+	fields := make([]wire.Field, len(ns.Fields))
+	for i := range ns.Fields {
+		fd := &ns.Fields[i]
+		if fd.Name == "" {
+			return wire.ErrOperateSchema
+		}
+		used[fd.Name] = true
+		si := treeFindField(st.rec.Fields, fd.Name)
+
+		if fd.Type != wire.OperateTypeTable {
+			var src wire.Cell
+			if si >= 0 {
+				if st.rec.Fields[si].Cell.Type == wire.OperateTypeTable {
+					return wire.ErrOperateType
+				}
+				src = st.rec.Fields[si].Cell
+			}
+			cell, err := treeConvertCell(src, si >= 0, fd.Type, fd.N)
+			if err != nil {
+				return err
+			}
+			fields[i] = wire.Field{Name: fd.Name, Cell: cell}
+			continue
+		}
+
+		tbl := &wire.Table{Cap: fd.Table.Cap, Policy: fd.Table.Policy, ByCol: fd.Table.ByCol}
+		if si >= 0 {
+			src := &st.rec.Fields[si]
+			if src.Cell.Type != wire.OperateTypeTable || src.Table == nil {
+				return wire.ErrOperateType
+			}
+			keyWidth := wire.CellWidth(fd.Table.KeyType, fd.Table.KeyN)
+			for _, r := range src.Table.Rows {
+				// Ruling: a schema-mode row key is exactly the table's key
+				// width, so a dynamic key of any other length cannot be
+				// packed and the freeze is rejected.
+				if len(r.Key) != keyWidth {
+					return wire.ErrOperateSchema
+				}
+				row := wire.Row{Key: append([]byte(nil), r.Key...), Cols: make([]wire.Col, len(fd.Table.Cols))}
+				matched := 0
+				for c := range fd.Table.Cols {
+					cd := &fd.Table.Cols[c]
+					if cd.Name == "" {
+						return wire.ErrOperateSchema
+					}
+					ci := treeFindCol(r.Cols, cd.Name)
+					var src wire.Cell
+					if ci >= 0 {
+						src = r.Cols[ci].Cell
+						matched++
+					}
+					cell, err := treeConvertCell(src, ci >= 0, cd.Type, cd.N)
+					if err != nil {
+						return err
+					}
+					row.Cols[c] = wire.Col{Cell: cell}
+				}
+				if matched != len(r.Cols) && !dropExtra {
+					return wire.ErrOperateSchema
+				}
+				tbl.Rows = append(tbl.Rows, row)
+			}
+		}
+		treeSortRows(tbl, fd.Table.KeyType, false)
+		for tbl.Cap > 0 && uint32(len(tbl.Rows)) > tbl.Cap {
+			treeEvictOne(tbl, tbl.Policy, int(tbl.ByCol), "", false)
+		}
+		fields[i] = wire.Field{Name: fd.Name, Cell: wire.Cell{Type: wire.OperateTypeTable}, Table: tbl}
+	}
+
+	if !dropExtra {
+		for i := range st.rec.Fields {
+			if !used[st.rec.Fields[i].Name] {
+				return wire.ErrOperateSchema
+			}
+		}
+	}
+	st.rec = &wire.Record{Mode: wire.OperateModeSchema, Schema: ns, Fields: fields}
+	treeNormalize(st.rec)
+	return nil
+}
+
+func (st *treeState) fieldCount() int {
+	if st.rec.Mode == wire.OperateModeSchema {
+		return len(st.rec.Schema.Fields)
+	}
+	return len(st.rec.Fields)
+}
+
+// --- path resolution -------------------------------------------------------
+
+// treeNode is a resolved path: which field, row and column it lands on, the
+// declared type of the scalar there, and whether that scalar existed before
+// this op (the "absent is zero" flag, design doc §2.4).
+type treeNode struct {
+	kind    uint8
+	fi      int
+	tbl     *wire.Table
+	ri      int
+	ci      int
+	typ     uint8
+	n       uint8
+	present bool
+	isTable bool
+	retype  bool // dynamic SET replacing the stored type
+}
+
+func (st *treeState) resolve(p wire.OperatePath, o wire.OperateOp, create bool) (*treeNode, error) {
+	nd := &treeNode{kind: p.Kind, fi: -1, ri: -1, ci: -1}
+	if p.Kind > wire.OperatePathCol {
+		return nil, wire.ErrOperatePath
+	}
+	if p.Kind == wire.OperatePathRecord {
+		// Ruling: the record's presence is whether it existed before this
+		// call, so CHECK((), ABSENT) means "this call created it". Presence
+		// "now" would make both comparators constants, since a call that
+		// reaches the op list always has a record.
+		nd.present = st.existed
+		return nd, nil
+	}
+	if st.rec.Mode == wire.OperateModeSchema {
+		return st.resolveSchema(nd, p, o, create)
+	}
+	return st.resolveDynamic(nd, p, o, create)
+}
+
+func (st *treeState) resolveSchema(nd *treeNode, p wire.OperatePath, o wire.OperateOp, create bool) (*treeNode, error) {
+	s := st.rec.Schema
+	if p.Field.ByName {
+		// Names address a schema record only when it stores them (§2.4).
+		if !s.StoreNames {
+			return nil, wire.ErrOperatePath
+		}
+		pos, ok := s.FieldPos(p.Field.Name)
+		if !ok {
+			return nil, wire.ErrOperatePath
+		}
+		nd.fi = pos
+	} else {
+		if p.Field.Pos >= uint32(len(s.Fields)) {
+			return nil, wire.ErrOperatePath
+		}
+		nd.fi = int(p.Field.Pos)
+	}
+	fd := &s.Fields[nd.fi]
+
+	if p.Kind == wire.OperatePathField {
+		nd.present = true // every declared schema field exists (§2.5)
+		if fd.Type == wire.OperateTypeTable {
+			nd.isTable = true
+			nd.tbl = st.rec.Fields[nd.fi].Table
+			return nd, nil
+		}
+		nd.typ, nd.n = fd.Type, fd.N
+		if err := treeCheckSchemaType(o, fd.Type); err != nil {
+			return nil, err
+		}
+		return nd, nil
+	}
+
+	if fd.Type != wire.OperateTypeTable {
+		return nil, wire.ErrOperatePath // a row path into a non-table field
+	}
+	td := fd.Table
+	nd.tbl = st.rec.Fields[nd.fi].Table
+	if len(p.Key) != wire.CellWidth(td.KeyType, td.KeyN) {
+		return nil, wire.ErrOperatePath
+	}
+
+	if p.Kind == wire.OperatePathCol {
+		if p.Col.ByName {
+			if !s.StoreNames {
+				return nil, wire.ErrOperatePath
+			}
+			nd.ci = -1
+			for j := range td.Cols {
+				if p.Col.Name != "" && td.Cols[j].Name == p.Col.Name {
+					nd.ci = j
+					break
+				}
+			}
+			if nd.ci < 0 {
+				return nil, wire.ErrOperatePath
+			}
+		} else {
+			if p.Col.Pos >= uint32(len(td.Cols)) {
+				return nil, wire.ErrOperatePath
+			}
+			nd.ci = int(p.Col.Pos)
+		}
+		nd.typ, nd.n = td.Cols[nd.ci].Type, td.Cols[nd.ci].N
+		if err := treeCheckSchemaType(o, td.Cols[nd.ci].Type); err != nil {
+			return nil, err
+		}
+	}
+
+	ri, found := treeFindRow(nd.tbl.Rows, p.Key, td.KeyType, false)
+	nd.present = found
+	if !found {
+		if !create {
+			return nd, nil
+		}
+		if err := treeInsertSchemaRow(nd.tbl, td, p.Key); err != nil {
+			return nil, err
+		}
+		ri, _ = treeFindRow(nd.tbl.Rows, p.Key, td.KeyType, false)
+	}
+	nd.ri = ri
+	return nd, nil
+}
+
+func (st *treeState) resolveDynamic(nd *treeNode, p wire.OperatePath, o wire.OperateOp, create bool) (*treeNode, error) {
+	// Positions are unstable in dynamic mode (fields are kept sorted by
+	// name), so only names address it (§2.4).
+	if !p.Field.ByName {
+		return nil, wire.ErrOperatePath
+	}
+	if len(p.Field.Name) > wire.OperateMaxNameLen {
+		return nil, wire.ErrOperateCap
+	}
+	if p.Kind != wire.OperatePathField {
+		if len(p.Key) == 0 {
+			return nil, wire.ErrOperatePath
+		}
+		if len(p.Key) > wire.OperateMaxKeyLen {
+			return nil, wire.ErrOperateCap
+		}
+	}
+	if p.Kind == wire.OperatePathCol {
+		if !p.Col.ByName {
+			return nil, wire.ErrOperatePath
+		}
+		if len(p.Col.Name) > wire.OperateMaxNameLen {
+			return nil, wire.ErrOperateCap
+		}
+	}
+	fi := treeFindField(st.rec.Fields, p.Field.Name)
+
+	if p.Kind == wire.OperatePathField {
+		if fi < 0 {
+			if !create {
+				nd.typ, nd.n = treeZeroTypeFor(o)
+				return nd, nil
+			}
+			typ, n, err := treeCreateType(o)
+			if err != nil {
+				return nil, err
+			}
+			if len(st.rec.Fields)+1 > wire.OperateMaxFields {
+				return nil, wire.ErrOperateCap
+			}
+			st.rec.Fields = append(st.rec.Fields, wire.Field{Name: p.Field.Name, Cell: wire.ZeroCell(typ, n)})
+			treeSortFields(st.rec)
+			nd.fi = treeFindField(st.rec.Fields, p.Field.Name)
+			nd.typ, nd.n = typ, n
+			return nd, nil
+		}
+		nd.fi = fi
+		nd.present = true
+		f := &st.rec.Fields[fi]
+		if f.Cell.Type == wire.OperateTypeTable {
+			nd.isTable = true
+			nd.tbl = f.Table
+			return nd, nil
+		}
+		nd.typ, nd.n = f.Cell.Type, f.Cell.N
+		if err := treeCheckDynType(o, f.Cell.Type); err != nil {
+			return nil, err
+		}
+		if typ, n, ok := treeRetype(o); ok {
+			nd.typ, nd.n, nd.retype = typ, n, true
+		}
+		return nd, nil
+	}
+
+	// Row and column paths: the field must be (or become) a table.
+	if fi < 0 {
+		if !create {
+			nd.typ, nd.n = treeZeroTypeFor(o)
+			return nd, nil
+		}
+		if len(st.rec.Fields)+1 > wire.OperateMaxFields {
+			return nil, wire.ErrOperateCap
+		}
+		st.rec.Fields = append(st.rec.Fields, wire.Field{Name: p.Field.Name,
+			Cell: wire.Cell{Type: wire.OperateTypeTable}, Table: &wire.Table{}})
+		treeSortFields(st.rec)
+		fi = treeFindField(st.rec.Fields, p.Field.Name)
+	} else if st.rec.Fields[fi].Cell.Type != wire.OperateTypeTable {
+		return nil, wire.ErrOperatePath // a row path into a scalar field
+	}
+	nd.fi = fi
+	nd.tbl = st.rec.Fields[fi].Table
+
+	ri, found := treeFindRow(nd.tbl.Rows, p.Key, 0, true)
+	if !found {
+		if !create {
+			nd.typ, nd.n = treeZeroTypeFor(o)
+			return nd, nil
+		}
+		if nd.tbl.Cap > 0 && uint32(len(nd.tbl.Rows)) >= nd.tbl.Cap {
+			treeEvictOne(nd.tbl, nd.tbl.Policy, int(nd.tbl.ByCol), nd.tbl.ByColName, true)
+		}
+		if len(nd.tbl.Rows)+1 > wire.OperateMaxRows {
+			return nil, wire.ErrOperateCap
+		}
+		nd.tbl.Rows = append(nd.tbl.Rows, wire.Row{Key: append([]byte(nil), p.Key...)})
+		treeSortRows(nd.tbl, 0, true)
+		ri, _ = treeFindRow(nd.tbl.Rows, p.Key, 0, true)
+	}
+	nd.ri = ri
+	if p.Kind == wire.OperatePathRow {
+		nd.present = found
+		return nd, nil
+	}
+
+	row := &nd.tbl.Rows[ri]
+	ci := treeFindCol(row.Cols, p.Col.Name)
+	if ci < 0 {
+		if !create {
+			nd.typ, nd.n = treeZeroTypeFor(o)
+			return nd, nil
+		}
+		typ, n, err := treeCreateType(o)
+		if err != nil {
+			return nil, err
+		}
+		if len(row.Cols)+1 > wire.OperateMaxCols {
+			return nil, wire.ErrOperateCap
+		}
+		row.Cols = append(row.Cols, wire.Col{Name: p.Col.Name, Cell: wire.ZeroCell(typ, n)})
+		treeSortCols(row)
+		nd.ci = treeFindCol(row.Cols, p.Col.Name)
+		nd.typ, nd.n = typ, n
+		return nd, nil
+	}
+	nd.ci = ci
+	nd.present = true
+	c := row.Cols[ci].Cell
+	nd.typ, nd.n = c.Type, c.N
+	if err := treeCheckDynType(o, c.Type); err != nil {
+		return nil, err
+	}
+	if typ, n, ok := treeRetype(o); ok {
+		nd.typ, nd.n, nd.retype = typ, n, true
+	}
+	return nd, nil
+}
+
+// treeInsertSchemaRow vivifies a row, evicting first if the table is full
+// (design doc §2.3/§2.4).
+func treeInsertSchemaRow(tbl *wire.Table, td *wire.TableDef, key []byte) error {
+	if td.Cap > 0 && uint32(len(tbl.Rows)) >= td.Cap {
+		treeEvictOne(tbl, td.Policy, int(td.ByCol), "", false)
+	}
+	if len(tbl.Rows)+1 > wire.OperateMaxRows {
+		return wire.ErrOperateCap
+	}
+	row := wire.Row{Key: append([]byte(nil), key...), Cols: make([]wire.Col, len(td.Cols))}
+	for c := range td.Cols {
+		row.Cols[c] = wire.Col{Cell: wire.ZeroCell(td.Cols[c].Type, td.Cols[c].N)}
+	}
+	tbl.Rows = append(tbl.Rows, row)
+	treeSortRows(tbl, td.KeyType, false)
+	return nil
+}
+
+// --- type rules (design doc §2.4) ------------------------------------------
+
+// treeIsControl reports whether an opcode's type byte is meaningless: the
+// control, table and structural ops do not read or write a typed value, so
+// they neither check nor create a type.
+func treeIsControl(opcode uint8) bool {
+	switch opcode {
+	case wire.OperateOpIF, wire.OperateOpCHECK, wire.OperateOpDEL,
+		wire.OperateOpTRIM, wire.OperateOpCONFIG, wire.OperateOpMIGRATE:
+		return true
+	default:
+		return false
+	}
+}
+
+// treeValidScalarType reports whether t names a type a value can have.
+func treeValidScalarType(t uint8) bool {
+	return t < wire.OperateTypeCount && t != wire.OperateTypeTable && t != wire.OperateTypeUnset
+}
+
+// treeDomain groups types the way §2.4's "the domain must match" rule does.
+func treeDomain(t uint8) int {
+	switch {
+	case wire.TypeIsFloat(t):
+		return 1
+	case wire.TypeIsInt(t):
+		return 0
+	case wire.TypeIsBytes(t):
+		return 2
+	default:
+		return -1
+	}
+}
+
+// treeCheckSchemaType enforces §2.4's schema-mode rule: an op's type byte is
+// either 0xFF ("from schema") or exactly the schema's type.
+func treeCheckSchemaType(o wire.OperateOp, want uint8) error {
+	if treeIsControl(o.Opcode) || o.Type == wire.OperateTypeFromSchema || o.Type == want {
+		return nil
+	}
+	return wire.ErrOperateType
+}
+
+// treeCheckDynType enforces §2.4's dynamic-mode rule on an existing target:
+// the op's domain must match the stored one, except for SET, which replaces
+// the scalar including its type (§2.9).
+func treeCheckDynType(o wire.OperateOp, stored uint8) error {
+	if treeIsControl(o.Opcode) || o.Type == wire.OperateTypeFromSchema {
+		return nil
+	}
+	if !treeValidScalarType(o.Type) {
+		return wire.ErrOperateType
+	}
+	if o.Opcode == wire.OperateOpSET {
+		return nil
+	}
+	if treeDomain(o.Type) != treeDomain(stored) {
+		return wire.ErrOperateType
+	}
+	return nil
+}
+
+// treeCreateType is the type a missing dynamic field or column is created
+// with: the op's own type byte, never "from schema" (there is no schema).
+// A FIXED target takes its width from the operand bytes.
+func treeCreateType(o wire.OperateOp) (uint8, uint8, error) {
+	if o.Type == wire.OperateTypeFromSchema || !treeValidScalarType(o.Type) {
+		return 0, 0, wire.ErrOperateType
+	}
+	if o.Type == wire.OperateTypeFixed {
+		if len(o.Bytes) < 1 || len(o.Bytes) > wire.OperateMaxKeyLen {
+			return 0, 0, wire.ErrOperateType
+		}
+		return o.Type, uint8(len(o.Bytes)), nil
+	}
+	return o.Type, 0, nil
+}
+
+// treeRetype reports the new type of a dynamic SET that names one.
+func treeRetype(o wire.OperateOp) (uint8, uint8, bool) {
+	if o.Opcode != wire.OperateOpSET || o.Type == wire.OperateTypeFromSchema {
+		return 0, 0, false
+	}
+	typ, n, err := treeCreateType(o)
+	if err != nil {
+		return 0, 0, false
+	}
+	return typ, n, true
+}
+
+// treeZeroTypeFor is the type an absent dynamic target reads as. Ruling: the
+// op's type byte picks the zero's domain when it names a type (so a bytes
+// comparison against an absent field compares bytewise), and an integer zero
+// is the fallback.
+func treeZeroTypeFor(o wire.OperateOp) (uint8, uint8) {
+	if treeValidScalarType(o.Type) {
+		if o.Type != wire.OperateTypeFixed {
+			return o.Type, 0
+		}
+		if len(o.Bytes) >= 1 && len(o.Bytes) <= wire.OperateMaxKeyLen {
+			return o.Type, uint8(len(o.Bytes))
+		}
+	}
+	return wire.OperateTypeU8, 0
+}
+
+// treeConvertCell re-types src as (typ, n) for a freeze (design doc §2.9):
+// the domains must match and widths saturate, which is exactly a SET of the
+// source value into a zero cell of the target type.
+func treeConvertCell(src wire.Cell, present bool, typ, n uint8) (wire.Cell, error) {
+	dst := wire.ZeroCell(typ, n)
+	if !present {
+		return dst, nil
+	}
+	if treeDomain(src.Type) != treeDomain(typ) || treeDomain(typ) < 0 {
+		return wire.Cell{}, wire.ErrOperateType
+	}
+	var opnd wire.Operand
+	switch treeDomain(typ) {
+	case 0:
+		opnd.A = treeIntOperand(src)
+	case 1:
+		opnd.A = int64(math.Float64bits(src.F))
+	default:
+		opnd.Bytes = src.B
+	}
+	return wire.ApplyScalar(wire.OperateOpSET, dst, false, opnd)
+}
+
+// treeIntOperand renders an integer cell as the int64 operand a SET carries,
+// saturating an unsigned value that does not fit.
+func treeIntOperand(c wire.Cell) int64 {
+	if wire.TypeIsUnsigned(c.Type) && c.U > math.MaxInt64 {
+		return math.MaxInt64
+	}
+	return int64(c.U)
+}
+
+// --- cells -----------------------------------------------------------------
+
+// treeCellAt reads the scalar a resolved node addresses, or the zero of its
+// declared type when it is absent (design doc §2.4, "absent is zero").
+func treeCellAt(rec *wire.Record, nd *treeNode) wire.Cell {
+	if nd.retype {
+		return wire.ZeroCell(nd.typ, nd.n)
+	}
+	switch nd.kind {
+	case wire.OperatePathField:
+		if nd.fi < 0 {
+			return wire.ZeroCell(nd.typ, nd.n)
+		}
+		if rec.Mode == wire.OperateModeSchema {
+			return treeSchemaCell(rec.Fields[nd.fi].Cell, nd.typ, nd.n)
+		}
+		return rec.Fields[nd.fi].Cell
+	case wire.OperatePathCol:
+		if nd.fi < 0 || nd.ri < 0 || nd.ci < 0 {
+			return wire.ZeroCell(nd.typ, nd.n)
+		}
+		c := rec.Fields[nd.fi].Table.Rows[nd.ri].Cols[nd.ci].Cell
+		if rec.Mode == wire.OperateModeSchema {
+			return treeSchemaCell(c, nd.typ, nd.n)
+		}
+		return c
+	default:
+		return wire.ZeroCell(nd.typ, nd.n)
+	}
+}
+
+func treeSetCell(rec *wire.Record, nd *treeNode, c wire.Cell) {
+	switch nd.kind {
+	case wire.OperatePathField:
+		rec.Fields[nd.fi].Cell = c
+	case wire.OperatePathCol:
+		rec.Fields[nd.fi].Table.Rows[nd.ri].Cols[nd.ci].Cell = c
+	}
+}
+
+// treeSchemaCell re-types a tree cell at the schema's declared type: in
+// schema mode the schema, never the cell's own Type, says how a value is
+// stored, and a Go zero-value cell is the declared type's zero (mirrors
+// wire's schemaCellOrZero, whose reasoning applies identically here).
+func treeSchemaCell(c wire.Cell, typ, n uint8) wire.Cell {
+	if c.Type == wire.OperateTypeUnset || treeIsZeroCell(c) {
+		return wire.ZeroCell(typ, n)
+	}
+	return wire.Cell{Type: typ, N: n, U: c.U, F: c.F, B: c.B}
+}
+
+func treeIsZeroCell(c wire.Cell) bool {
+	return c.Type == 0 && c.N == 0 && c.U == 0 && c.F == 0 && len(c.B) == 0
+}
+
+// --- rows, ordering and eviction -------------------------------------------
+
+// treeCompareKey orders two row keys: bytewise in dynamic mode and for FIXED
+// keys, as little-endian integers for the numeric key types (§2.3).
+func treeCompareKey(a, b []byte, keyType uint8, dynamic bool) int {
+	if dynamic || keyType == wire.OperateTypeFixed {
+		return bytes.Compare(a, b)
+	}
+	var av, bv uint64
+	for i := len(a) - 1; i >= 0; i-- {
+		av = av<<8 | uint64(a[i])
+	}
+	for i := len(b) - 1; i >= 0; i-- {
+		bv = bv<<8 | uint64(b[i])
+	}
+	switch {
+	case av < bv:
+		return -1
+	case av > bv:
+		return 1
+	default:
+		return 0
+	}
+}
+
+func treeFindRow(rows []wire.Row, key []byte, keyType uint8, dynamic bool) (int, bool) {
+	i := sort.Search(len(rows), func(i int) bool {
+		return treeCompareKey(rows[i].Key, key, keyType, dynamic) >= 0
+	})
+	if i < len(rows) && treeCompareKey(rows[i].Key, key, keyType, dynamic) == 0 {
+		return i, true
+	}
+	return i, false
+}
+
+func treeFindField(fields []wire.Field, name string) int {
+	for i := range fields {
+		if fields[i].Name == name {
+			return i
+		}
+	}
+	return -1
+}
+
+func treeFindCol(cols []wire.Col, name string) int {
+	for i := range cols {
+		if cols[i].Name == name {
+			return i
+		}
+	}
+	return -1
+}
+
+func treeSortRows(tbl *wire.Table, keyType uint8, dynamic bool) {
+	sort.SliceStable(tbl.Rows, func(i, j int) bool {
+		return treeCompareKey(tbl.Rows[i].Key, tbl.Rows[j].Key, keyType, dynamic) < 0
+	})
+}
+
+func treeSortFields(rec *wire.Record) {
+	sort.SliceStable(rec.Fields, func(i, j int) bool { return rec.Fields[i].Name < rec.Fields[j].Name })
+}
+
+func treeSortCols(row *wire.Row) {
+	sort.SliceStable(row.Cols, func(i, j int) bool { return row.Cols[i].Name < row.Cols[j].Name })
+}
+
+// treeEvictOne removes the victim the policy names (design doc §2.3). Rows
+// are kept sorted by key, so MIN_KEY/MAX_KEY are the ends of the slice.
+// Ruling: PolicyNone with a cap above 0 passes Schema.Validate, so it still
+// needs a deterministic victim — it evicts by MIN_KEY.
+func treeEvictOne(tbl *wire.Table, policy uint8, byCol int, byColName string, dynamic bool) {
+	if len(tbl.Rows) == 0 {
+		return
+	}
+	victim := 0
+	switch policy {
+	case wire.OperatePolicyMaxKey:
+		victim = len(tbl.Rows) - 1
+	case wire.OperatePolicyMinCol, wire.OperatePolicyMaxCol:
+		victim = treeColVictim(tbl, policy == wire.OperatePolicyMaxCol, byCol, byColName, dynamic)
+	default:
+		victim = 0
+	}
+	tbl.Rows = append(tbl.Rows[:victim], tbl.Rows[victim+1:]...)
+}
+
+// treeColVictim picks the row with the smallest (or largest) value in the
+// eviction column; ties go to the smallest key, which is the first row in
+// stored order.
+func treeColVictim(tbl *wire.Table, wantMax bool, byCol int, byColName string, dynamic bool) int {
+	best := 0
+	bestCell := treeEvictCell(tbl.Rows[0], byCol, byColName, dynamic)
+	for i := 1; i < len(tbl.Rows); i++ {
+		c := treeEvictCell(tbl.Rows[i], byCol, byColName, dynamic)
+		ord := treeCompareCells(c, bestCell)
+		if (wantMax && ord > 0) || (!wantMax && ord < 0) {
+			best, bestCell = i, c
+		}
+	}
+	return best
+}
+
+// treeEvictCell reads a row's eviction column; a dynamic row that does not
+// carry the column reads as zero (design doc §2.4, "absent is zero").
+func treeEvictCell(row wire.Row, byCol int, byColName string, dynamic bool) wire.Cell {
+	if dynamic {
+		if ci := treeFindCol(row.Cols, byColName); ci >= 0 {
+			return row.Cols[ci].Cell
+		}
+		return wire.Cell{Type: wire.OperateTypeU8}
+	}
+	if byCol >= 0 && byCol < len(row.Cols) {
+		return row.Cols[byCol].Cell
+	}
+	return wire.Cell{Type: wire.OperateTypeU8}
+}
+
+// treeCompareCells orders two cells deterministically. Within a domain the
+// comparison is the natural one; across domains (only reachable in dynamic
+// mode, where two rows may store different types under one column name) the
+// domain rank orders them, so the victim is still a pure function of the
+// stored bytes.
+func treeCompareCells(a, b wire.Cell) int {
+	da, db := treeDomain(a.Type), treeDomain(b.Type)
+	if da != db {
+		switch {
+		case da < db:
+			return -1
+		default:
+			return 1
+		}
+	}
+	switch da {
+	case 1:
+		switch {
+		case a.F < b.F:
+			return -1
+		case a.F > b.F:
+			return 1
+		default:
+			return 0
+		}
+	case 2:
+		return bytes.Compare(a.B, b.B)
+	case 0:
+		return treeCompareInts(a, b)
+	default:
+		return 0
+	}
+}
+
+func treeCompareInts(a, b wire.Cell) int {
+	au, bu := wire.TypeIsUnsigned(a.Type), wire.TypeIsUnsigned(b.Type)
+	switch {
+	case au && bu:
+		switch {
+		case a.U < b.U:
+			return -1
+		case a.U > b.U:
+			return 1
+		default:
+			return 0
+		}
+	case !au && !bu:
+		x, y := int64(a.U), int64(b.U)
+		switch {
+		case x < y:
+			return -1
+		case x > y:
+			return 1
+		default:
+			return 0
+		}
+	case au: // a unsigned, b signed
+		return -treeCompareMixed(b, a)
+	default: // a signed, b unsigned
+		return treeCompareMixed(a, b)
+	}
+}
+
+// treeCompareMixed compares a signed cell against an unsigned one exactly:
+// a negative signed value is below every unsigned value, otherwise both fit
+// in uint64.
+func treeCompareMixed(signed, unsigned wire.Cell) int {
+	s := int64(signed.U)
+	if s < 0 {
+		return -1
+	}
+	switch {
+	case uint64(s) < unsigned.U:
+		return -1
+	case uint64(s) > unsigned.U:
+		return 1
+	default:
+		return 0
+	}
+}
+
+// --- record construction, copying and normalization ------------------------
+
+func treeNewSchemaRecord(s *wire.Schema) *wire.Record {
+	rec := &wire.Record{Mode: wire.OperateModeSchema, Schema: s, Fields: make([]wire.Field, len(s.Fields))}
+	treeNormalize(rec)
+	return rec
+}
+
+func treeClone(r *wire.Record) *wire.Record {
+	if r == nil {
+		return nil
+	}
+	out := &wire.Record{Mode: r.Mode, Schema: r.Schema, Fields: make([]wire.Field, len(r.Fields))}
+	for i := range r.Fields {
+		f := &r.Fields[i]
+		nf := wire.Field{Name: f.Name, Cell: treeCloneCell(f.Cell)}
+		if f.Table != nil {
+			t := &wire.Table{Cap: f.Table.Cap, Policy: f.Table.Policy, ByCol: f.Table.ByCol,
+				ByColName: f.Table.ByColName, Rows: make([]wire.Row, len(f.Table.Rows))}
+			for j := range f.Table.Rows {
+				src := &f.Table.Rows[j]
+				row := wire.Row{Key: append([]byte(nil), src.Key...), Cols: make([]wire.Col, len(src.Cols))}
+				for k := range src.Cols {
+					row.Cols[k] = wire.Col{Name: src.Cols[k].Name, Cell: treeCloneCell(src.Cols[k].Cell)}
+				}
+				t.Rows[j] = row
+			}
+			nf.Table = t
+		}
+		out.Fields[i] = nf
+	}
+	return out
+}
+
+func treeCloneCell(c wire.Cell) wire.Cell {
+	if c.B != nil {
+		c.B = append([]byte(nil), c.B...)
+	}
+	return c
+}
+
+// treeNormalize puts a record into the canonical shape the encoder expects:
+// schema-mode fields and columns fully materialized at their declared types
+// with the schema's eviction triple, dynamic fields and columns sorted by
+// name, rows sorted by key (design doc §2.5).
+func treeNormalize(rec *wire.Record) {
+	if rec == nil {
+		return
+	}
+	if rec.Mode != wire.OperateModeSchema {
+		treeSortFields(rec)
+		for i := range rec.Fields {
+			if rec.Fields[i].Cell.Type == wire.OperateTypeTable {
+				if rec.Fields[i].Table == nil {
+					rec.Fields[i].Table = &wire.Table{}
+				}
+				treeSortRows(rec.Fields[i].Table, 0, true)
+				for j := range rec.Fields[i].Table.Rows {
+					treeSortCols(&rec.Fields[i].Table.Rows[j])
+				}
+			}
+		}
+		return
+	}
+
+	s := rec.Schema
+	if len(rec.Fields) < len(s.Fields) {
+		grown := make([]wire.Field, len(s.Fields))
+		copy(grown, rec.Fields)
+		rec.Fields = grown
+	}
+	rec.Fields = rec.Fields[:len(s.Fields)]
+	for i := range s.Fields {
+		fd := &s.Fields[i]
+		f := &rec.Fields[i]
+		f.Name = fd.Name
+		if fd.Type != wire.OperateTypeTable {
+			f.Table = nil
+			f.Cell = treeSchemaCell(f.Cell, fd.Type, fd.N)
+			continue
+		}
+		if f.Table == nil {
+			f.Table = &wire.Table{}
+		}
+		f.Cell = wire.Cell{Type: wire.OperateTypeTable}
+		// The schema, not the stored tree, owns the eviction triple.
+		f.Table.Cap, f.Table.Policy, f.Table.ByCol = fd.Table.Cap, fd.Table.Policy, fd.Table.ByCol
+		f.Table.ByColName = ""
+		for r := range f.Table.Rows {
+			row := &f.Table.Rows[r]
+			if len(row.Cols) < len(fd.Table.Cols) {
+				grown := make([]wire.Col, len(fd.Table.Cols))
+				copy(grown, row.Cols)
+				row.Cols = grown
+			}
+			row.Cols = row.Cols[:len(fd.Table.Cols)]
+			for c := range fd.Table.Cols {
+				row.Cols[c].Name = ""
+				row.Cols[c].Cell = treeSchemaCell(row.Cols[c].Cell, fd.Table.Cols[c].Type, fd.Table.Cols[c].N)
+			}
+		}
+		treeSortRows(f.Table, fd.Table.KeyType, false)
+	}
+}
+
+// --- return specs (design doc §3.4) ----------------------------------------
+
+func treeRets(rec *wire.Record, existed bool, rets []wire.OperateRet) ([][]byte, error) {
+	if len(rets) == 0 {
+		return nil, nil
+	}
+	vals := make([][]byte, 0, len(rets))
+	for _, r := range rets {
+		if r.Mode > wire.OperateRetCount {
+			return nil, wire.ErrOperateArgs
+		}
+		// Ruling: against an absent record every return is absent, without
+		// resolving the path — there is no record for it to resolve against.
+		if rec == nil {
+			if r.Mode == wire.OperateRetCount {
+				vals = append(vals, treeCountValue(0))
+			} else {
+				vals = append(vals, []byte{wire.OperateTypeUnset})
+			}
+			continue
+		}
+		st := &treeState{rec: rec, existed: existed}
+		nd, err := st.resolve(r.Path, wire.OperateOp{Opcode: wire.OperateOpIF, Type: wire.OperateTypeFromSchema}, false)
+		if err != nil {
+			return nil, err
+		}
+		if r.Mode == wire.OperateRetCount {
+			vals = append(vals, treeCountValue(treeCountOf(st, nd)))
+			continue
+		}
+		vals = append(vals, treeValueOf(rec, nd))
+	}
+	return vals, nil
+}
+
+func treeCountValue(n uint64) []byte {
+	return wire.AppendTaggedCell(nil, wire.Cell{Type: wire.OperateTypeU64, U: n})
+}
+
+func treeCountOf(st *treeState, nd *treeNode) uint64 {
+	switch {
+	case nd.kind == wire.OperatePathRecord:
+		return uint64(st.fieldCount())
+	case nd.isTable:
+		if nd.tbl == nil {
+			return 0
+		}
+		return uint64(len(nd.tbl.Rows))
+	default:
+		if nd.present {
+			return 1
+		}
+		return 0
+	}
+}
+
+func treeValueOf(rec *wire.Record, nd *treeNode) []byte {
+	switch {
+	case nd.kind == wire.OperatePathRecord:
+		return rec.Encode()
+	case nd.isTable:
+		return treeTableValue(rec, nd.fi)
+	case nd.kind == wire.OperatePathRow:
+		if !nd.present || nd.ri < 0 {
+			return []byte{wire.OperateTypeUnset}
+		}
+		return treeRowValue(rec, nd)
+	default:
+		if !nd.present {
+			return []byte{wire.OperateTypeUnset}
+		}
+		return wire.AppendTaggedCell(nil, treeCellAt(rec, nd))
+	}
+}
+
+// treeTableValue is the table's full stored encoding with the record's mode
+// byte in front, so it is decodable knowing only the mode (§3.4). The bytes
+// are exactly what the record encoder emits for that field: they are taken
+// from a one-field record built around it, rather than re-implemented.
+func treeTableValue(rec *wire.Record, fi int) []byte {
+	if rec.Mode == wire.OperateModeSchema {
+		sub := &wire.Schema{Version: rec.Schema.Version, StoreNames: rec.Schema.StoreNames,
+			Fields: []wire.FieldDef{rec.Schema.Fields[fi]}}
+		subRec := &wire.Record{Mode: wire.OperateModeSchema, Schema: sub, Fields: []wire.Field{rec.Fields[fi]}}
+		enc := subRec.Encode()
+		return append([]byte{wire.OperateModeSchema}, enc[1+len(sub.Encode()):]...)
+	}
+	name := rec.Fields[fi].Name
+	subRec := &wire.Record{Mode: wire.OperateModeDynamic, Fields: []wire.Field{{
+		Name: name, Cell: wire.Cell{Type: wire.OperateTypeTable}, Table: rec.Fields[fi].Table}}}
+	enc := subRec.Encode()
+	// [mode][nFields uvarint = 1][nlen u8][name][type u8] then the table.
+	return append([]byte{wire.OperateModeDynamic}, enc[1+1+1+len(name)+1:]...)
+}
+
+// treeRowValue is [mode][nCols]{tagged} in column order (schema mode) or
+// [mode][nCols]{[nlen][name] tagged} (dynamic mode), per §3.4.
+func treeRowValue(rec *wire.Record, nd *treeNode) []byte {
+	row := rec.Fields[nd.fi].Table.Rows[nd.ri]
+	out := []byte{rec.Mode}
+	if rec.Mode == wire.OperateModeSchema {
+		cols := rec.Schema.Fields[nd.fi].Table.Cols
+		out = binary.AppendUvarint(out, uint64(len(cols)))
+		for c := range cols {
+			cell := wire.ZeroCell(cols[c].Type, cols[c].N)
+			if c < len(row.Cols) {
+				cell = treeSchemaCell(row.Cols[c].Cell, cols[c].Type, cols[c].N)
+			}
+			out = wire.AppendTaggedCell(out, cell)
+		}
+		return out
+	}
+	out = binary.AppendUvarint(out, uint64(len(row.Cols)))
+	for _, c := range row.Cols {
+		out = append(out, byte(len(c.Name)))
+		out = append(out, c.Name...)
+		out = wire.AppendTaggedCell(out, c.Cell)
+	}
+	return out
+}

--- a/ops/operate_oracle_test.go
+++ b/ops/operate_oracle_test.go
@@ -17,22 +17,10 @@ package ops
 import (
 	"bytes"
 	"encoding/binary"
-	"errors"
 	"math"
 	"sort"
 
 	"github.com/rostamlabs/rostam/sdk/wire"
-)
-
-var (
-	// errOperateAbsent is the "create = NONE and the key does not exist"
-	// error of design doc §3.5. The handler maps it to the store's
-	// not-found error.
-	errOperateAbsent = errors.New("ops: operate record absent")
-	// errOperateIfRange marks an IF whose skip count is negative or reaches
-	// past the end of the op list (design doc §3.3, "n bounded by the
-	// remaining list").
-	errOperateIfRange = errors.New("ops: operate IF skip count out of range")
 )
 
 // --- shared test helpers ---------------------------------------------------
@@ -229,6 +217,12 @@ func applyTree(rec *wire.Record, a *wire.OperateArgs, stampMs int64) (*wire.Reco
 	}
 	if out != nil {
 		treeNormalize(out)
+		// §2.7's backstop, checked on the result rather than op by op: a call
+		// that would store an over-large record fails with the record
+		// unchanged.
+		if len(out.Encode()) > maxOperateRecordBytes {
+			return rec, nil, wire.ErrOperateCap
+		}
 	}
 	vals, verr := treeRets(out, true, a.Rets)
 	if verr != nil {
@@ -314,14 +308,18 @@ func (st *treeState) run(ops []wire.OperateOp) (uint8, uint16, error) {
 		}
 		switch o.Opcode {
 		case wire.OperateOpIF:
+			// The skip count is validated whenever the IF runs, not only when
+			// the branch is taken: a malformed op list is malformed whatever
+			// the record happens to hold (design doc §3.3, "n bounded by the
+			// remaining list").
+			if o.B < 0 || o.B > int64(len(ops)-i-1) {
+				return 0, 0, errOperateIfRange
+			}
 			ok, err := st.compare(o)
 			if err != nil {
 				return 0, 0, err
 			}
 			if !ok {
-				if o.B < 0 || o.B > int64(len(ops)-i-1) {
-					return 0, 0, errOperateIfRange
-				}
 				i += int(o.B)
 			}
 		case wire.OperateOpCHECK:
@@ -1569,8 +1567,10 @@ func treeValueOf(rec *wire.Record, nd *treeNode) []byte {
 	}
 }
 
-// treeTableValue is the table's full stored encoding with the record's mode
-// byte in front, so it is decodable knowing only the mode (§3.4). The bytes
+// treeTableValue is the table's stored encoding with the record's mode byte
+// in front (§3.4). Ruling: no schema blob rides along — the caller holds the
+// schema, and the mode byte is all a reader needs to know which of the two
+// table layouts follows. The bytes
 // are exactly what the record encoder emits for that field: they are taken
 // from a one-field record built around it, rather than re-implemented.
 func treeTableValue(rec *wire.Record, fi int) []byte {

--- a/ops/operate_oracle_test.go
+++ b/ops/operate_oracle_test.go
@@ -17,7 +17,9 @@ package ops
 import (
 	"bytes"
 	"encoding/binary"
+	"fmt"
 	"math"
+	"math/rand"
 	"sort"
 
 	"github.com/rostamlabs/rostam/sdk/wire"
@@ -1613,4 +1615,395 @@ func treeRowValue(rec *wire.Record, nd *treeNode) []byte {
 		out = wire.AppendTaggedCell(out, c.Cell)
 	}
 	return out
+}
+
+// --- random schemas and calls ----------------------------------------------
+//
+// The generators the equivalence property tests drive both appliers with.
+// They live here, next to the oracle, because every byte-level engine reuses
+// them.
+
+// randomScalarTypes are the types a record field may have; randomColTypes are
+// the subset a table column may have (columns are fixed-width only, §2.3).
+var randomScalarTypes = []uint8{
+	wire.OperateTypeU8, wire.OperateTypeU16, wire.OperateTypeU32, wire.OperateTypeU64,
+	wire.OperateTypeI8, wire.OperateTypeI16, wire.OperateTypeI32, wire.OperateTypeI64,
+	wire.OperateTypeF32, wire.OperateTypeF64, wire.OperateTypeUVarint, wire.OperateTypeIVarint,
+	wire.OperateTypeBytes, wire.OperateTypeFixed,
+}
+
+var randomColTypes = []uint8{
+	wire.OperateTypeU8, wire.OperateTypeU16, wire.OperateTypeU32, wire.OperateTypeU64,
+	wire.OperateTypeI8, wire.OperateTypeI16, wire.OperateTypeI32, wire.OperateTypeI64,
+	wire.OperateTypeF32, wire.OperateTypeF64, wire.OperateTypeFixed,
+}
+
+var randomKeyTypes = []uint8{
+	wire.OperateTypeU8, wire.OperateTypeU16, wire.OperateTypeU32, wire.OperateTypeU64, wire.OperateTypeFixed,
+}
+
+// randomSchema builds a small, always-valid schema: 1-6 fields with up to two
+// tables, small caps so eviction fires often, and every eviction policy. Names
+// are always assigned (so name paths are generatable) but only addressable
+// when StoreNames is set.
+func randomSchema(rng *rand.Rand) *wire.Schema {
+	for {
+		s := &wire.Schema{Version: 1, StoreNames: rng.Intn(2) == 0}
+		nFields := 1 + rng.Intn(6)
+		tables := 0
+		for i := 0; i < nFields; i++ {
+			f := wire.FieldDef{Name: fmt.Sprintf("f%d", i)}
+			if tables < 2 && rng.Intn(3) == 0 {
+				tables++
+				f.Type = wire.OperateTypeTable
+				f.Table = randomTableDef(rng)
+			} else {
+				f.Type = randomScalarTypes[rng.Intn(len(randomScalarTypes))]
+				if f.Type == wire.OperateTypeFixed {
+					f.N = uint8(1 + rng.Intn(4))
+				}
+			}
+			s.Fields = append(s.Fields, f)
+		}
+		if s.Validate() == nil {
+			return s
+		}
+	}
+}
+
+func randomTableDef(rng *rand.Rand) *wire.TableDef {
+	td := &wire.TableDef{KeyType: randomKeyTypes[rng.Intn(len(randomKeyTypes))]}
+	if td.KeyType == wire.OperateTypeFixed {
+		td.KeyN = uint8(1 + rng.Intn(3))
+	}
+	for c := 0; c < 1+rng.Intn(3); c++ {
+		cd := wire.ColumnDef{Name: fmt.Sprintf("c%d", c), Type: randomColTypes[rng.Intn(len(randomColTypes))]}
+		if cd.Type == wire.OperateTypeFixed {
+			cd.N = uint8(1 + rng.Intn(3))
+		}
+		td.Cols = append(td.Cols, cd)
+	}
+	td.Cap = uint32(rng.Intn(5))
+	td.Policy = uint8(rng.Intn(int(wire.OperatePolicyMaxCol) + 1))
+	if td.Policy == wire.OperatePolicyMinCol || td.Policy == wire.OperatePolicyMaxCol {
+		td.ByCol = uint16(rng.Intn(len(td.Cols)))
+	}
+	return td
+}
+
+// randomArgs builds one call against s: 1-8 ops drawn from the whole
+// vocabulary (including the control, table and structural ops and deliberately
+// invalid ones, so the error paths are compared too) plus up to three return
+// specs of both modes.
+func randomArgs(rng *rand.Rand, s *wire.Schema) *wire.OperateArgs {
+	a := &wire.OperateArgs{Create: wire.OperateCreateSchema, Schema: s.Encode()}
+	if rng.Intn(16) == 0 {
+		a.Create = wire.OperateCreateNone
+		a.Schema = nil
+	}
+	// A migration travels alone: it rewrites the schema the rest of the call
+	// would have been written against.
+	if rng.Intn(24) == 0 {
+		a.Create = wire.OperateCreateNone
+		a.Schema = nil
+		a.Ops = []wire.OperateOp{{Opcode: wire.OperateOpMIGRATE, Type: wire.OperateTypeFromSchema,
+			Path: recPath(), A: int64(s.Version), Bytes: randomExtension(rng, s).Encode()}}
+		return a
+	}
+
+	nOps := 1 + rng.Intn(8)
+	for i := 0; i < nOps; i++ {
+		a.Ops = append(a.Ops, randomOp(rng, s))
+	}
+	for i := range a.Ops {
+		if a.Ops[i].Opcode != wire.OperateOpIF {
+			continue
+		}
+		if rng.Intn(16) == 0 {
+			a.Ops[i].B = int64(len(a.Ops)) // out of range on purpose
+			continue
+		}
+		a.Ops[i].B = int64(rng.Intn(len(a.Ops) - i))
+	}
+	for i := 0; i < rng.Intn(4); i++ {
+		mode := uint8(wire.OperateRetValue)
+		if rng.Intn(2) == 0 {
+			mode = wire.OperateRetCount
+		}
+		a.Rets = append(a.Rets, wire.OperateRet{Mode: mode, Path: randomPath(rng, s)})
+	}
+	return a
+}
+
+// randomOpcodes is the whole vocabulary, plus one value that is not an opcode
+// at all so the unknown-opcode path is compared too. randomOp draws from it
+// directly only occasionally: a uniformly random opcode against a uniformly
+// random target is almost always a type error, which would make the property
+// compare error paths and little else.
+var randomOpcodes = []uint8{
+	wire.OperateOpSET, wire.OperateOpDEL, wire.OperateOpADD, wire.OperateOpMUL,
+	wire.OperateOpMIN, wire.OperateOpMAX, wire.OperateOpAND, wire.OperateOpOR,
+	wire.OperateOpXOR, wire.OperateOpSHL, wire.OperateOpSHR, wire.OperateOpSTAMP,
+	wire.OperateOpCONFIG, wire.OperateOpTRIM, wire.OperateOpIF, wire.OperateOpCHECK, 99,
+}
+
+// opcodes that apply to each kind of target (design doc §3.1/§3.2).
+var (
+	intOpcodes = []uint8{wire.OperateOpSET, wire.OperateOpADD, wire.OperateOpMUL, wire.OperateOpMIN,
+		wire.OperateOpMAX, wire.OperateOpAND, wire.OperateOpOR, wire.OperateOpXOR,
+		wire.OperateOpSHL, wire.OperateOpSHR, wire.OperateOpSTAMP, wire.OperateOpDEL,
+		wire.OperateOpIF, wire.OperateOpCHECK}
+	varintOpcodes = []uint8{wire.OperateOpSET, wire.OperateOpADD, wire.OperateOpMUL, wire.OperateOpMIN,
+		wire.OperateOpMAX, wire.OperateOpSTAMP, wire.OperateOpDEL, wire.OperateOpIF, wire.OperateOpCHECK}
+	floatOpcodes = []uint8{wire.OperateOpSET, wire.OperateOpADD, wire.OperateOpMUL, wire.OperateOpMIN,
+		wire.OperateOpMAX, wire.OperateOpDEL, wire.OperateOpIF, wire.OperateOpCHECK}
+	bytesOpcodes = []uint8{wire.OperateOpSET, wire.OperateOpMIN, wire.OperateOpMAX,
+		wire.OperateOpDEL, wire.OperateOpIF, wire.OperateOpCHECK}
+	tableOpcodes = []uint8{wire.OperateOpDEL, wire.OperateOpTRIM, wire.OperateOpIF, wire.OperateOpCHECK}
+	nodeOpcodes  = []uint8{wire.OperateOpDEL, wire.OperateOpIF, wire.OperateOpCHECK}
+)
+
+func randomOp(rng *rand.Rand, s *wire.Schema) wire.OperateOp {
+	p := randomPath(rng, s)
+	typ, n, ok := targetType(s, p)
+	o := wire.OperateOp{Type: wire.OperateTypeFromSchema, Path: p}
+	if !ok || rng.Intn(8) == 0 {
+		o.Opcode = randomOpcodes[rng.Intn(len(randomOpcodes))]
+	} else {
+		pool := opcodePool(typ)
+		o.Opcode = pool[rng.Intn(len(pool))]
+	}
+	switch o.Opcode {
+	case wire.OperateOpIF, wire.OperateOpCHECK:
+		o.Aux = uint8(rng.Intn(int(wire.OperateCmpAbsent) + 2)) // one past the last comparator
+	case wire.OperateOpTRIM, wire.OperateOpCONFIG:
+		o.A = int64(rng.Intn(5))
+		if rng.Intn(16) == 0 {
+			o.A = -1
+		}
+		o.Aux = uint8(rng.Intn(int(wire.OperatePolicyMaxCol) + 2))
+		o.B = int64(rng.Intn(4))
+	case wire.OperateOpSTAMP:
+		o.Aux = uint8(rng.Intn(2))
+	}
+	o.A = randomOperandA(rng, o, typ)
+	o.Bytes = randomOperandBytes(rng, typ, n)
+	if rng.Intn(8) == 0 { // a type byte that may or may not match the schema
+		if ok && rng.Intn(2) == 0 {
+			o.Type = typ
+		} else {
+			o.Type = randomScalarTypes[rng.Intn(len(randomScalarTypes))]
+		}
+	}
+	return o
+}
+
+// opcodePool is the set of opcodes that can apply to a target of type typ.
+// OperateTypeTable stands for a table field and OperateTypeUnset for a row or
+// the record itself — neither has a value of its own.
+func opcodePool(typ uint8) []uint8 {
+	switch {
+	case typ == wire.OperateTypeTable:
+		return tableOpcodes
+	case typ == wire.OperateTypeUnset:
+		return nodeOpcodes
+	case wire.TypeIsFloat(typ):
+		return floatOpcodes
+	case wire.TypeIsFixedInt(typ):
+		return intOpcodes
+	case wire.TypeIsInt(typ):
+		return varintOpcodes
+	default:
+		return bytesOpcodes
+	}
+}
+
+// targetType reports the declared type (and FIXED width) of what p addresses,
+// or ok == false when the path does not resolve at all — in which case the op
+// is an error whatever it says, and randomOp draws its opcode uniformly.
+func targetType(s *wire.Schema, p wire.OperatePath) (uint8, uint8, bool) {
+	if p.Kind == wire.OperatePathRecord {
+		return wire.OperateTypeUnset, 0, true
+	}
+	pos := -1
+	if p.Field.ByName {
+		if s.StoreNames {
+			if i, found := s.FieldPos(p.Field.Name); found {
+				pos = i
+			}
+		}
+	} else if int(p.Field.Pos) < len(s.Fields) {
+		pos = int(p.Field.Pos)
+	}
+	if pos < 0 {
+		return 0, 0, false
+	}
+	fd := &s.Fields[pos]
+	if p.Kind == wire.OperatePathField {
+		return fd.Type, fd.N, true
+	}
+	if fd.Type != wire.OperateTypeTable || len(p.Key) != wire.CellWidth(fd.Table.KeyType, fd.Table.KeyN) {
+		return 0, 0, false
+	}
+	if p.Kind == wire.OperatePathRow {
+		return wire.OperateTypeUnset, 0, true
+	}
+	col := -1
+	if p.Col.ByName {
+		for j := range fd.Table.Cols {
+			if p.Col.Name != "" && fd.Table.Cols[j].Name == p.Col.Name {
+				col = j
+			}
+		}
+	} else if int(p.Col.Pos) < len(fd.Table.Cols) {
+		col = int(p.Col.Pos)
+	}
+	if col < 0 {
+		return 0, 0, false
+	}
+	return fd.Table.Cols[col].Type, fd.Table.Cols[col].N, true
+}
+
+func randomOperandA(rng *rand.Rand, o wire.OperateOp, typ uint8) int64 {
+	switch o.Opcode {
+	case wire.OperateOpTRIM, wire.OperateOpCONFIG, wire.OperateOpSTAMP:
+		return o.A
+	}
+	if wire.TypeIsFloat(typ) && rng.Intn(4) != 0 {
+		// A float operand always travels as the bit pattern of a float64.
+		return f64(float64(rng.Intn(200)-100) / 4)
+	}
+	switch rng.Intn(6) {
+	case 0:
+		return -1
+	case 1:
+		return 0
+	case 2:
+		return rng.Int63n(1 << 20)
+	case 3:
+		return rng.Int63n(1 << 40)
+	case 4:
+		return math.MaxInt64
+	default:
+		return int64(rng.Intn(8))
+	}
+}
+
+// randomOperandBytes sizes a bytes operand for the target: exactly N for a
+// FIXED one (any other width is ErrOperateType), otherwise short and drawn
+// from a tiny alphabet so MIN/MAX comparisons actually change the value.
+func randomOperandBytes(rng *rand.Rand, typ, n uint8) []byte {
+	size := 1 + rng.Intn(4)
+	if typ == wire.OperateTypeFixed && rng.Intn(8) != 0 {
+		size = int(n)
+	}
+	b := make([]byte, size)
+	for i := range b {
+		b[i] = byte(rng.Intn(4))
+	}
+	return b
+}
+
+// randomPath builds a path against s: usually a valid one (a field, or a row
+// or column of a table field), sometimes an out-of-range position, an unknown
+// name, or a key of the wrong width.
+func randomPath(rng *rand.Rand, s *wire.Schema) wire.OperatePath {
+	if rng.Intn(12) == 0 {
+		return recPath()
+	}
+	pos := rng.Intn(len(s.Fields))
+	if rng.Intn(16) == 0 {
+		return fieldPath(uint32(len(s.Fields) + rng.Intn(3)))
+	}
+	fd := &s.Fields[pos]
+	byName := s.StoreNames && rng.Intn(3) == 0
+
+	if fd.Type != wire.OperateTypeTable || rng.Intn(6) == 0 {
+		if byName {
+			return namePath(fd.Name)
+		}
+		return fieldPath(uint32(pos))
+	}
+
+	key := randomRowKey(rng, fd.Table)
+	if rng.Intn(2) == 0 { // a row path
+		if byName {
+			return nameRowPath(fd.Name, key)
+		}
+		return rowPath(uint32(pos), key)
+	}
+	col := rng.Intn(len(fd.Table.Cols))
+	if rng.Intn(16) == 0 {
+		col = len(fd.Table.Cols) + rng.Intn(2)
+	}
+	if byName && col < len(fd.Table.Cols) {
+		return nameColPath(fd.Name, key, fd.Table.Cols[col].Name)
+	}
+	return colPath(uint32(pos), key, uint32(col))
+}
+
+// randomRowKey draws from a small pool so rows collide often, occasionally
+// returning a key of the wrong width.
+func randomRowKey(rng *rand.Rand, td *wire.TableDef) []byte {
+	w := wire.CellWidth(td.KeyType, td.KeyN)
+	if rng.Intn(16) == 0 {
+		w++
+	}
+	key := make([]byte, w)
+	if w > 0 {
+		key[0] = byte(rng.Intn(6))
+	}
+	return key
+}
+
+// randomExtension builds an append-only evolution of s (design doc §2.8):
+// usually a legal one, sometimes not, so MIGRATE's rejection path is compared
+// as well.
+func randomExtension(rng *rand.Rand, s *wire.Schema) *wire.Schema {
+	ns := &wire.Schema{Version: s.Version + 1, StoreNames: s.StoreNames}
+	for i := range s.Fields {
+		f := s.Fields[i]
+		if f.Table != nil {
+			td := *f.Table
+			td.Cols = append([]wire.ColumnDef(nil), f.Table.Cols...)
+			if rng.Intn(2) == 0 {
+				td.Cols = append(td.Cols, wire.ColumnDef{
+					Name: fmt.Sprintf("c%d", len(td.Cols)), Type: wire.OperateTypeU16})
+			}
+			td.Cap = uint32(rng.Intn(4))
+			td.Policy = uint8(rng.Intn(int(wire.OperatePolicyMaxCol) + 1))
+			td.ByCol = 0
+			if td.Policy == wire.OperatePolicyMinCol || td.Policy == wire.OperatePolicyMaxCol {
+				td.ByCol = uint16(rng.Intn(len(td.Cols)))
+			}
+			f.Table = &td
+		}
+		ns.Fields = append(ns.Fields, f)
+	}
+	if rng.Intn(2) == 0 {
+		ns.Fields = append(ns.Fields, wire.FieldDef{
+			Name: fmt.Sprintf("f%d", len(ns.Fields)), Type: randomScalarTypes[rng.Intn(len(randomScalarTypes))], N: 2})
+	}
+	if rng.Intn(8) == 0 && len(ns.Fields) > 0 { // not append-only: widen a field
+		ns.Fields[0].Type = wire.OperateTypeU64
+		ns.Fields[0].Table = nil
+	}
+	if ns.Validate() != nil {
+		return s
+	}
+	return ns
+}
+
+// migratedSchema reports the schema a call migrates the record to, or nil if
+// it is not a migration. The property test uses it to keep speaking the
+// record's current version after a successful MIGRATE.
+func migratedSchema(a *wire.OperateArgs) *wire.Schema {
+	if len(a.Ops) != 1 || a.Ops[0].Opcode != wire.OperateOpMIGRATE {
+		return nil
+	}
+	s, n, err := wire.DecodeSchema(a.Ops[0].Bytes)
+	if err != nil || n != len(a.Ops[0].Bytes) {
+		return nil
+	}
+	return s
 }

--- a/ops/operate_oracle_test.go
+++ b/ops/operate_oracle_test.go
@@ -1697,6 +1697,11 @@ func randomTableDef(rng *rand.Rand) *wire.TableDef {
 // specs of both modes.
 func randomArgs(rng *rand.Rand, s *wire.Schema) *wire.OperateArgs {
 	a := &wire.OperateArgs{Create: wire.OperateCreateSchema, Schema: s.Encode()}
+	if rng.Intn(24) == 0 {
+		// A blob with something after it is not a schema blob, on a fresh
+		// record or an existing one.
+		a.Schema = append(a.Schema, byte(rng.Intn(256))) //nolint:gosec // deterministic test input
+	}
 	if rng.Intn(16) == 0 {
 		a.Create = wire.OperateCreateNone
 		a.Schema = nil
@@ -1783,6 +1788,12 @@ func randomOp(rng *rand.Rand, s *wire.Schema) wire.OperateOp {
 		}
 		o.Aux = uint8(rng.Intn(int(wire.OperatePolicyMaxCol) + 2))
 		o.B = int64(rng.Intn(4))
+		if rng.Intn(8) == 0 {
+			// Out of range, including the two values that would alias column
+			// 0 and column 2 if the operand were merely truncated to uint16.
+			o.B = []int64{-1, -65536, 1 << 16, 1<<16 + 2, int64(wire.OperateMaxCols),
+				math.MaxInt64}[rng.Intn(6)]
+		}
 	case wire.OperateOpSTAMP:
 		o.Aux = uint8(rng.Intn(2))
 	}

--- a/ops/operate_oracle_test.go
+++ b/ops/operate_oracle_test.go
@@ -852,6 +852,12 @@ func (st *treeState) resolveDynamic(nd *treeNode, p wire.OperatePath, o wire.Ope
 	if len(p.Field.Name) > wire.OperateMaxNameLen {
 		return nil, wire.ErrOperateCap
 	}
+	if create && p.Field.Name == "" {
+		// Names are 1-255 bytes, like row keys (design doc §2.4): a create
+		// that would vivify a field with an empty name is rejected here,
+		// mirroring the engine.
+		return nil, wire.ErrOperatePath
+	}
 	if p.Kind != wire.OperatePathField {
 		if len(p.Key) == 0 {
 			return nil, wire.ErrOperatePath
@@ -866,6 +872,9 @@ func (st *treeState) resolveDynamic(nd *treeNode, p wire.OperatePath, o wire.Ope
 		}
 		if len(p.Col.Name) > wire.OperateMaxNameLen {
 			return nil, wire.ErrOperateCap
+		}
+		if create && p.Col.Name == "" {
+			return nil, wire.ErrOperatePath
 		}
 	}
 	fi := treeFindField(st.rec.Fields, p.Field.Name)

--- a/ops/operate_oracle_test.go
+++ b/ops/operate_oracle_test.go
@@ -2018,3 +2018,221 @@ func migratedSchema(a *wire.OperateArgs) *wire.Schema {
 	}
 	return s
 }
+
+// --- random dynamic-mode calls ---------------------------------------------
+//
+// The dynamic generators mirror the schema ones above: a small pool of names
+// so ops collide on the same fields, columns and rows often enough to
+// exercise the stored-type, eviction and freeze rules, plus a steady trickle
+// of deliberately invalid ops so the error paths are compared too.
+
+// dynNames is the name pool every dynamic path draws from.
+var dynNames = []string{"a", "bb", "c", "dd", "e", "ff"}
+
+// randomDynamicArgs builds one call against a dynamic record: 1-8 ops from
+// the whole vocabulary plus up to three return specs, or — occasionally — a
+// lone MIGRATE freeze into a names-carrying schema built from the same pool.
+func randomDynamicArgs(rng *rand.Rand) *wire.OperateArgs {
+	a := &wire.OperateArgs{Create: wire.OperateCreateDynamic}
+	if rng.Intn(16) == 0 {
+		a.Create = wire.OperateCreateNone
+	}
+	if rng.Intn(12) == 0 {
+		// A freeze travels alone: it rewrites the record into the schema mode
+		// the rest of the call would no longer be written against.
+		a.Create = wire.OperateCreateNone
+		o := wire.OperateOp{Opcode: wire.OperateOpMIGRATE, Type: wire.OperateTypeFromSchema,
+			Path: recPath(), A: wire.OperateMigrateFromDynamic, Bytes: randomFreezeSchema(rng).Encode()}
+		if rng.Intn(2) == 0 {
+			o.Aux = wire.OperateMigrateDropExtra
+		}
+		if rng.Intn(16) == 0 {
+			o.A = int64(rng.Intn(3)) // not a freeze at all: a dynamic record has no version to extend
+		}
+		a.Ops = []wire.OperateOp{o}
+		return a
+	}
+
+	nOps := 1 + rng.Intn(8)
+	for i := 0; i < nOps; i++ {
+		a.Ops = append(a.Ops, randomDynamicOp(rng))
+	}
+	for i := range a.Ops {
+		if a.Ops[i].Opcode != wire.OperateOpIF {
+			continue
+		}
+		if rng.Intn(16) == 0 {
+			a.Ops[i].B = int64(len(a.Ops)) // out of range on purpose
+			continue
+		}
+		a.Ops[i].B = int64(rng.Intn(len(a.Ops) - i))
+	}
+	for i := 0; i < rng.Intn(4); i++ {
+		mode := uint8(wire.OperateRetValue)
+		if rng.Intn(2) == 0 {
+			mode = wire.OperateRetCount
+		}
+		a.Rets = append(a.Rets, wire.OperateRet{Mode: mode, Path: randomDynamicPath(rng)})
+	}
+	return a
+}
+
+// randomDynamicOp draws one op. Unlike schema mode there is no declared type
+// to aim at — whatever the record already stores wins — so the op picks a
+// type first and an opcode that suits it, which is what makes the stored-type
+// and SET-retype rules (§2.9) fire rather than only the error paths.
+func randomDynamicOp(rng *rand.Rand) wire.OperateOp {
+	p := randomDynamicPath(rng)
+	typ := randomScalarTypes[rng.Intn(len(randomScalarTypes))]
+	o := wire.OperateOp{Type: typ, Path: p}
+	switch {
+	case p.Kind == wire.OperatePathRecord:
+		// DEL () is terminal and takes the whole record with it, so it is
+		// drawn rarely: an op list that deletes the record every other call
+		// never builds one deep enough to be interesting.
+		o.Opcode = wire.OperateOpIF
+		switch {
+		case rng.Intn(10) == 0:
+			o.Opcode = wire.OperateOpDEL
+		case rng.Intn(2) == 0:
+			o.Opcode = wire.OperateOpCHECK
+		}
+	case p.Kind == wire.OperatePathRow:
+		o.Opcode = nodeOpcodes[rng.Intn(len(nodeOpcodes))]
+	case p.Kind == wire.OperatePathField && rng.Intn(5) == 0:
+		// A table-shaped op against a field path: CONFIG and TRIM only ever
+		// address the field itself.
+		o.Opcode = tableOpcodes[rng.Intn(len(tableOpcodes))]
+		if rng.Intn(2) == 0 {
+			o.Opcode = wire.OperateOpCONFIG
+		}
+	case rng.Intn(8) == 0:
+		o.Opcode = randomOpcodes[rng.Intn(len(randomOpcodes))]
+	default:
+		pool := opcodePool(typ)
+		o.Opcode = pool[rng.Intn(len(pool))]
+	}
+
+	switch o.Opcode {
+	case wire.OperateOpIF, wire.OperateOpCHECK:
+		o.Aux = uint8(rng.Intn(int(wire.OperateCmpAbsent) + 2)) // one past the last comparator
+	case wire.OperateOpTRIM, wire.OperateOpCONFIG:
+		o.A = int64(rng.Intn(5))
+		if rng.Intn(16) == 0 {
+			o.A = -1
+		}
+		o.Aux = uint8(rng.Intn(int(wire.OperatePolicyMaxCol) + 2))
+		o.B = int64(rng.Intn(4))
+	case wire.OperateOpSTAMP:
+		o.Aux = uint8(rng.Intn(2))
+	}
+	o.A = randomOperandA(rng, o, typ)
+	o.Bytes = randomOperandBytes(rng, wire.OperateTypeBytes, 0)
+	if o.Opcode == wire.OperateOpTRIM || o.Opcode == wire.OperateOpCONFIG {
+		// For a table op the bytes operand is the eviction column's NAME.
+		o.Bytes = nil
+		if rng.Intn(3) != 0 {
+			o.Bytes = []byte(dynNames[rng.Intn(len(dynNames))])
+		}
+	}
+	if rng.Intn(8) == 0 {
+		o.Type = wire.OperateTypeFromSchema // "whatever is stored", which a missing target has none of
+	}
+	return o
+}
+
+// randomDynamicPath builds a dynamic path: usually a name-addressed field,
+// row or column, sometimes a position segment (which dynamic mode rejects
+// outright) or an empty key.
+func randomDynamicPath(rng *rand.Rand) wire.OperatePath {
+	if rng.Intn(12) == 0 {
+		return recPath()
+	}
+	if rng.Intn(20) == 0 {
+		return fieldPath(uint32(rng.Intn(3))) // a position segment
+	}
+	name := dynNames[rng.Intn(len(dynNames))]
+	switch rng.Intn(3) {
+	case 0:
+		return namePath(name)
+	case 1:
+		return nameRowPath(name, randomDynamicKey(rng))
+	default:
+		if rng.Intn(20) == 0 {
+			return colPath(0, randomDynamicKey(rng), 0) // a position column segment
+		}
+		return nameColPath(name, randomDynamicKey(rng), dynNames[rng.Intn(len(dynNames))])
+	}
+}
+
+// randomDynamicKey draws a row key of 1-8 bytes from a tiny alphabet so rows
+// collide often, biased towards the 8-byte width a freeze into a U64-keyed
+// table needs. An empty key (which no row may have) turns up occasionally.
+func randomDynamicKey(rng *rand.Rand) []byte {
+	if rng.Intn(24) == 0 {
+		return nil
+	}
+	n := 8
+	if rng.Intn(2) == 0 {
+		n = 1 + rng.Intn(8)
+	}
+	key := make([]byte, n)
+	key[0] = byte(rng.Intn(6))
+	for i := 1; i < n; i++ {
+		key[i] = byte(rng.Intn(3))
+	}
+	return key
+}
+
+// randomFreezeSchema builds the target of a dynamic-mode freeze: names from
+// the same pool the record's fields are drawn from (a freeze matches by
+// name), always valid, and always carrying its names.
+func randomFreezeSchema(rng *rand.Rand) *wire.Schema {
+	for {
+		s := &wire.Schema{Version: uint16(1 + rng.Intn(3)), StoreNames: true} //nolint:gosec // deterministic test input
+		perm := rng.Perm(len(dynNames))
+		nFields := 1 + rng.Intn(4)
+		tables := 0
+		for i := 0; i < nFields; i++ {
+			f := wire.FieldDef{Name: dynNames[perm[i]]}
+			if tables < 2 && rng.Intn(3) == 0 {
+				tables++
+				f.Type = wire.OperateTypeTable
+				f.Table = randomFreezeTableDef(rng)
+			} else {
+				f.Type = randomScalarTypes[rng.Intn(len(randomScalarTypes))]
+				if f.Type == wire.OperateTypeFixed {
+					f.N = uint8(1 + rng.Intn(4)) //nolint:gosec // bounded
+				}
+			}
+			s.Fields = append(s.Fields, f)
+		}
+		if s.Validate() == nil {
+			return s
+		}
+	}
+}
+
+func randomFreezeTableDef(rng *rand.Rand) *wire.TableDef {
+	td := &wire.TableDef{KeyType: wire.OperateTypeU64}
+	if rng.Intn(3) == 0 {
+		td.KeyType = randomKeyTypes[rng.Intn(len(randomKeyTypes))]
+		if td.KeyType == wire.OperateTypeFixed {
+			td.KeyN = uint8(1 + rng.Intn(3)) //nolint:gosec // bounded
+		}
+	}
+	perm := rng.Perm(len(dynNames))
+	for c := 0; c < 1+rng.Intn(3); c++ {
+		cd := wire.ColumnDef{Name: dynNames[perm[c]], Type: randomColTypes[rng.Intn(len(randomColTypes))]}
+		if cd.Type == wire.OperateTypeFixed {
+			cd.N = uint8(1 + rng.Intn(3)) //nolint:gosec // bounded
+		}
+		td.Cols = append(td.Cols, cd)
+	}
+	td.Cap = uint32(rng.Intn(4)) //nolint:gosec // bounded
+	td.Policy = uint8(rng.Intn(int(wire.OperatePolicyMaxCol) + 1))
+	if td.Policy == wire.OperatePolicyMinCol || td.Policy == wire.OperatePolicyMaxCol {
+		td.ByCol = uint16(rng.Intn(len(td.Cols))) //nolint:gosec // bounded by the column count
+	}
+	return td
+}

--- a/ops/operate_schema_engine.go
+++ b/ops/operate_schema_engine.go
@@ -1,0 +1,1203 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package ops
+
+// The schema-mode byte engine (design doc §2.6): it navigates and patches a
+// stored operate record's bytes directly, never building a tree. A
+// fixed-width field's offset is a schema constant, a row is a binary search
+// over fixed-width rows, and a column is rowStart + colOffset; only the
+// variable-length tail costs a short walk, which reindexTail does once per
+// call and again after any splice that moves it.
+//
+// The tree oracle (operate_oracle_test.go) is the definition of what this
+// file must do; TestSchemaEngineMatchesOracle compares them byte for byte.
+//
+// Stored bytes are untrusted — a plain `put` can store anything under the
+// key — so newSchemaEngine validates the whole frame with a bounds-checked
+// walk before any offset here is trusted, and every method below is written
+// to be unable to panic on input that passed that walk.
+
+import (
+	"bytes"
+	"encoding/binary"
+	"math"
+	"sync"
+
+	"github.com/rostamlabs/rostam/sdk/wire"
+)
+
+// --- schema cache ----------------------------------------------------------
+
+// schemaEntry is one decoded schema: the schema itself, its byte layout, its
+// canonical blob (what a record stores in front of its values), and the
+// reverse of layout.VarTail — field position to tail slot, -1 for a
+// fixed-width field. Every member is immutable once published, so entries are
+// shared across calls and goroutines without copying.
+type schemaEntry struct {
+	schema   *wire.Schema
+	layout   *wire.Layout
+	blob     []byte
+	tailSlot []int
+}
+
+// schemaCache is the design doc §2.8 offset cache: a bounded map from schema
+// blob bytes to the decoded schema and its layout, so a call whose record
+// carries a known schema resolves every path by arithmetic with no parsing.
+// It is a pure function of the bytes — it can never affect what a call
+// stores, only how fast it gets there.
+//
+// Eviction is deliberately crude: at max entries the whole map is dropped and
+// rebuilt. A schema blob is at most maxSchemaBytes, the working set of one
+// deployment is a handful of shapes, and "clear when full" needs no ordering
+// state (and so cannot leak Go map iteration order into anything).
+type schemaCache struct {
+	mu   sync.Mutex
+	max  int
+	ents map[string]*schemaEntry
+}
+
+// operateSchemas is the process-wide schema cache.
+var operateSchemas = newSchemaCache(256)
+
+func newSchemaCache(max int) *schemaCache {
+	if max < 1 {
+		max = 1
+	}
+	return &schemaCache{max: max, ents: make(map[string]*schemaEntry, max)}
+}
+
+// get decodes the schema blob at the front of b, returning the schema and its
+// layout. It is the contract's entry point; lookup below is the internal form
+// that also reports how many bytes the blob occupied (a stored record's blob
+// is a prefix of the record, a call's blob is the whole argument).
+func (c *schemaCache) get(b []byte) (*wire.Schema, *wire.Layout, error) {
+	ent, _, err := c.lookup(b)
+	if err != nil {
+		return nil, nil, err
+	}
+	return ent.schema, ent.layout, nil
+}
+
+// lookup returns the cached entry for the schema blob at the front of b and
+// the blob's encoded length.
+//
+// The cache is keyed by the exact blob bytes, so a hit needs the blob's
+// length before the map lookup: schemaBlobLen walks the framing without
+// decoding. A wrong length from that walk cannot produce a wrong answer —
+// b[:n] only matches a key if it is byte-identical to an already-decoded,
+// already-validated blob, which fixes n — and on a miss DecodeSchema is
+// authoritative for both the schema and the length.
+func (c *schemaCache) lookup(b []byte) (*schemaEntry, int, error) {
+	if n, ok := schemaBlobLen(b); ok {
+		c.mu.Lock()
+		ent := c.ents[string(b[:n])] // no allocation: Go elides the key copy
+		c.mu.Unlock()
+		if ent != nil {
+			return ent, n, nil
+		}
+	}
+
+	s, n, err := wire.DecodeSchema(b)
+	if err != nil {
+		return nil, 0, err
+	}
+	layout, err := s.Layout()
+	if err != nil {
+		return nil, 0, err
+	}
+	ent := &schemaEntry{schema: s, layout: layout, blob: s.Encode(), tailSlot: tailSlots(s, layout)}
+
+	c.mu.Lock()
+	if len(c.ents) >= c.max {
+		c.ents = make(map[string]*schemaEntry, c.max)
+	}
+	c.ents[string(ent.blob)] = ent
+	c.mu.Unlock()
+	return ent, n, nil
+}
+
+// tailSlots inverts layout.VarTail: field position to its index in the
+// variable-length tail, or -1 for a fixed-width field.
+func tailSlots(s *wire.Schema, l *wire.Layout) []int {
+	slots := make([]int, len(s.Fields))
+	for i := range slots {
+		slots[i] = -1
+	}
+	for slot, field := range l.VarTail {
+		slots[field] = slot
+	}
+	return slots
+}
+
+// schemaBlobLen returns the encoded length of the schema blob at the front of
+// b, mirroring Encode's framing (design doc §2.2) without decoding anything.
+// It exists only so the cache can be keyed by the blob's exact bytes without
+// paying for a decode on every call; ok == false means "cannot tell", which
+// is never an error by itself — the caller falls through to DecodeSchema,
+// which is the authority on both validity and length.
+func schemaBlobLen(b []byte) (int, bool) {
+	off := 3 // version u16 + flags u8
+	if len(b) < off+1 {
+		return 0, false
+	}
+	// byteAt consumes one byte, and uvarintAt one uvarint, each reporting
+	// failure rather than reading past the end: b is untrusted (it is the
+	// front of a stored record), so every step is bounds-checked even though
+	// a wrong answer here would only ever cost a cache miss.
+	byteAt := func() (uint8, bool) {
+		if len(b)-off < 1 {
+			return 0, false
+		}
+		v := b[off]
+		off++
+		return v, true
+	}
+	uvarintAt := func() (uint64, bool) {
+		if off > len(b) {
+			return 0, false
+		}
+		v, m, ok := scanUvarint(b[off:])
+		if !ok {
+			return 0, false
+		}
+		off += m
+		return v, true
+	}
+
+	nFields, ok := uvarintAt()
+	if !ok || nFields > wire.OperateMaxFields {
+		return 0, false
+	}
+	for i := uint64(0); i < nFields; i++ {
+		typ, ok := byteAt()
+		if !ok {
+			return 0, false
+		}
+		if typ == wire.OperateTypeFixed {
+			if _, ok := byteAt(); !ok {
+				return 0, false
+			}
+		}
+		if typ != wire.OperateTypeTable {
+			continue
+		}
+		keyType, ok := byteAt()
+		if !ok {
+			return 0, false
+		}
+		if keyType == wire.OperateTypeFixed {
+			if _, ok := byteAt(); !ok {
+				return 0, false
+			}
+		}
+		nCols, ok := uvarintAt()
+		if !ok || nCols > wire.OperateMaxCols {
+			return 0, false
+		}
+		for j := uint64(0); j < nCols; j++ {
+			ctyp, ok := byteAt()
+			if !ok {
+				return 0, false
+			}
+			if ctyp == wire.OperateTypeFixed {
+				if _, ok := byteAt(); !ok {
+					return 0, false
+				}
+			}
+		}
+		if _, ok := uvarintAt(); !ok { // cap
+			return 0, false
+		}
+		if _, ok := byteAt(); !ok { // policy
+			return 0, false
+		}
+		if _, ok := uvarintAt(); !ok { // byCol
+			return 0, false
+		}
+	}
+	nameBytes, ok := uvarintAt()
+	if !ok || nameBytes > wire.OperateMaxNameBytes {
+		return 0, false
+	}
+	if !wire.CountFitsIn(int(nameBytes), len(b)-off, 1) { //nolint:gosec // bounded above
+		return 0, false
+	}
+	return off + int(nameBytes), true //nolint:gosec // bounded above
+}
+
+// scanUvarint reads one uvarint, reporting failure rather than an error: it
+// is only ever used by schemaBlobLen, whose caller treats "cannot tell" as a
+// cache miss.
+func scanUvarint(b []byte) (uint64, int, bool) {
+	v, m := binary.Uvarint(b)
+	if m <= 0 {
+		return 0, 0, false
+	}
+	return v, m, true
+}
+
+// --- construction and structural validation --------------------------------
+
+// tailEntry is one variable-length field's position in the stored tail: the
+// offset of its value area and, for a table, its row count (-1 otherwise).
+type tailEntry struct {
+	off  int
+	rows int
+}
+
+// inlineTail is the number of variable-length fields whose tail index rides
+// inside the engine struct. Schemas in practice have one or two (the session
+// shape has exactly one table); a wider one falls back to a heap slice.
+const inlineTail = 4
+
+// schemaEngine implements engine over a schema-mode record's stored bytes.
+// buf is the engine's own copy, which it patches in place and splices as
+// needed; every other member is derived from it.
+type schemaEngine struct {
+	buf     []byte
+	cache   *schemaCache
+	ent     *schemaEntry
+	schema  *wire.Schema
+	layout  *wire.Layout
+	hdrLen  int // 1 (mode byte) + len(schema blob)
+	tail    []tailEntry
+	existed bool
+	deleted bool
+
+	tailArr [inlineTail]tailEntry
+	// scratch encodes one cell's data without allocating. 256 bytes covers
+	// every fixed-width type and the widest FIXED(n); BYTES is spliced from
+	// its operand directly and never uses it.
+	scratch [256]byte
+}
+
+// newSchemaEngine builds an engine over buf, which becomes the engine's
+// private buffer (it is patched in place). buf is untrusted: the whole frame
+// is validated here — mode byte, schema blob, the fixed-width area, and every
+// tail field's length walked to exactly the end of the buffer — and anything
+// that does not fit is wire.ErrOperateRecord.
+func newSchemaEngine(buf []byte, cache *schemaCache) (*schemaEngine, error) {
+	e := &schemaEngine{}
+	if err := e.reset(buf, cache); err != nil {
+		return nil, err
+	}
+	return e, nil
+}
+
+// reset re-points an engine at buf, so a pooled engine can be reused without
+// re-allocating its tail index. It performs the same validation as
+// newSchemaEngine.
+func (e *schemaEngine) reset(buf []byte, cache *schemaCache) error {
+	e.clear()
+	e.cache = cache
+	if len(buf) < 1 || buf[0] != wire.OperateModeSchema {
+		return wire.ErrOperateRecord
+	}
+	ent, n, err := cache.lookup(buf[1:])
+	if err != nil {
+		// A stored record whose own schema will not decode is a malformed
+		// record, not a malformed call.
+		return wire.ErrOperateRecord
+	}
+	e.buf, e.ent, e.schema, e.layout = buf, ent, ent.schema, ent.layout
+	e.hdrLen = 1 + n
+	if len(e.layout.VarTail) <= inlineTail {
+		e.tail = e.tailArr[:0]
+	} else {
+		e.tail = make([]tailEntry, 0, len(e.layout.VarTail))
+	}
+	return e.reindexTail()
+}
+
+// clear drops the engine's references so a pooled engine does not pin a
+// record buffer between calls.
+func (e *schemaEngine) clear() {
+	e.buf, e.cache, e.ent, e.schema, e.layout = nil, nil, nil, nil, nil
+	e.hdrLen, e.tail, e.existed, e.deleted = 0, nil, false, false
+}
+
+// reindexTail walks the variable-length tail, recording each field's offset
+// and each table's row count, and checks that the walk lands exactly on the
+// end of the buffer. It is both the structural validator (on an untrusted
+// buffer) and the index rebuild after any splice that moved the tail; it is
+// O(number of variable-length fields), since a table is skipped by
+// arithmetic rather than read.
+func (e *schemaEngine) reindexTail() error {
+	off := e.hdrLen + e.layout.FixedLen
+	if off < 0 || off > len(e.buf) {
+		return wire.ErrOperateRecord
+	}
+	e.tail = e.tail[:0]
+	for _, i := range e.layout.VarTail {
+		ent := tailEntry{off: off, rows: -1}
+		switch e.schema.Fields[i].Type {
+		case wire.OperateTypeTable:
+			n, m, err := readUvarint(e.buf[off:])
+			if err != nil {
+				return err
+			}
+			if n > wire.OperateMaxRows {
+				return wire.ErrOperateRecord
+			}
+			tl := e.layout.Tables[i]
+			if !wire.CountFitsIn(int(n), len(e.buf)-off-m, tl.RowWidth) { //nolint:gosec // bounded above
+				return wire.ErrOperateRecord
+			}
+			ent.rows = int(n) //nolint:gosec // bounded by OperateMaxRows above
+			off += m + ent.rows*tl.RowWidth
+		case wire.OperateTypeBytes:
+			ln, m, err := readUvarint(e.buf[off:])
+			if err != nil {
+				return err
+			}
+			if ln > wire.OperateMaxBytesLen {
+				return wire.ErrOperateRecord
+			}
+			if !wire.CountFitsIn(int(ln), len(e.buf)-off-m, 1) { //nolint:gosec // bounded above
+				return wire.ErrOperateRecord
+			}
+			off += m + int(ln) //nolint:gosec // bounded above
+		default: // UVARINT, IVARINT
+			_, m, err := readUvarint(e.buf[off:])
+			if err != nil {
+				return err
+			}
+			off += m
+		}
+		e.tail = append(e.tail, ent)
+	}
+	if off != len(e.buf) {
+		return wire.ErrOperateRecord
+	}
+	return nil
+}
+
+// readUvarint reads one canonically encoded uvarint. A non-minimal encoding
+// is rejected: the record codec never produces one, and accepting it would
+// break the byte-for-byte identity with the oracle's output.
+func readUvarint(b []byte) (uint64, int, error) {
+	v, m := binary.Uvarint(b)
+	if m <= 0 {
+		return 0, 0, wire.ErrOperateRecord
+	}
+	if m != uvarintLen(v) {
+		return 0, 0, wire.ErrOperateRecord
+	}
+	return v, m, nil
+}
+
+// uvarintLen is the number of bytes binary.AppendUvarint uses for v.
+func uvarintLen(v uint64) int {
+	n := 1
+	for v >= 0x80 {
+		v >>= 7
+		n++
+	}
+	return n
+}
+
+// newSchemaRecord returns the stored bytes of a fresh, empty record for the
+// schema blob: [mode][blob][zeroed fixed-width fields][each tail field's
+// zero]. Every tail field's zero is a single 0x00 byte — a BYTES length of
+// zero, a varint zero, or a table with zero rows.
+func newSchemaRecord(schemaBlob []byte, cache *schemaCache) ([]byte, error) {
+	if len(schemaBlob) == 0 {
+		return nil, wire.ErrOperateSchema
+	}
+	ent, n, err := cache.lookup(schemaBlob)
+	if err != nil {
+		return nil, err
+	}
+	if n != len(schemaBlob) {
+		// Trailing bytes after the schema: the call's blob must be exactly
+		// one schema (mirrors the oracle's treeOpen).
+		return nil, wire.ErrOperateSchema
+	}
+	size := 1 + len(ent.blob) + ent.layout.FixedLen + len(ent.layout.VarTail)
+	if size > maxOperateRecordBytes {
+		return nil, wire.ErrOperateCap
+	}
+	buf := make([]byte, size, size+64)
+	buf[0] = wire.OperateModeSchema
+	copy(buf[1:], ent.blob)
+	// The fixed area and every tail field's zero byte are already zero.
+	return buf, nil
+}
+
+// --- resolve ---------------------------------------------------------------
+
+// resolve implements engine.resolve for schema mode: a field is a schema
+// position (or a name, when the schema stores names), a row is a binary
+// search, and a column is a constant offset within that row. Schema-mode
+// fields and columns always exist (design doc §2.5), so create only ever
+// vivifies a row.
+func (e *schemaEngine) resolve(p wire.OperatePath, create bool, typ, n uint8) (ref, error) {
+	_ = n // schema mode takes widths from the schema, never from the op
+	if p.Kind > wire.OperatePathCol {
+		return ref{}, wire.ErrOperatePath
+	}
+	if p.Kind == wire.OperatePathRecord {
+		// Presence of the record is whether it existed before this call
+		// (oracle ruling): CHECK((), ABSENT) means "this call created it".
+		return ref{kind: refKindRecord, field: -1, row: -1, col: -1, present: e.existed}, nil
+	}
+
+	pos, err := e.fieldPos(p.Field)
+	if err != nil {
+		return ref{}, err
+	}
+	fd := &e.schema.Fields[pos]
+
+	if p.Kind == wire.OperatePathField {
+		if fd.Type == wire.OperateTypeTable {
+			return ref{kind: refKindTable, field: pos, row: -1, col: -1, present: true}, nil
+		}
+		if err := e.checkType(create, typ, fd.Type); err != nil {
+			return ref{}, err
+		}
+		return ref{kind: refKindScalar, field: pos, row: -1, col: -1,
+			off: e.fieldOff(pos), typ: fd.Type, n: fd.N, present: true}, nil
+	}
+
+	if fd.Type != wire.OperateTypeTable {
+		return ref{}, wire.ErrOperatePath // a row path into a non-table field
+	}
+	td := fd.Table
+	tl := e.layout.Tables[pos]
+	if len(p.Key) != tl.KeyWidth {
+		return ref{}, wire.ErrOperatePath
+	}
+
+	col := -1
+	if p.Kind == wire.OperatePathCol {
+		col, err = e.colPos(td, p.Col)
+		if err != nil {
+			return ref{}, err
+		}
+		if err := e.checkType(create, typ, td.Cols[col].Type); err != nil {
+			return ref{}, err
+		}
+	}
+
+	idx, found := e.findRow(pos, p.Key)
+	if !found && create {
+		// The oracle vivifies the row for any create=true resolve, including
+		// a row-kind path (whose op applyOps then rejects); mirrored here so
+		// the two agree on which error comes out.
+		if idx, err = e.insertRow(pos, idx, p.Key); err != nil {
+			return ref{}, err
+		}
+	}
+	if p.Kind == wire.OperatePathRow {
+		return ref{kind: refKindRow, field: pos, row: idx, col: -1, present: found}, nil
+	}
+	r := ref{kind: refKindScalar, field: pos, row: idx, col: col,
+		typ: td.Cols[col].Type, n: td.Cols[col].N, present: found, off: -1}
+	if found || create {
+		r.off = e.rowStart(pos, idx) + tl.ColOff[col]
+	}
+	return r, nil
+}
+
+// fieldPos resolves a path's field segment to a schema position. A name
+// addresses a schema record only when the schema stores names (design doc
+// §2.4).
+func (e *schemaEngine) fieldPos(seg wire.OperateSeg) (int, error) {
+	if seg.ByName {
+		if !e.schema.StoreNames {
+			return 0, wire.ErrOperatePath
+		}
+		pos, ok := e.schema.FieldPos(seg.Name)
+		if !ok {
+			return 0, wire.ErrOperatePath
+		}
+		return pos, nil
+	}
+	if seg.Pos >= uint32(len(e.schema.Fields)) { //nolint:gosec // len is bounded by OperateMaxFields
+		return 0, wire.ErrOperatePath
+	}
+	return int(seg.Pos), nil
+}
+
+// colPos resolves a path's column segment to a column position.
+func (e *schemaEngine) colPos(td *wire.TableDef, seg wire.OperateSeg) (int, error) {
+	if seg.ByName {
+		if !e.schema.StoreNames || seg.Name == "" {
+			return 0, wire.ErrOperatePath
+		}
+		for j := range td.Cols {
+			if td.Cols[j].Name == seg.Name {
+				return j, nil
+			}
+		}
+		return 0, wire.ErrOperatePath
+	}
+	if seg.Pos >= uint32(len(td.Cols)) { //nolint:gosec // len is bounded by OperateMaxCols
+		return 0, wire.ErrOperatePath
+	}
+	return int(seg.Pos), nil
+}
+
+// checkType enforces design doc §2.4's schema-mode rule: an op's type byte is
+// either 0xFF ("from the schema") or exactly the schema's type.
+//
+// Ruling: applyOps passes typ=0 for every op whose type byte is meaningless
+// (IF, CHECK, DEL, TRIM, and every return spec) and the op's own type byte
+// only for the scalar ops, which are exactly the ops that pass create=true —
+// so create is the signal that typ is a real type byte to check. The one
+// op this mis-reads is CONFIG, which also resolves with create=true (typ =
+// TABLE): aimed at a scalar field it fails here with ErrOperateType where the
+// oracle reports ErrOperateOpcode. Both reject the call with the record
+// unchanged, and CONFIG is never valid in schema mode at all.
+func (e *schemaEngine) checkType(create bool, typ, want uint8) error {
+	if !create || typ == wire.OperateTypeFromSchema || typ == want {
+		return nil
+	}
+	return wire.ErrOperateType
+}
+
+// fieldOff is the byte offset of field pos's value: a schema constant for a
+// fixed-width field, the walked tail offset for a variable-length one.
+func (e *schemaEngine) fieldOff(pos int) int {
+	if off := e.layout.FixedOff[pos]; off >= 0 {
+		return e.hdrLen + off
+	}
+	return e.tail[e.ent.tailSlot[pos]].off
+}
+
+// rows is the row count of the table field at pos.
+func (e *schemaEngine) rows(pos int) int { return e.tail[e.ent.tailSlot[pos]].rows }
+
+// rowsOff is the offset of the table field's row count uvarint.
+func (e *schemaEngine) rowsOff(pos int) int { return e.tail[e.ent.tailSlot[pos]].off }
+
+// rowStart is the offset of row idx of the table field at pos.
+func (e *schemaEngine) rowStart(pos, idx int) int {
+	ent := &e.tail[e.ent.tailSlot[pos]]
+	return ent.off + uvarintLen(uint64(ent.rows)) + idx*e.layout.Tables[pos].RowWidth //nolint:gosec // rows >= 0
+}
+
+// findRow binary-searches the table field at pos for key, returning the row
+// index and whether it matched; when it did not, the index is where the row
+// would be inserted to keep the table sorted. Numeric keys compare as
+// little-endian integers and FIXED keys bytewise (design doc §2.3).
+func (e *schemaEngine) findRow(pos int, key []byte) (int, bool) {
+	tl := e.layout.Tables[pos]
+	keyType := e.schema.Fields[pos].Table.KeyType
+	start := e.rowStart(pos, 0)
+	lo, hi := 0, e.rows(pos)
+	for lo < hi {
+		mid := int(uint(lo+hi) >> 1)
+		at := start + mid*tl.RowWidth
+		if compareRowKey(e.buf[at:at+tl.KeyWidth], key, keyType) < 0 {
+			lo = mid + 1
+		} else {
+			hi = mid
+		}
+	}
+	if lo < e.rows(pos) {
+		at := start + lo*tl.RowWidth
+		if compareRowKey(e.buf[at:at+tl.KeyWidth], key, keyType) == 0 {
+			return lo, true
+		}
+	}
+	return lo, false
+}
+
+// compareRowKey orders two row keys of the same width: bytewise for a FIXED
+// key, as little-endian unsigned integers for the numeric key types.
+func compareRowKey(a, b []byte, keyType uint8) int {
+	if keyType == wire.OperateTypeFixed {
+		return bytes.Compare(a, b)
+	}
+	av, bv := leUint(a), leUint(b)
+	switch {
+	case av < bv:
+		return -1
+	case av > bv:
+		return 1
+	default:
+		return 0
+	}
+}
+
+// leUint reads up to 8 little-endian bytes as an unsigned integer.
+func leUint(b []byte) uint64 {
+	var v uint64
+	for i := len(b) - 1; i >= 0; i-- {
+		v = v<<8 | uint64(b[i])
+	}
+	return v
+}
+
+// --- in-place patching -----------------------------------------------------
+
+// get implements engine.get: the scalar at r, or its type's zero when r
+// addresses a column of a row that does not exist (design doc §2.4).
+func (e *schemaEngine) get(r ref) (wire.Cell, error) {
+	if r.kind != refKindScalar {
+		return wire.Cell{}, wire.ErrOperatePath
+	}
+	if r.off < 0 {
+		return wire.ZeroCell(r.typ, r.n), nil
+	}
+	c, _, err := wire.DecodeCellData(r.typ, r.n, e.buf[r.off:])
+	if err != nil {
+		return wire.Cell{}, err
+	}
+	return c, nil
+}
+
+// set implements engine.set: a fixed-width cell is overwritten in place (the
+// width cannot change, the schema owns it), and a BYTES or varint field is
+// spliced when its encoded width does.
+func (e *schemaEngine) set(r ref, c wire.Cell) error {
+	if r.kind != refKindScalar || r.off < 0 {
+		return wire.ErrOperatePath
+	}
+	if w := wire.CellWidth(r.typ, r.n); w >= 0 {
+		if r.typ == wire.OperateTypeFixed && len(c.B) != int(r.n) {
+			return wire.ErrOperateType
+		}
+		copy(e.buf[r.off:r.off+w], e.encodeCell(c))
+		return nil
+	}
+	if r.typ == wire.OperateTypeBytes {
+		return e.setBytes(r.off, c.B)
+	}
+	// UVARINT / IVARINT: at most 10 bytes, encoded through the same
+	// canonical writer the record codec uses.
+	_, m, err := readUvarint(e.buf[r.off:])
+	if err != nil {
+		return err
+	}
+	return e.spliceTail(r.off, m, e.encodeCell(c))
+}
+
+// encodeCell renders one cell's data into the engine's scratch space. It
+// never allocates for a fixed-width type, a FIXED(n), or a varint — the only
+// callers — because scratch is wider than any of them.
+func (e *schemaEngine) encodeCell(c wire.Cell) []byte {
+	return wire.AppendCellData(e.scratch[:0], c)
+}
+
+// setBytes replaces the BYTES field stored at off with b, splicing the length
+// prefix and the payload separately so no scratch buffer has to hold both.
+func (e *schemaEngine) setBytes(off int, b []byte) error {
+	ln, m, err := readUvarint(e.buf[off:])
+	if err != nil {
+		return err
+	}
+	if len(b) > wire.OperateMaxBytesLen {
+		return wire.ErrOperateCap
+	}
+	delta := (uvarintLen(uint64(len(b))) + len(b)) - (m + int(ln)) //nolint:gosec // ln bounded by reindexTail
+	if err := e.charge(delta); err != nil {
+		return err
+	}
+	buf, m2 := spliceUvarint(e.buf, off, m, uint64(len(b)))
+	e.buf = splice(buf, off+m2, int(ln), b) //nolint:gosec // ln bounded by reindexTail
+	return e.reindexTail()
+}
+
+// spliceTail replaces buf[off:off+oldLen] with repl and re-walks the tail.
+func (e *schemaEngine) spliceTail(off, oldLen int, repl []byte) error {
+	if err := e.charge(len(repl) - oldLen); err != nil {
+		return err
+	}
+	e.buf = splice(e.buf, off, oldLen, repl)
+	return e.reindexTail()
+}
+
+// charge rejects a growth that would take the record past the §2.7
+// record-size cap before the splice allocates for it. The oracle checks the
+// same bound once, on the finished record; charging every splice is stricter
+// only for an op list that grows past the cap and shrinks back under it
+// within one call.
+func (e *schemaEngine) charge(delta int) error {
+	if delta > 0 && len(e.buf)+delta > maxOperateRecordBytes {
+		return wire.ErrOperateCap
+	}
+	return nil
+}
+
+// --- splice paths: rows ----------------------------------------------------
+
+// insertRow vivifies the row for key at sorted position idx, evicting first
+// if the table is at its cap (design doc §2.3/§2.4). It returns the index the
+// new row ended up at, which the eviction may have moved.
+func (e *schemaEngine) insertRow(pos, idx int, key []byte) (int, error) {
+	td := e.schema.Fields[pos].Table
+	tl := e.layout.Tables[pos]
+	if td.Cap > 0 && uint32(e.rows(pos)) >= td.Cap { //nolint:gosec // rows bounded by OperateMaxRows
+		if err := e.evictOne(pos, td.Policy, int(td.ByCol)); err != nil {
+			return 0, err
+		}
+		var found bool
+		if idx, found = e.findRow(pos, key); found {
+			// The evicted row cannot be the one being inserted (it is not
+			// there yet), so this is unreachable; treated as "already
+			// present" rather than inserting a duplicate.
+			return idx, nil
+		}
+	}
+	rows := e.rows(pos)
+	if rows+1 > wire.OperateMaxRows {
+		return 0, wire.ErrOperateCap
+	}
+	grow := tl.RowWidth + uvarintLen(uint64(rows+1)) - uvarintLen(uint64(rows)) //nolint:gosec // rows >= 0
+	if err := e.charge(grow); err != nil {
+		return 0, err
+	}
+
+	at := e.rowStart(pos, idx)
+	e.buf = insertGap(e.buf, at, tl.RowWidth)
+	copy(e.buf[at:at+tl.KeyWidth], key)
+	off := e.rowsOff(pos)
+	e.buf, _ = spliceUvarint(e.buf, off, uvarintLen(uint64(rows)), uint64(rows+1)) //nolint:gosec // rows >= 0
+	if err := e.reindexTail(); err != nil {
+		return 0, err
+	}
+	return idx, nil
+}
+
+// removeRows splices count rows out of the table field at pos, starting at
+// row index idx, and rewrites its row count.
+func (e *schemaEngine) removeRows(pos, idx, count int) error {
+	if count <= 0 {
+		return nil
+	}
+	rows := e.rows(pos)
+	tl := e.layout.Tables[pos]
+	at := e.rowStart(pos, idx)
+	e.buf = splice(e.buf, at, count*tl.RowWidth, nil)
+	off := e.rowsOff(pos)
+	e.buf, _ = spliceUvarint(e.buf, off, uvarintLen(uint64(rows)), uint64(rows-count)) //nolint:gosec // 0 <= count <= rows
+	return e.reindexTail()
+}
+
+// insertGap opens n zeroed bytes at off, growing buf in one append when its
+// capacity cannot absorb the gap.
+func insertGap(buf []byte, off, n int) []byte {
+	if n <= 0 {
+		return buf
+	}
+	old := len(buf)
+	if cap(buf)-old >= n {
+		buf = buf[:old+n]
+	} else {
+		grown := make([]byte, old+n, old+n+64)
+		copy(grown, buf[:off])
+		copy(grown[off+n:], buf[off:old])
+		for i := off; i < off+n; i++ {
+			grown[i] = 0
+		}
+		return grown
+	}
+	copy(buf[off+n:], buf[off:old])
+	for i := off; i < off+n; i++ {
+		buf[i] = 0
+	}
+	return buf
+}
+
+// --- del, count ------------------------------------------------------------
+
+// del implements engine.del (design doc §3.1/§2.5): the record is marked
+// deleted, a schema field or column is zeroed (it cannot be removed — the
+// schema declares it, so it is always present), a table is emptied, and a row
+// is spliced out. Deleting something absent is a no-op.
+func (e *schemaEngine) del(r ref) error {
+	switch r.kind {
+	case refKindRecord:
+		e.deleted = true
+		return nil
+	case refKindTable:
+		return e.removeRows(r.field, 0, e.rows(r.field))
+	case refKindRow:
+		if !r.present {
+			return nil
+		}
+		return e.removeRows(r.field, r.row, 1)
+	default: // refKindScalar: a field or a column
+		if !r.present || r.off < 0 {
+			return nil
+		}
+		return e.set(r, wire.ZeroCell(r.typ, r.n))
+	}
+}
+
+// count implements engine.count (design doc §3.3/§3.4): fields for the
+// record, rows for a table, and presence as 1/0 for a row or a scalar.
+func (e *schemaEngine) count(r ref) (uint64, error) {
+	switch r.kind {
+	case refKindRecord:
+		return uint64(len(e.schema.Fields)), nil
+	case refKindTable:
+		return uint64(e.rows(r.field)), nil //nolint:gosec // rows >= 0
+	default:
+		if r.present {
+			return 1, nil
+		}
+		return 0, nil
+	}
+}
+
+// --- eviction and TRIM -----------------------------------------------------
+
+// evictOne removes the victim the policy names (design doc §2.3): the
+// smallest or largest key (the ends of the sorted table), or the smallest or
+// largest value in the eviction column, ties going to the smallest key.
+//
+// Ruling (mirrors the oracle): a cap above 0 with PolicyNone passes
+// Schema.Validate, so it still needs a deterministic victim — it evicts by
+// MIN_KEY, as does any policy byte outside the known set.
+func (e *schemaEngine) evictOne(pos int, policy uint8, byCol int) error {
+	rows := e.rows(pos)
+	if rows == 0 {
+		return nil
+	}
+	victim := 0
+	switch policy {
+	case wire.OperatePolicyMaxKey:
+		victim = rows - 1
+	case wire.OperatePolicyMinCol, wire.OperatePolicyMaxCol:
+		victim = e.colVictim(pos, policy == wire.OperatePolicyMaxCol, byCol)
+	default:
+		victim = 0
+	}
+	return e.removeRows(pos, victim, 1)
+}
+
+// colVictim scans the table once for the row with the smallest (or largest)
+// value in the eviction column; ties go to the first row in stored order,
+// which is the smallest key.
+func (e *schemaEngine) colVictim(pos int, wantMax bool, byCol int) int {
+	td := e.schema.Fields[pos].Table
+	tl := e.layout.Tables[pos]
+	if byCol < 0 || byCol >= len(td.Cols) {
+		// Unreachable: a *_COL schema policy is validated against the column
+		// count, and TRIM checks its own byCol. Kept as a total function.
+		return 0
+	}
+	typ, n := td.Cols[byCol].Type, td.Cols[byCol].N
+	width := wire.CellWidth(typ, n)
+	start := e.rowStart(pos, 0) + tl.ColOff[byCol]
+	best := 0
+	bestAt := start
+	for i := 1; i < e.rows(pos); i++ {
+		at := start + i*tl.RowWidth
+		ord := compareCellBytes(e.buf[at:at+width], e.buf[bestAt:bestAt+width], typ)
+		if (wantMax && ord > 0) || (!wantMax && ord < 0) {
+			best, bestAt = i, at
+		}
+	}
+	return best
+}
+
+// compareCellBytes orders two stored cells of the same type without decoding
+// them into a Cell. Floats compare as float64s (a NaN compares equal to
+// everything, so it never wins a tie-break), signed integers sign-extended,
+// unsigned ones zero-extended, and FIXED bytewise — the same order the
+// oracle's treeCompareCells produces for two cells of one type.
+func compareCellBytes(a, b []byte, typ uint8) int {
+	switch {
+	case wire.TypeIsFloat(typ):
+		af, bf := cellFloat(a, typ), cellFloat(b, typ)
+		switch {
+		case af < bf:
+			return -1
+		case af > bf:
+			return 1
+		default:
+			return 0
+		}
+	case wire.TypeIsUnsigned(typ):
+		av, bv := leUint(a), leUint(b)
+		switch {
+		case av < bv:
+			return -1
+		case av > bv:
+			return 1
+		default:
+			return 0
+		}
+	case wire.TypeIsInt(typ):
+		av, bv := signExtendLE(a), signExtendLE(b)
+		switch {
+		case av < bv:
+			return -1
+		case av > bv:
+			return 1
+		default:
+			return 0
+		}
+	default: // FIXED
+		return bytes.Compare(a, b)
+	}
+}
+
+func cellFloat(b []byte, typ uint8) float64 {
+	if typ == wire.OperateTypeF32 {
+		return float64(math.Float32frombits(uint32(leUint(b)))) //nolint:gosec // 4 bytes by construction
+	}
+	return math.Float64frombits(leUint(b))
+}
+
+// signExtendLE reads up to 8 little-endian bytes as a signed integer of that
+// width.
+func signExtendLE(b []byte) int64 {
+	v := leUint(b)
+	bits := uint(len(b)) * 8
+	if bits >= 64 {
+		return int64(v) //nolint:gosec // reinterpret the stored bits
+	}
+	shift := 64 - bits
+	return int64(v<<shift) >> shift //nolint:gosec // sign-extend
+}
+
+// trim implements engine.trim (design doc §3.2): a one-off shrink to keep
+// rows by the op's own policy, leaving the table's stored eviction config
+// alone. It evicts one row at a time (O(n·k)); k is the number of rows over
+// the target, which is small in every intended use.
+func (e *schemaEngine) trim(r ref, keep uint32, policy uint8, byCol uint16, byColName string) error {
+	_ = byColName // schema mode addresses the eviction column by position
+	if policy > wire.OperatePolicyMaxCol {
+		// An unknown policy byte is a schema-shaped error, the same one
+		// Schema.Validate returns for a table declaring it (oracle ruling).
+		return wire.ErrOperateSchema
+	}
+	if r.kind != refKindTable {
+		return wire.ErrOperatePath
+	}
+	td := e.schema.Fields[r.field].Table
+	if policy == wire.OperatePolicyMinCol || policy == wire.OperatePolicyMaxCol {
+		if int(byCol) >= len(td.Cols) {
+			return wire.ErrOperatePath
+		}
+	}
+	for e.rows(r.field) > int(keep) {
+		if err := e.evictOne(r.field, policy, int(byCol)); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// config implements engine.config: a schema-mode table's eviction triple
+// comes from its schema and cannot be set per record (design doc §3.2).
+func (e *schemaEngine) config(_ ref, _ uint32, _ uint8, _ string) error {
+	return wire.ErrOperateOpcode
+}
+
+// --- migrate ---------------------------------------------------------------
+
+// migrate implements engine.migrate for schema mode (design doc §2.8):
+// append-only schema evolution in one deterministic rewrite. Existing fields
+// and columns keep their bytes, appended ones are zero-filled, and a table
+// whose cap the new schema lowered is evicted down to it by the new policy.
+func (e *schemaEngine) migrate(from int64, flags uint8, schemaBlob []byte) error {
+	_ = flags // DROP_EXTRA only means anything to a dynamic-mode freeze
+	ent, n, err := e.cache.lookup(schemaBlob)
+	if err != nil {
+		return err
+	}
+	if n != len(schemaBlob) {
+		return wire.ErrOperateSchema
+	}
+	if from == wire.OperateMigrateFromDynamic {
+		// A freeze targets a dynamic record; this one is already frozen.
+		return wire.ErrOperateMode
+	}
+	if from < 0 || from > math.MaxUint16 || uint16(from) != e.schema.Version { //nolint:gosec // range-checked
+		return wire.ErrOperateSchemaVersion
+	}
+	if err := e.schema.Extends(ent.schema); err != nil {
+		return err
+	}
+	return e.rebuild(ent)
+}
+
+// rebuild rewrites the record under a new (append-only extended) schema:
+// fixed-width fields keep their bytes at their new offsets, each table's rows
+// are copied with the appended columns zero-filled, and appended fields start
+// at their zero.
+func (e *schemaEngine) rebuild(ent *schemaEntry) error {
+	old, oldLayout := e.schema, e.layout
+	size, err := e.rebuiltSize(ent)
+	if err != nil {
+		return err
+	}
+	out := make([]byte, 0, size+64)
+	out = append(out, wire.OperateModeSchema)
+	out = append(out, ent.blob...)
+
+	for i := range ent.schema.Fields {
+		off := ent.layout.FixedOff[i]
+		if off < 0 {
+			continue
+		}
+		w := wire.CellWidth(ent.schema.Fields[i].Type, ent.schema.Fields[i].N)
+		if i < len(old.Fields) {
+			at := e.hdrLen + oldLayout.FixedOff[i]
+			out = append(out, e.buf[at:at+w]...)
+			continue
+		}
+		out = appendZeros(out, w)
+	}
+
+	for _, i := range ent.layout.VarTail {
+		fd := &ent.schema.Fields[i]
+		if i >= len(old.Fields) { // an appended field: its zero is one byte
+			out = append(out, 0)
+			continue
+		}
+		if fd.Type != wire.OperateTypeTable {
+			at := e.fieldOff(i)
+			end := at + e.varFieldLen(i)
+			out = append(out, e.buf[at:end]...)
+			continue
+		}
+		out = e.appendMigratedTable(out, i, ent)
+	}
+
+	e.buf = out
+	e.ent, e.schema, e.layout = ent, ent.schema, ent.layout
+	e.hdrLen = 1 + len(ent.blob)
+	if len(ent.layout.VarTail) <= inlineTail {
+		e.tail = e.tailArr[:0]
+	} else {
+		e.tail = make([]tailEntry, 0, len(ent.layout.VarTail))
+	}
+	if err := e.reindexTail(); err != nil {
+		return err
+	}
+	// A lowered cap trims during the migration, by the new policy.
+	for _, i := range ent.layout.VarTail {
+		td := ent.schema.Fields[i].Table
+		if td == nil || td.Cap == 0 {
+			continue
+		}
+		for uint32(e.rows(i)) > td.Cap { //nolint:gosec // rows bounded by OperateMaxRows
+			if err := e.evictOne(i, td.Policy, int(td.ByCol)); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+// rebuiltSize is the exact byte length the rebuilt record will have, charged
+// against the record-size cap before anything is allocated for it.
+func (e *schemaEngine) rebuiltSize(ent *schemaEntry) (int, error) {
+	size := 1 + len(ent.blob) + ent.layout.FixedLen
+	for _, i := range ent.layout.VarTail {
+		if i >= len(e.schema.Fields) {
+			size++
+			continue
+		}
+		if ent.schema.Fields[i].Type != wire.OperateTypeTable {
+			size += e.varFieldLen(i)
+			continue
+		}
+		rows := e.rows(i)
+		size += uvarintLen(uint64(rows)) + rows*ent.layout.Tables[i].RowWidth //nolint:gosec // rows >= 0
+		if size < 0 || size > maxOperateRecordBytes {
+			return 0, wire.ErrOperateCap
+		}
+	}
+	if size > maxOperateRecordBytes {
+		return 0, wire.ErrOperateCap
+	}
+	return size, nil
+}
+
+// varFieldLen is the stored length of variable-length field i under the
+// engine's current schema.
+func (e *schemaEngine) varFieldLen(i int) int {
+	off := e.fieldOff(i)
+	slot := e.ent.tailSlot[i]
+	if slot+1 < len(e.tail) {
+		return e.tail[slot+1].off - off
+	}
+	return len(e.buf) - off
+}
+
+// appendMigratedTable copies table field i's rows into out under the new
+// schema, zero-filling every appended column.
+func (e *schemaEngine) appendMigratedTable(out []byte, i int, ent *schemaEntry) []byte {
+	rows := e.rows(i)
+	oldWidth := e.layout.Tables[i].RowWidth
+	newWidth := ent.layout.Tables[i].RowWidth
+	out = binary.AppendUvarint(out, uint64(rows)) //nolint:gosec // rows >= 0
+	at := e.rowStart(i, 0)
+	for r := 0; r < rows; r++ {
+		out = append(out, e.buf[at:at+oldWidth]...)
+		out = appendZeros(out, newWidth-oldWidth)
+		at += oldWidth
+	}
+	return out
+}
+
+func appendZeros(dst []byte, n int) []byte {
+	for i := 0; i < n; i++ {
+		dst = append(dst, 0)
+	}
+	return dst
+}
+
+// --- value, bytes, empty ---------------------------------------------------
+
+// value implements engine.value (design doc §3.4): the whole record, a
+// table's stored encoding behind the mode byte, a row's columns as tagged
+// cells, or one tagged scalar.
+func (e *schemaEngine) value(r ref) ([]byte, error) {
+	switch r.kind {
+	case refKindRecord:
+		return append([]byte(nil), e.buf...), nil
+	case refKindTable:
+		// Ruling (the oracle's): no schema blob rides along — the caller
+		// holds the schema, and the mode byte says which table layout
+		// follows.
+		off := e.rowsOff(r.field)
+		end := off + uvarintLen(uint64(e.rows(r.field))) + e.rows(r.field)*e.layout.Tables[r.field].RowWidth //nolint:gosec // rows >= 0
+		out := make([]byte, 0, 1+end-off)
+		out = append(out, wire.OperateModeSchema)
+		return append(out, e.buf[off:end]...), nil
+	case refKindRow:
+		return e.rowValue(r)
+	default:
+		c, err := e.get(r)
+		if err != nil {
+			return nil, err
+		}
+		return wire.AppendTaggedCell(nil, c), nil
+	}
+}
+
+// rowValue is [mode][nCols uvarint]{tagged cell}* in column order.
+func (e *schemaEngine) rowValue(r ref) ([]byte, error) {
+	td := e.schema.Fields[r.field].Table
+	tl := e.layout.Tables[r.field]
+	start := e.rowStart(r.field, r.row)
+	out := make([]byte, 0, 2+tl.RowWidth+len(td.Cols))
+	out = append(out, wire.OperateModeSchema)
+	out = binary.AppendUvarint(out, uint64(len(td.Cols)))
+	for c := range td.Cols {
+		cell, _, err := wire.DecodeCellData(td.Cols[c].Type, td.Cols[c].N, e.buf[start+tl.ColOff[c]:])
+		if err != nil {
+			return nil, err
+		}
+		out = wire.AppendTaggedCell(out, cell)
+	}
+	return out, nil
+}
+
+// bytes implements engine.bytes: the record's current encoded form, which is
+// the engine's working buffer itself.
+func (e *schemaEngine) bytes() []byte { return e.buf }
+
+// empty implements engine.empty. A schema-mode record is never implicitly
+// deleted — every declared field exists and an all-zero record is a valid
+// state (design doc §2.5) — so only DEL () empties it.
+func (e *schemaEngine) empty() bool { return e.deleted }

--- a/ops/operate_schema_engine.go
+++ b/ops/operate_schema_engine.go
@@ -1120,6 +1120,14 @@ func (e *schemaEngine) rebuiltSize(ent *schemaEntry) (int, error) {
 			return 0, wire.ErrOperateCap
 		}
 	}
+	// Unconditionally, not only per tail field: a target schema may have no
+	// variable-length fields at all (every field fixed-width is legal), and
+	// then the loop above never runs — while the header and the fixed area it
+	// already counted can exceed the cap on their own, since OperateMaxFields
+	// FIXED(255) fields are ~16.7 MB.
+	if size > uint64(maxOperateRecordBytes) { //nolint:gosec // maxOperateRecordBytes > 0
+		return 0, wire.ErrOperateCap
+	}
 	return int(size), nil //nolint:gosec // bounded by maxOperateRecordBytes, itself an int
 }
 

--- a/ops/operate_schema_engine.go
+++ b/ops/operate_schema_engine.go
@@ -440,8 +440,13 @@ func newSchemaRecord(schemaBlob []byte, cache *schemaCache) ([]byte, error) {
 // search, and a column is a constant offset within that row. Schema-mode
 // fields and columns always exist (design doc §2.5), so create only ever
 // vivifies a row.
-func (e *schemaEngine) resolve(p wire.OperatePath, create bool, typ, n uint8) (ref, error) {
+func (e *schemaEngine) resolve(p wire.OperatePath, create bool, opcode, typ, n uint8) (ref, error) {
 	_ = n // schema mode takes widths from the schema, never from the op
+	// The opcode only matters where a stored type can be replaced, which is
+	// dynamic mode's SET (design doc §2.9). A schema-mode field's type is
+	// the schema's, whatever the op says, so checkType below is the whole
+	// rule here.
+	_ = opcode
 	if p.Kind > wire.OperatePathCol {
 		return ref{}, wire.ErrOperatePath
 	}

--- a/ops/operate_schema_engine.go
+++ b/ops/operate_schema_engine.go
@@ -566,11 +566,12 @@ func (e *schemaEngine) colPos(td *wire.TableDef, seg wire.OperateSeg) (int, erro
 // Ruling: applyOps passes typ=0 for every op whose type byte is meaningless
 // (IF, CHECK, DEL, TRIM, and every return spec) and the op's own type byte
 // only for the scalar ops, which are exactly the ops that pass create=true —
-// so create is the signal that typ is a real type byte to check. The one
-// op this mis-reads is CONFIG, which also resolves with create=true (typ =
-// TABLE): aimed at a scalar field it fails here with ErrOperateType where the
-// oracle reports ErrOperateOpcode. Both reject the call with the record
-// unchanged, and CONFIG is never valid in schema mode at all.
+// so create is the signal that typ is a real type byte to check. CONFIG is
+// never reached here: resolve rejects it with ErrOperateOpcode before the
+// path is even looked at, because CONFIG is not a valid op on a schema-mode
+// record at all (its eviction triple comes from the schema, design doc
+// §3.2). checkType's only callers are the field- and column-path scalar
+// cases above, both already past that CONFIG check.
 func (e *schemaEngine) checkType(create bool, typ, want uint8) error {
 	if !create || typ == wire.OperateTypeFromSchema || typ == want {
 		return nil

--- a/ops/operate_schema_engine.go
+++ b/ops/operate_schema_engine.go
@@ -442,11 +442,19 @@ func newSchemaRecord(schemaBlob []byte, cache *schemaCache) ([]byte, error) {
 // vivifies a row.
 func (e *schemaEngine) resolve(p wire.OperatePath, create bool, opcode, typ, n uint8) (ref, error) {
 	_ = n // schema mode takes widths from the schema, never from the op
-	// The opcode only matters where a stored type can be replaced, which is
-	// dynamic mode's SET (design doc §2.9). A schema-mode field's type is
-	// the schema's, whatever the op says, so checkType below is the whole
-	// rule here.
-	_ = opcode
+	if opcode == wire.OperateOpCONFIG {
+		// A schema-mode table's eviction triple comes from its schema and
+		// cannot be set per record (design doc §3.2), so CONFIG is not an op
+		// this record has at all — reported here, before the path is even
+		// looked at, because that is where the oracle reports it (its config
+		// checks the record's mode first). config() answers the same thing
+		// for a caller that gets past this.
+		return ref{}, wire.ErrOperateOpcode
+	}
+	// The opcode otherwise only matters where a stored type can be replaced,
+	// which is dynamic mode's SET (design doc §2.9). A schema-mode field's
+	// type is the schema's, whatever the op says, so checkType below is the
+	// whole rule here.
 	if p.Kind > wire.OperatePathCol {
 		return ref{}, wire.ErrOperatePath
 	}

--- a/ops/operate_schema_engine.go
+++ b/ops/operate_schema_engine.go
@@ -66,16 +66,30 @@ func newSchemaCache(max int) *schemaCache {
 	return &schemaCache{max: max, ents: make(map[string]*schemaEntry, max)}
 }
 
-// get decodes the schema blob at the front of b, returning the schema and its
-// layout. It is the contract's entry point; lookup below is the internal form
-// that also reports how many bytes the blob occupied (a stored record's blob
-// is a prefix of the record, a call's blob is the whole argument).
+// get decodes a call's schema blob, returning the schema and its layout. It is
+// the contract's entry point and, like every call-argument path, requires the
+// blob to be exactly one schema.
 func (c *schemaCache) get(b []byte) (*wire.Schema, *wire.Layout, error) {
-	ent, _, err := c.lookup(b)
+	ent, err := c.lookupCall(b)
 	if err != nil {
 		return nil, nil, err
 	}
 	return ent.schema, ent.layout, nil
+}
+
+// lookupCall is the call-argument form of lookup: the blob a call carries must
+// be exactly one schema, with nothing after it (the oracle's treeOpen rejects a
+// trailing byte the same way). A stored record's blob, by contrast, is a prefix
+// of the record and uses lookup directly.
+func (c *schemaCache) lookupCall(b []byte) (*schemaEntry, error) {
+	ent, n, err := c.lookup(b)
+	if err != nil {
+		return nil, err
+	}
+	if n != len(b) {
+		return nil, wire.ErrOperateSchema
+	}
+	return ent, nil
 }
 
 // lookup returns the cached entry for the schema blob at the front of b and
@@ -404,14 +418,9 @@ func newSchemaRecord(schemaBlob []byte, cache *schemaCache) ([]byte, error) {
 	if len(schemaBlob) == 0 {
 		return nil, wire.ErrOperateSchema
 	}
-	ent, n, err := cache.lookup(schemaBlob)
+	ent, err := cache.lookupCall(schemaBlob)
 	if err != nil {
 		return nil, err
-	}
-	if n != len(schemaBlob) {
-		// Trailing bytes after the schema: the call's blob must be exactly
-		// one schema (mirrors the oracle's treeOpen).
-		return nil, wire.ErrOperateSchema
 	}
 	size := 1 + len(ent.blob) + ent.layout.FixedLen + len(ent.layout.VarTail)
 	if size > maxOperateRecordBytes {
@@ -571,7 +580,13 @@ func (e *schemaEngine) rows(pos int) int { return e.tail[e.ent.tailSlot[pos]].ro
 // rowsOff is the offset of the table field's row count uvarint.
 func (e *schemaEngine) rowsOff(pos int) int { return e.tail[e.ent.tailSlot[pos]].off }
 
-// rowStart is the offset of row idx of the table field at pos.
+// rowStart is the offset of row idx of the table field at pos. idx*RowWidth
+// cannot overflow: reindexTail admitted the table only after CountFitsIn
+// proved rows*RowWidth fits the buffer, and idx <= rows. Every other
+// count-times-width product in this file (reindexTail, removeRows, colVictim,
+// value) is bounded the same way, by the buffer that already holds the rows;
+// rebuiltSize is the one that projects a *new* width and so does its
+// arithmetic in uint64.
 func (e *schemaEngine) rowStart(pos, idx int) int {
 	ent := &e.tail[e.ent.tailSlot[pos]]
 	return ent.off + uvarintLen(uint64(ent.rows)) + idx*e.layout.Tables[pos].RowWidth //nolint:gosec // rows >= 0
@@ -998,12 +1013,9 @@ func (e *schemaEngine) config(_ ref, _ uint32, _ uint8, _ string) error {
 // whose cap the new schema lowered is evicted down to it by the new policy.
 func (e *schemaEngine) migrate(from int64, flags uint8, schemaBlob []byte) error {
 	_ = flags // DROP_EXTRA only means anything to a dynamic-mode freeze
-	ent, n, err := e.cache.lookup(schemaBlob)
+	ent, err := e.cache.lookupCall(schemaBlob)
 	if err != nil {
 		return err
-	}
-	if n != len(schemaBlob) {
-		return wire.ErrOperateSchema
 	}
 	if from == wire.OperateMigrateFromDynamic {
 		// A freeze targets a dynamic record; this one is already frozen.
@@ -1090,26 +1102,36 @@ func (e *schemaEngine) rebuild(ent *schemaEntry) error {
 // rebuiltSize is the exact byte length the rebuilt record will have, charged
 // against the record-size cap before anything is allocated for it.
 func (e *schemaEngine) rebuiltSize(ent *schemaEntry) (int, error) {
-	size := 1 + len(ent.blob) + ent.layout.FixedLen
+	// Accumulated in uint64, never int: the migration can widen every row, so
+	// rows x newRowWidth reaches 2^20 x 4096 = 2^32 — which wraps to a small
+	// positive on a 32-bit int and would slip past the cap check, leaving
+	// rebuild to append unbounded.
+	size := uint64(1) + uint64(len(ent.blob)) + uint64(ent.layout.FixedLen)
 	for _, i := range ent.layout.VarTail {
-		if i >= len(e.schema.Fields) {
+		switch {
+		case i >= len(e.schema.Fields):
 			size++
-			continue
+		case ent.schema.Fields[i].Type != wire.OperateTypeTable:
+			size += uint64(e.varFieldLen(i)) //nolint:gosec // a stored length, bounded by the buffer
+		default:
+			size += tableBytes(e.rows(i), ent.layout.Tables[i].RowWidth)
 		}
-		if ent.schema.Fields[i].Type != wire.OperateTypeTable {
-			size += e.varFieldLen(i)
-			continue
-		}
-		rows := e.rows(i)
-		size += uvarintLen(uint64(rows)) + rows*ent.layout.Tables[i].RowWidth //nolint:gosec // rows >= 0
-		if size < 0 || size > maxOperateRecordBytes {
+		if size > uint64(maxOperateRecordBytes) { //nolint:gosec // maxOperateRecordBytes > 0
 			return 0, wire.ErrOperateCap
 		}
 	}
-	if size > maxOperateRecordBytes {
-		return 0, wire.ErrOperateCap
+	return int(size), nil //nolint:gosec // bounded by maxOperateRecordBytes, itself an int
+}
+
+// tableBytes is the stored size of a table of rows rows at rowWidth bytes each,
+// computed in uint64 so the product cannot wrap: rows is bounded by
+// OperateMaxRows (2^20) and rowWidth by OperateMaxRowWidth (4096), whose
+// product does not fit a 32-bit int.
+func tableBytes(rows, rowWidth int) uint64 {
+	if rows < 0 || rowWidth < 0 {
+		return 0
 	}
-	return size, nil
+	return uint64(uvarintLen(uint64(rows))) + uint64(rows)*uint64(rowWidth)
 }
 
 // varFieldLen is the stored length of variable-length field i under the

--- a/ops/operate_schema_engine_test.go
+++ b/ops/operate_schema_engine_test.go
@@ -49,9 +49,9 @@ func TestSchemaEngineMatchesOracle(t *testing.T) {
 			a := randomArgs(sub, s)
 			o, ores, oerr := applyTree(oracle, a, int64(iter))
 			e, eres, eerr := bytesApply(engine, a, int64(iter))
-			if (oerr == nil) != (eerr == nil) {
-				t.Fatalf("seed %d call %d: oracle err %v, engine err %v\nschema %+v\nargs %+v",
-					seed, call, oerr, eerr, s, a)
+			if operateErrName(oerr) != operateErrName(eerr) {
+				t.Fatalf("seed %d call %d: oracle err %q, engine err %q\nschema %+v\nargs %+v",
+					seed, call, operateErrName(oerr), operateErrName(eerr), s, a)
 			}
 			if oerr != nil {
 				continue

--- a/ops/operate_schema_engine_test.go
+++ b/ops/operate_schema_engine_test.go
@@ -468,3 +468,83 @@ func mustDecode(t *testing.T, b []byte) *wire.Record {
 	}
 	return rec
 }
+
+// TestMigrateSizeCapAllFixedTarget covers the record-size check for a target
+// schema with no variable-length fields at all: the per-tail-field check
+// inside rebuiltSize's loop never runs there, so the cap has to be tested
+// unconditionally as well. A maximal all-fixed schema (OperateMaxFields
+// FIXED(255) fields) is ~16.7 MB of fixed area on its own, past the 16 MiB
+// record cap, with no table anywhere to trip the in-loop check.
+func TestMigrateSizeCapAllFixedTarget(t *testing.T) {
+	s := &wire.Schema{Version: 1, Fields: []wire.FieldDef{{Name: "f0", Type: wire.OperateTypeU64}}}
+	base, _, _, err := applyRecordBytes(nil, &wire.OperateArgs{Create: wire.OperateCreateSchema,
+		Schema: s.Encode(), Ops: []wire.OperateOp{
+			{Opcode: wire.OperateOpADD, Type: opFromSchema, Path: fieldPath(0), A: 7}}}, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	stored := append([]byte(nil), base...)
+
+	ns := &wire.Schema{Version: 2, Fields: append([]wire.FieldDef(nil), s.Fields...)}
+	for i := 0; i < 40; i++ { // 40 x 255 = 10200 bytes of fixed area, no tail at all
+		ns.Fields = append(ns.Fields, wire.FieldDef{
+			Name: fmt.Sprintf("w%d", i), Type: wire.OperateTypeFixed, N: 255})
+	}
+	if err := ns.Validate(); err != nil {
+		t.Fatal(err)
+	}
+	layout, err := ns.Layout()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(layout.VarTail) != 0 {
+		t.Fatalf("the target schema must have an empty tail for this test to mean anything: %v", layout.VarTail)
+	}
+	migrate := &wire.OperateArgs{Create: wire.OperateCreateNone, Ops: []wire.OperateOp{
+		{Opcode: wire.OperateOpMIGRATE, Type: opFromSchema, Path: recPath(), A: 1, Bytes: ns.Encode()}}}
+
+	// It fits under the default cap.
+	out, _, _, err := applyRecordBytes(stored, migrate, 0)
+	if err != nil {
+		t.Fatalf("migration under the cap: %v", err)
+	}
+	if _, derr := wire.DecodeRecord(out); derr != nil {
+		t.Fatalf("migrated record does not decode: %v", derr)
+	}
+
+	// It does not fit under a lowered one. The assertion that matters is on
+	// rebuiltSize itself: applyRecordBytes also checks the finished record, so
+	// an end-to-end ErrOperateCap alone would pass even with the cap check
+	// missing — while rebuild would already have allocated and filled the
+	// oversized buffer to get there.
+	restore := maxOperateRecordBytes
+	maxOperateRecordBytes = 1024
+	t.Cleanup(func() { maxOperateRecordBytes = restore })
+
+	e, err := newSchemaEngine(append([]byte(nil), stored...), operateSchemas)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ent, err := operateSchemas.lookupCall(ns.Encode())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(ent.layout.VarTail) != 0 {
+		t.Fatal("the cached target entry must have an empty tail")
+	}
+	if _, err := e.rebuiltSize(ent); !errors.Is(err, wire.ErrOperateCap) {
+		t.Fatalf("rebuiltSize err=%v, want ErrOperateCap — an all-fixed target schema reaches "+
+			"no per-tail-field check, so the size must be tested unconditionally", err)
+	}
+
+	out, deleted, res, err := applyRecordBytes(stored, migrate, 0)
+	if !errors.Is(err, wire.ErrOperateCap) {
+		t.Fatalf("err=%v, want ErrOperateCap", err)
+	}
+	if out != nil || deleted || res != nil {
+		t.Fatalf("a refused migration returned out=%x deleted=%v res=%+v", out, deleted, res)
+	}
+	if !bytes.Equal(stored, base) {
+		t.Fatal("the stored record was mutated by a refused migration")
+	}
+}

--- a/ops/operate_schema_engine_test.go
+++ b/ops/operate_schema_engine_test.go
@@ -22,8 +22,10 @@ import (
 )
 
 // TestSchemaEngineSemantics runs the whole semantics suite against the byte
-// engine. Dynamic-mode sub-tests are skipped until the dynamic engine lands
-// (Task 10); every other rule in the suite must hold here.
+// engine with dynamic mode switched off: this is the schema-only lane, which
+// keeps the skipDynamic mechanism exercised and pins that every schema-mode
+// and mode-independent rule holds without the dynamic engine ever running.
+// TestDynamicEngineSemantics runs the same suite with both modes enabled.
 func TestSchemaEngineSemantics(t *testing.T) {
 	skipDynamic = true
 	t.Cleanup(func() { skipDynamic = false })
@@ -282,7 +284,7 @@ func TestNewSchemaEngineValidates(t *testing.T) {
 	if e.empty() {
 		t.Fatal("a fresh engine reports the record deleted")
 	}
-	r, err := e.resolve(colPath(3, keyU64(1), 0), false, opFromSchema, 0)
+	r, err := e.resolve(colPath(3, keyU64(1), 0), false, wire.OperateOpIF, opFromSchema, 0)
 	if err != nil || !r.present {
 		t.Fatalf("resolve: %v %+v", err, r)
 	}

--- a/ops/operate_schema_engine_test.go
+++ b/ops/operate_schema_engine_test.go
@@ -378,8 +378,6 @@ func TestTableBytesIs64Bit(t *testing.T) {
 // rebuilt record has to fit maxRecordBytes, and a migration that would blow it
 // fails with the record unchanged.
 func TestMigrateSizeCap(t *testing.T) {
-	s := sessionSchema()
-	s.Fields[3].Table.Cap = 0
 	base := bigSessionRecord(t, 64)
 	var stored []byte
 	stored = append(stored, base...)

--- a/ops/operate_schema_engine_test.go
+++ b/ops/operate_schema_engine_test.go
@@ -12,6 +12,7 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
+	"math"
 	"math/rand"
 	"reflect"
 	"sync"
@@ -223,8 +224,9 @@ func TestSchemaEngineNeverPanics(t *testing.T) {
 	}
 }
 
-// safeApply turns a panic into a test failure signal rather than tearing the
-// run down, so the frame that caused it is reported.
+// safeApply re-panics with the frame that caused it: a bare panic from deep
+// inside the engine says nothing about which of the thousand corpus entries
+// reached it, and that input is the whole finding.
 func safeApply(cur []byte, a *wire.OperateArgs) (out []byte, deleted bool, res *wire.OperateResult, err error) {
 	defer func() {
 		if r := recover(); r != nil {
@@ -339,4 +341,130 @@ func TestSchemaEngineConcurrent(t *testing.T) {
 		}(g)
 	}
 	wg.Wait()
+}
+
+// TestTableBytesIs64Bit pins the arithmetic MIGRATE's size check depends on. A
+// migration may widen every row, so the projected size is rows x the NEW row
+// width — at the caps, 2^20 x 4096 = 2^32, which wraps to a small positive on
+// a 32-bit int and would slip past the record cap, leaving the rebuild to
+// append unbounded inside FSM apply. The product cannot be built as a real
+// record (it is 4 GiB), so the arithmetic is tested directly.
+func TestTableBytesIs64Bit(t *testing.T) {
+	const rows, width = 1 << 20, 4096 // wire.OperateMaxRows x wire.OperateMaxRowWidth
+	got := tableBytes(rows, width)
+	want := uint64(uvarintLen(rows)) + uint64(rows)*uint64(width)
+	if got != want {
+		t.Fatalf("tableBytes=%d, want %d", got, want)
+	}
+	if got <= math.MaxInt32 {
+		t.Fatalf("tableBytes=%d does not exceed MaxInt32, so this test proves nothing", got)
+	}
+	// The naive 32-bit product this replaces wrapped to a value that passes
+	// every cap check.
+	if wrapped := int32(uint32(got)); wrapped >= 0 && wrapped < 16<<20 { //nolint:gosec // demonstrating the wrap
+		t.Logf("a 32-bit int would have seen %d bytes instead of %d", wrapped, got)
+	}
+	if got <= uint64(maxOperateRecordBytes) {
+		t.Fatalf("tableBytes=%d is under the record cap %d", got, maxOperateRecordBytes)
+	}
+	if tableBytes(-1, width) != 0 || tableBytes(rows, -1) != 0 {
+		t.Fatal("negative inputs must not produce a size")
+	}
+}
+
+// TestMigrateSizeCap drives the same check through a real migration: the
+// rebuilt record has to fit maxRecordBytes, and a migration that would blow it
+// fails with the record unchanged.
+func TestMigrateSizeCap(t *testing.T) {
+	s := sessionSchema()
+	s.Fields[3].Table.Cap = 0
+	base := bigSessionRecord(t, 64)
+	var stored []byte
+	stored = append(stored, base...)
+
+	// Widen every row by appending eight FIXED(255) columns: 64 rows x 2040
+	// new bytes is far past the lowered cap.
+	ns := sessionSchema()
+	ns.Version = 2
+	for i := 0; i < 8; i++ {
+		ns.Fields[3].Table.Cols = append(ns.Fields[3].Table.Cols,
+			wire.ColumnDef{Name: fmt.Sprintf("w%d", i), Type: wire.OperateTypeFixed, N: 255})
+	}
+	if err := ns.Validate(); err != nil {
+		t.Fatal(err)
+	}
+	migrate := &wire.OperateArgs{Create: wire.OperateCreateNone, Ops: []wire.OperateOp{
+		{Opcode: wire.OperateOpMIGRATE, Type: opFromSchema, Path: recPath(), A: 1, Bytes: ns.Encode()}}}
+
+	// It fits by default...
+	out, _, _, err := applyRecordBytes(stored, migrate, 0)
+	if err != nil {
+		t.Fatalf("migration under the cap: %v", err)
+	}
+	if _, derr := wire.DecodeRecord(out); derr != nil {
+		t.Fatalf("migrated record does not decode: %v", derr)
+	}
+	// ...and is refused when it does not.
+	restore := maxOperateRecordBytes
+	maxOperateRecordBytes = len(stored) + 1024
+	t.Cleanup(func() { maxOperateRecordBytes = restore })
+	out, _, _, err = applyRecordBytes(stored, migrate, 0)
+	if !errors.Is(err, wire.ErrOperateCap) {
+		t.Fatalf("err=%v, want ErrOperateCap", err)
+	}
+	if out != nil {
+		t.Fatal("a refused migration returned a record to store")
+	}
+	if !bytes.Equal(stored, base) {
+		t.Fatal("the stored record was mutated by a refused migration")
+	}
+}
+
+// TestSchemaBlobMustBeExact: a call's schema blob is exactly one schema. A
+// trailing byte is rejected whether the record exists or not — the oracle
+// rejects it in treeOpen either way, and accepting it on one path only would
+// make "the same call" mean two things.
+func TestSchemaBlobMustBeExact(t *testing.T) {
+	s := sessionSchema()
+	exact := s.Encode()
+	trailing := append(append([]byte(nil), exact...), 0)
+
+	mk := func(blob []byte) *wire.OperateArgs {
+		return &wire.OperateArgs{Create: wire.OperateCreateSchema, Schema: blob,
+			Ops: []wire.OperateOp{{Opcode: wire.OperateOpADD, Type: opFromSchema, Path: fieldPath(0), A: 1}}}
+	}
+	base, _, _, err := applyRecordBytes(nil, mk(exact), 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, tc := range []struct {
+		name string
+		cur  []byte
+	}{{"absent record", nil}, {"existing record", base}} {
+		out, _, _, err := applyRecordBytes(tc.cur, mk(trailing), 0)
+		if !errors.Is(err, wire.ErrOperateSchema) {
+			t.Errorf("%s: err=%v, want ErrOperateSchema", tc.name, err)
+		}
+		if out != nil {
+			t.Errorf("%s: returned a record to store", tc.name)
+		}
+	}
+	// The oracle agrees, on both paths.
+	for _, tc := range []struct {
+		name string
+		rec  *wire.Record
+	}{{"absent record", nil}, {"existing record", mustDecode(t, base)}} {
+		if _, _, err := applyTree(tc.rec, mk(trailing), 0); !errors.Is(err, wire.ErrOperateSchema) {
+			t.Errorf("oracle, %s: err=%v, want ErrOperateSchema", tc.name, err)
+		}
+	}
+}
+
+func mustDecode(t *testing.T, b []byte) *wire.Record {
+	t.Helper()
+	rec, err := wire.DecodeRecord(b)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return rec
 }

--- a/ops/operate_schema_engine_test.go
+++ b/ops/operate_schema_engine_test.go
@@ -1,0 +1,342 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package ops
+
+// Tests for the schema-mode byte engine (design doc §2.6). The engine's
+// correctness is defined by the tree oracle in operate_oracle_test.go: the
+// semantics suite runs against both, and the property test below compares
+// them op-for-op on random schemas and random op lists, down to the stored
+// bytes.
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"math/rand"
+	"reflect"
+	"sync"
+	"testing"
+
+	"github.com/rostamlabs/rostam/sdk/wire"
+)
+
+// TestSchemaEngineSemantics runs the whole semantics suite against the byte
+// engine. Dynamic-mode sub-tests are skipped until the dynamic engine lands
+// (Task 10); every other rule in the suite must hold here.
+func TestSchemaEngineSemantics(t *testing.T) {
+	skipDynamic = true
+	t.Cleanup(func() { skipDynamic = false })
+	runSemantics(t, bytesApply)
+}
+
+// TestSchemaEngineMatchesOracle is the equivalence property: for random
+// schemas and random op lists drawn from the whole vocabulary, the byte
+// engine and the tree oracle must agree on whether the call errors, on the
+// result frame, and on the stored bytes — call after call, so divergences
+// that only show up on an already-diverged record are caught too.
+func TestSchemaEngineMatchesOracle(t *testing.T) {
+	const iters = 2000
+	rng := rand.New(rand.NewSource(1)) //nolint:gosec // deterministic test input, not cryptography
+	for iter := 0; iter < iters; iter++ {
+		seed := rng.Int63()
+		sub := rand.New(rand.NewSource(seed)) //nolint:gosec // deterministic test input
+		s := randomSchema(sub)
+		var oracle, engine *wire.Record
+		for call := 0; call < 5; call++ {
+			a := randomArgs(sub, s)
+			o, ores, oerr := applyTree(oracle, a, int64(iter))
+			e, eres, eerr := bytesApply(engine, a, int64(iter))
+			if (oerr == nil) != (eerr == nil) {
+				t.Fatalf("seed %d call %d: oracle err %v, engine err %v\nschema %+v\nargs %+v",
+					seed, call, oerr, eerr, s, a)
+			}
+			if oerr != nil {
+				continue
+			}
+			if !reflect.DeepEqual(ores, eres) {
+				t.Fatalf("seed %d call %d: results differ\noracle %+v\nengine %+v\nargs %+v",
+					seed, call, ores, eres, a)
+			}
+			if (o == nil) != (e == nil) {
+				t.Fatalf("seed %d call %d: oracle nil=%v engine nil=%v\nargs %+v", seed, call, o == nil, e == nil, a)
+			}
+			if o != nil && !bytes.Equal(o.Encode(), e.Encode()) {
+				t.Fatalf("seed %d call %d: bytes differ\noracle %x\nengine %x\nargs %+v",
+					seed, call, o.Encode(), e.Encode(), a)
+			}
+			oracle, engine = o, e
+			// A MIGRATE call moves the record to the schema it carries, so
+			// later calls in this iteration must speak the new version.
+			if ns := migratedSchema(a); ns != nil {
+				s = ns
+			}
+		}
+	}
+}
+
+// bigSessionRecord builds the design doc's §4 session record with n bidder
+// rows: the shape the §2.6 allocation budget is quoted against.
+func bigSessionRecord(t *testing.T, n int) []byte {
+	t.Helper()
+	s := sessionSchema()
+	a := &wire.OperateArgs{Create: wire.OperateCreateSchema, Schema: s.Encode()}
+	for k := 0; k < n; k++ {
+		a.Ops = append(a.Ops, wire.OperateOp{Opcode: wire.OperateOpADD, Type: opFromSchema,
+			Path: colPath(3, keyU64(uint64(k)), 0), A: 1})
+	}
+	out, _, _, err := applyRecordBytes(nil, a, 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, derr := wire.DecodeRecord(out); derr != nil {
+		t.Fatal(derr)
+	}
+	return out
+}
+
+// sessionArgsFor is the worked example's per-request op list against one
+// existing bidder row: six ops that all patch fixed-width cells in place.
+func sessionArgsFor(key []byte) *wire.OperateArgs {
+	s := sessionSchema()
+	return &wire.OperateArgs{Create: wire.OperateCreateSchema, Schema: s.Encode(), Ops: []wire.OperateOp{
+		{Opcode: wire.OperateOpADD, Type: opFromSchema, Path: fieldPath(0), A: 1},
+		{Opcode: wire.OperateOpADD, Type: opFromSchema, Path: fieldPath(1), A: 1},
+		{Opcode: wire.OperateOpOR, Type: opFromSchema, Path: fieldPath(2), A: 4},
+		{Opcode: wire.OperateOpADD, Type: opFromSchema, Path: colPath(3, key, 0), A: 1},
+		{Opcode: wire.OperateOpMAX, Type: opFromSchema, Path: colPath(3, key, 1), A: 500},
+		{Opcode: wire.OperateOpSTAMP, Type: opFromSchema, Aux: wire.OperateStampS, Path: colPath(3, key, 2)},
+	}}
+}
+
+// TestSchemaEngineAllocs pins the design doc §2.6 budget for the in-place
+// path: one allocation for the record copy and one for the result frame. A
+// regression here means the engine started building something per call —
+// exactly the cost the byte engine exists to avoid.
+func TestSchemaEngineAllocs(t *testing.T) {
+	rec := bigSessionRecord(t, 1024)
+	a := sessionArgsFor(keyU64(512))
+	a.Rets = nil
+	allocs := testing.AllocsPerRun(50, func() {
+		if _, _, _, err := applyRecordBytes(rec, a, 1); err != nil {
+			t.Fatal(err)
+		}
+	})
+	if allocs > 2 {
+		t.Fatalf("%v allocations per apply, want at most 2", allocs)
+	}
+	t.Logf("allocations per apply: %v", allocs)
+}
+
+// TestSchemaRecordSizeCap covers §2.7's record-size backstop: a call that
+// would store an over-large record fails with ErrOperateCap and the stored
+// bytes untouched.
+func TestSchemaRecordSizeCap(t *testing.T) {
+	s := floatSchema()
+	base, _, _, err := applyRecordBytes(nil, &wire.OperateArgs{Create: wire.OperateCreateSchema, Schema: s.Encode(),
+		Ops: []wire.OperateOp{{Opcode: wire.OperateOpSET, Type: opFromSchema, Path: fieldPath(2),
+			Bytes: bytes.Repeat([]byte{7}, 64)}}}, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	before := append([]byte(nil), base...)
+
+	restore := maxOperateRecordBytes
+	maxOperateRecordBytes = len(base) + 16
+	t.Cleanup(func() { maxOperateRecordBytes = restore })
+
+	out, deleted, res, err := applyRecordBytes(base, &wire.OperateArgs{Create: wire.OperateCreateSchema, Schema: s.Encode(),
+		Ops: []wire.OperateOp{{Opcode: wire.OperateOpSET, Type: opFromSchema, Path: fieldPath(2),
+			Bytes: bytes.Repeat([]byte{7}, 4096)}}}, 0)
+	if !errors.Is(err, wire.ErrOperateCap) {
+		t.Fatalf("err=%v, want ErrOperateCap", err)
+	}
+	if out != nil || deleted || res != nil {
+		t.Fatalf("a failed call returned out=%x deleted=%v res=%+v", out, deleted, res)
+	}
+	if !bytes.Equal(base, before) {
+		t.Fatal("the stored record was mutated by a failing call")
+	}
+}
+
+// TestSchemaEngineNeverPanics feeds applyRecordBytes stored bytes it must
+// treat as hostile: a plain `put` can store anything under an operate key, so
+// every offset in the engine is derived from a bounds-checked walk. Truncated
+// records, single-byte mutations and the shared hostile frames must all come
+// back as an error with no output, never a panic.
+func TestSchemaEngineNeverPanics(t *testing.T) {
+	valid := bigSessionRecord(t, 4)
+	a := sessionArgsFor(keyU64(2))
+	a.Rets = []wire.OperateRet{
+		{Mode: wire.OperateRetValue, Path: recPath()},
+		{Mode: wire.OperateRetValue, Path: fieldPath(3)},
+		{Mode: wire.OperateRetValue, Path: rowPath(3, keyU64(2))},
+		{Mode: wire.OperateRetCount, Path: fieldPath(3)},
+	}
+	del := &wire.OperateArgs{Create: wire.OperateCreateNone, Ops: []wire.OperateOp{
+		{Opcode: wire.OperateOpDEL, Type: opFromSchema, Path: rowPath(3, keyU64(1))},
+		{Opcode: wire.OperateOpTRIM, Type: opFromSchema, Path: fieldPath(3), A: 1,
+			Aux: wire.OperatePolicyMinCol, B: 2},
+	}}
+
+	var corpus [][]byte
+	for i := 0; i <= len(valid); i++ { // every prefix, including the empty one
+		corpus = append(corpus, append([]byte(nil), valid[:i]...))
+	}
+	for i := range valid { // every single-byte mutation
+		for _, delta := range []byte{1, 0x80, 0xFF} {
+			m := append([]byte(nil), valid...)
+			m[i] += delta
+			corpus = append(corpus, m)
+		}
+	}
+	for _, body := range hostileBodies() { // the shared hostile frames, as schema records
+		corpus = append(corpus, append([]byte{wire.OperateModeSchema}, body...))
+	}
+
+	for _, args := range []*wire.OperateArgs{a, del} {
+		for _, in := range corpus {
+			before := append([]byte(nil), in...)
+			out, deleted, res, err := safeApply(in, args)
+			if err != nil {
+				if out != nil || deleted || res != nil {
+					t.Fatalf("error path returned output for %x: out=%x deleted=%v res=%+v", in, out, deleted, res)
+				}
+			} else if out != nil {
+				// Ruling: the engine bounds-checks the frame but does not
+				// re-verify that stored rows are strictly ascending — that is
+				// an O(rows) walk on every call, exactly the cost §2.6 exists
+				// to avoid, and getting it wrong only ever garbles a record
+				// that was already garbled. So the guarantee is valid in,
+				// valid out: a record the codec accepts must still be one
+				// after the call.
+				if _, derr := wire.DecodeRecord(in); derr != nil {
+					continue
+				}
+				if _, derr := wire.DecodeRecord(out); derr != nil {
+					t.Fatalf("accepted valid %x and produced undecodable %x: %v", in, out, derr)
+				}
+			}
+			if !bytes.Equal(in, before) {
+				t.Fatalf("input mutated: %x -> %x", before, in)
+			}
+		}
+	}
+}
+
+// safeApply turns a panic into a test failure signal rather than tearing the
+// run down, so the frame that caused it is reported.
+func safeApply(cur []byte, a *wire.OperateArgs) (out []byte, deleted bool, res *wire.OperateResult, err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			panic(fmt.Sprintf("applyRecordBytes panicked on %x: %v", cur, r))
+		}
+	}()
+	return applyRecordBytes(cur, a, 1)
+}
+
+// TestSchemaBlobLenAgreesWithDecode checks the cache's fast path against the
+// authority: for any well-formed blob, the framing walk must report exactly
+// the length DecodeSchema consumes, or a cache hit could be keyed on the
+// wrong bytes.
+func TestSchemaBlobLenAgreesWithDecode(t *testing.T) {
+	rng := rand.New(rand.NewSource(3)) //nolint:gosec // deterministic test input
+	schemas := []*wire.Schema{sessionSchema(), frozenSchema(), floatSchema(), widenedSchema()}
+	for i := 0; i < 500; i++ {
+		schemas = append(schemas, randomSchema(rng))
+	}
+	for _, s := range schemas {
+		blob := s.Encode()
+		_, n, err := wire.DecodeSchema(blob)
+		if err != nil {
+			t.Fatalf("%+v: %v", s, err)
+		}
+		got, ok := schemaBlobLen(blob)
+		if !ok || got != n {
+			t.Fatalf("schemaBlobLen=%d,%v want %d for %x", got, ok, n, blob)
+		}
+		// Trailing bytes must not change the answer: a stored record's blob
+		// is a prefix of the record.
+		got, ok = schemaBlobLen(append(blob, 1, 2, 3))
+		if !ok || got != n {
+			t.Fatalf("with a suffix: schemaBlobLen=%d,%v want %d", got, ok, n)
+		}
+	}
+}
+
+// TestNewSchemaEngineValidates covers the constructor directly: it must accept
+// a well-formed stored record and index its tail, and reject anything whose
+// frame does not walk exactly to the end of the buffer.
+func TestNewSchemaEngineValidates(t *testing.T) {
+	valid := bigSessionRecord(t, 3)
+	cache := newSchemaCache(4)
+
+	e, err := newSchemaEngine(append([]byte(nil), valid...), cache)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := e.rows(3); got != 3 {
+		t.Fatalf("rows=%d, want 3", got)
+	}
+	if e.empty() {
+		t.Fatal("a fresh engine reports the record deleted")
+	}
+	r, err := e.resolve(colPath(3, keyU64(1), 0), false, opFromSchema, 0)
+	if err != nil || !r.present {
+		t.Fatalf("resolve: %v %+v", err, r)
+	}
+	c, err := e.get(r)
+	if err != nil || c.U != 1 || c.Type != wire.OperateTypeU16 {
+		t.Fatalf("get: %v %+v", err, c)
+	}
+
+	bad := map[string][]byte{
+		"empty":            {},
+		"unknown mode":     {9},
+		"dynamic mode":     {wire.OperateModeDynamic, 0},
+		"schema only":      append([]byte{wire.OperateModeSchema}, sessionSchema().Encode()...),
+		"truncated tail":   valid[:len(valid)-1],
+		"trailing garbage": append(append([]byte(nil), valid...), 0),
+	}
+	for name, in := range bad {
+		if _, err := newSchemaEngine(append([]byte(nil), in...), cache); !errors.Is(err, wire.ErrOperateRecord) {
+			t.Errorf("%s: err=%v, want ErrOperateRecord", name, err)
+		}
+	}
+}
+
+// TestSchemaEngineConcurrent exercises the two pieces of state applies share —
+// the schema cache and the engine pool — from several goroutines at once, so
+// the race detector has something to look at. Each goroutine drives its own
+// record, so the results are deterministic despite the sharing.
+func TestSchemaEngineConcurrent(t *testing.T) {
+	schemas := []*wire.Schema{sessionSchema(), floatSchema(), frozenSchema()}
+	var wg sync.WaitGroup
+	for g := 0; g < 8; g++ {
+		wg.Add(1)
+		go func(g int) {
+			defer wg.Done()
+			s := schemas[g%len(schemas)]
+			var cur []byte
+			for i := 0; i < 200; i++ {
+				a := &wire.OperateArgs{Create: wire.OperateCreateSchema, Schema: s.Encode(),
+					Ops: []wire.OperateOp{{Opcode: wire.OperateOpADD, Type: opFromSchema,
+						Path: fieldPath(0), A: 1}},
+					Rets: []wire.OperateRet{{Mode: wire.OperateRetValue, Path: fieldPath(0)}}}
+				out, _, res, err := applyRecordBytes(cur, a, int64(i))
+				if err != nil {
+					t.Errorf("goroutine %d call %d: %v", g, i, err)
+					return
+				}
+				if res.Status != wire.OperateStatusOK {
+					t.Errorf("goroutine %d call %d: status %d", g, i, res.Status)
+					return
+				}
+				cur = out
+			}
+			if _, err := wire.DecodeRecord(cur); err != nil {
+				t.Errorf("goroutine %d: %v", g, err)
+			}
+		}(g)
+	}
+	wg.Wait()
+}

--- a/ops/operate_semantics_test.go
+++ b/ops/operate_semantics_test.go
@@ -890,6 +890,16 @@ func runSemantics(t *testing.T, apply applier) { //nolint:maintidx // one sub-te
 		}
 	})
 
+	sub(t, "dynamic: names are 1-255 bytes", func(t *testing.T) {
+		if _, _, err := apply(nil, dynArgs(op(wire.OperateOpSET, wire.OperateTypeU8, namePath(""), 1)), 0); !errors.Is(err, wire.ErrOperatePath) {
+			t.Fatalf("field creation with an empty name: %v", err)
+		}
+		if _, _, err := apply(nil, dynArgs(
+			op(wire.OperateOpSET, wire.OperateTypeU8, nameColPath("t", []byte("k"), ""), 1)), 0); !errors.Is(err, wire.ErrOperatePath) {
+			t.Fatalf("column creation with an empty name: %v", err)
+		}
+	})
+
 	sub(t, "MIGRATE is append-only and must be the first op", func(t *testing.T) {
 		s1 := sessionSchema()
 		var rec *wire.Record

--- a/ops/operate_semantics_test.go
+++ b/ops/operate_semantics_test.go
@@ -1,0 +1,1211 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package ops
+
+// The operate v2 semantics suite.
+//
+// runSemantics is the executable form of the design doc's rules (§2.4 paths
+// and typing, §2.5 determinism and deletion, §2.8 schema lifecycle, §2.9
+// dynamic mode, §3.1–§3.5 the op vocabulary, returns, and call parameters).
+// It is written once, against the `applier` function type, and run by every
+// implementation of those semantics: the tree oracle here (TestOracleSemantics)
+// and, in later tasks, each byte-level engine. An engine that passes this
+// suite is, by definition, semantically equivalent to the oracle.
+//
+// Skipping dynamic mode. A sub-test whose name starts with "dynamic:" needs
+// dynamic-mode records. An engine that implements only schema mode sets the
+// package-level `skipDynamic` to true before calling runSemantics (and back
+// to false afterwards); `sub` then skips exactly those sub-tests. Every other
+// sub-test is schema mode (or mode-independent) and must pass everywhere.
+
+import (
+	"bytes"
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/rostamlabs/rostam/sdk/wire"
+)
+
+// applier is one implementation of the operate apply semantics: rec == nil
+// means the key is absent, and a nil returned record means the key is deleted
+// (design doc §2.5). stampMs is the transaction timestamp STAMP writes; 0
+// means unstamped.
+type applier func(rec *wire.Record, a *wire.OperateArgs, stampMs int64) (*wire.Record, *wire.OperateResult, error)
+
+// skipDynamic makes sub tests whose name starts with "dynamic:" skip. Set by
+// an engine test whose engine implements schema mode only.
+var skipDynamic bool
+
+// sub runs one semantics sub-test, honouring skipDynamic.
+func sub(t *testing.T, name string, fn func(t *testing.T)) {
+	t.Helper()
+	t.Run(name, func(t *testing.T) {
+		if skipDynamic && strings.HasPrefix(name, "dynamic:") {
+			t.Skip("engine under test implements schema mode only")
+		}
+		fn(t)
+	})
+}
+
+// opFromSchema is the "type comes from the schema (or the stored field)" type
+// byte, spelled short because nearly every op carries it (design doc §2.4).
+const opFromSchema = wire.OperateTypeFromSchema
+
+func TestOracleSemantics(t *testing.T) { runSemantics(t, applyTree) }
+
+// TestOracleRoundTrips runs the same suite through an applier that encodes
+// every record the oracle returns and decodes it again before handing it back.
+// It proves two things at once: the oracle only ever builds canonical,
+// decodable trees (design doc §2.5), and the suite really is written against
+// the applier type, not against applyTree — which is how the byte engines will
+// consume it.
+func TestOracleRoundTrips(t *testing.T) {
+	runSemantics(t, func(rec *wire.Record, a *wire.OperateArgs, stampMs int64) (*wire.Record, *wire.OperateResult, error) {
+		out, res, err := applyTree(rec, a, stampMs)
+		if err != nil || out == nil {
+			return out, res, err
+		}
+		b := out.Encode()
+		got, derr := wire.DecodeRecord(b)
+		if derr != nil {
+			return nil, nil, fmt.Errorf("oracle produced undecodable bytes %x: %w", b, derr)
+		}
+		if !bytes.Equal(got.Encode(), b) {
+			return nil, nil, fmt.Errorf("record does not round-trip: %x", b)
+		}
+		return got, res, nil
+	})
+}
+
+// TestSemanticsSkipDynamic checks the mechanism a schema-only engine uses to
+// opt out of the dynamic-mode sub-tests.
+func TestSemanticsSkipDynamic(t *testing.T) {
+	skipDynamic = true
+	defer func() { skipDynamic = false }()
+	sub(t, "dynamic: sentinel", func(t *testing.T) { t.Fatal("a dynamic sub-test ran with skipDynamic set") })
+	ran := false
+	sub(t, "schema sentinel", func(t *testing.T) { ran = true })
+	if !ran {
+		t.Fatal("skipDynamic skipped a non-dynamic sub-test")
+	}
+}
+
+func runSemantics(t *testing.T, apply applier) { //nolint:maintidx // one sub-test per spec rule, deliberately flat
+	sub(t, "session flow", func(t *testing.T) {
+		s := sessionSchema()
+		a := &wire.OperateArgs{Key: []byte("s"), Create: wire.OperateCreateSchema, Schema: s.Encode(), Ops: []wire.OperateOp{
+			{Opcode: wire.OperateOpIF, Aux: wire.OperateCmpGE, Path: fieldPath(0), A: 255, B: 2},
+			{Opcode: wire.OperateOpSHR, Type: opFromSchema, Path: fieldPath(0), A: 1},
+			{Opcode: wire.OperateOpSHR, Type: opFromSchema, Path: fieldPath(1), A: 1},
+			{Opcode: wire.OperateOpADD, Type: opFromSchema, Path: fieldPath(0), A: 1},
+			{Opcode: wire.OperateOpADD, Type: opFromSchema, Path: colPath(3, keyU64(77), 0), A: 1},
+			{Opcode: wire.OperateOpMAX, Type: opFromSchema, Path: colPath(3, keyU64(77), 1), A: 500},
+			{Opcode: wire.OperateOpSTAMP, Type: opFromSchema, Aux: wire.OperateStampS, Path: colPath(3, keyU64(77), 2)},
+		}, Rets: []wire.OperateRet{
+			{Mode: wire.OperateRetValue, Path: fieldPath(0)},
+			{Mode: wire.OperateRetValue, Path: rowPath(3, keyU64(77))},
+			{Mode: wire.OperateRetCount, Path: fieldPath(3)},
+		}}
+		var rec *wire.Record
+		var res *wire.OperateResult
+		var err error
+		for i := 0; i < 300; i++ {
+			rec, res, err = apply(rec, a, 1_700_000_000_000)
+			if err != nil {
+				t.Fatal(i, err)
+			}
+		}
+		if res.Status != wire.OperateStatusOK {
+			t.Fatal(res.Status)
+		}
+		rc, _, _ := wire.DecodeTaggedCell(res.Values[0])
+		// 300 increments with a halve-at-255 guard: 255 → 127 → … never
+		// exceeds 255 and is > 127.
+		if rc.U > 255 || rc.U <= 127 {
+			t.Fatalf("rc=%d", rc.U)
+		}
+		row := rec.Fields[3].Table.Rows[0]
+		if row.Cols[0].Cell.U != 300 || row.Cols[1].Cell.U != 500 || row.Cols[2].Cell.U != 1_700_000_000 {
+			t.Fatalf("%+v", row)
+		}
+		cnt, _, _ := wire.DecodeTaggedCell(res.Values[2])
+		if cnt.U != 1 {
+			t.Fatal(cnt.U)
+		}
+	})
+
+	sub(t, "eviction MIN_COL with ties by key", func(t *testing.T) {
+		s := sessionSchema()
+		s.Fields[3].Table.Cap = 3
+		mk := func(k uint64) *wire.OperateArgs {
+			return schemaArgs(s,
+				op(wire.OperateOpADD, opFromSchema, colPath(3, keyU64(k), 0), 1),
+				op(wire.OperateOpSTAMP, opFromSchema, colPath(3, keyU64(k), 2), 0).withAux(wire.OperateStampS))
+		}
+		var rec *wire.Record
+		for _, step := range []struct {
+			k  uint64
+			st int64
+		}{{5, 1000}, {9, 1000}, {1, 2000}, {7, 3000}} {
+			var err error
+			rec, _, err = apply(rec, mk(step.k), step.st*1000)
+			if err != nil {
+				t.Fatal(step.k, err)
+			}
+		}
+		keys := rowKeys(rec.Fields[3].Table)
+		if !reflect.DeepEqual(keys, []uint64{1, 7, 9}) {
+			t.Fatalf("victim should be key 5 (oldest stamp, smallest key): %v", keys)
+		}
+	})
+
+	sub(t, "eviction MIN_KEY orders numeric keys as integers", func(t *testing.T) {
+		// LE key bytes of 256 are {0,1,0,...}, of 4 are {4,0,0,...}: bytewise
+		// 256 < 4, as integers 4 < 256. The victim and the stored row order
+		// both prove the comparison is integer, not bytewise (design doc §2.3).
+		s := sessionSchema()
+		s.Fields[3].Table.Cap = 2
+		s.Fields[3].Table.Policy = wire.OperatePolicyMinKey
+		var rec *wire.Record
+		for _, k := range []uint64{4, 256, 5} {
+			var err error
+			rec, _, err = apply(rec, schemaArgs(s, op(wire.OperateOpADD, opFromSchema, colPath(3, keyU64(k), 0), 1)), 0)
+			if err != nil {
+				t.Fatal(k, err)
+			}
+		}
+		if keys := rowKeys(rec.Fields[3].Table); !reflect.DeepEqual(keys, []uint64{5, 256}) {
+			t.Fatalf("want [5 256] (evict integer-smallest 4, sort as integers), got %v", keys)
+		}
+	})
+
+	sub(t, "PolicyNone with a cap evicts by MIN_KEY", func(t *testing.T) {
+		// Ruling: cap 0 is unbounded, but a cap > 0 with PolicyNone passes
+		// Schema.Validate, so the applier must still pick a deterministic
+		// victim; it evicts the smallest key.
+		s := sessionSchema()
+		s.Fields[3].Table.Cap = 2
+		s.Fields[3].Table.Policy = wire.OperatePolicyNone
+		var rec *wire.Record
+		for _, k := range []uint64{4, 256, 5} {
+			var err error
+			rec, _, err = apply(rec, schemaArgs(s, op(wire.OperateOpADD, opFromSchema, colPath(3, keyU64(k), 0), 1)), 0)
+			if err != nil {
+				t.Fatal(k, err)
+			}
+		}
+		if keys := rowKeys(rec.Fields[3].Table); !reflect.DeepEqual(keys, []uint64{5, 256}) {
+			t.Fatalf("want [5 256], got %v", keys)
+		}
+	})
+
+	sub(t, "dynamic: CHECK aborts atomically and returns the old record", func(t *testing.T) {
+		rec, _, err := apply(nil, dynArgs(op(wire.OperateOpSET, wire.OperateTypeI32, namePath("stock"), 3)), 0)
+		if err != nil {
+			t.Fatal(err)
+		}
+		before := rec.Encode()
+		rec2, res, err := apply(rec, withRet(dynArgs(
+			op(wire.OperateOpCHECK, 0, namePath("stock"), 5).withAux(wire.OperateCmpGE),
+			op(wire.OperateOpADD, wire.OperateTypeI32, namePath("stock"), -5),
+			op(wire.OperateOpADD, wire.OperateTypeI32, namePath("reserved"), 5)), namePath("stock")), 0)
+		if err != nil || res.Status != wire.OperateStatusCheckFailed || res.FailedOp != 0 {
+			t.Fatal(res, err)
+		}
+		if !bytes.Equal(rec2.Encode(), before) || !bytes.Equal(rec.Encode(), before) {
+			t.Fatal("record changed on CHECK failure")
+		}
+		v, _, _ := wire.DecodeTaggedCell(res.Values[0])
+		if int64(v.U) != 3 {
+			t.Fatal("return not evaluated against the unchanged record")
+		}
+	})
+
+	sub(t, "CHECK aborts atomically in schema mode", func(t *testing.T) {
+		s := sessionSchema()
+		rec, _, err := apply(nil, schemaArgs(s, op(wire.OperateOpADD, opFromSchema, fieldPath(0), 3)), 0)
+		if err != nil {
+			t.Fatal(err)
+		}
+		before := rec.Encode()
+		rec2, res, err := apply(rec, withRet(schemaArgs(s,
+			op(wire.OperateOpCHECK, opFromSchema, fieldPath(0), 5).withAux(wire.OperateCmpGE),
+			op(wire.OperateOpADD, opFromSchema, fieldPath(0), 10)), fieldPath(0)), 0)
+		if err != nil || res.Status != wire.OperateStatusCheckFailed || res.FailedOp != 0 {
+			t.Fatal(res, err)
+		}
+		if !bytes.Equal(rec2.Encode(), before) {
+			t.Fatal("record changed on CHECK failure")
+		}
+		v, _, _ := wire.DecodeTaggedCell(res.Values[0])
+		if v.U != 3 {
+			t.Fatalf("rc=%d, want the pre-call 3", v.U)
+		}
+		// A CHECK that fails after an op has already written must roll that
+		// write back too: the list is all-or-nothing (design doc §3.3).
+		rec3, res, err := apply(rec, withRet(schemaArgs(s,
+			op(wire.OperateOpADD, opFromSchema, fieldPath(0), 10),
+			op(wire.OperateOpCHECK, opFromSchema, fieldPath(0), 100).withAux(wire.OperateCmpGE),
+			op(wire.OperateOpADD, opFromSchema, colPath(3, keyU64(1), 0), 1)), fieldPath(0)), 0)
+		if err != nil || res.Status != wire.OperateStatusCheckFailed || res.FailedOp != 1 {
+			t.Fatal(res, err)
+		}
+		if !bytes.Equal(rec3.Encode(), before) {
+			t.Fatal("a write before the failing CHECK was not rolled back")
+		}
+		v, _, _ = wire.DecodeTaggedCell(res.Values[0])
+		if v.U != 3 {
+			t.Fatalf("rc=%d, want the pre-call 3", v.U)
+		}
+	})
+
+	sub(t, "CHECK failure on an absent record leaves it absent", func(t *testing.T) {
+		s := sessionSchema()
+		rec, res, err := apply(nil, withRet(schemaArgs(s,
+			op(wire.OperateOpCHECK, opFromSchema, fieldPath(0), 5).withAux(wire.OperateCmpGE),
+			op(wire.OperateOpADD, opFromSchema, fieldPath(0), 1)), fieldPath(0)), 0)
+		if err != nil || res.Status != wire.OperateStatusCheckFailed {
+			t.Fatal(res, err)
+		}
+		if rec != nil {
+			t.Fatal("record created despite CHECK failure")
+		}
+		if !bytes.Equal(res.Values[0], []byte{wire.OperateTypeUnset}) {
+			t.Fatalf("want UNSET for a return against an absent record, got %x", res.Values[0])
+		}
+	})
+
+	sub(t, "IF skips n ops", func(t *testing.T) {
+		// The fixed-window rate limiter of design doc §4: 150 calls, each
+		// guarded by IF(rc LT 100, skip 1), leave rc pinned at 100.
+		s := sessionSchema()
+		a := schemaArgs(s,
+			op(wire.OperateOpIF, opFromSchema, fieldPath(0), 100).withAux(wire.OperateCmpLT).withB(1),
+			op(wire.OperateOpADD, opFromSchema, fieldPath(0), 1))
+		var rec *wire.Record
+		for i := 0; i < 150; i++ {
+			var err error
+			rec, _, err = apply(rec, a, 0)
+			if err != nil {
+				t.Fatal(i, err)
+			}
+		}
+		if rec.Fields[0].Cell.U != 100 {
+			t.Fatalf("rc=%d, want 100", rec.Fields[0].Cell.U)
+		}
+	})
+
+	sub(t, "IF skip count out of range is an error", func(t *testing.T) {
+		s := sessionSchema()
+		for _, n := range []int64{-1, 5} {
+			_, _, err := apply(nil, schemaArgs(s,
+				op(wire.OperateOpIF, opFromSchema, fieldPath(0), 100).withAux(wire.OperateCmpGE).withB(n),
+				op(wire.OperateOpADD, opFromSchema, fieldPath(0), 1)), 0)
+			if !errors.Is(err, errOperateIfRange) {
+				t.Fatalf("n=%d: err=%v, want errOperateIfRange", n, err)
+			}
+		}
+		// n exactly equal to the remaining op count is legal.
+		rec, _, err := apply(nil, schemaArgs(s,
+			op(wire.OperateOpIF, opFromSchema, fieldPath(0), 100).withAux(wire.OperateCmpGE).withB(1),
+			op(wire.OperateOpADD, opFromSchema, fieldPath(0), 1)), 0)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if rec.Fields[0].Cell.U != 0 {
+			t.Fatal("guarded op ran")
+		}
+	})
+
+	sub(t, "dynamic: vivify, stored type wins, domain mismatch errors", func(t *testing.T) {
+		rec, _, err := apply(nil, dynArgs(op(wire.OperateOpSET, wire.OperateTypeU8, namePath("x"), 200)), 0)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(rec.Fields) != 1 || rec.Fields[0].Name != "x" ||
+			rec.Fields[0].Cell.Type != wire.OperateTypeU8 || rec.Fields[0].Cell.U != 200 {
+			t.Fatalf("%+v", rec.Fields)
+		}
+		if _, _, err := apply(rec, dynArgs(op(wire.OperateOpADD, wire.OperateTypeF64, namePath("x"), f64(1.5))), 0); !errors.Is(err, wire.ErrOperateType) {
+			t.Fatalf("float op on an int field: %v", err)
+		}
+		got, _, err := apply(rec, dynArgs(op(wire.OperateOpADD, wire.OperateTypeU32, namePath("x"), 100)), 0)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got.Fields[0].Cell.Type != wire.OperateTypeU8 || got.Fields[0].Cell.U != 255 {
+			t.Fatalf("stored U8 must win and saturate: %+v", got.Fields[0].Cell)
+		}
+		if _, _, err := apply(rec, dynArgs(op(wire.OperateOpADD, opFromSchema, namePath("fresh"), 1)), 0); !errors.Is(err, wire.ErrOperateType) {
+			t.Fatalf("0xFF on a missing dynamic target: %v", err)
+		}
+		// SET replaces the scalar including its type (design doc §2.9).
+		got, _, err = apply(rec, dynArgs(op(wire.OperateOpSET, wire.OperateTypeBytes, namePath("x"), 0).withBytes([]byte("hi"))), 0)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got.Fields[0].Cell.Type != wire.OperateTypeBytes || string(got.Fields[0].Cell.B) != "hi" {
+			t.Fatalf("SET did not replace the type: %+v", got.Fields[0].Cell)
+		}
+		// A signed field stores the sign-extended bit pattern.
+		got, _, err = apply(nil, dynArgs(op(wire.OperateOpSET, wire.OperateTypeI32, namePath("d"), -5)), 0)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got.Fields[0].Cell.U != su64(-5) {
+			t.Fatalf("%+v", got.Fields[0].Cell)
+		}
+		// A FIXED field created in dynamic mode takes N = len(Bytes).
+		got, _, err = apply(nil, dynArgs(op(wire.OperateOpSET, wire.OperateTypeFixed, namePath("cc"), 0).withBytes([]byte("DE"))), 0)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got.Fields[0].Cell.N != 2 || string(got.Fields[0].Cell.B) != "DE" {
+			t.Fatalf("%+v", got.Fields[0].Cell)
+		}
+	})
+
+	sub(t, "dynamic: a scalar and a table never swap without DEL", func(t *testing.T) {
+		rec, _, err := apply(nil, dynArgs(op(wire.OperateOpSET, wire.OperateTypeU8, nameColPath("t", keyU64(1), "c"), 4)), 0)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if _, _, err := apply(rec, dynArgs(op(wire.OperateOpSET, wire.OperateTypeU8, namePath("t"), 1)), 0); !errors.Is(err, wire.ErrOperatePath) {
+			t.Fatalf("scalar SET over a table: %v", err)
+		}
+		scalar, _, err := apply(nil, dynArgs(op(wire.OperateOpSET, wire.OperateTypeU8, namePath("t"), 1)), 0)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if _, _, err := apply(scalar, dynArgs(op(wire.OperateOpSET, wire.OperateTypeU8, nameColPath("t", keyU64(1), "c"), 4)), 0); !errors.Is(err, wire.ErrOperatePath) {
+			t.Fatalf("row path into a scalar field: %v", err)
+		}
+		// DEL first, then the other kind is free to appear.
+		swapped, _, err := apply(scalar, dynArgs(
+			op(wire.OperateOpDEL, opFromSchema, namePath("t"), 0),
+			op(wire.OperateOpSET, wire.OperateTypeU8, nameColPath("t", keyU64(1), "c"), 4)), 0)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if swapped.Fields[0].Cell.Type != wire.OperateTypeTable || len(swapped.Fields[0].Table.Rows) != 1 {
+			t.Fatalf("%+v", swapped.Fields[0])
+		}
+	})
+
+	sub(t, "schema mode rejects bad paths, types, versions and modes", func(t *testing.T) {
+		s := sessionSchema()
+		base, _, err := apply(nil, schemaArgs(s, op(wire.OperateOpADD, opFromSchema, colPath(3, keyU64(1), 0), 1)), 0)
+		if err != nil {
+			t.Fatal(err)
+		}
+		v2 := sessionSchema()
+		v2.Version = 2
+		cases := []struct {
+			name string
+			rec  *wire.Record
+			args *wire.OperateArgs
+			want error
+		}{
+			{"position outside the schema", base,
+				schemaArgs(s, op(wire.OperateOpADD, opFromSchema, fieldPath(9), 1)), wire.ErrOperatePath},
+			{"name segment without stored names", base,
+				schemaArgs(s, op(wire.OperateOpADD, opFromSchema, namePath("rc"), 1)), wire.ErrOperatePath},
+			{"column outside the schema", base,
+				schemaArgs(s, op(wire.OperateOpADD, opFromSchema, colPath(3, keyU64(1), 7), 1)), wire.ErrOperatePath},
+			{"row path into a non-table field", base,
+				schemaArgs(s, op(wire.OperateOpADD, opFromSchema, rowPath(0, keyU64(1)), 1)), wire.ErrOperatePath},
+			{"scalar op on a table field", base,
+				schemaArgs(s, op(wire.OperateOpADD, opFromSchema, fieldPath(3), 1)), wire.ErrOperatePath},
+			{"row key of the wrong width", base,
+				schemaArgs(s, op(wire.OperateOpADD, opFromSchema, colPath(3, []byte{1, 2, 3, 4}, 0), 1)), wire.ErrOperatePath},
+			{"type byte disagreeing with the schema", base,
+				schemaArgs(s, op(wire.OperateOpADD, wire.OperateTypeU16, fieldPath(0), 1)), wire.ErrOperateType},
+			{"schema version mismatch", base,
+				schemaArgs(v2, op(wire.OperateOpADD, opFromSchema, fieldPath(0), 1)), wire.ErrOperateSchemaVersion},
+			{"create mode disagreeing with the record", base,
+				dynArgs(op(wire.OperateOpADD, wire.OperateTypeU8, namePath("rc"), 1)), wire.ErrOperateMode},
+			{"create NONE against an absent record", nil,
+				noneArgs(op(wire.OperateOpADD, opFromSchema, fieldPath(0), 1)), errOperateAbsent},
+			{"CONFIG in schema mode", base,
+				schemaArgs(s, op(wire.OperateOpCONFIG, opFromSchema, fieldPath(3), 4).withAux(wire.OperatePolicyMinKey)), wire.ErrOperateOpcode},
+			{"unknown opcode", base,
+				schemaArgs(s, op(99, opFromSchema, fieldPath(0), 1)), wire.ErrOperateOpcode},
+			{"unknown comparator", base,
+				schemaArgs(s, op(wire.OperateOpIF, opFromSchema, fieldPath(0), 1).withAux(99).withB(0)), wire.ErrOperateCmp},
+			{"create SCHEMA without a blob", base,
+				&wire.OperateArgs{Create: wire.OperateCreateSchema}, wire.ErrOperateSchema},
+		}
+		for _, tc := range cases {
+			_, _, err := apply(tc.rec, tc.args, 0)
+			if !errors.Is(err, tc.want) {
+				t.Errorf("%s: err=%v, want %v", tc.name, err, tc.want)
+			}
+		}
+		// create NONE against an existing record of either mode is fine.
+		if _, _, err := apply(base, noneArgs(op(wire.OperateOpADD, opFromSchema, fieldPath(0), 1)), 0); err != nil {
+			t.Fatalf("create NONE on an existing record: %v", err)
+		}
+	})
+
+	sub(t, "schema mode accepts name segments when the schema stores names", func(t *testing.T) {
+		s := sessionSchema()
+		s.StoreNames = true
+		rec, _, err := apply(nil, schemaArgs(s,
+			op(wire.OperateOpADD, opFromSchema, namePath("rc"), 2),
+			op(wire.OperateOpADD, opFromSchema, nameColPath("b", keyU64(9), "c"), 3)), 0)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if rec.Fields[0].Cell.U != 2 || rec.Fields[3].Table.Rows[0].Cols[0].Cell.U != 3 {
+			t.Fatalf("%+v", rec.Fields)
+		}
+		if _, _, err := apply(rec, schemaArgs(s, op(wire.OperateOpADD, opFromSchema, namePath("nope"), 1)), 0); !errors.Is(err, wire.ErrOperatePath) {
+			t.Fatalf("unknown name: %v", err)
+		}
+	})
+
+	sub(t, "schema fields are always present and read as zero", func(t *testing.T) {
+		// A schema-mode record cannot distinguish "written 0" from "never
+		// written" — a fixed-width field is the same bytes either way — so
+		// every declared field is present, and an all-zero record is a valid
+		// state (design doc §2.5), while arithmetic still sees zero.
+		s := sessionSchema()
+		rec, _, err := apply(nil, schemaArgs(s,
+			op(wire.OperateOpIF, opFromSchema, fieldPath(0), 1).withAux(wire.OperateCmpLT).withB(1),
+			op(wire.OperateOpADD, opFromSchema, fieldPath(2), 7)), 0)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if rec.Fields[2].Cell.U != 7 {
+			t.Fatalf("absent-is-zero guard did not fire: %+v", rec.Fields[2].Cell)
+		}
+		_, res, err := apply(rec, schemaArgs(s, op(wire.OperateOpCHECK, opFromSchema, fieldPath(1), 0).withAux(wire.OperateCmpExists)), 0)
+		if err != nil || res.Status != wire.OperateStatusOK {
+			t.Fatalf("EXISTS on a declared field: %v %+v", err, res)
+		}
+		_, res, err = apply(rec, schemaArgs(s, op(wire.OperateOpCHECK, opFromSchema, fieldPath(1), 0).withAux(wire.OperateCmpAbsent)), 0)
+		if err != nil || res.Status != wire.OperateStatusCheckFailed {
+			t.Fatalf("ABSENT on a declared field: %v %+v", err, res)
+		}
+	})
+
+	sub(t, "reads and comparisons never vivify", func(t *testing.T) {
+		s := sessionSchema()
+		rec, res, err := apply(nil, withCount(schemaArgs(s,
+			op(wire.OperateOpIF, opFromSchema, rowPath(3, keyU64(4)), 0).withAux(wire.OperateCmpExists).withB(0),
+			op(wire.OperateOpCHECK, opFromSchema, rowPath(3, keyU64(4)), 0).withAux(wire.OperateCmpAbsent)),
+			fieldPath(3)), 0)
+		if err != nil || res.Status != wire.OperateStatusOK {
+			t.Fatal(err, res)
+		}
+		if len(rec.Fields[3].Table.Rows) != 0 {
+			t.Fatal("a comparison vivified a row")
+		}
+		cnt, _, _ := wire.DecodeTaggedCell(res.Values[0])
+		if cnt.U != 0 {
+			t.Fatalf("count=%d", cnt.U)
+		}
+	})
+
+	sub(t, "dynamic: absent is zero; EXISTS and ABSENT", func(t *testing.T) {
+		rec, _, err := apply(nil, dynArgs(
+			op(wire.OperateOpIF, 0, namePath("x"), 1).withAux(wire.OperateCmpLT).withB(1),
+			op(wire.OperateOpSET, wire.OperateTypeU8, namePath("x"), 7)), 0)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(rec.Fields) != 1 || rec.Fields[0].Cell.U != 7 {
+			t.Fatalf("absent read as zero should have let the guarded SET run: %+v", rec.Fields)
+		}
+		_, res, err := apply(rec, dynArgs(
+			op(wire.OperateOpCHECK, 0, namePath("z"), 0).withAux(wire.OperateCmpExists),
+			op(wire.OperateOpSET, wire.OperateTypeU8, namePath("z"), 1)), 0)
+		if err != nil || res.Status != wire.OperateStatusCheckFailed || res.FailedOp != 0 {
+			t.Fatalf("%v %+v", err, res)
+		}
+		got, _, err := apply(rec, dynArgs(op(wire.OperateOpIF, 0, namePath("q"), 1).withAux(wire.OperateCmpLT).withB(0)), 0)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(got.Fields) != 1 {
+			t.Fatal("an IF vivified a dynamic field")
+		}
+	})
+
+	sub(t, "DEL semantics in schema mode", func(t *testing.T) {
+		s := sessionSchema()
+		base, _, err := apply(nil, schemaArgs(s,
+			op(wire.OperateOpADD, opFromSchema, fieldPath(0), 5),
+			op(wire.OperateOpADD, opFromSchema, colPath(3, keyU64(1), 0), 1),
+			op(wire.OperateOpADD, opFromSchema, colPath(3, keyU64(2), 0), 2)), 0)
+		if err != nil {
+			t.Fatal(err)
+		}
+		got, _, err := apply(base, schemaArgs(s, op(wire.OperateOpDEL, opFromSchema, fieldPath(0), 0)), 0)
+		if err != nil || got == nil {
+			t.Fatal(err, got)
+		}
+		if got.Fields[0].Cell.U != 0 {
+			t.Fatalf("DEL of a schema field must zero it: %+v", got.Fields[0].Cell)
+		}
+		got, _, err = apply(base, schemaArgs(s, op(wire.OperateOpDEL, opFromSchema, colPath(3, keyU64(1), 0), 0)), 0)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got.Fields[3].Table.Rows[0].Cols[0].Cell.U != 0 || len(got.Fields[3].Table.Rows) != 2 {
+			t.Fatalf("DEL of a column must zero it and keep the row: %+v", got.Fields[3].Table.Rows)
+		}
+		got, _, err = apply(base, schemaArgs(s, op(wire.OperateOpDEL, opFromSchema, rowPath(3, keyU64(1)), 0)), 0)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if keys := rowKeys(got.Fields[3].Table); !reflect.DeepEqual(keys, []uint64{2}) {
+			t.Fatalf("DEL of a row: %v", keys)
+		}
+		got, _, err = apply(base, schemaArgs(s, op(wire.OperateOpDEL, opFromSchema, rowPath(3, keyU64(99)), 0)), 0)
+		if err != nil {
+			t.Fatalf("DEL of an absent row must be a no-op: %v", err)
+		}
+		if len(got.Fields[3].Table.Rows) != 2 {
+			t.Fatal("DEL of an absent row changed the table")
+		}
+		got, _, err = apply(base, schemaArgs(s, op(wire.OperateOpDEL, opFromSchema, fieldPath(3), 0)), 0)
+		if err != nil || got == nil {
+			t.Fatal(err, got)
+		}
+		if len(got.Fields[3].Table.Rows) != 0 {
+			t.Fatal("DEL of a table field must empty it")
+		}
+		// A schema-mode record is never deleted implicitly: an all-zero
+		// record survives (design doc §2.5).
+		got, _, err = apply(base, schemaArgs(s,
+			op(wire.OperateOpDEL, opFromSchema, fieldPath(0), 0),
+			op(wire.OperateOpDEL, opFromSchema, fieldPath(3), 0)), 0)
+		if err != nil || got == nil {
+			t.Fatal("an emptied schema record must survive", err)
+		}
+		got, _, err = apply(base, schemaArgs(s, op(wire.OperateOpDEL, opFromSchema, recPath(), 0)), 0)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got != nil {
+			t.Fatal("DEL () must delete the record")
+		}
+	})
+
+	sub(t, "dynamic: DEL of the last field deletes the record", func(t *testing.T) {
+		base, _, err := apply(nil, dynArgs(
+			op(wire.OperateOpSET, wire.OperateTypeU8, namePath("a"), 1),
+			op(wire.OperateOpSET, wire.OperateTypeU8, namePath("b"), 2)), 0)
+		if err != nil {
+			t.Fatal(err)
+		}
+		one, _, err := apply(base, dynArgs(op(wire.OperateOpDEL, opFromSchema, namePath("a"), 0)), 0)
+		if err != nil || one == nil || len(one.Fields) != 1 {
+			t.Fatalf("%v %+v", err, one)
+		}
+		gone, _, err := apply(one, dynArgs(op(wire.OperateOpDEL, opFromSchema, namePath("b"), 0)), 0)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if gone != nil {
+			t.Fatal("deleting the last dynamic field must delete the record")
+		}
+		// A dynamic column is removed, not zeroed, and the row survives.
+		tbl, _, err := apply(nil, dynArgs(
+			op(wire.OperateOpSET, wire.OperateTypeU8, nameColPath("t", keyU64(1), "c"), 4),
+			op(wire.OperateOpSET, wire.OperateTypeU8, nameColPath("t", keyU64(1), "d"), 5)), 0)
+		if err != nil {
+			t.Fatal(err)
+		}
+		tbl, _, err = apply(tbl, dynArgs(op(wire.OperateOpDEL, opFromSchema, nameColPath("t", keyU64(1), "c"), 0)), 0)
+		if err != nil {
+			t.Fatal(err)
+		}
+		row := tbl.Fields[0].Table.Rows[0]
+		if len(row.Cols) != 1 || row.Cols[0].Name != "d" {
+			t.Fatalf("%+v", row)
+		}
+	})
+
+	sub(t, "dynamic: TRIM and CONFIG", func(t *testing.T) {
+		rec, _, err := apply(nil, dynArgs(
+			op(wire.OperateOpCONFIG, opFromSchema, namePath("ev"), 2).withAux(wire.OperatePolicyMinKey)), 0)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if rec.Fields[0].Table == nil || rec.Fields[0].Table.Cap != 2 || rec.Fields[0].Table.Policy != wire.OperatePolicyMinKey {
+			t.Fatalf("CONFIG must create the table with the eviction triple: %+v", rec.Fields[0])
+		}
+		for k := uint64(1); k <= 3; k++ {
+			rec, _, err = apply(rec, dynArgs(op(wire.OperateOpSET, wire.OperateTypeU8, nameColPath("ev", keyU64(k), "v"), int64(k))), 0)
+			if err != nil {
+				t.Fatal(k, err)
+			}
+		}
+		if keys := rowKeys(rec.Fields[0].Table); !reflect.DeepEqual(keys, []uint64{2, 3}) {
+			t.Fatalf("cap 2 MIN_KEY: %v", keys)
+		}
+		rec, _, err = apply(rec, dynArgs(op(wire.OperateOpTRIM, opFromSchema, namePath("ev"), 1).withAux(wire.OperatePolicyMaxKey)), 0)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if keys := rowKeys(rec.Fields[0].Table); !reflect.DeepEqual(keys, []uint64{2}) {
+			t.Fatalf("TRIM keep 1 MAX_KEY: %v", keys)
+		}
+		if rec.Fields[0].Table.Policy != wire.OperatePolicyMinKey {
+			t.Fatal("TRIM must not change the stored policy")
+		}
+	})
+
+	sub(t, "dynamic: MIN_COL treats a missing column as zero", func(t *testing.T) {
+		rec, _, err := apply(nil, dynArgs(
+			op(wire.OperateOpCONFIG, opFromSchema, namePath("ev"), 2).
+				withAux(wire.OperatePolicyMinCol).withBytes([]byte("s")),
+			op(wire.OperateOpSET, wire.OperateTypeU32, nameColPath("ev", keyU64(1), "s"), 5),
+			op(wire.OperateOpSET, wire.OperateTypeU32, nameColPath("ev", keyU64(2), "v"), 9)), 0)
+		if err != nil {
+			t.Fatal(err)
+		}
+		rec, _, err = apply(rec, dynArgs(op(wire.OperateOpSET, wire.OperateTypeU32, nameColPath("ev", keyU64(3), "s"), 7)), 0)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if keys := rowKeys(rec.Fields[0].Table); !reflect.DeepEqual(keys, []uint64{1, 3}) {
+			t.Fatalf("row 2 (no 's' column, so 0) should be the victim: %v", keys)
+		}
+	})
+
+	sub(t, "TRIM in schema mode keeps the stored policy", func(t *testing.T) {
+		s := sessionSchema()
+		var rec *wire.Record
+		var err error
+		for k := uint64(1); k <= 3; k++ {
+			rec, _, err = apply(rec, schemaArgs(s, op(wire.OperateOpADD, opFromSchema, colPath(3, keyU64(k), 0), 1)), 0)
+			if err != nil {
+				t.Fatal(k, err)
+			}
+		}
+		rec, _, err = apply(rec, schemaArgs(s, op(wire.OperateOpTRIM, opFromSchema, fieldPath(3), 1).withAux(wire.OperatePolicyMinKey)), 0)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if keys := rowKeys(rec.Fields[3].Table); !reflect.DeepEqual(keys, []uint64{3}) {
+			t.Fatalf("%v", keys)
+		}
+		if rec.Fields[3].Table.Policy != wire.OperatePolicyMinCol {
+			t.Fatal("TRIM changed the stored policy")
+		}
+	})
+
+	sub(t, "caps are enforced with the record unchanged", func(t *testing.T) {
+		s := sessionSchema()
+		base, _, err := apply(nil, schemaArgs(s, op(wire.OperateOpADD, opFromSchema, colPath(3, keyU64(1), 0), 1)), 0)
+		if err != nil {
+			t.Fatal(err)
+		}
+		before := base.Encode()
+		big := int64(wire.OperateMaxRows) + 1
+		cases := []struct {
+			name string
+			args *wire.OperateArgs
+		}{
+			{"TRIM keep above maxRows", schemaArgs(s, op(wire.OperateOpTRIM, opFromSchema, fieldPath(3), big).withAux(wire.OperatePolicyMinKey))},
+			{"TRIM keep negative", schemaArgs(s, op(wire.OperateOpTRIM, opFromSchema, fieldPath(3), -1).withAux(wire.OperatePolicyMinKey))},
+		}
+		for _, tc := range cases {
+			got, _, err := apply(base, tc.args, 0)
+			if !errors.Is(err, wire.ErrOperateCap) {
+				t.Errorf("%s: err=%v, want ErrOperateCap", tc.name, err)
+			}
+			if got != nil && !bytes.Equal(got.Encode(), before) {
+				t.Errorf("%s: record changed", tc.name)
+			}
+		}
+		if !bytes.Equal(base.Encode(), before) {
+			t.Fatal("input record mutated by a failing call")
+		}
+	})
+
+	sub(t, "dynamic: names and keys are capped at 255 bytes", func(t *testing.T) {
+		long := strings.Repeat("n", 256)
+		if _, _, err := apply(nil, dynArgs(op(wire.OperateOpSET, wire.OperateTypeU8, namePath(long), 1)), 0); !errors.Is(err, wire.ErrOperateCap) {
+			t.Fatalf("long name: %v", err)
+		}
+		if _, _, err := apply(nil, dynArgs(
+			op(wire.OperateOpSET, wire.OperateTypeU8, nameColPath("t", bytes.Repeat([]byte{7}, 256), "c"), 1)), 0); !errors.Is(err, wire.ErrOperateCap) {
+			t.Fatalf("long key: %v", err)
+		}
+		if _, _, err := apply(nil, dynArgs(
+			op(wire.OperateOpSET, wire.OperateTypeBytes, namePath("b"), 0).withBytes(bytes.Repeat([]byte{1}, wire.OperateMaxBytesLen+1))), 0); !errors.Is(err, wire.ErrOperateCap) {
+			t.Fatalf("long BYTES: %v", err)
+		}
+		if _, _, err := apply(nil, dynArgs(
+			op(wire.OperateOpCONFIG, opFromSchema, namePath("ev"), int64(wire.OperateMaxRows)+1).withAux(wire.OperatePolicyMinKey)), 0); !errors.Is(err, wire.ErrOperateCap) {
+			t.Fatalf("CONFIG cap above maxRows: %v", err)
+		}
+		if _, _, err := apply(nil, dynArgs(
+			op(wire.OperateOpCONFIG, opFromSchema, namePath("ev"), 2).withAux(wire.OperatePolicyMinCol)), 0); !errors.Is(err, wire.ErrOperatePath) {
+			t.Fatalf("CONFIG MIN_COL without a column name: %v", err)
+		}
+	})
+
+	sub(t, "MIGRATE is append-only and must be the first op", func(t *testing.T) {
+		s1 := sessionSchema()
+		var rec *wire.Record
+		var err error
+		for i, k := range []uint64{1, 2, 3} {
+			rec, _, err = apply(rec, schemaArgs(s1,
+				op(wire.OperateOpADD, opFromSchema, colPath(3, keyU64(k), 0), int64(i+1)),
+				op(wire.OperateOpSTAMP, opFromSchema, colPath(3, keyU64(k), 2), 0).withAux(wire.OperateStampS)),
+				int64(i+1)*1000*1000)
+			if err != nil {
+				t.Fatal(k, err)
+			}
+		}
+		s2 := sessionSchema()
+		s2.Version = 2
+		s2.Fields[3].Table.Cols = append(s2.Fields[3].Table.Cols, wire.ColumnDef{Name: "n", Type: wire.OperateTypeU8})
+		s2.Fields[3].Table.Cap = 2
+		s2.Fields = append(s2.Fields, wire.FieldDef{Name: "extra", Type: wire.OperateTypeI16})
+		migrate := op(wire.OperateOpMIGRATE, opFromSchema, recPath(), 1).withBytes(s2.Encode())
+
+		got, _, err := apply(rec, noneArgs(migrate), 0)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got.Schema.Version != 2 || len(got.Fields) != 5 {
+			t.Fatalf("%+v", got.Schema)
+		}
+		if keys := rowKeys(got.Fields[3].Table); !reflect.DeepEqual(keys, []uint64{2, 3}) {
+			t.Fatalf("lowered cap must trim by the new policy (MIN_COL t): %v", keys)
+		}
+		row := got.Fields[3].Table.Rows[0]
+		if len(row.Cols) != 4 || row.Cols[0].Cell.U != 2 || row.Cols[3].Cell.U != 0 {
+			t.Fatalf("append-only rebuild: %+v", row)
+		}
+		if got.Fields[4].Cell.U != 0 || got.Fields[4].Cell.Type != wire.OperateTypeI16 {
+			t.Fatalf("appended field: %+v", got.Fields[4].Cell)
+		}
+		// The migrated record now demands the new version.
+		if _, _, err := apply(got, schemaArgs(s1, op(wire.OperateOpADD, opFromSchema, fieldPath(0), 1)), 0); !errors.Is(err, wire.ErrOperateSchemaVersion) {
+			t.Fatalf("stale version accepted: %v", err)
+		}
+		bad := []struct {
+			name string
+			args *wire.OperateArgs
+			want error
+		}{
+			{"wrong from-version", noneArgs(op(wire.OperateOpMIGRATE, opFromSchema, recPath(), 5).withBytes(s2.Encode())), wire.ErrOperateSchemaVersion},
+			{"not the first op", noneArgs(op(wire.OperateOpADD, opFromSchema, fieldPath(0), 1), migrate), wire.ErrOperateOpcode},
+			{"not an append-only extension", noneArgs(op(wire.OperateOpMIGRATE, opFromSchema, recPath(), 1).withBytes(widenedSchema().Encode())), wire.ErrOperateSchema},
+			{"malformed schema blob", noneArgs(op(wire.OperateOpMIGRATE, opFromSchema, recPath(), 1).withBytes([]byte{9, 9})), wire.ErrShortArgs},
+		}
+		for _, tc := range bad {
+			if _, _, err := apply(rec, tc.args, 0); !errors.Is(err, tc.want) {
+				t.Errorf("%s: err=%v, want %v", tc.name, err, tc.want)
+			}
+		}
+	})
+
+	sub(t, "dynamic: MIGRATE freezes a dynamic record into a schema", func(t *testing.T) {
+		base, _, err := apply(nil, dynArgs(
+			op(wire.OperateOpSET, wire.OperateTypeU32, namePath("hits"), 7),
+			op(wire.OperateOpSET, wire.OperateTypeBytes, namePath("name"), 0).withBytes([]byte("ab")),
+			op(wire.OperateOpSET, wire.OperateTypeU16, nameColPath("b", keyU64(9), "c"), 3)), 0)
+		if err != nil {
+			t.Fatal(err)
+		}
+		fs := frozenSchema()
+		migrate := op(wire.OperateOpMIGRATE, opFromSchema, recPath(), wire.OperateMigrateFromDynamic).withBytes(fs.Encode())
+		got, _, err := apply(base, noneArgs(migrate), 0)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got.Mode != wire.OperateModeSchema || got.Schema.Version != 3 {
+			t.Fatalf("%+v", got.Schema)
+		}
+		if got.Fields[0].Cell.U != 7 || string(got.Fields[1].Cell.B) != "ab" {
+			t.Fatalf("values not preserved: %+v", got.Fields)
+		}
+		row := got.Fields[2].Table.Rows[0]
+		if !bytes.Equal(row.Key, keyU64(9)) || row.Cols[0].Cell.U != 3 {
+			t.Fatalf("rows not packed: %+v", row)
+		}
+		// An extra dynamic field is an error unless DROP_EXTRA is set.
+		withExtra, _, err := apply(base, dynArgs(op(wire.OperateOpSET, wire.OperateTypeU8, namePath("zz"), 1)), 0)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if _, _, err := apply(withExtra, noneArgs(migrate), 0); !errors.Is(err, wire.ErrOperateSchema) {
+			t.Fatalf("extra field accepted: %v", err)
+		}
+		dropped, _, err := apply(withExtra, noneArgs(migrate.withAux(wire.OperateMigrateDropExtra)), 0)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(dropped.Fields) != 3 || dropped.Fields[0].Cell.U != 7 {
+			t.Fatalf("%+v", dropped.Fields)
+		}
+		// A domain mismatch between the dynamic value and the schema is an error.
+		wrong, _, err := apply(nil, dynArgs(op(wire.OperateOpSET, wire.OperateTypeBytes, namePath("hits"), 0).withBytes([]byte("x"))), 0)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if _, _, err := apply(wrong, noneArgs(migrate.withAux(wire.OperateMigrateDropExtra)), 0); !errors.Is(err, wire.ErrOperateType) {
+			t.Fatalf("domain mismatch accepted: %v", err)
+		}
+		// Freezing needs names in the target schema.
+		nameless := frozenSchema()
+		nameless.StoreNames = false
+		anon := op(wire.OperateOpMIGRATE, opFromSchema, recPath(), wire.OperateMigrateFromDynamic).withBytes(nameless.Encode())
+		if _, _, err := apply(base, noneArgs(anon), 0); !errors.Is(err, wire.ErrOperateSchema) {
+			t.Fatalf("nameless target schema accepted: %v", err)
+		}
+	})
+
+	sub(t, "VALUE and COUNT of record, table, row, scalar and absent", func(t *testing.T) {
+		s := sessionSchema()
+		k := keyU64(77)
+		rec, res, err := apply(nil, &wire.OperateArgs{Create: wire.OperateCreateSchema, Schema: s.Encode(),
+			Ops: []wire.OperateOp{
+				wire.OperateOp(op(wire.OperateOpADD, opFromSchema, fieldPath(0), 9)),
+				wire.OperateOp(op(wire.OperateOpADD, opFromSchema, colPath(3, k, 0), 1)),
+				wire.OperateOp(op(wire.OperateOpMAX, opFromSchema, colPath(3, k, 1), 500)),
+				wire.OperateOp(op(wire.OperateOpSTAMP, opFromSchema, colPath(3, k, 2), 0).withAux(wire.OperateStampS)),
+			},
+			Rets: []wire.OperateRet{
+				{Mode: wire.OperateRetValue, Path: recPath()},
+				{Mode: wire.OperateRetValue, Path: fieldPath(3)},
+				{Mode: wire.OperateRetValue, Path: rowPath(3, k)},
+				{Mode: wire.OperateRetValue, Path: fieldPath(0)},
+				{Mode: wire.OperateRetValue, Path: colPath(3, keyU64(999), 0)},
+				{Mode: wire.OperateRetValue, Path: rowPath(3, keyU64(999))},
+				{Mode: wire.OperateRetCount, Path: recPath()},
+				{Mode: wire.OperateRetCount, Path: fieldPath(3)},
+				{Mode: wire.OperateRetCount, Path: rowPath(3, k)},
+				{Mode: wire.OperateRetCount, Path: rowPath(3, keyU64(999))},
+				{Mode: wire.OperateRetCount, Path: fieldPath(0)},
+			}}, 1_700_000_000_000)
+		if err != nil || res.Status != wire.OperateStatusOK {
+			t.Fatal(err, res)
+		}
+		if !bytes.Equal(res.Values[0], rec.Encode()) {
+			t.Fatal("record VALUE must be the full stored encoding")
+		}
+
+		cCell := wire.Cell{Type: wire.OperateTypeU16, U: 1}
+		hiCell := wire.Cell{Type: wire.OperateTypeI64, U: 500}
+		tCell := wire.Cell{Type: wire.OperateTypeU32, U: 1_700_000_000}
+
+		wantTable := []byte{wire.OperateModeSchema}
+		wantTable = binary.AppendUvarint(wantTable, 1)
+		wantTable = append(wantTable, k...)
+		for _, c := range []wire.Cell{cCell, hiCell, tCell} {
+			wantTable = wire.AppendCellData(wantTable, c)
+		}
+		if !bytes.Equal(res.Values[1], wantTable) {
+			t.Fatalf("table VALUE\n got %x\nwant %x", res.Values[1], wantTable)
+		}
+
+		wantRow := []byte{wire.OperateModeSchema}
+		wantRow = binary.AppendUvarint(wantRow, 3)
+		for _, c := range []wire.Cell{cCell, hiCell, tCell} {
+			wantRow = wire.AppendTaggedCell(wantRow, c)
+		}
+		if !bytes.Equal(res.Values[2], wantRow) {
+			t.Fatalf("row VALUE\n got %x\nwant %x", res.Values[2], wantRow)
+		}
+
+		if !bytes.Equal(res.Values[3], wire.AppendTaggedCell(nil, wire.Cell{Type: wire.OperateTypeU8, U: 9})) {
+			t.Fatalf("scalar VALUE %x", res.Values[3])
+		}
+		for _, i := range []int{4, 5} {
+			if !bytes.Equal(res.Values[i], []byte{wire.OperateTypeUnset}) {
+				t.Fatalf("absent VALUE %d: %x", i, res.Values[i])
+			}
+		}
+		for i, want := range map[int]uint64{6: 4, 7: 1, 8: 1, 9: 0, 10: 1} {
+			c, _, derr := wire.DecodeTaggedCell(res.Values[i])
+			if derr != nil || c.Type != wire.OperateTypeU64 || c.U != want {
+				t.Fatalf("COUNT %d: %+v %v, want %d", i, c, derr, want)
+			}
+		}
+	})
+
+	sub(t, "dynamic: VALUE of a table and a row carry names", func(t *testing.T) {
+		rec, res, err := apply(nil, &wire.OperateArgs{Create: wire.OperateCreateDynamic,
+			Ops: []wire.OperateOp{
+				wire.OperateOp(op(wire.OperateOpSET, wire.OperateTypeU8, nameColPath("ev", keyU64(1), "v"), 4)),
+				wire.OperateOp(op(wire.OperateOpSET, wire.OperateTypeU8, nameColPath("ev", keyU64(1), "a"), 5)),
+			},
+			Rets: []wire.OperateRet{
+				{Mode: wire.OperateRetValue, Path: namePath("ev")},
+				{Mode: wire.OperateRetValue, Path: nameRowPath("ev", keyU64(1))},
+				{Mode: wire.OperateRetValue, Path: namePath("nope")},
+				{Mode: wire.OperateRetCount, Path: recPath()},
+				{Mode: wire.OperateRetCount, Path: namePath("nope")},
+				{Mode: wire.OperateRetCount, Path: namePath("ev")},
+			}}, 0)
+		if err != nil {
+			t.Fatal(err)
+		}
+		// The record holds exactly one field, "ev", so the bytes its encoder
+		// emits for that field are everything after
+		// [mode][nFields=1][nlen=2]["ev"][type=TABLE].
+		enc := rec.Encode()
+		wantTable := append([]byte{wire.OperateModeDynamic}, enc[1+1+1+2+1:]...)
+		if !bytes.Equal(res.Values[0], wantTable) {
+			t.Fatalf("table VALUE\n got %x\nwant %x", res.Values[0], wantTable)
+		}
+		wantRow := []byte{wire.OperateModeDynamic}
+		wantRow = binary.AppendUvarint(wantRow, 2)
+		for _, c := range []struct {
+			name string
+			cell wire.Cell
+		}{{"a", wire.Cell{Type: wire.OperateTypeU8, U: 5}}, {"v", wire.Cell{Type: wire.OperateTypeU8, U: 4}}} {
+			wantRow = append(wantRow, byte(len(c.name)))
+			wantRow = append(wantRow, c.name...)
+			wantRow = wire.AppendTaggedCell(wantRow, c.cell)
+		}
+		if !bytes.Equal(res.Values[1], wantRow) {
+			t.Fatalf("row VALUE\n got %x\nwant %x", res.Values[1], wantRow)
+		}
+		if !bytes.Equal(res.Values[2], []byte{wire.OperateTypeUnset}) {
+			t.Fatalf("absent field VALUE %x", res.Values[2])
+		}
+		c, _, _ := wire.DecodeTaggedCell(res.Values[3])
+		if c.U != 1 {
+			t.Fatalf("record COUNT %d, want 1 dynamic field", c.U)
+		}
+		if c, _, _ = wire.DecodeTaggedCell(res.Values[4]); c.U != 0 {
+			t.Fatalf("COUNT of an absent field %d, want 0", c.U)
+		}
+		if c, _, _ = wire.DecodeTaggedCell(res.Values[5]); c.U != 1 {
+			t.Fatalf("COUNT of a table %d, want 1 row", c.U)
+		}
+	})
+
+	sub(t, "unstamped STAMP writes 0", func(t *testing.T) {
+		s := sessionSchema()
+		rec, _, err := apply(nil, schemaArgs(s,
+			op(wire.OperateOpSTAMP, opFromSchema, colPath(3, keyU64(1), 2), 0).withAux(wire.OperateStampS),
+			op(wire.OperateOpSTAMP, opFromSchema, fieldPath(2), 0).withAux(wire.OperateStampMs)), 0)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if rec.Fields[3].Table.Rows[0].Cols[2].Cell.U != 0 || rec.Fields[2].Cell.U != 0 {
+			t.Fatalf("unstamped STAMP must write 0: %+v", rec.Fields)
+		}
+	})
+
+	sub(t, "determinism: op order never leaks into the stored bytes", func(t *testing.T) {
+		s := sessionSchema()
+		mk := func(keys []uint64) *wire.OperateArgs {
+			ops := make([]oper, 0, len(keys))
+			for _, k := range keys {
+				ops = append(ops, op(wire.OperateOpADD, opFromSchema, colPath(3, keyU64(k), 0), 1))
+			}
+			return schemaArgs(s, ops...)
+		}
+		a, _, err := apply(nil, mk([]uint64{9, 1, 5}), 0)
+		if err != nil {
+			t.Fatal(err)
+		}
+		b, _, err := apply(nil, mk([]uint64{5, 9, 1}), 0)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !bytes.Equal(a.Encode(), b.Encode()) {
+			t.Fatal("insert order changed the stored bytes")
+		}
+	})
+
+	sub(t, "dynamic: determinism across field, column and row order", func(t *testing.T) {
+		mk := func(names []string) *wire.OperateArgs {
+			ops := make([]oper, 0, len(names))
+			for i, n := range names {
+				ops = append(ops, op(wire.OperateOpSET, wire.OperateTypeU8, namePath(n), int64(i)))
+			}
+			return dynArgs(ops...)
+		}
+		a, _, err := apply(nil, mk([]string{"z", "a", "m"}), 0)
+		if err != nil {
+			t.Fatal(err)
+		}
+		b, _, err := apply(nil, mk([]string{"a", "m", "z"}), 0)
+		if err != nil {
+			t.Fatal(err)
+		}
+		// The values differ (they are the op index), so compare the field
+		// order, not the bytes.
+		var an, bn []string
+		for i := range a.Fields {
+			an = append(an, a.Fields[i].Name)
+			bn = append(bn, b.Fields[i].Name)
+		}
+		if !reflect.DeepEqual(an, []string{"a", "m", "z"}) || !reflect.DeepEqual(bn, an) {
+			t.Fatalf("dynamic fields must be sorted by name: %v %v", an, bn)
+		}
+	})
+
+	sub(t, "record EXISTS and ABSENT distinguish a created record", func(t *testing.T) {
+		// Ruling: the record path's presence is whether the record existed
+		// before this call, which is the only reading under which §2.4's
+		// "() is valid for CHECK EXISTS/ABSENT" says anything — a call that
+		// reaches the op list always has a record by then.
+		s := sessionSchema()
+		mk := func(cmp uint8) *wire.OperateArgs {
+			return schemaArgs(s, op(wire.OperateOpCHECK, opFromSchema, recPath(), 0).withAux(cmp))
+		}
+		rec, res, err := apply(nil, mk(wire.OperateCmpAbsent), 0)
+		if err != nil || res.Status != wire.OperateStatusOK {
+			t.Fatalf("ABSENT on a record this call created: %v %+v", err, res)
+		}
+		if rec == nil {
+			t.Fatal("record not created")
+		}
+		if _, res, err = apply(nil, mk(wire.OperateCmpExists), 0); err != nil || res.Status != wire.OperateStatusCheckFailed {
+			t.Fatalf("EXISTS on a record this call created: %v %+v", err, res)
+		}
+		if _, res, err = apply(rec, mk(wire.OperateCmpExists), 0); err != nil || res.Status != wire.OperateStatusOK {
+			t.Fatalf("EXISTS on a stored record: %v %+v", err, res)
+		}
+		if _, res, err = apply(rec, mk(wire.OperateCmpAbsent), 0); err != nil || res.Status != wire.OperateStatusCheckFailed {
+			t.Fatalf("ABSENT on a stored record: %v %+v", err, res)
+		}
+	})
+
+	sub(t, "dynamic: a position segment is rejected", func(t *testing.T) {
+		rec, _, err := apply(nil, dynArgs(op(wire.OperateOpSET, wire.OperateTypeU8, namePath("x"), 1)), 0)
+		if err != nil {
+			t.Fatal(err)
+		}
+		// Positions are unstable in dynamic mode: fields are kept sorted by
+		// name, so only names address them (design doc §2.4).
+		if _, _, err := apply(rec, dynArgs(op(wire.OperateOpADD, wire.OperateTypeU8, fieldPath(0), 1)), 0); !errors.Is(err, wire.ErrOperatePath) {
+			t.Fatalf("field position: %v", err)
+		}
+		if _, _, err := apply(rec, dynArgs(op(wire.OperateOpADD, wire.OperateTypeU8, colPath(0, keyU64(1), 0), 1)), 0); !errors.Is(err, wire.ErrOperatePath) {
+			t.Fatalf("column position: %v", err)
+		}
+	})
+
+	sub(t, "schema mode floats and the variable-length tail", func(t *testing.T) {
+		s := floatSchema()
+		rec, _, err := apply(nil, schemaArgs(s,
+			op(wire.OperateOpSET, opFromSchema, fieldPath(0), f64(1.1)),
+			op(wire.OperateOpADD, opFromSchema, fieldPath(1), f64(2.5)),
+			op(wire.OperateOpADD, opFromSchema, fieldPath(1), f64(2.5)),
+			op(wire.OperateOpSET, opFromSchema, fieldPath(2), 0).withBytes([]byte("hello")),
+			op(wire.OperateOpSET, opFromSchema, fieldPath(3), 0).withBytes([]byte("DE")),
+			op(wire.OperateOpADD, opFromSchema, fieldPath(4), 300)), 0)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if rec.Fields[0].Cell.F != float64(float32(1.1)) {
+			t.Fatalf("F32 must be stored rounded: %v", rec.Fields[0].Cell.F)
+		}
+		if rec.Fields[1].Cell.F != 5 || string(rec.Fields[2].Cell.B) != "hello" ||
+			string(rec.Fields[3].Cell.B) != "DE" || rec.Fields[4].Cell.U != 300 {
+			t.Fatalf("%+v", rec.Fields)
+		}
+		rec, _, err = apply(rec, schemaArgs(s, op(wire.OperateOpMAX, opFromSchema, fieldPath(2), 0).withBytes([]byte("zz"))), 0)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if string(rec.Fields[2].Cell.B) != "zz" {
+			t.Fatalf("bytewise MAX: %q", rec.Fields[2].Cell.B)
+		}
+		// An op that cannot apply to the field's type is ErrOperateType
+		// (design doc §2.4), and a FIXED operand must be exactly N bytes.
+		for _, tc := range []struct {
+			name string
+			args *wire.OperateArgs
+		}{
+			{"shift on a float", schemaArgs(s, op(wire.OperateOpSHL, opFromSchema, fieldPath(0), 1))},
+			{"add on bytes", schemaArgs(s, op(wire.OperateOpADD, opFromSchema, fieldPath(2), 1))},
+			{"shift on a varint", schemaArgs(s, op(wire.OperateOpSHR, opFromSchema, fieldPath(4), 1))},
+			{"FIXED operand of the wrong width", schemaArgs(s, op(wire.OperateOpSET, opFromSchema, fieldPath(3), 0).withBytes([]byte("DEU")))},
+		} {
+			if _, _, err := apply(rec, tc.args, 0); !errors.Is(err, wire.ErrOperateType) {
+				t.Errorf("%s: err=%v, want ErrOperateType", tc.name, err)
+			}
+		}
+	})
+
+	sub(t, "every scalar opcode reaches the arithmetic", func(t *testing.T) {
+		s := sessionSchema()
+		rec, _, err := apply(nil, schemaArgs(s,
+			op(wire.OperateOpSET, opFromSchema, fieldPath(0), 3),
+			op(wire.OperateOpMUL, opFromSchema, fieldPath(0), 4), // 12
+			op(wire.OperateOpMIN, opFromSchema, fieldPath(0), 5), // 5
+			op(wire.OperateOpSET, opFromSchema, fieldPath(2), 0b1010),
+			op(wire.OperateOpSHL, opFromSchema, fieldPath(2), 2), // 0b101000
+			op(wire.OperateOpOR, opFromSchema, fieldPath(2), 1),  // 0b101001
+			op(wire.OperateOpAND, opFromSchema, fieldPath(2), 0b111100),
+			op(wire.OperateOpXOR, opFromSchema, fieldPath(2), 0b000100)), 0)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if rec.Fields[0].Cell.U != 5 {
+			t.Fatalf("MUL/MIN: %d", rec.Fields[0].Cell.U)
+		}
+		// 0b1010 <<2 = 0b101000, |1 = 0b101001, &0b111100 = 0b101000, ^0b100 = 0b101100.
+		if rec.Fields[2].Cell.U != 0b101100 {
+			t.Fatalf("SHL/OR/AND/XOR: %b", rec.Fields[2].Cell.U)
+		}
+	})
+
+	sub(t, "a table compares by its row count", func(t *testing.T) {
+		s := sessionSchema()
+		var rec *wire.Record
+		var err error
+		for k := uint64(1); k <= 2; k++ {
+			rec, _, err = apply(rec, schemaArgs(s, op(wire.OperateOpADD, opFromSchema, colPath(3, keyU64(k), 0), 1)), 0)
+			if err != nil {
+				t.Fatal(k, err)
+			}
+		}
+		// "if the table has >= 2 rows" is a plain IF (design doc §3.3).
+		got, _, err := apply(rec, schemaArgs(s,
+			op(wire.OperateOpIF, opFromSchema, fieldPath(3), 2).withAux(wire.OperateCmpGE).withB(1),
+			op(wire.OperateOpADD, opFromSchema, fieldPath(0), 1)), 0)
+		if err != nil || got.Fields[0].Cell.U != 1 {
+			t.Fatalf("%v %+v", err, got.Fields[0].Cell)
+		}
+		_, res, err := apply(rec, schemaArgs(s, op(wire.OperateOpCHECK, opFromSchema, fieldPath(3), 3).withAux(wire.OperateCmpEQ)), 0)
+		if err != nil || res.Status != wire.OperateStatusCheckFailed {
+			t.Fatalf("%v %+v", err, res)
+		}
+	})
+
+	sub(t, "maxOps and maxRet are enforced", func(t *testing.T) {
+		s := sessionSchema()
+		many := make([]oper, wire.OperateMaxOps+1)
+		for i := range many {
+			many[i] = op(wire.OperateOpADD, opFromSchema, fieldPath(0), 0)
+		}
+		if _, _, err := apply(nil, schemaArgs(s, many...), 0); !errors.Is(err, wire.ErrOperateCap) {
+			t.Fatalf("maxOps: %v", err)
+		}
+		a := schemaArgs(s)
+		for i := 0; i <= wire.OperateMaxRet; i++ {
+			a.Rets = append(a.Rets, wire.OperateRet{Mode: wire.OperateRetCount, Path: fieldPath(0)})
+		}
+		if _, _, err := apply(nil, a, 0); !errors.Is(err, wire.ErrOperateCap) {
+			t.Fatalf("maxRet: %v", err)
+		}
+	})
+
+	sub(t, "TTL modes are reported", func(t *testing.T) {
+		// The applier signature carries no expiry: TTL/ttlMode live in the
+		// handler around it (design doc §3.5) and are covered by the handler
+		// task's tests, not by the semantics oracle.
+		t.Skip("ttlMode is a handler concern; covered by the operate handler tests")
+	})
+}

--- a/ops/operate_semantics_test.go
+++ b/ops/operate_semantics_test.go
@@ -38,6 +38,9 @@ type applier func(rec *wire.Record, a *wire.OperateArgs, stampMs int64) (*wire.R
 
 // skipDynamic makes sub tests whose name starts with "dynamic:" skip. Set by
 // an engine test whose engine implements schema mode only.
+//
+// It is package-level state, as is maxOperateRecordBytes, which one sub-test
+// lowers and restores. No test in this file may call t.Parallel.
 var skipDynamic bool
 
 // sub runs one semantics sub-test, honouring skipDynamic.
@@ -309,6 +312,13 @@ func runSemantics(t *testing.T, apply applier) { //nolint:maintidx // one sub-te
 				t.Fatalf("n=%d: err=%v, want errOperateIfRange", n, err)
 			}
 		}
+		// The bound is eager: an out-of-range n is an error even when the
+		// condition holds and nothing would be skipped.
+		if _, _, err := apply(nil, schemaArgs(s,
+			op(wire.OperateOpIF, opFromSchema, fieldPath(0), 0).withAux(wire.OperateCmpEQ).withB(5),
+			op(wire.OperateOpADD, opFromSchema, fieldPath(0), 1)), 0); !errors.Is(err, errOperateIfRange) {
+			t.Fatalf("condition true, n out of range: %v", err)
+		}
 		// n exactly equal to the remaining op count is legal.
 		rec, _, err := apply(nil, schemaArgs(s,
 			op(wire.OperateOpIF, opFromSchema, fieldPath(0), 100).withAux(wire.OperateCmpGE).withB(1),
@@ -445,7 +455,9 @@ func runSemantics(t *testing.T, apply applier) { //nolint:maintidx // one sub-te
 				t.Errorf("%s: err=%v, want %v", tc.name, err, tc.want)
 			}
 		}
-		// create NONE against an existing record of either mode is fine.
+		// create NONE against an existing schema-mode record is fine. The
+		// dynamic-mode half of that rule is exercised by the freeze sub-test,
+		// which migrates a dynamic record with noneArgs.
 		if _, _, err := apply(base, noneArgs(op(wire.OperateOpADD, opFromSchema, fieldPath(0), 1)), 0); err != nil {
 			t.Fatalf("create NONE on an existing record: %v", err)
 		}
@@ -630,6 +642,20 @@ func runSemantics(t *testing.T, apply applier) { //nolint:maintidx // one sub-te
 		if len(row.Cols) != 1 || row.Cols[0].Name != "d" {
 			t.Fatalf("%+v", row)
 		}
+		// Ruling: a row is a keyed entity, so it survives losing its last
+		// column and still counts as present.
+		bare, res, err := apply(tbl, withCount(dynArgs(
+			op(wire.OperateOpDEL, opFromSchema, nameColPath("t", keyU64(1), "d"), 0)),
+			nameRowPath("t", keyU64(1))), 0)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(bare.Fields[0].Table.Rows) != 1 || len(bare.Fields[0].Table.Rows[0].Cols) != 0 {
+			t.Fatalf("the row should survive its last column: %+v", bare.Fields[0].Table.Rows)
+		}
+		if c, _, _ := wire.DecodeTaggedCell(res.Values[0]); c.U != 1 {
+			t.Fatalf("COUNT of a column-less row %d, want 1", c.U)
+		}
 	})
 
 	sub(t, "dynamic: TRIM and CONFIG", func(t *testing.T) {
@@ -659,6 +685,15 @@ func runSemantics(t *testing.T, apply applier) { //nolint:maintidx // one sub-te
 		}
 		if rec.Fields[0].Table.Policy != wire.OperatePolicyMinKey {
 			t.Fatal("TRIM must not change the stored policy")
+		}
+		// CONFIG is a table op: its type byte is meaningless and ignored.
+		rec, _, err = apply(rec, dynArgs(
+			op(wire.OperateOpCONFIG, wire.OperateTypeF32, namePath("ev"), 5).withAux(wire.OperatePolicyMaxKey)), 0)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if rec.Fields[0].Table.Cap != 5 || rec.Fields[0].Table.Policy != wire.OperatePolicyMaxKey {
+			t.Fatalf("%+v", rec.Fields[0].Table)
 		}
 	})
 
@@ -802,6 +837,7 @@ func runSemantics(t *testing.T, apply applier) { //nolint:maintidx // one sub-te
 		}{
 			{"wrong from-version", noneArgs(op(wire.OperateOpMIGRATE, opFromSchema, recPath(), 5).withBytes(s2.Encode())), wire.ErrOperateSchemaVersion},
 			{"not the first op", noneArgs(op(wire.OperateOpADD, opFromSchema, fieldPath(0), 1), migrate), wire.ErrOperateOpcode},
+			{"path is not the record", noneArgs(op(wire.OperateOpMIGRATE, opFromSchema, fieldPath(0), 1).withBytes(s2.Encode())), wire.ErrOperatePath},
 			{"not an append-only extension", noneArgs(op(wire.OperateOpMIGRATE, opFromSchema, recPath(), 1).withBytes(widenedSchema().Encode())), wire.ErrOperateSchema},
 			{"malformed schema blob", noneArgs(op(wire.OperateOpMIGRATE, opFromSchema, recPath(), 1).withBytes([]byte{9, 9})), wire.ErrShortArgs},
 		}
@@ -858,6 +894,16 @@ func runSemantics(t *testing.T, apply applier) { //nolint:maintidx // one sub-te
 		}
 		if _, _, err := apply(wrong, noneArgs(migrate.withAux(wire.OperateMigrateDropExtra)), 0); !errors.Is(err, wire.ErrOperateType) {
 			t.Fatalf("domain mismatch accepted: %v", err)
+		}
+		// A dynamic row key that is not exactly the schema's key width cannot
+		// be packed fixed-width.
+		narrow, _, err := apply(nil, dynArgs(
+			op(wire.OperateOpSET, wire.OperateTypeU16, nameColPath("b", []byte{1, 2, 3, 4}, "c"), 3)), 0)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if _, _, err := apply(narrow, noneArgs(migrate.withAux(wire.OperateMigrateDropExtra)), 0); !errors.Is(err, wire.ErrOperateSchema) {
+			t.Fatalf("row key of the wrong width accepted: %v", err)
 		}
 		// Freezing needs names in the target schema.
 		nameless := frozenSchema()
@@ -1199,6 +1245,220 @@ func runSemantics(t *testing.T, apply applier) { //nolint:maintidx // one sub-te
 		}
 		if _, _, err := apply(nil, a, 0); !errors.Is(err, wire.ErrOperateCap) {
 			t.Fatalf("maxRet: %v", err)
+		}
+	})
+
+	sub(t, "DEL () is terminal and later ops do not resurrect the record", func(t *testing.T) {
+		// Ruling: DEL () ends the op list. An engine that instead cleared the
+		// record and let a later write refill it would return a live record
+		// here.
+		s := sessionSchema()
+		base, _, err := apply(nil, schemaArgs(s, op(wire.OperateOpADD, opFromSchema, fieldPath(0), 5)), 0)
+		if err != nil {
+			t.Fatal(err)
+		}
+		got, res, err := apply(base, withCount(withRet(schemaArgs(s,
+			op(wire.OperateOpDEL, opFromSchema, recPath(), 0),
+			op(wire.OperateOpADD, opFromSchema, fieldPath(0), 1)), fieldPath(0)), recPath()), 0)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got != nil {
+			t.Fatalf("an op after DEL () resurrected the record: %+v", got.Fields)
+		}
+		if !bytes.Equal(res.Values[0], []byte{wire.OperateTypeUnset}) {
+			t.Fatalf("VALUE after DEL (): %x, want UNSET", res.Values[0])
+		}
+		if c, _, _ := wire.DecodeTaggedCell(res.Values[1]); c.U != 0 {
+			t.Fatalf("COUNT after DEL (): %d, want 0", c.U)
+		}
+	})
+
+	sub(t, "create NONE ignores a schema blob", func(t *testing.T) {
+		// Ruling: §3.5 says a create = NONE call carries no blob, so one that
+		// arrives anyway is ignored — not checked against the stored version.
+		s := sessionSchema()
+		base, _, err := apply(nil, schemaArgs(s, op(wire.OperateOpADD, opFromSchema, fieldPath(0), 1)), 0)
+		if err != nil {
+			t.Fatal(err)
+		}
+		other := sessionSchema()
+		other.Version = 9
+		other.StoreNames = true
+		a := noneArgs(op(wire.OperateOpADD, opFromSchema, fieldPath(0), 1))
+		a.Schema = other.Encode()
+		got, _, err := apply(base, a, 0)
+		if err != nil {
+			t.Fatalf("create NONE must ignore the blob: %v", err)
+		}
+		if got.Fields[0].Cell.U != 2 || got.Schema.Version != 1 {
+			t.Fatalf("%d v%d", got.Fields[0].Cell.U, got.Schema.Version)
+		}
+	})
+
+	sub(t, "create SCHEMA compares the version, not the blob bytes", func(t *testing.T) {
+		// Ruling: §2.8 matches versions. The stored schema stays
+		// authoritative, so a call may carry a differently encoded blob of the
+		// same version without changing the record.
+		s := sessionSchema()
+		base, _, err := apply(nil, schemaArgs(s, op(wire.OperateOpADD, opFromSchema, fieldPath(0), 1)), 0)
+		if err != nil {
+			t.Fatal(err)
+		}
+		named := sessionSchema()
+		named.StoreNames = true // same version, different bytes
+		if bytes.Equal(named.Encode(), s.Encode()) {
+			t.Fatal("the two blobs must differ for this test to mean anything")
+		}
+		got, _, err := apply(base, schemaArgs(named, op(wire.OperateOpADD, opFromSchema, fieldPath(0), 1)), 0)
+		if err != nil {
+			t.Fatalf("same version, different blob: %v", err)
+		}
+		if got.Fields[0].Cell.U != 2 {
+			t.Fatalf("rc=%d", got.Fields[0].Cell.U)
+		}
+		// The stored schema won: it still does not store names, so a name
+		// segment is still rejected.
+		if _, _, err := apply(got, schemaArgs(named, op(wire.OperateOpADD, opFromSchema, namePath("rc"), 1)), 0); !errors.Is(err, wire.ErrOperatePath) {
+			t.Fatalf("the call's blob replaced the stored schema: %v", err)
+		}
+	})
+
+	sub(t, "control and table ops ignore their type byte", func(t *testing.T) {
+		// Ruling: IF, CHECK, DEL, TRIM, CONFIG and MIGRATE neither read nor
+		// write a typed value, so a type byte that disagrees with the schema
+		// is not an error for them. (CONFIG's half is in the dynamic
+		// TRIM/CONFIG sub-test; MIGRATE's is in the MIGRATE sub-test, which
+		// passes 0xFF against a table-bearing schema.)
+		s := sessionSchema()
+		base, _, err := apply(nil, schemaArgs(s,
+			op(wire.OperateOpADD, opFromSchema, fieldPath(0), 5),
+			op(wire.OperateOpADD, opFromSchema, colPath(3, keyU64(1), 0), 1)), 0)
+		if err != nil {
+			t.Fatal(err)
+		}
+		got, _, err := apply(base, schemaArgs(s,
+			op(wire.OperateOpIF, wire.OperateTypeF64, fieldPath(0), 1).withAux(wire.OperateCmpGE).withB(1),
+			op(wire.OperateOpADD, opFromSchema, fieldPath(0), 1)), 0)
+		if err != nil || got.Fields[0].Cell.U != 6 {
+			t.Fatalf("IF: %v %+v", err, got.Fields[0].Cell)
+		}
+		_, res, err := apply(base, schemaArgs(s,
+			op(wire.OperateOpCHECK, wire.OperateTypeBytes, fieldPath(0), 1).withAux(wire.OperateCmpGE)), 0)
+		if err != nil || res.Status != wire.OperateStatusOK {
+			t.Fatalf("CHECK: %v %+v", err, res)
+		}
+		got, _, err = apply(base, schemaArgs(s, op(wire.OperateOpDEL, wire.OperateTypeF32, fieldPath(0), 0)), 0)
+		if err != nil || got.Fields[0].Cell.U != 0 {
+			t.Fatalf("DEL: %v %+v", err, got.Fields[0].Cell)
+		}
+		got, _, err = apply(base, schemaArgs(s,
+			op(wire.OperateOpTRIM, wire.OperateTypeBytes, fieldPath(3), 0).withAux(wire.OperatePolicyMinKey)), 0)
+		if err != nil || len(got.Fields[3].Table.Rows) != 0 {
+			t.Fatalf("TRIM: %v %+v", err, got.Fields[3].Table)
+		}
+	})
+
+	sub(t, "dynamic: an absent target reads as the zero of the op's type byte", func(t *testing.T) {
+		// Ruling: the op's type byte picks the domain an absent dynamic target
+		// compares in. Here the same comparison is true as bytes (empty equals
+		// empty) and false as an integer (0 != 5).
+		mk := func(typ uint8) *wire.OperateArgs {
+			return dynArgs(
+				op(wire.OperateOpSET, wire.OperateTypeU8, namePath("base"), 1),
+				op(wire.OperateOpIF, typ, namePath("x"), 5).withAux(wire.OperateCmpEQ).withB(1),
+				op(wire.OperateOpSET, wire.OperateTypeU8, namePath("hit"), 1))
+		}
+		asBytes, _, err := apply(nil, mk(wire.OperateTypeBytes), 0)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(asBytes.Fields) != 2 {
+			t.Fatalf("empty BYTES should equal the empty operand: %+v", asBytes.Fields)
+		}
+		asInt, _, err := apply(nil, mk(wire.OperateTypeU8), 0)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(asInt.Fields) != 1 {
+			t.Fatalf("integer zero should not equal 5: %+v", asInt.Fields)
+		}
+	})
+
+	sub(t, "dynamic: MIN_COL orders mixed column types by domain", func(t *testing.T) {
+		// Ruling: in dynamic mode two rows may store different types under one
+		// column name. They order by domain rank (int < float < bytes) so the
+		// victim stays a pure function of the stored bytes.
+		mk := func(a, b oper) []uint64 {
+			rec, _, err := apply(nil, dynArgs(
+				op(wire.OperateOpCONFIG, opFromSchema, namePath("ev"), 2).
+					withAux(wire.OperatePolicyMinCol).withBytes([]byte("s")),
+				a, b), 0)
+			if err != nil {
+				t.Fatal(err)
+			}
+			rec, _, err = apply(rec, dynArgs(
+				op(wire.OperateOpSET, wire.OperateTypeU32, nameColPath("ev", keyU64(3), "s"), 1)), 0)
+			if err != nil {
+				t.Fatal(err)
+			}
+			return rowKeys(rec.Fields[0].Table)
+		}
+		// Row 1 holds an int, row 2 a float: the int row goes even though 999
+		// is numerically the larger value.
+		keys := mk(
+			op(wire.OperateOpSET, wire.OperateTypeU32, nameColPath("ev", keyU64(1), "s"), 999),
+			op(wire.OperateOpSET, wire.OperateTypeF64, nameColPath("ev", keyU64(2), "s"), f64(1)))
+		if !reflect.DeepEqual(keys, []uint64{2, 3}) {
+			t.Fatalf("int must sort below float: %v", keys)
+		}
+		// Row 1 holds bytes, row 2 an int: the int row goes.
+		keys = mk(
+			op(wire.OperateOpSET, wire.OperateTypeBytes, nameColPath("ev", keyU64(1), "s"), 0).withBytes([]byte("a")),
+			op(wire.OperateOpSET, wire.OperateTypeU32, nameColPath("ev", keyU64(2), "s"), 5))
+		if !reflect.DeepEqual(keys, []uint64{1, 3}) {
+			t.Fatalf("int must sort below bytes: %v", keys)
+		}
+	})
+
+	sub(t, "dynamic: TRIM on an absent table field is a no-op", func(t *testing.T) {
+		// Ruling: TRIM is a shrink, not a write, so it does not vivify.
+		rec, _, err := apply(nil, dynArgs(op(wire.OperateOpSET, wire.OperateTypeU8, namePath("a"), 1)), 0)
+		if err != nil {
+			t.Fatal(err)
+		}
+		got, _, err := apply(rec, dynArgs(
+			op(wire.OperateOpTRIM, opFromSchema, namePath("ev"), 1).withAux(wire.OperatePolicyMinKey)), 0)
+		if err != nil {
+			t.Fatalf("TRIM of an absent table field: %v", err)
+		}
+		if len(got.Fields) != 1 || got.Fields[0].Name != "a" {
+			t.Fatalf("TRIM vivified a table: %+v", got.Fields)
+		}
+	})
+
+	sub(t, "an over-large record is a cap error with the record unchanged", func(t *testing.T) {
+		// §2.7's maxRecordBytes backstop. The bound is lowered rather than
+		// building 16 MiB of record; it is package-level state, so no test in
+		// this file may run in parallel.
+		restore := maxOperateRecordBytes
+		maxOperateRecordBytes = 512
+		t.Cleanup(func() { maxOperateRecordBytes = restore })
+
+		s := floatSchema()
+		small, _, err := apply(nil, schemaArgs(s,
+			op(wire.OperateOpSET, opFromSchema, fieldPath(2), 0).withBytes(bytes.Repeat([]byte{7}, 64))), 0)
+		if err != nil || small == nil {
+			t.Fatalf("a record under the bound must still apply: %v", err)
+		}
+		before := small.Encode()
+		got, _, err := apply(small, schemaArgs(s,
+			op(wire.OperateOpSET, opFromSchema, fieldPath(2), 0).withBytes(bytes.Repeat([]byte{7}, 1024))), 0)
+		if !errors.Is(err, wire.ErrOperateCap) {
+			t.Fatalf("err=%v, want ErrOperateCap", err)
+		}
+		if got != nil && !bytes.Equal(got.Encode(), before) {
+			t.Fatal("record changed by a call that hit the record-size cap")
 		}
 	})
 

--- a/ops/operate_semantics_test.go
+++ b/ops/operate_semantics_test.go
@@ -379,6 +379,55 @@ func runSemantics(t *testing.T, apply applier) { //nolint:maintidx // one sub-te
 		}
 	})
 
+	sub(t, "dynamic: a SET declaring FIXED needs an operand that fits a cell", func(t *testing.T) {
+		// Ruling: SET replaces the scalar INCLUDING its type (§2.9), so a
+		// FIXED type byte whose operand cannot form a FIXED(1-255) cell has
+		// no width to write and no stored type to fall back on — it is
+		// wire.ErrOperateType on an existing target exactly as on a missing
+		// one (§2.4: an op that cannot apply to the field's type is an
+		// error, never a silent reinterpretation).
+		base, _, err := apply(nil, dynArgs(
+			op(wire.OperateOpSET, wire.OperateTypeU8, namePath("x"), 200),
+			op(wire.OperateOpSET, wire.OperateTypeU8, nameColPath("t", keyU64(1), "c"), 4)), 0)
+		if err != nil {
+			t.Fatal(err)
+		}
+		tooWide := bytes.Repeat([]byte{9}, wire.OperateMaxKeyLen+1)
+		for _, tc := range []struct {
+			name  string
+			path  wire.OperatePath
+			bytes []byte
+		}{
+			{"existing field, no operand", namePath("x"), nil},
+			{"existing field, over-wide operand", namePath("x"), tooWide},
+			{"missing field, no operand", namePath("fresh"), nil},
+			{"existing column, no operand", nameColPath("t", keyU64(1), "c"), nil},
+			{"missing column, over-wide operand", nameColPath("t", keyU64(1), "d"), tooWide},
+		} {
+			_, _, err := apply(base, dynArgs(
+				op(wire.OperateOpSET, wire.OperateTypeFixed, tc.path, 0).withBytes(tc.bytes)), 0)
+			if !errors.Is(err, wire.ErrOperateType) {
+				t.Errorf("%s: err=%v, want ErrOperateType", tc.name, err)
+			}
+		}
+		// The same op against a table field or a row is a PATH error, not a
+		// type error: the width is only meaningless once the path has landed
+		// on something that could hold a scalar.
+		for _, tc := range []struct {
+			name string
+			path wire.OperatePath
+		}{
+			{"table field", namePath("t")},
+			{"row", nameRowPath("t", keyU64(1))},
+		} {
+			_, _, err := apply(base, dynArgs(
+				op(wire.OperateOpSET, wire.OperateTypeFixed, tc.path, 0).withBytes(nil)), 0)
+			if !errors.Is(err, wire.ErrOperatePath) {
+				t.Errorf("%s: err=%v, want ErrOperatePath", tc.name, err)
+			}
+		}
+	})
+
 	sub(t, "dynamic: a scalar and a table never swap without DEL", func(t *testing.T) {
 		rec, _, err := apply(nil, dynArgs(op(wire.OperateOpSET, wire.OperateTypeU8, nameColPath("t", keyU64(1), "c"), 4)), 0)
 		if err != nil {
@@ -442,6 +491,13 @@ func runSemantics(t *testing.T, apply applier) { //nolint:maintidx // one sub-te
 				noneArgs(op(wire.OperateOpADD, opFromSchema, fieldPath(0), 1)), errOperateAbsent},
 			{"CONFIG in schema mode", base,
 				schemaArgs(s, op(wire.OperateOpCONFIG, opFromSchema, fieldPath(3), 4).withAux(wire.OperatePolicyMinKey)), wire.ErrOperateOpcode},
+			// A schema-mode record has no eviction config to set at all, so
+			// CONFIG is rejected as an opcode before anything about the op's
+			// path or operands is looked at.
+			{"CONFIG in schema mode, at a row path", base,
+				schemaArgs(s, op(wire.OperateOpCONFIG, opFromSchema, rowPath(3, keyU64(1)), 4).withAux(wire.OperatePolicyMinKey)), wire.ErrOperateOpcode},
+			{"CONFIG in schema mode, with an out-of-range cap", base,
+				schemaArgs(s, op(wire.OperateOpCONFIG, opFromSchema, fieldPath(3), -1).withAux(wire.OperatePolicyMinKey)), wire.ErrOperateOpcode},
 			{"unknown opcode", base,
 				schemaArgs(s, op(99, opFromSchema, fieldPath(0), 1)), wire.ErrOperateOpcode},
 			{"unknown comparator", base,
@@ -694,6 +750,51 @@ func runSemantics(t *testing.T, apply applier) { //nolint:maintidx // one sub-te
 		}
 		if rec.Fields[0].Table.Cap != 5 || rec.Fields[0].Table.Policy != wire.OperatePolicyMaxKey {
 			t.Fatalf("%+v", rec.Fields[0].Table)
+		}
+	})
+
+	sub(t, "dynamic: CONFIG says no in a fixed order", func(t *testing.T) {
+		// Every one of CONFIG's checks fails with a different error, so which
+		// one wins is part of the contract (design doc §3.2). The order is:
+		// the record's mode, the path's kind, its name segment, the name
+		// lengths, the cap operand, the policy byte, a *_COL policy's column
+		// name, and last the field's own kind. Each case below is malformed
+		// in two ways at once, so it can only pass if the earlier check wins.
+		rec, _, err := apply(nil, dynArgs(
+			op(wire.OperateOpSET, wire.OperateTypeU8, namePath("x"), 1),
+			op(wire.OperateOpSET, wire.OperateTypeU8, nameColPath("t", keyU64(1), "c"), 4)), 0)
+		if err != nil {
+			t.Fatal(err)
+		}
+		long := strings.Repeat("n", 256)
+		cases := []struct {
+			name string
+			args *wire.OperateArgs
+			want error
+		}{
+			{"a record path beats the cap operand",
+				dynArgs(op(wire.OperateOpCONFIG, opFromSchema, recPath(), -1).withAux(wire.OperatePolicyMinKey)),
+				wire.ErrOperatePath},
+			{"a position segment beats the cap operand",
+				dynArgs(op(wire.OperateOpCONFIG, opFromSchema, fieldPath(0), -1).withAux(wire.OperatePolicyMinKey)),
+				wire.ErrOperatePath},
+			{"a name too long beats the cap operand",
+				dynArgs(op(wire.OperateOpCONFIG, opFromSchema, namePath(long), -1).withAux(wire.OperatePolicyMinKey)),
+				wire.ErrOperateCap},
+			{"the cap operand beats the policy byte",
+				dynArgs(op(wire.OperateOpCONFIG, opFromSchema, namePath("t"), -1).withAux(99)),
+				wire.ErrOperateCap},
+			{"the policy byte beats the field's kind",
+				dynArgs(op(wire.OperateOpCONFIG, opFromSchema, namePath("x"), 2).withAux(99)),
+				wire.ErrOperateSchema},
+			{"a scalar field is the last word",
+				dynArgs(op(wire.OperateOpCONFIG, opFromSchema, namePath("x"), 2).withAux(wire.OperatePolicyMinKey)),
+				wire.ErrOperatePath},
+		}
+		for _, tc := range cases {
+			if _, _, err := apply(rec, tc.args, 0); !errors.Is(err, tc.want) {
+				t.Errorf("%s: err=%v, want %v", tc.name, err, tc.want)
+			}
 		}
 	})
 

--- a/ops/operate_test.go
+++ b/ops/operate_test.go
@@ -166,13 +166,9 @@ func handlerApply(rec *wire.Record, a *wire.OperateArgs, stampMs int64) (*wire.R
 // TestOperateHandlerSemantics runs the whole operate semantics suite twice:
 // once against applyRecordBytes directly (bytesApply, Task 8's adapter) and
 // once through the real handler (handlerApply, above) on a live TxContext.
-// Dynamic mode is not implemented until Task 10, so both runs skip its
-// sub-tests; every schema-mode and mode-independent rule must hold through
-// both adapters.
+// Both modes run in both lanes: every rule in the suite must hold through the
+// handler exactly as it does against the apply core.
 func TestOperateHandlerSemantics(t *testing.T) {
-	skipDynamic = true
-	t.Cleanup(func() { skipDynamic = false })
-
 	t.Run("bytes", func(t *testing.T) {
 		runSemantics(t, bytesApply)
 	})
@@ -263,12 +259,9 @@ func TestOperateTTLModes(t *testing.T) {
 }
 
 // TestOperateDeleteOnEmptyDynamic pins DEL of a dynamic record's last field
-// (design doc §2.5): the record itself disappears. Dynamic mode is not
-// implemented until Task 10 (openMode returns wire.ErrOperateMode for it), so
-// this is written against the intended behavior and skipped for now.
+// (design doc §2.5) through the real handler: the record itself disappears,
+// and the key is gone from the store rather than holding an empty record.
 func TestOperateDeleteOnEmptyDynamic(t *testing.T) {
-	t.Skip("dynamic engine: Task 10")
-
 	_, tx := newTestSetup(t)
 	key := []byte("dyn-key")
 	set := &wire.OperateArgs{Key: key, Create: wire.OperateCreateDynamic,

--- a/ops/operate_test.go
+++ b/ops/operate_test.go
@@ -1,0 +1,503 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package ops
+
+// Handler-level tests for "operate" (design doc §3.5): registration, TTL
+// modes, all-or-nothing behavior against a real TxContext/cache, and
+// determinism across replicas. The op's own apply semantics are covered
+// exhaustively by operate_semantics_test.go (against applyRecordBytes
+// directly and, here, against the handler through handlerApply) and by the
+// schema-engine equivalence property in operate_schema_engine_test.go; this
+// file does not re-derive that coverage.
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/rostamlabs/rostam/cache"
+	"github.com/rostamlabs/rostam/sdk/wire"
+)
+
+// callOperate encodes a, runs it through handleOperate under the given apply
+// stamp, and decodes the result frame. stampMs == 0 means unstamped, matching
+// applyStamp's contract elsewhere in this package.
+func callOperate(t *testing.T, tx *TxContext, stampMs int64, a *wire.OperateArgs) *wire.OperateResult {
+	t.Helper()
+	tx.SetApplyStamp(uint64(stampMs), stampMs != 0) //nolint:gosec // test stamps are small positive millis
+	defer tx.SetApplyStamp(0, false)
+	b, err := wire.EncodeOperateArgs(a)
+	if err != nil {
+		t.Fatalf("EncodeOperateArgs: %v", err)
+	}
+	out, err := handleOperate(tx, b)
+	if err != nil {
+		t.Fatalf("handleOperate: %v", err)
+	}
+	res, err := wire.DecodeOperateResult(out)
+	if err != nil {
+		t.Fatalf("DecodeOperateResult: %v", err)
+	}
+	return res
+}
+
+// readAt reads key's value and expiry judged against the EXPLICIT clock
+// stampMs, exactly as the replicated apply path would. Every TTL-sensitive
+// assertion in this file goes through readAt rather than the wall-clock
+// Get/GetWithExpiry: this file's stamps are small, arbitrary millis (matching
+// the operate semantics suite's convention), which the real wall clock would
+// judge as already expired.
+func readAt(t *testing.T, tx *TxContext, stampMs int64, key []byte) ([]byte, uint64) {
+	t.Helper()
+	tx.SetApplyStamp(uint64(stampMs), true) //nolint:gosec // test stamps are small positive millis
+	defer tx.SetApplyStamp(0, false)
+	v, expiryMs, err := tx.GetWithExpiry(key)
+	if err != nil {
+		t.Fatalf("GetWithExpiry at stamp %d: %v", stampMs, err)
+	}
+	return v, expiryMs
+}
+
+// addField0 is the simplest possible schema-mode call: bump sessionSchema's
+// first counter field by 1. Several tests below only need SOME call that
+// creates and then mutates a schema record; they share this rather than
+// each inventing their own.
+func addField0(key []byte) *wire.OperateArgs {
+	return &wire.OperateArgs{Key: key, Create: wire.OperateCreateSchema, Schema: sessionSchema().Encode(),
+		Ops: []wire.OperateOp{{Opcode: wire.OperateOpADD, Type: opFromSchema, Path: fieldPath(0), A: 1}}}
+}
+
+func TestOperatePersistsAcrossCalls(t *testing.T) {
+	_, tx := newTestSetup(t)
+	key := []byte("persist-key")
+	a := addField0(key)
+
+	for i := 0; i < 3; i++ {
+		res := callOperate(t, tx, 0, a)
+		if res.Status != wire.OperateStatusOK {
+			t.Fatalf("call %d: status = %v, want OperateStatusOK", i, res.Status)
+		}
+	}
+
+	v, err := tx.Get(key)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	rec, err := wire.DecodeRecord(v)
+	if err != nil {
+		t.Fatalf("DecodeRecord: %v", err)
+	}
+	if got := rec.Fields[0].Cell.U; got != 3 {
+		t.Fatalf("field 0 = %d, want 3 (three ADD calls persisted)", got)
+	}
+}
+
+// handlerApplyTx is the TxContext handlerApply drives. It is package-level
+// (mirroring skipDynamic's pattern) because the applier function type it
+// implements carries no state of its own: TestOperateHandlerSemantics sets
+// it before calling runSemantics(t, handlerApply) and clears it via
+// t.Cleanup.
+var handlerApplyTx *TxContext
+
+// handlerApply adapts handleOperate to the semantics suite's applier type
+// (operate_semantics_test.go), the handler-level counterpart of Task 8's
+// bytesApply: it seeds handlerApplyTx's store with rec's encoded bytes (or
+// clears the key when rec is nil), stamps the apply clock exactly as a
+// replicated apply would, drives the call through the real handler, and
+// decodes whatever ends up stored back into a tree. Running the whole suite
+// through it proves handleOperate's TTL/key-lookup wrapper does not change
+// the semantics applyRecordBytes already establishes.
+func handlerApply(rec *wire.Record, a *wire.OperateArgs, stampMs int64) (*wire.Record, *wire.OperateResult, error) {
+	tx := handlerApplyTx
+	if _, err := tx.Del(a.Key); err != nil {
+		return nil, nil, err
+	}
+	if rec != nil {
+		if err := tx.Put(a.Key, rec.Encode(), 0); err != nil {
+			return nil, nil, err
+		}
+	}
+
+	tx.SetApplyStamp(uint64(stampMs), stampMs != 0) //nolint:gosec // suite stamps are small positive millis
+	argBytes, err := wire.EncodeOperateArgs(a)
+	if err != nil {
+		tx.SetApplyStamp(0, false)
+		return nil, nil, err
+	}
+	out, err := handleOperate(tx, argBytes)
+	tx.SetApplyStamp(0, false)
+	if err != nil {
+		if errors.Is(err, cache.ErrNotFound) {
+			// handleOperate maps errOperateAbsent (create=NONE against an
+			// absent key) to the store's own not-found error at the handler
+			// boundary (see its doc comment; TestOperateCreateNoneOnAbsent
+			// pins that mapping directly). The semantics suite compares
+			// against the pre-mapped sentinel, so translate back here. This
+			// is safe because it is the ONLY way handleOperate itself can
+			// return cache.ErrNotFound: a genuine absent-on-read never
+			// reaches the caller as an error — GetWithExpiry's ErrNotFound
+			// is caught and turned into the `absent` bool before any of
+			// this handler's own error returns.
+			return nil, nil, errOperateAbsent
+		}
+		return nil, nil, err
+	}
+	res, err := wire.DecodeOperateResult(out)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	v, _, err := tx.GetWithExpiry(a.Key)
+	switch {
+	case errors.Is(err, cache.ErrNotFound):
+		return nil, res, nil
+	case err != nil:
+		return nil, nil, err
+	}
+	got, derr := wire.DecodeRecord(v)
+	if derr != nil {
+		return nil, nil, fmt.Errorf("handler produced undecodable bytes %x: %w", v, derr)
+	}
+	return got, res, nil
+}
+
+// TestOperateHandlerSemantics runs the whole operate semantics suite twice:
+// once against applyRecordBytes directly (bytesApply, Task 8's adapter) and
+// once through the real handler (handlerApply, above) on a live TxContext.
+// Dynamic mode is not implemented until Task 10, so both runs skip its
+// sub-tests; every schema-mode and mode-independent rule must hold through
+// both adapters.
+func TestOperateHandlerSemantics(t *testing.T) {
+	skipDynamic = true
+	t.Cleanup(func() { skipDynamic = false })
+
+	t.Run("bytes", func(t *testing.T) {
+		runSemantics(t, bytesApply)
+	})
+
+	t.Run("handler", func(t *testing.T) {
+		_, tx := newTestSetup(t)
+		handlerApplyTx = tx
+		t.Cleanup(func() { handlerApplyTx = nil })
+		runSemantics(t, handlerApply)
+	})
+}
+
+func TestOperateTTLModes(t *testing.T) {
+	t.Run("keep", func(t *testing.T) {
+		_, tx := newTestSetup(t)
+		key := []byte("keep-key")
+		a := addField0(key)
+		a.TTLMode = wire.OperateTTLKeep
+
+		callOperate(t, tx, 1_000, a)
+		if _, expiryMs := readAt(t, tx, 1_000, key); expiryMs != 0 {
+			t.Fatalf("KEEP on create set an expiry: %d, want 0 (none)", expiryMs)
+		}
+
+		// Give the record an expiry out of band (as if an earlier SET call
+		// had put one there), then confirm KEEP leaves it alone.
+		v, _, err := tx.GetWithExpiry(key)
+		if err != nil {
+			t.Fatalf("GetWithExpiry: %v", err)
+		}
+		if err := tx.PutAbs(key, v, 5_000); err != nil {
+			t.Fatalf("PutAbs: %v", err)
+		}
+
+		callOperate(t, tx, 1_000, a)
+		if _, expiryMs := readAt(t, tx, 1_000, key); expiryMs != 5_000 {
+			t.Fatalf("KEEP on an existing key changed the expiry: got %d, want 5000", expiryMs)
+		}
+	})
+
+	t.Run("set", func(t *testing.T) {
+		_, tx := newTestSetup(t)
+		key := []byte("set-key")
+		a := addField0(key)
+		a.TTLMode = wire.OperateTTLSet
+		a.TTL = 10 * time.Second
+
+		callOperate(t, tx, 1_000_000, a)
+		if _, expiryMs := readAt(t, tx, 1_000_000, key); expiryMs != 1_010_000 {
+			t.Fatalf("SET on create expiry = %d, want 1010000 (stamp+ttl)", expiryMs)
+		}
+
+		callOperate(t, tx, 1_005_000, a)
+		if _, expiryMs := readAt(t, tx, 1_005_000, key); expiryMs != 1_015_000 {
+			t.Fatalf("SET on an existing key did not refresh: expiry = %d, want 1015000", expiryMs)
+		}
+	})
+
+	t.Run("create_only", func(t *testing.T) {
+		_, tx := newTestSetup(t)
+		key := []byte("create-only-key")
+		a := addField0(key)
+		a.TTLMode = wire.OperateTTLCreateOnly
+		a.TTL = 10 * time.Second
+
+		callOperate(t, tx, 1_000_000, a)
+		if _, expiryMs := readAt(t, tx, 1_000_000, key); expiryMs != 1_010_000 {
+			t.Fatalf("CREATE_ONLY on create expiry = %d, want 1010000 (stamp+ttl)", expiryMs)
+		}
+
+		// A later stamp must not move the deadline once the key exists.
+		callOperate(t, tx, 1_005_000, a)
+		if _, expiryMs := readAt(t, tx, 1_005_000, key); expiryMs != 1_010_000 {
+			t.Fatalf("CREATE_ONLY changed the expiry on an existing key: got %d, want unchanged 1010000", expiryMs)
+		}
+	})
+}
+
+// TestOperateDeleteOnEmptyDynamic pins DEL of a dynamic record's last field
+// (design doc §2.5): the record itself disappears. Dynamic mode is not
+// implemented until Task 10 (openMode returns wire.ErrOperateMode for it), so
+// this is written against the intended behavior and skipped for now.
+func TestOperateDeleteOnEmptyDynamic(t *testing.T) {
+	t.Skip("dynamic engine: Task 10")
+
+	_, tx := newTestSetup(t)
+	key := []byte("dyn-key")
+	set := &wire.OperateArgs{Key: key, Create: wire.OperateCreateDynamic,
+		Ops: []wire.OperateOp{{Opcode: wire.OperateOpSET, Type: wire.OperateTypeU8, Path: namePath("a"), A: 1}}}
+	callOperate(t, tx, 0, set)
+
+	del := &wire.OperateArgs{Key: key, Create: wire.OperateCreateDynamic,
+		Ops: []wire.OperateOp{{Opcode: wire.OperateOpDEL, Path: namePath("a")}}}
+	callOperate(t, tx, 0, del)
+
+	if _, err := tx.Get(key); !errors.Is(err, cache.ErrNotFound) {
+		t.Fatalf("Get after deleting the last dynamic field: err = %v, want cache.ErrNotFound", err)
+	}
+}
+
+func TestOperateAllOrNothing(t *testing.T) {
+	_, tx := newTestSetup(t)
+	s := sessionSchema()
+	key := []byte("aon-key")
+	callOperate(t, tx, 1_000, addField0(key))
+
+	// Give the record an expiry too, so a would-be TTL change would also be
+	// visible.
+	v, _, err := tx.GetWithExpiry(key)
+	if err != nil {
+		t.Fatalf("GetWithExpiry: %v", err)
+	}
+	if err := tx.PutAbs(key, v, 50_000); err != nil {
+		t.Fatalf("PutAbs: %v", err)
+	}
+	before, beforeExpiry := readAt(t, tx, 1_000, key)
+
+	t.Run("bad opcode", func(t *testing.T) {
+		bad := &wire.OperateArgs{Key: key, Create: wire.OperateCreateSchema, Schema: s.Encode(),
+			Ops: []wire.OperateOp{
+				{Opcode: wire.OperateOpADD, Type: opFromSchema, Path: fieldPath(0), A: 1},
+				{Opcode: 250, Path: fieldPath(0)}, // not a defined opcode
+			}}
+		b, err := wire.EncodeOperateArgs(bad)
+		if err != nil {
+			t.Fatalf("EncodeOperateArgs: %v", err)
+		}
+		tx.SetApplyStamp(1_000, true)
+		_, err = handleOperate(tx, b)
+		tx.SetApplyStamp(0, false)
+		if err == nil {
+			t.Fatal("bad opcode after a successful op: want an error, got nil")
+		}
+		got, gotExpiry := readAt(t, tx, 1_000, key)
+		if !bytes.Equal(got, before) || gotExpiry != beforeExpiry {
+			t.Fatalf("record changed after a failing op list: bytes %x (want %x), expiry %d (want %d)",
+				got, before, gotExpiry, beforeExpiry)
+		}
+	})
+
+	t.Run("check false", func(t *testing.T) {
+		chk := &wire.OperateArgs{Key: key, Create: wire.OperateCreateSchema, Schema: s.Encode(),
+			Ops: []wire.OperateOp{
+				{Opcode: wire.OperateOpADD, Type: opFromSchema, Path: fieldPath(0), A: 1},
+				{Opcode: wire.OperateOpCHECK, Aux: wire.OperateCmpEQ, Path: fieldPath(0), A: 999},
+			}}
+		res := callOperate(t, tx, 1_000, chk)
+		if res.Status != wire.OperateStatusCheckFailed {
+			t.Fatalf("status = %v, want OperateStatusCheckFailed", res.Status)
+		}
+		got, gotExpiry := readAt(t, tx, 1_000, key)
+		if !bytes.Equal(got, before) || gotExpiry != beforeExpiry {
+			t.Fatalf("record changed after CHECK_FAILED: bytes %x (want %x), expiry %d (want %d)",
+				got, before, gotExpiry, beforeExpiry)
+		}
+	})
+}
+
+func TestOperateCreateNoneOnAbsent(t *testing.T) {
+	_, tx := newTestSetup(t)
+	key := []byte("absent-key")
+	a := &wire.OperateArgs{Key: key, Create: wire.OperateCreateNone,
+		Ops: []wire.OperateOp{{Opcode: wire.OperateOpADD, Type: wire.OperateTypeU8, Path: fieldPath(0), A: 1}}}
+	b, err := wire.EncodeOperateArgs(a)
+	if err != nil {
+		t.Fatalf("EncodeOperateArgs: %v", err)
+	}
+	if _, err := handleOperate(tx, b); !errors.Is(err, cache.ErrNotFound) {
+		t.Fatalf("err = %v, want cache.ErrNotFound", err)
+	}
+	if _, err := tx.Get(key); !errors.Is(err, cache.ErrNotFound) {
+		t.Fatalf("Get after a create=NONE call against an absent key: err = %v, want cache.ErrNotFound", err)
+	}
+}
+
+func TestOperateRejectsPlainPutValue(t *testing.T) {
+	_, tx := newTestSetup(t)
+	key := []byte("plain-key")
+	plain := []byte{0, 1, 2}
+	if err := tx.Put(key, plain, 0); err != nil {
+		t.Fatalf("Put: %v", err)
+	}
+
+	a := &wire.OperateArgs{Key: key, Create: wire.OperateCreateNone,
+		Ops: []wire.OperateOp{{Opcode: wire.OperateOpADD, Type: wire.OperateTypeU8, Path: fieldPath(0), A: 1}}}
+	b, err := wire.EncodeOperateArgs(a)
+	if err != nil {
+		t.Fatalf("EncodeOperateArgs: %v", err)
+	}
+	if _, err := handleOperate(tx, b); !errors.Is(err, wire.ErrOperateRecord) {
+		t.Fatalf("err = %v, want wire.ErrOperateRecord", err)
+	}
+	got, err := tx.Get(key)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if !bytes.Equal(got, plain) {
+		t.Fatalf("value changed: got %x, want %x", got, plain)
+	}
+}
+
+func TestOperateRecordTooLargeRejected(t *testing.T) {
+	old := maxOperateRecordBytes
+	maxOperateRecordBytes = 64
+	t.Cleanup(func() { maxOperateRecordBytes = old })
+
+	_, tx := newTestSetup(t)
+	s := floatSchema()
+	key := []byte("too-big-key")
+	a := &wire.OperateArgs{Key: key, Create: wire.OperateCreateSchema, Schema: s.Encode(),
+		Ops: []wire.OperateOp{{Opcode: wire.OperateOpSET, Type: wire.OperateTypeBytes, Path: fieldPath(2), Bytes: make([]byte, 100)}}}
+	b, err := wire.EncodeOperateArgs(a)
+	if err != nil {
+		t.Fatalf("EncodeOperateArgs: %v", err)
+	}
+	if _, err := handleOperate(tx, b); !errors.Is(err, wire.ErrOperateCap) {
+		t.Fatalf("err = %v, want wire.ErrOperateCap", err)
+	}
+	if _, err := tx.Get(key); !errors.Is(err, cache.ErrNotFound) {
+		t.Fatalf("Get after a cap-rejected create: err = %v, want cache.ErrNotFound (key stays absent)", err)
+	}
+}
+
+// TestOperateReplicaReapplyMatches drives two independent TxContexts (each
+// its own cache) through the same STAMP-and-eviction call sequence with
+// identical stamps, and requires byte-identical stored records and
+// byte-identical expiries after every call — the property that makes
+// operate safe to replay on every Raft follower.
+func TestOperateReplicaReapplyMatches(t *testing.T) {
+	_, tx1 := newTestSetup(t)
+	_, tx2 := newTestSetup(t)
+
+	s := sessionSchema()
+	s.Fields[3].Table.Cap = 3
+	key := []byte("replica-key")
+	mk := func(k uint64) *wire.OperateArgs {
+		a := schemaArgs(s,
+			op(wire.OperateOpADD, opFromSchema, colPath(3, keyU64(k), 0), 1),
+			op(wire.OperateOpSTAMP, opFromSchema, colPath(3, keyU64(k), 2), 0).withAux(wire.OperateStampS))
+		a.Key = key
+		a.TTLMode = wire.OperateTTLSet
+		a.TTL = 60 * time.Second
+		return a
+	}
+
+	steps := []struct {
+		k  uint64
+		st int64
+	}{{5, 1_000_000}, {9, 1_000_000}, {1, 1_001_000}, {7, 1_002_000}}
+	for _, step := range steps {
+		r1 := callOperate(t, tx1, step.st, mk(step.k))
+		r2 := callOperate(t, tx2, step.st, mk(step.k))
+		if r1.Status != r2.Status {
+			t.Fatalf("k=%d: status diverged: %v vs %v", step.k, r1.Status, r2.Status)
+		}
+		v1, e1 := readAt(t, tx1, step.st, key)
+		v2, e2 := readAt(t, tx2, step.st, key)
+		if !bytes.Equal(v1, v2) {
+			t.Fatalf("k=%d: stored bytes diverged:\n  %x\nvs\n  %x", step.k, v1, v2)
+		}
+		if e1 != e2 {
+			t.Fatalf("k=%d: expiry diverged: %d vs %d", step.k, e1, e2)
+		}
+	}
+}
+
+// TestOperateUnstampedIsDeterministic mirrors TestOperateReplicaReapplyMatches
+// for the unstamped path (stampMs == 0, LRU-by-stamp degrades to the
+// oracle-defined tie-break): two replicas fed the same call sequence with no
+// stamp at all must still land on identical bytes.
+func TestOperateUnstampedIsDeterministic(t *testing.T) {
+	_, tx1 := newTestSetup(t)
+	_, tx2 := newTestSetup(t)
+
+	s := sessionSchema()
+	s.Fields[3].Table.Cap = 2
+	s.Fields[3].Table.Policy = wire.OperatePolicyMinKey
+	key := []byte("unstamped-key")
+	mk := func(k uint64) *wire.OperateArgs {
+		a := schemaArgs(s, op(wire.OperateOpADD, opFromSchema, colPath(3, keyU64(k), 0), 1))
+		a.Key = key
+		return a
+	}
+
+	for _, k := range []uint64{4, 256, 5} {
+		callOperate(t, tx1, 0, mk(k))
+		callOperate(t, tx2, 0, mk(k))
+	}
+	v1, err := tx1.Get(key)
+	if err != nil {
+		t.Fatalf("Get tx1: %v", err)
+	}
+	v2, err := tx2.Get(key)
+	if err != nil {
+		t.Fatalf("Get tx2: %v", err)
+	}
+	if !bytes.Equal(v1, v2) {
+		t.Fatalf("unstamped apply diverged:\n  %x\nvs\n  %x", v1, v2)
+	}
+}
+
+func TestOperateRegistered(t *testing.T) {
+	r, _ := newTestSetup(t)
+	h, kind, _, ok := r.Lookup("operate")
+	if !ok {
+		t.Fatal("\"operate\" not registered")
+	}
+	if h == nil {
+		t.Fatal("\"operate\" has a nil handler")
+	}
+	if kind != OpReadWrite {
+		t.Fatalf("\"operate\" kind = %v, want OpReadWrite", kind)
+	}
+
+	found := false
+	for _, o := range wire.BuiltinOps {
+		if o.Name == "operate" {
+			found = true
+			if o.Kind != OpReadWrite {
+				t.Fatalf("wire.BuiltinOps[\"operate\"].Kind = %v, want OpReadWrite", o.Kind)
+			}
+			break
+		}
+	}
+	if !found {
+		t.Fatal("wire.BuiltinOps does not contain \"operate\"")
+	}
+}

--- a/ops/operate_test.go
+++ b/ops/operate_test.go
@@ -505,3 +505,58 @@ func TestOperateRegistered(t *testing.T) {
 		t.Fatal("wire.BuiltinOps does not contain \"operate\"")
 	}
 }
+
+// TestOperateOversizedStoredValueNotCopied covers the §2.7 ceiling on the
+// way IN. The value under an operate key is whatever the store holds — a
+// plain `put` can leave anything there — so it can be far larger than a
+// valid operate record. copyRecord must reject it BEFORE it copies: without
+// the check, one call would allocate an arbitrary multiple of the record cap
+// just to discover the bytes are not a record.
+func TestOperateOversizedStoredValueNotCopied(t *testing.T) {
+	old := maxOperateRecordBytes
+	maxOperateRecordBytes = 256
+	t.Cleanup(func() { maxOperateRecordBytes = old })
+
+	// A well-formed dynamic record one byte over the lowered cap: it is only
+	// the SIZE that must reject it, not its contents.
+	rec := &wire.Record{Mode: wire.OperateModeDynamic, Fields: []wire.Field{
+		{Name: "a", Cell: wire.Cell{Type: wire.OperateTypeBytes, B: make([]byte, 300)}}}}
+	stored := rec.Encode()
+	if len(stored) <= maxOperateRecordBytes {
+		t.Fatalf("fixture is %d bytes, not over the %d-byte cap", len(stored), maxOperateRecordBytes)
+	}
+	if _, derr := wire.DecodeRecord(stored); derr != nil {
+		t.Fatalf("fixture is not a well-formed record: %v", derr)
+	}
+
+	a := &wire.OperateArgs{Create: wire.OperateCreateDynamic, Ops: []wire.OperateOp{
+		{Opcode: wire.OperateOpADD, Type: wire.OperateTypeU64, Path: namePath("n"), A: 1}}}
+	out, deleted, res, err := applyRecordBytes(stored, a, 0)
+	if !errors.Is(err, wire.ErrOperateRecord) {
+		t.Fatalf("err = %v, want wire.ErrOperateRecord", err)
+	}
+	if out != nil || deleted || res != nil {
+		t.Fatalf("the rejected call returned out=%x deleted=%v res=%+v", out, deleted, res)
+	}
+
+	// And it costs no copy: the whole point of checking before copyRecord's
+	// make. The pooled engines are already warm after the call above, so the
+	// only allocation this could make is the copy itself.
+	if n := testing.AllocsPerRun(50, func() { _, _, _, _ = applyRecordBytes(stored, a, 0) }); n != 0 {
+		t.Fatalf("the rejected call allocated %v times; the size check must precede the copy", n)
+	}
+
+	// At exactly the cap the same record opens: the rejection above is the
+	// ceiling, not the record. A call that changes nothing is used here, so
+	// the §2.7 check on the FINISHED record cannot be what passes or fails.
+	maxOperateRecordBytes = len(stored)
+	noop := &wire.OperateArgs{Create: wire.OperateCreateDynamic}
+	if _, _, _, err := applyRecordBytes(stored, noop, 0); err != nil {
+		t.Fatalf("a stored record exactly at the cap must open: %v", err)
+	}
+	// With headroom for the new field, the mutating call goes through too.
+	maxOperateRecordBytes = len(stored) + 64
+	if _, _, _, err := applyRecordBytes(stored, a, 0); err != nil {
+		t.Fatalf("a stored record under the cap must apply: %v", err)
+	}
+}

--- a/ops/operate_test.go
+++ b/ops/operate_test.go
@@ -229,6 +229,17 @@ func TestOperateTTLModes(t *testing.T) {
 		if _, expiryMs := readAt(t, tx, 1_005_000, key); expiryMs != 1_015_000 {
 			t.Fatalf("SET on an existing key did not refresh: expiry = %d, want 1015000", expiryMs)
 		}
+
+		// SET with TTL == 0 means "refresh to no expiry" (design doc §3.5):
+		// it must clear the deadline on an existing key, not leave the old
+		// one in place or misinterpret zero as "unspecified".
+		clear := addField0(key)
+		clear.TTLMode = wire.OperateTTLSet
+		clear.TTL = 0
+		callOperate(t, tx, 1_010_000, clear)
+		if _, expiryMs := readAt(t, tx, 1_010_000, key); expiryMs != 0 {
+			t.Fatalf("SET with TTL=0 did not clear the expiry: got %d, want 0 (none)", expiryMs)
+		}
 	})
 
 	t.Run("create_only", func(t *testing.T) {

--- a/ops/wire_aliases.go
+++ b/ops/wire_aliases.go
@@ -210,6 +210,8 @@ var (
 	DecodeNamedSearchArgsOpts                 = wire.DecodeNamedSearchArgsOpts
 	DecodeNamedSparseSearchArgs               = wire.DecodeNamedSparseSearchArgs
 	DecodeNamedSparseSearchArgsOpts           = wire.DecodeNamedSparseSearchArgsOpts
+	DecodeOperateArgs                         = wire.DecodeOperateArgs
+	DecodeOperateResult                       = wire.DecodeOperateResult
 	DecodePayloadResult                       = wire.DecodePayloadResult
 	DecodePutArgs                             = wire.DecodePutArgs
 	DecodePutBatchArgs                        = wire.DecodePutBatchArgs
@@ -220,6 +222,7 @@ var (
 	DecodeQueryResultGroupedFanOut            = wire.DecodeQueryResultGroupedFanOut
 	DecodeQuerySpecArgs                       = wire.DecodeQuerySpecArgs
 	DecodeQueryTreeLanes                      = wire.DecodeQueryTreeLanes
+	DecodeRecord                              = wire.DecodeRecord
 	DecodeReshardAbortArgs                    = wire.DecodeReshardAbortArgs
 	DecodeReshardArgs                         = wire.DecodeReshardArgs
 	DecodeResplitArgs                         = wire.DecodeResplitArgs
@@ -227,6 +230,7 @@ var (
 	DecodeResplitCleanupResult                = wire.DecodeResplitCleanupResult
 	DecodeScanVectorsArgs                     = wire.DecodeScanVectorsArgs
 	DecodeScanVectorsResult                   = wire.DecodeScanVectorsResult
+	DecodeSchema                              = wire.DecodeSchema
 	DecodeScrollArgs                          = wire.DecodeScrollArgs
 	DecodeScrollArgsCursor                    = wire.DecodeScrollArgsCursor
 	DecodeScrollArgsOpts                      = wire.DecodeScrollArgsOpts

--- a/sdk/wire/builtin_routing.go
+++ b/sdk/wire/builtin_routing.go
@@ -45,6 +45,10 @@ var BuiltinOps = []BuiltinOp{
 	{"ttl", OpReadOnly, StdKeyExtractor, RouteLayoutNone, false},
 	{"incr_ex", OpReadWrite, StdKeyExtractor, RouteLayoutNone, false},
 	{"caex", OpReadWrite, StdKeyExtractor, RouteLayoutNone, false},
+	// operate is a generic atomic multi-field read/check/write op against one
+	// stored record. It leads with [keyLen u16][key] like every other point op,
+	// so it routes by that key via StdKeyExtractor exactly like get/put/incr.
+	{"operate", OpReadWrite, StdKeyExtractor, RouteLayoutNone, false},
 	// put_batch packs N puts into one Raft log entry. It routes by its FIRST key,
 	// so every key in a batch must hash to the same shard — the cluster fan-out
 	// (Node.PutBatch) guarantees that by grouping before it calls.

--- a/sdk/wire/operate.go
+++ b/sdk/wire/operate.go
@@ -258,17 +258,29 @@ func decodeOp(b []byte) (OperateOp, int, error) {
 	return OperateOp{Opcode: opcode, Type: typ, Aux: aux, Path: path, A: a, B: bv, Bytes: opBytes}, off, nil
 }
 
-// appendRet appends one ret: [mode u8][path] (design doc §3.4/§3.5).
+// appendRet appends one ret: [mode u8][path] (design doc §3.4/§3.5). A mode
+// outside OperateRet* is ErrOperateArgs: the apply engine has no branch for
+// one, so encoding it would ship a frame that can only be rejected server
+// side.
 func appendRet(buf []byte, ret OperateRet) ([]byte, error) {
+	if ret.Mode > OperateRetCount {
+		return nil, ErrOperateArgs
+	}
 	buf = append(buf, ret.Mode)
 	return appendPath(buf, ret.Path)
 }
 
 // decodeRet reads one ret from the front of b, returning the ret and the
-// number of bytes consumed.
+// number of bytes consumed. A mode byte outside OperateRet* is
+// ErrOperateArgs, checked here rather than left to the apply engine, so a
+// decoded OperateArgs always re-encodes (the FuzzDecodeOperateArgs identity)
+// and every OperateRet a caller sees is one it has a branch for.
 func decodeRet(b []byte) (OperateRet, int, error) {
 	if len(b) < 1 {
 		return OperateRet{}, 0, ErrShortArgs
+	}
+	if b[0] > OperateRetCount {
+		return OperateRet{}, 0, ErrOperateArgs
 	}
 	path, n, err := decodePath(b[1:])
 	if err != nil {
@@ -522,7 +534,13 @@ func DecodeOperateResult(b []byte) (*OperateResult, error) {
 	}
 	nRet := int(binary.BigEndian.Uint16(b[off : off+2]))
 	off += 2
-	if nRet > OperateMaxRet || !CountFitsIn(nRet, len(b)-off, 4) {
+	// Split for the same reason DecodeOperateArgs splits its two: over the
+	// cap is a frame declaring more values than a call may return,
+	// over the byte budget is a truncated or lying frame.
+	if nRet > OperateMaxRet {
+		return nil, ErrOperateCap
+	}
+	if !CountFitsIn(nRet, len(b)-off, 4) {
 		return nil, ErrShortArgs
 	}
 	var values [][]byte

--- a/sdk/wire/operate.go
+++ b/sdk/wire/operate.go
@@ -88,8 +88,10 @@ func appendSeg(buf []byte, seg OperateSeg) ([]byte, error) {
 }
 
 // decodeSeg reads one fseg/cseg from the front of b, returning the segment
-// and the number of bytes consumed. An unknown seg-kind byte is
-// ErrOperateArgs; a truncated frame is ErrShortArgs.
+// and the number of bytes consumed. An unknown seg-kind byte, or a position
+// past the uint32 an OperateSeg addresses with, is ErrOperateArgs — the
+// frame is complete and well-formed, its content is out of range, which is
+// what ErrOperateArgs means. A truncated frame is ErrShortArgs.
 func decodeSeg(b []byte) (OperateSeg, int, error) {
 	if len(b) < 1 {
 		return OperateSeg{}, 0, ErrShortArgs
@@ -101,7 +103,7 @@ func decodeSeg(b []byte) (OperateSeg, int, error) {
 			return OperateSeg{}, 0, ErrShortArgs
 		}
 		if v > math.MaxUint32 {
-			return OperateSeg{}, 0, ErrShortArgs
+			return OperateSeg{}, 0, ErrOperateArgs
 		}
 		return OperateSeg{Pos: uint32(v)}, 1 + n, nil
 	case 1:
@@ -345,9 +347,12 @@ func EncodeOperateArgs(a *OperateArgs) ([]byte, error) {
 
 // DecodeOperateArgs reads args produced by EncodeOperateArgs, applying v1
 // decode discipline throughout: every read is truncation-checked before it
-// happens, and every declared count (nOps, nRet) is bounded with
-// CountFitsIn against the smallest honest encoding of that kind of element,
-// and against its cap, BEFORE any slice sized by it is allocated. Decoded
+// happens, and every declared count (nOps, nRet) is bounded against its cap
+// (ErrOperateCap) and with CountFitsIn against the smallest honest encoding
+// of that kind of element (ErrShortArgs), BEFORE any slice sized by it is
+// allocated. The two bounds report different errors because they mean
+// different things: over the cap is a call asking for more than the protocol
+// allows, over the byte budget is a truncated or lying frame. Decoded
 // Key/Schema/Bytes/Name/path-Key fields may alias b: the apply path only
 // reads them during one call and never retains them past it.
 func DecodeOperateArgs(b []byte) (*OperateArgs, error) {
@@ -400,7 +405,14 @@ func DecodeOperateArgs(b []byte) (*OperateArgs, error) {
 	}
 	nOps := int(binary.BigEndian.Uint16(b[off : off+2]))
 	off += 2
-	if nOps > OperateMaxOps || !CountFitsIn(nOps, len(b)-off, minOpBytes) {
+	// Two distinct failures, reported as two distinct errors: a count over
+	// the design doc §2.7 cap is ErrOperateCap (the frame asked for more ops
+	// than a call may carry), while a count the remaining bytes cannot
+	// possibly hold is a truncated frame.
+	if nOps > OperateMaxOps {
+		return nil, ErrOperateCap
+	}
+	if !CountFitsIn(nOps, len(b)-off, minOpBytes) {
 		return nil, ErrShortArgs
 	}
 	var ops []OperateOp
@@ -421,7 +433,10 @@ func DecodeOperateArgs(b []byte) (*OperateArgs, error) {
 	}
 	nRet := int(binary.BigEndian.Uint16(b[off : off+2]))
 	off += 2
-	if nRet > OperateMaxRet || !CountFitsIn(nRet, len(b)-off, minRetBytes) {
+	if nRet > OperateMaxRet {
+		return nil, ErrOperateCap
+	}
+	if !CountFitsIn(nRet, len(b)-off, minRetBytes) {
 		return nil, ErrShortArgs
 	}
 	var rets []OperateRet

--- a/sdk/wire/operate.go
+++ b/sdk/wire/operate.go
@@ -309,6 +309,12 @@ func EncodeOperateArgs(a *OperateArgs) ([]byte, error) {
 	if a.Create > OperateCreateDynamic {
 		return nil, ErrOperateArgs
 	}
+	// ttlMs rides the wire as an unsigned 64-bit count of milliseconds, so a
+	// negative duration has no encoding: converting it would wrap to a
+	// ~584-million-year TTL rather than the expiry the caller asked for.
+	if a.TTL < 0 {
+		return nil, ErrOperateArgs
+	}
 
 	buf := make([]byte, 0, 2+len(a.Key)+8+1+1+2+len(a.Schema)+2+2)
 	buf = binary.BigEndian.AppendUint16(buf, uint16(len(a.Key))) //nolint:gosec // bounded by the check above
@@ -446,18 +452,30 @@ func DecodeOperateArgs(b []byte) (*OperateArgs, error) {
 // [status u8][failedOp u16 iff status==OperateStatusCheckFailed][nRet
 // u16]{[vlen u32][value]}*. failedOp is written only when the status is
 // OperateStatusCheckFailed; every other status omits it entirely.
-func EncodeOperateResult(r *OperateResult) []byte {
+//
+// It returns an error rather than truncating: nRet is a uint16 on the wire,
+// so more than OperateMaxRet values could not be counted honestly, and a
+// silent narrowing would ship a frame whose declared count does not match
+// the values behind it. A status outside OperateStatus* is rejected for the
+// same reason — DecodeOperateResult would not accept it back.
+func EncodeOperateResult(r *OperateResult) ([]byte, error) {
+	if len(r.Values) > OperateMaxRet {
+		return nil, ErrOperateCap
+	}
+	if r.Status != OperateStatusOK && r.Status != OperateStatusCheckFailed {
+		return nil, ErrOperateArgs
+	}
 	buf := make([]byte, 0, 1+2+2+len(r.Values)*4)
 	buf = append(buf, r.Status)
 	if r.Status == OperateStatusCheckFailed {
 		buf = binary.BigEndian.AppendUint16(buf, r.FailedOp)
 	}
-	buf = binary.BigEndian.AppendUint16(buf, uint16(len(r.Values))) //nolint:gosec // bounded by OperateMaxRet upstream
+	buf = binary.BigEndian.AppendUint16(buf, uint16(len(r.Values))) //nolint:gosec // bounded by OperateMaxRet above
 	for _, v := range r.Values {
 		buf = binary.BigEndian.AppendUint32(buf, uint32(len(v))) //nolint:gosec // bounded by the apply engine upstream
 		buf = append(buf, v...)
 	}
-	return buf
+	return buf, nil
 }
 
 // DecodeOperateResult reads a frame produced by EncodeOperateResult, with
@@ -468,6 +486,12 @@ func DecodeOperateResult(b []byte) (*OperateResult, error) {
 		return nil, ErrShortArgs
 	}
 	status := b[0]
+	if status != OperateStatusOK && status != OperateStatusCheckFailed {
+		// An unknown status byte changes the frame's own shape (only
+		// CHECK_FAILED carries failedOp), so accepting one would mean
+		// guessing at the layout of the bytes behind it.
+		return nil, ErrOperateArgs
+	}
 	off := 1
 	var failedOp uint16
 	if status == OperateStatusCheckFailed {

--- a/sdk/wire/operate.go
+++ b/sdk/wire/operate.go
@@ -1,0 +1,511 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package wire
+
+import (
+	"encoding/binary"
+	"errors"
+	"math"
+	"time"
+)
+
+// ErrOperateArgs marks an operate call's parameters as structurally invalid:
+// an out-of-range ttlMode/create byte, an out-of-range path kind or segment
+// kind byte, or a Row/Col path with an empty key. It is returned both by
+// EncodeOperateArgs (a caller building an invalid call) and by
+// DecodeOperateArgs (a wire frame carrying one) — see design doc §3.5.
+var ErrOperateArgs = errors.New("wire: operate call arguments invalid")
+
+// OperateSeg addresses one hop of an OperatePath (design doc §2.4/§3.5): a
+// field or column identified by its schema position, or, for a record that
+// stores names, by name.
+type OperateSeg struct {
+	ByName bool
+	Pos    uint32
+	Name   string
+}
+
+// OperatePath addresses a node inside an operate record: the record itself,
+// one of its fields, a row of a table field (by key), or one column of that
+// row (design doc §2.4).
+type OperatePath struct {
+	Kind  uint8
+	Field OperateSeg
+	Key   []byte
+	Col   OperateSeg
+}
+
+// OperateOp is one instruction in a call's op list: a scalar/table op, a
+// control op (IF/CHECK), or a MIGRATE/CONFIG/TRIM (design doc §3.1-§3.3).
+type OperateOp struct {
+	Opcode, Type, Aux uint8
+	Path              OperatePath
+	A, B              int64
+	Bytes             []byte
+}
+
+// OperateRet is one return spec, evaluated after all ops apply, or against
+// the original record on CHECK_FAILED (design doc §3.4).
+type OperateRet struct {
+	Mode uint8
+	Path OperatePath
+}
+
+// OperateArgs is a decoded operate call (design doc §3.5).
+type OperateArgs struct {
+	Key     []byte
+	TTL     time.Duration
+	TTLMode uint8
+	Create  uint8
+	Schema  []byte
+	Ops     []OperateOp
+	Rets    []OperateRet
+}
+
+// OperateResult is a decoded operate result frame (design doc §3.4). Values
+// holds one tagged-encoded node per return spec, in the same order; an
+// absent node is []byte{OperateTypeUnset}.
+type OperateResult struct {
+	Status   uint8
+	FailedOp uint16
+	Values   [][]byte
+}
+
+// appendSeg appends one fseg/cseg (design doc §3.5): [0][pos uvarint] when
+// addressed by schema position, or [1][len u8][name] when addressed by name.
+func appendSeg(buf []byte, seg OperateSeg) ([]byte, error) {
+	if seg.ByName {
+		if len(seg.Name) > OperateMaxNameLen {
+			return nil, ErrOperateCap
+		}
+		buf = append(buf, 1, byte(len(seg.Name))) //nolint:gosec // bounded by the check above
+		buf = append(buf, seg.Name...)
+		return buf, nil
+	}
+	buf = append(buf, 0)
+	buf = binary.AppendUvarint(buf, uint64(seg.Pos))
+	return buf, nil
+}
+
+// decodeSeg reads one fseg/cseg from the front of b, returning the segment
+// and the number of bytes consumed. An unknown seg-kind byte is
+// ErrOperateArgs; a truncated frame is ErrShortArgs.
+func decodeSeg(b []byte) (OperateSeg, int, error) {
+	if len(b) < 1 {
+		return OperateSeg{}, 0, ErrShortArgs
+	}
+	switch b[0] {
+	case 0:
+		v, n := binary.Uvarint(b[1:])
+		if n <= 0 {
+			return OperateSeg{}, 0, ErrShortArgs
+		}
+		if v > math.MaxUint32 {
+			return OperateSeg{}, 0, ErrShortArgs
+		}
+		return OperateSeg{Pos: uint32(v)}, 1 + n, nil
+	case 1:
+		if len(b) < 2 {
+			return OperateSeg{}, 0, ErrShortArgs
+		}
+		nlen := int(b[1])
+		if len(b)-2 < nlen {
+			return OperateSeg{}, 0, ErrShortArgs
+		}
+		return OperateSeg{ByName: true, Name: string(b[2 : 2+nlen])}, 2 + nlen, nil
+	default:
+		return OperateSeg{}, 0, ErrOperateArgs
+	}
+}
+
+// appendPath appends [kind u8] and, per kind, the fseg/kseg/cseg that follow
+// it (design doc §2.4/§3.5). A Row or Col path requires a non-empty key.
+func appendPath(buf []byte, p OperatePath) ([]byte, error) {
+	if p.Kind > OperatePathCol {
+		return nil, ErrOperateArgs
+	}
+	buf = append(buf, p.Kind)
+	if p.Kind == OperatePathRecord {
+		return buf, nil
+	}
+	var err error
+	buf, err = appendSeg(buf, p.Field)
+	if err != nil {
+		return nil, err
+	}
+	if p.Kind == OperatePathField {
+		return buf, nil
+	}
+	if len(p.Key) == 0 {
+		return nil, ErrOperateArgs
+	}
+	if len(p.Key) > OperateMaxKeyLen {
+		return nil, ErrOperateCap
+	}
+	buf = append(buf, byte(len(p.Key))) //nolint:gosec // bounded by the check above
+	buf = append(buf, p.Key...)
+	if p.Kind == OperatePathRow {
+		return buf, nil
+	}
+	buf, err = appendSeg(buf, p.Col)
+	if err != nil {
+		return nil, err
+	}
+	return buf, nil
+}
+
+// decodePath reads one path from the front of b, returning the path and the
+// number of bytes consumed. An out-of-range kind byte, or a Row/Col path
+// with an empty key, is ErrOperateArgs; a truncated frame is ErrShortArgs.
+func decodePath(b []byte) (OperatePath, int, error) {
+	if len(b) < 1 {
+		return OperatePath{}, 0, ErrShortArgs
+	}
+	kind := b[0]
+	if kind > OperatePathCol {
+		return OperatePath{}, 0, ErrOperateArgs
+	}
+	off := 1
+	if kind == OperatePathRecord {
+		return OperatePath{Kind: kind}, off, nil
+	}
+	fseg, n, err := decodeSeg(b[off:])
+	if err != nil {
+		return OperatePath{}, 0, err
+	}
+	off += n
+	p := OperatePath{Kind: kind, Field: fseg}
+	if kind == OperatePathField {
+		return p, off, nil
+	}
+	if len(b)-off < 1 {
+		return OperatePath{}, 0, ErrShortArgs
+	}
+	klen := int(b[off])
+	off++
+	if len(b)-off < klen {
+		return OperatePath{}, 0, ErrShortArgs
+	}
+	if klen == 0 {
+		return OperatePath{}, 0, ErrOperateArgs
+	}
+	p.Key = b[off : off+klen]
+	off += klen
+	if kind == OperatePathRow {
+		return p, off, nil
+	}
+	cseg, n2, err := decodeSeg(b[off:])
+	if err != nil {
+		return OperatePath{}, 0, err
+	}
+	off += n2
+	p.Col = cseg
+	return p, off, nil
+}
+
+// appendOp appends one op: [opcode u8][type u8][aux u8][path][a i64][b
+// i64][blen u16][bytes] (design doc §3.5).
+func appendOp(buf []byte, op OperateOp) ([]byte, error) {
+	if len(op.Bytes) > OperateMaxBytesLen {
+		return nil, ErrOperateCap
+	}
+	buf = append(buf, op.Opcode, op.Type, op.Aux)
+	var err error
+	buf, err = appendPath(buf, op.Path)
+	if err != nil {
+		return nil, err
+	}
+	buf = binary.BigEndian.AppendUint64(buf, uint64(op.A))          //nolint:gosec // reinterpret i64 as u64 for binary write
+	buf = binary.BigEndian.AppendUint64(buf, uint64(op.B))          //nolint:gosec // reinterpret i64 as u64 for binary write
+	buf = binary.BigEndian.AppendUint16(buf, uint16(len(op.Bytes))) //nolint:gosec // bounded by the check above
+	buf = append(buf, op.Bytes...)
+	return buf, nil
+}
+
+// decodeOp reads one op from the front of b, returning the op and the
+// number of bytes consumed. op.Bytes and op.Path.Key/Name may alias b:
+// callers only read them during apply, never retain them past the call.
+func decodeOp(b []byte) (OperateOp, int, error) {
+	if len(b) < 3 {
+		return OperateOp{}, 0, ErrShortArgs
+	}
+	opcode, typ, aux := b[0], b[1], b[2]
+	off := 3
+	path, n, err := decodePath(b[off:])
+	if err != nil {
+		return OperateOp{}, 0, err
+	}
+	off += n
+	if len(b)-off < 8+8+2 { // a(8) + b(8) + blen(2)
+		return OperateOp{}, 0, ErrShortArgs
+	}
+	a := int64(binary.BigEndian.Uint64(b[off : off+8])) //nolint:gosec // reinterpret stored u64 as i64 for binary read
+	off += 8
+	bv := int64(binary.BigEndian.Uint64(b[off : off+8])) //nolint:gosec // reinterpret stored u64 as i64 for binary read
+	off += 8
+	blen := int(binary.BigEndian.Uint16(b[off : off+2]))
+	off += 2
+	if len(b)-off < blen {
+		return OperateOp{}, 0, ErrShortArgs
+	}
+	var opBytes []byte
+	if blen > 0 {
+		opBytes = b[off : off+blen]
+	}
+	off += blen
+	return OperateOp{Opcode: opcode, Type: typ, Aux: aux, Path: path, A: a, B: bv, Bytes: opBytes}, off, nil
+}
+
+// appendRet appends one ret: [mode u8][path] (design doc §3.4/§3.5).
+func appendRet(buf []byte, ret OperateRet) ([]byte, error) {
+	buf = append(buf, ret.Mode)
+	return appendPath(buf, ret.Path)
+}
+
+// decodeRet reads one ret from the front of b, returning the ret and the
+// number of bytes consumed.
+func decodeRet(b []byte) (OperateRet, int, error) {
+	if len(b) < 1 {
+		return OperateRet{}, 0, ErrShortArgs
+	}
+	path, n, err := decodePath(b[1:])
+	if err != nil {
+		return OperateRet{}, 0, err
+	}
+	return OperateRet{Mode: b[0], Path: path}, 1 + n, nil
+}
+
+// minOpBytes is the smallest an encoded op can be: a record-path op with no
+// operand bytes (opcode+type+aux(3) + path kind byte(1) + a+b(16) +
+// blen(2) = 22). DecodeOperateArgs bounds the declared op count against it
+// before allocating (v1 discipline: CountFitsIn before any reservation).
+const minOpBytes = 1 + 1 + 1 + 1 + 8 + 8 + 2
+
+// minRetBytes is the smallest an encoded ret can be: a record-path ret
+// (mode(1) + path kind byte(1) = 2).
+const minRetBytes = 1 + 1
+
+// EncodeOperateArgs encodes an operate call (design doc §3.5):
+// [keyLen u16][key][ttlMs u64][ttlMode u8][create u8][schemaLen
+// u16][schema][nOps u16]{op}*[nRet u16]{ret}*. It returns an error, rather
+// than silently truncating or wrapping, for any field that cannot be
+// represented on the wire or that exceeds a cap (design doc §2.7).
+func EncodeOperateArgs(a *OperateArgs) ([]byte, error) {
+	if len(a.Key) > 0xFFFF {
+		return nil, ErrOperateCap
+	}
+	if len(a.Schema) > OperateMaxSchemaBytes {
+		return nil, ErrOperateCap
+	}
+	if len(a.Ops) > OperateMaxOps {
+		return nil, ErrOperateCap
+	}
+	if len(a.Rets) > OperateMaxRet {
+		return nil, ErrOperateCap
+	}
+	if a.TTLMode > OperateTTLCreateOnly {
+		return nil, ErrOperateArgs
+	}
+	if a.Create > OperateCreateDynamic {
+		return nil, ErrOperateArgs
+	}
+
+	buf := make([]byte, 0, 2+len(a.Key)+8+1+1+2+len(a.Schema)+2+2)
+	buf = binary.BigEndian.AppendUint16(buf, uint16(len(a.Key))) //nolint:gosec // bounded by the check above
+	buf = append(buf, a.Key...)
+	buf = binary.BigEndian.AppendUint64(buf, uint64(a.TTL/time.Millisecond)) //nolint:gosec // duration to milliseconds always non-negative
+	buf = append(buf, a.TTLMode, a.Create)
+	buf = binary.BigEndian.AppendUint16(buf, uint16(len(a.Schema))) //nolint:gosec // bounded by the check above
+	buf = append(buf, a.Schema...)
+
+	buf = binary.BigEndian.AppendUint16(buf, uint16(len(a.Ops))) //nolint:gosec // bounded by the check above
+	for _, op := range a.Ops {
+		var err error
+		buf, err = appendOp(buf, op)
+		if err != nil {
+			return nil, err
+		}
+	}
+	buf = binary.BigEndian.AppendUint16(buf, uint16(len(a.Rets))) //nolint:gosec // bounded by the check above
+	for _, ret := range a.Rets {
+		var err error
+		buf, err = appendRet(buf, ret)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return buf, nil
+}
+
+// DecodeOperateArgs reads args produced by EncodeOperateArgs, applying v1
+// decode discipline throughout: every read is truncation-checked before it
+// happens, and every declared count (nOps, nRet) is bounded with
+// CountFitsIn against the smallest honest encoding of that kind of element,
+// and against its cap, BEFORE any slice sized by it is allocated. Decoded
+// Key/Schema/Bytes/Name/path-Key fields may alias b: the apply path only
+// reads them during one call and never retains them past it.
+func DecodeOperateArgs(b []byte) (*OperateArgs, error) {
+	if len(b) < 2 {
+		return nil, ErrShortArgs
+	}
+	klen := int(binary.BigEndian.Uint16(b[0:2]))
+	off := 2
+	if len(b)-off < klen {
+		return nil, ErrShortArgs
+	}
+	var key []byte
+	if klen > 0 {
+		key = b[off : off+klen]
+	}
+	off += klen
+
+	if len(b)-off < 8+1+1+2 { // ttlMs(8) + ttlMode(1) + create(1) + schemaLen(2)
+		return nil, ErrShortArgs
+	}
+	ttl, err := ttlFromMs(binary.BigEndian.Uint64(b[off : off+8]))
+	if err != nil {
+		return nil, err
+	}
+	off += 8
+	ttlMode := b[off]
+	off++
+	create := b[off]
+	off++
+	if ttlMode > OperateTTLCreateOnly {
+		return nil, ErrOperateArgs
+	}
+	if create > OperateCreateDynamic {
+		return nil, ErrOperateArgs
+	}
+
+	schemaLen := int(binary.BigEndian.Uint16(b[off : off+2]))
+	off += 2
+	if len(b)-off < schemaLen {
+		return nil, ErrShortArgs
+	}
+	var schema []byte
+	if schemaLen > 0 {
+		schema = b[off : off+schemaLen]
+	}
+	off += schemaLen
+
+	if len(b)-off < 2 {
+		return nil, ErrShortArgs
+	}
+	nOps := int(binary.BigEndian.Uint16(b[off : off+2]))
+	off += 2
+	if nOps > OperateMaxOps || !CountFitsIn(nOps, len(b)-off, minOpBytes) {
+		return nil, ErrShortArgs
+	}
+	var ops []OperateOp
+	if nOps > 0 {
+		ops = make([]OperateOp, 0, nOps)
+		for i := 0; i < nOps; i++ {
+			op, n, oerr := decodeOp(b[off:])
+			if oerr != nil {
+				return nil, oerr
+			}
+			ops = append(ops, op)
+			off += n
+		}
+	}
+
+	if len(b)-off < 2 {
+		return nil, ErrShortArgs
+	}
+	nRet := int(binary.BigEndian.Uint16(b[off : off+2]))
+	off += 2
+	if nRet > OperateMaxRet || !CountFitsIn(nRet, len(b)-off, minRetBytes) {
+		return nil, ErrShortArgs
+	}
+	var rets []OperateRet
+	if nRet > 0 {
+		rets = make([]OperateRet, 0, nRet)
+		for i := 0; i < nRet; i++ {
+			ret, n, rerr := decodeRet(b[off:])
+			if rerr != nil {
+				return nil, rerr
+			}
+			rets = append(rets, ret)
+			off += n
+		}
+	}
+
+	return &OperateArgs{
+		Key:     key,
+		TTL:     ttl,
+		TTLMode: ttlMode,
+		Create:  create,
+		Schema:  schema,
+		Ops:     ops,
+		Rets:    rets,
+	}, nil
+}
+
+// EncodeOperateResult encodes an operate result frame (design doc §3.4):
+// [status u8][failedOp u16 iff status==OperateStatusCheckFailed][nRet
+// u16]{[vlen u32][value]}*. failedOp is written only when the status is
+// OperateStatusCheckFailed; every other status omits it entirely.
+func EncodeOperateResult(r *OperateResult) []byte {
+	buf := make([]byte, 0, 1+2+2+len(r.Values)*4)
+	buf = append(buf, r.Status)
+	if r.Status == OperateStatusCheckFailed {
+		buf = binary.BigEndian.AppendUint16(buf, r.FailedOp)
+	}
+	buf = binary.BigEndian.AppendUint16(buf, uint16(len(r.Values))) //nolint:gosec // bounded by OperateMaxRet upstream
+	for _, v := range r.Values {
+		buf = binary.BigEndian.AppendUint32(buf, uint32(len(v))) //nolint:gosec // bounded by the apply engine upstream
+		buf = append(buf, v...)
+	}
+	return buf
+}
+
+// DecodeOperateResult reads a frame produced by EncodeOperateResult, with
+// the same truncation and bounded-count discipline as DecodeOperateArgs.
+// Decoded values may alias b.
+func DecodeOperateResult(b []byte) (*OperateResult, error) {
+	if len(b) < 1 {
+		return nil, ErrShortArgs
+	}
+	status := b[0]
+	off := 1
+	var failedOp uint16
+	if status == OperateStatusCheckFailed {
+		if len(b)-off < 2 {
+			return nil, ErrShortArgs
+		}
+		failedOp = binary.BigEndian.Uint16(b[off : off+2])
+		off += 2
+	}
+
+	if len(b)-off < 2 {
+		return nil, ErrShortArgs
+	}
+	nRet := int(binary.BigEndian.Uint16(b[off : off+2]))
+	off += 2
+	if nRet > OperateMaxRet || !CountFitsIn(nRet, len(b)-off, 4) {
+		return nil, ErrShortArgs
+	}
+	var values [][]byte
+	if nRet > 0 {
+		values = make([][]byte, 0, nRet)
+		for i := 0; i < nRet; i++ {
+			if len(b)-off < 4 {
+				return nil, ErrShortArgs
+			}
+			vlen := int(binary.BigEndian.Uint32(b[off : off+4]))
+			off += 4
+			if vlen < 0 || len(b)-off < vlen {
+				return nil, ErrShortArgs
+			}
+			var val []byte
+			if vlen > 0 {
+				val = b[off : off+vlen]
+			}
+			values = append(values, val)
+			off += vlen
+		}
+	}
+
+	return &OperateResult{Status: status, FailedOp: failedOp, Values: values}, nil
+}

--- a/sdk/wire/operate_cell.go
+++ b/sdk/wire/operate_cell.go
@@ -1,0 +1,307 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package wire
+
+import (
+	"encoding/binary"
+	"math"
+)
+
+// Cell is one decoded scalar value for the operate op family (design doc
+// §2.1). Its meaning depends on Type:
+//
+//   - the eight fixed-width int types (U8..I64) and the two varint types
+//     (UVARINT, IVARINT): U holds the value's bits reinterpreted as uint64 —
+//     zero-extended for an unsigned type, sign-extended (as an int64 bit
+//     pattern) for a signed type. This is the same convention v1 used so a
+//     signed and unsigned field share one arithmetic path.
+//   - F32/F64: F holds the value as a float64 (F32 stored rounded through
+//     float32, see CanonFloat).
+//   - BYTES: B holds the opaque payload.
+//   - FIXED: N is the declared width (1–255) and B holds exactly N bytes.
+//   - TABLE, UNSET: neither is stored cell data (TABLE is never a cell at
+//     all; UNSET carries no bytes).
+type Cell struct {
+	Type uint8
+	N    uint8 // FIXED width only; ignored otherwise
+	U    uint64
+	F    float64
+	B    []byte
+}
+
+// CellWidth returns the fixed on-the-wire width in bytes of a cell of the
+// given type, or 0 for UNSET (no data), or -1 when the type has no fixed
+// width (BYTES, UVARINT, IVARINT are variable-length; TABLE is not a cell).
+// n is the declared width for OperateTypeFixed and is ignored for every
+// other type.
+func CellWidth(t uint8, n uint8) int {
+	switch t {
+	case OperateTypeU8, OperateTypeI8:
+		return 1
+	case OperateTypeU16, OperateTypeI16:
+		return 2
+	case OperateTypeU32, OperateTypeI32, OperateTypeF32:
+		return 4
+	case OperateTypeU64, OperateTypeI64, OperateTypeF64:
+		return 8
+	case OperateTypeFixed:
+		return int(n)
+	case OperateTypeUnset:
+		return 0
+	default:
+		return -1
+	}
+}
+
+// ZeroCell returns the zero value of a cell of the given type: the value an
+// absent or UNSET path reads as (design doc §2.4, "absent is zero"). For
+// OperateTypeFixed it allocates n zero bytes so callers can compare/append
+// without a nil special case.
+func ZeroCell(t uint8, n uint8) Cell {
+	c := Cell{Type: t, N: n}
+	if t == OperateTypeFixed {
+		c.B = make([]byte, n)
+	}
+	return c
+}
+
+// TypeIsInt reports whether t is one of the eight fixed-width integer types
+// or one of the two varint types — every type ApplyScalar's integer path
+// handles.
+func TypeIsInt(t uint8) bool {
+	switch t {
+	case OperateTypeU8, OperateTypeU16, OperateTypeU32, OperateTypeU64,
+		OperateTypeI8, OperateTypeI16, OperateTypeI32, OperateTypeI64,
+		OperateTypeUVarint, OperateTypeIVarint:
+		return true
+	default:
+		return false
+	}
+}
+
+// TypeIsFixedInt reports whether t is one of the eight fixed-width integer
+// types (U8..I64) — the subset that bitwise/shift ops apply to (varints have
+// no fixed bit width to mask or shift within).
+func TypeIsFixedInt(t uint8) bool {
+	switch t {
+	case OperateTypeU8, OperateTypeU16, OperateTypeU32, OperateTypeU64,
+		OperateTypeI8, OperateTypeI16, OperateTypeI32, OperateTypeI64:
+		return true
+	default:
+		return false
+	}
+}
+
+// TypeIsUnsigned reports whether t is an unsigned fixed-width int type or the
+// unsigned varint type — the types whose stored bits in Cell.U are
+// zero-extended rather than sign-extended.
+func TypeIsUnsigned(t uint8) bool {
+	switch t {
+	case OperateTypeU8, OperateTypeU16, OperateTypeU32, OperateTypeU64, OperateTypeUVarint:
+		return true
+	default:
+		return false
+	}
+}
+
+// AppendCellData appends c's data-only encoding (no type tag, no FIXED
+// width) to dst: little-endian for the fixed-width int and float types,
+// binary.AppendUvarint for UVARINT, zigzagged binary.AppendUvarint for
+// IVARINT, [len uvarint][data] for BYTES, and the raw N bytes for FIXED.
+// UNSET appends nothing. It is the caller's responsibility not to call this
+// with OperateTypeTable, which is never cell data.
+func AppendCellData(dst []byte, c Cell) []byte {
+	switch c.Type {
+	case OperateTypeU8, OperateTypeI8:
+		return append(dst, byte(c.U))
+	case OperateTypeU16, OperateTypeI16:
+		return binary.LittleEndian.AppendUint16(dst, uint16(c.U)) //nolint:gosec // low 16 bits by design
+	case OperateTypeU32, OperateTypeI32:
+		return binary.LittleEndian.AppendUint32(dst, uint32(c.U)) //nolint:gosec // low 32 bits by design
+	case OperateTypeU64, OperateTypeI64:
+		return binary.LittleEndian.AppendUint64(dst, c.U)
+	case OperateTypeF32:
+		return binary.LittleEndian.AppendUint32(dst, math.Float32bits(float32(c.F)))
+	case OperateTypeF64:
+		return binary.LittleEndian.AppendUint64(dst, math.Float64bits(c.F))
+	case OperateTypeUVarint:
+		return binary.AppendUvarint(dst, c.U)
+	case OperateTypeIVarint:
+		return binary.AppendUvarint(dst, zigzag(int64(c.U))) //nolint:gosec // reinterpret stored signed bits
+	case OperateTypeBytes:
+		dst = binary.AppendUvarint(dst, uint64(len(c.B))) //nolint:gosec // bounded by OperateMaxBytesLen on encode paths
+		return append(dst, c.B...)
+	case OperateTypeFixed:
+		return append(dst, c.B...)
+	default: // OperateTypeUnset, OperateTypeTable: no data
+		return dst
+	}
+}
+
+// DecodeCellData reads one value of type t (and, for OperateTypeFixed,
+// declared width n) from the front of b, returning the decoded cell and the
+// number of bytes consumed. Every branch is truncation-checked; BYTES length
+// is additionally bounded by OperateMaxBytesLen before it is trusted to size
+// an allocation. t == OperateTypeTable is rejected: a table is never cell
+// data.
+func DecodeCellData(t uint8, n uint8, b []byte) (Cell, int, error) {
+	c := Cell{Type: t, N: n}
+	switch t {
+	case OperateTypeUnset:
+		return c, 0, nil
+	case OperateTypeU8:
+		if len(b) < 1 {
+			return Cell{}, 0, ErrShortArgs
+		}
+		c.U = uint64(b[0])
+		return c, 1, nil
+	case OperateTypeI8:
+		if len(b) < 1 {
+			return Cell{}, 0, ErrShortArgs
+		}
+		c.U = uint64(int64(int8(b[0]))) //nolint:gosec // sign-extend
+		return c, 1, nil
+	case OperateTypeU16:
+		if len(b) < 2 {
+			return Cell{}, 0, ErrShortArgs
+		}
+		c.U = uint64(binary.LittleEndian.Uint16(b[:2]))
+		return c, 2, nil
+	case OperateTypeI16:
+		if len(b) < 2 {
+			return Cell{}, 0, ErrShortArgs
+		}
+		c.U = uint64(int64(int16(binary.LittleEndian.Uint16(b[:2])))) //nolint:gosec // sign-extend
+		return c, 2, nil
+	case OperateTypeU32:
+		if len(b) < 4 {
+			return Cell{}, 0, ErrShortArgs
+		}
+		c.U = uint64(binary.LittleEndian.Uint32(b[:4]))
+		return c, 4, nil
+	case OperateTypeI32:
+		if len(b) < 4 {
+			return Cell{}, 0, ErrShortArgs
+		}
+		c.U = uint64(int64(int32(binary.LittleEndian.Uint32(b[:4])))) //nolint:gosec // sign-extend
+		return c, 4, nil
+	case OperateTypeU64, OperateTypeI64:
+		if len(b) < 8 {
+			return Cell{}, 0, ErrShortArgs
+		}
+		c.U = binary.LittleEndian.Uint64(b[:8])
+		return c, 8, nil
+	case OperateTypeF32:
+		if len(b) < 4 {
+			return Cell{}, 0, ErrShortArgs
+		}
+		c.F = float64(math.Float32frombits(binary.LittleEndian.Uint32(b[:4])))
+		return c, 4, nil
+	case OperateTypeF64:
+		if len(b) < 8 {
+			return Cell{}, 0, ErrShortArgs
+		}
+		c.F = math.Float64frombits(binary.LittleEndian.Uint64(b[:8]))
+		return c, 8, nil
+	case OperateTypeUVarint:
+		v, m := binary.Uvarint(b)
+		if m <= 0 { // 0 = truncated, <0 = overflow (> 10 bytes / > 64 bits)
+			return Cell{}, 0, ErrShortArgs
+		}
+		c.U = v
+		return c, m, nil
+	case OperateTypeIVarint:
+		v, m := binary.Uvarint(b)
+		if m <= 0 {
+			return Cell{}, 0, ErrShortArgs
+		}
+		c.U = uint64(unzigzag(v)) //nolint:gosec // store signed value bits
+		return c, m, nil
+	case OperateTypeBytes:
+		ln, m := binary.Uvarint(b)
+		if m <= 0 {
+			return Cell{}, 0, ErrShortArgs
+		}
+		if ln > OperateMaxBytesLen {
+			return Cell{}, 0, ErrOperateCap
+		}
+		if !CountFitsIn(int(ln), len(b)-m, 1) {
+			return Cell{}, 0, ErrShortArgs
+		}
+		data := make([]byte, ln)
+		copy(data, b[m:m+int(ln)])
+		c.B = data
+		return c, m + int(ln), nil
+	case OperateTypeFixed:
+		if !CountFitsIn(int(n), len(b), 1) {
+			return Cell{}, 0, ErrShortArgs
+		}
+		data := make([]byte, n)
+		copy(data, b[:n])
+		c.B = data
+		return c, int(n), nil
+	default: // includes OperateTypeTable
+		return Cell{}, 0, ErrOperateType
+	}
+}
+
+// AppendTaggedCell appends a self-describing cell: [type][n iff FIXED][data].
+// It is the wire form used wherever a value must carry its own type (a
+// dynamic-mode field, an operate return value).
+func AppendTaggedCell(dst []byte, c Cell) []byte {
+	dst = append(dst, c.Type)
+	if c.Type == OperateTypeFixed {
+		dst = append(dst, c.N)
+	}
+	return AppendCellData(dst, c)
+}
+
+// DecodeTaggedCell reads one AppendTaggedCell-encoded value from the front of
+// b, returning the decoded cell and the number of bytes consumed. A type tag
+// >= OperateTypeCount is unknown and rejected; OperateTypeTable is rejected
+// too, since a table is never a cell in its own right.
+func DecodeTaggedCell(b []byte) (Cell, int, error) {
+	if len(b) < 1 {
+		return Cell{}, 0, ErrShortArgs
+	}
+	t := b[0]
+	if t >= OperateTypeCount || t == OperateTypeTable {
+		return Cell{}, 0, ErrOperateType
+	}
+	off := 1
+	var n uint8
+	if t == OperateTypeFixed {
+		if len(b) < 2 {
+			return Cell{}, 0, ErrShortArgs
+		}
+		n = b[1]
+		off = 2
+	}
+	c, m, err := DecodeCellData(t, n, b[off:])
+	if err != nil {
+		return Cell{}, 0, err
+	}
+	return c, off + m, nil
+}
+
+// CanonFloat canonicalizes f for storage as type t (design doc §2.5): every
+// NaN becomes the canonical quiet NaN (float64 bits
+// 0x7FF8000000000000, which narrows to the canonical float32 quiet NaN
+// 0x7FC00000), and OperateTypeF32 values are rounded through float32 so the
+// stored bytes are a pure function of the value regardless of the caller's
+// native width.
+func CanonFloat(t uint8, f float64) float64 {
+	if math.IsNaN(f) {
+		f = math.Float64frombits(0x7FF8000000000000)
+	}
+	if t == OperateTypeF32 {
+		return float64(float32(f))
+	}
+	return f
+}
+
+// zigzag and unzigzag map a signed int64 to/from an unsigned "zigzag" value
+// so small magnitudes (positive or negative) encode as small LEB128 varints.
+// Copied verbatim from v1 (ops/operate.go).
+func zigzag(i int64) uint64   { return uint64((i << 1) ^ (i >> 63)) } //nolint:gosec // standard zigzag
+func unzigzag(u uint64) int64 { return int64(u>>1) ^ -int64(u&1) }    //nolint:gosec // standard zigzag

--- a/sdk/wire/operate_cell.go
+++ b/sdk/wire/operate_cell.go
@@ -104,6 +104,18 @@ func TypeIsUnsigned(t uint8) bool {
 	}
 }
 
+// TypeIsFloat reports whether t is F32 or F64 — the types ApplyScalar's
+// float path handles, stored in Cell.F.
+func TypeIsFloat(t uint8) bool {
+	return t == OperateTypeF32 || t == OperateTypeF64
+}
+
+// TypeIsBytes reports whether t is BYTES or FIXED — the types ApplyScalar's
+// bytewise path handles, stored in Cell.B.
+func TypeIsBytes(t uint8) bool {
+	return t == OperateTypeBytes || t == OperateTypeFixed
+}
+
 // AppendCellData appends c's data-only encoding (no type tag, no FIXED
 // width) to dst: little-endian for the fixed-width int and float types,
 // binary.AppendUvarint for UVARINT, zigzagged binary.AppendUvarint for

--- a/sdk/wire/operate_cell.go
+++ b/sdk/wire/operate_cell.go
@@ -313,7 +313,7 @@ func CanonFloat(t uint8, f float64) float64 {
 }
 
 // zigzag and unzigzag map a signed int64 to/from an unsigned "zigzag" value
-// so small magnitudes (positive or negative) encode as small LEB128 varints.
-// Copied verbatim from v1 (ops/operate.go).
+// so small magnitudes (positive or negative) encode as small LEB128 varints:
+// standard zigzag encoding.
 func zigzag(i int64) uint64   { return uint64((i << 1) ^ (i >> 63)) } //nolint:gosec // standard zigzag
 func unzigzag(u uint64) int64 { return int64(u>>1) ^ -int64(u&1) }    //nolint:gosec // standard zigzag

--- a/sdk/wire/operate_cell.go
+++ b/sdk/wire/operate_cell.go
@@ -122,6 +122,14 @@ func TypeIsBytes(t uint8) bool {
 // IVARINT, [len uvarint][data] for BYTES, and the raw N bytes for FIXED.
 // UNSET appends nothing. It is the caller's responsibility not to call this
 // with OperateTypeTable, which is never cell data.
+//
+// Float values are canonicalized on the way out (CanonFloat, design doc
+// §2.5): a payload NaN is written as the canonical quiet NaN and an F32 is
+// rounded through float32, so the stored bytes are a pure function of the
+// value no matter what bit pattern the caller handed in. DecodeCellData's
+// canonical-bytes check (decodeCellDataCanonical) mirrors this, so a stored
+// canonical NaN round-trips and every other NaN spelling is rejected as a
+// malformed record rather than silently rewritten.
 func AppendCellData(dst []byte, c Cell) []byte {
 	switch c.Type {
 	case OperateTypeU8, OperateTypeI8:
@@ -133,9 +141,9 @@ func AppendCellData(dst []byte, c Cell) []byte {
 	case OperateTypeU64, OperateTypeI64:
 		return binary.LittleEndian.AppendUint64(dst, c.U)
 	case OperateTypeF32:
-		return binary.LittleEndian.AppendUint32(dst, math.Float32bits(float32(c.F)))
+		return binary.LittleEndian.AppendUint32(dst, math.Float32bits(float32(CanonFloat(OperateTypeF32, c.F))))
 	case OperateTypeF64:
-		return binary.LittleEndian.AppendUint64(dst, math.Float64bits(c.F))
+		return binary.LittleEndian.AppendUint64(dst, math.Float64bits(CanonFloat(OperateTypeF64, c.F)))
 	case OperateTypeUVarint:
 		return binary.AppendUvarint(dst, c.U)
 	case OperateTypeIVarint:
@@ -155,7 +163,8 @@ func AppendCellData(dst []byte, c Cell) []byte {
 // number of bytes consumed. Every branch is truncation-checked; BYTES length
 // is additionally bounded by OperateMaxBytesLen before it is trusted to size
 // an allocation. t == OperateTypeTable is rejected: a table is never cell
-// data.
+// data, and so is OperateTypeFixed with n == 0, which is not a legal width
+// (design doc §2.1: FIXED(n) is 1-255 bytes).
 func DecodeCellData(t uint8, n uint8, b []byte) (Cell, int, error) {
 	c := Cell{Type: t, N: n}
 	switch t {
@@ -245,6 +254,12 @@ func DecodeCellData(t uint8, n uint8, b []byte) (Cell, int, error) {
 		c.B = data
 		return c, m + int(ln), nil
 	case OperateTypeFixed:
+		// FIXED(0) is not a type: the design doc §2.1 declares FIXED's width
+		// as 1-255, and a zero-width cell would be an alias for UNSET that
+		// encodes and decodes as a distinct, second spelling of "no bytes".
+		if n == 0 {
+			return Cell{}, 0, ErrOperateType
+		}
 		if !CountFitsIn(int(n), len(b), 1) {
 			return Cell{}, 0, ErrShortArgs
 		}

--- a/sdk/wire/operate_cell_test.go
+++ b/sdk/wire/operate_cell_test.go
@@ -1,0 +1,88 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package wire
+
+import (
+	"bytes"
+	"math"
+	"testing"
+)
+
+func TestCellWidth(t *testing.T) {
+	cases := map[[2]uint8]int{
+		{OperateTypeU8, 0}: 1, {OperateTypeI16, 0}: 2, {OperateTypeU32, 0}: 4, {OperateTypeI64, 0}: 8,
+		{OperateTypeF32, 0}: 4, {OperateTypeF64, 0}: 8, {OperateTypeFixed, 16}: 16, {OperateTypeUnset, 0}: 0,
+		{OperateTypeBytes, 0}: -1, {OperateTypeUVarint, 0}: -1, {OperateTypeIVarint, 0}: -1, {OperateTypeTable, 0}: -1,
+	}
+	for k, want := range cases {
+		if got := CellWidth(k[0], k[1]); got != want {
+			t.Errorf("CellWidth(%d,%d)=%d want %d", k[0], k[1], got, want)
+		}
+	}
+}
+
+// su64 reinterprets a signed int64 as its uint64 bit pattern at RUNTIME. It
+// exists only so the literals below (-5, math.MinInt32, -300) don't become
+// constant expressions: uint64(int64(-5)) is a compile error ("constant -5
+// overflows uint64") because Go's constant-conversion rule checks
+// representability at each step, even though the identical conversion of a
+// non-constant int64 wraps as intended (the convention Cell.U itself uses).
+func su64(i int64) uint64 { return uint64(i) }
+
+func TestCellDataRoundtrip(t *testing.T) {
+	cells := []Cell{
+		{Type: OperateTypeU8, U: 255}, {Type: OperateTypeI8, U: su64(-5)}, {Type: OperateTypeI32, U: su64(math.MinInt32)},
+		{Type: OperateTypeU64, U: math.MaxUint64}, {Type: OperateTypeF32, F: 1.5}, {Type: OperateTypeF64, F: -2.25},
+		{Type: OperateTypeUVarint, U: 300}, {Type: OperateTypeIVarint, U: su64(-300)},
+		{Type: OperateTypeBytes, B: []byte("hello")}, {Type: OperateTypeFixed, N: 2, B: []byte("DE")},
+	}
+	for _, c := range cells {
+		enc := AppendCellData(nil, c)
+		got, n, err := DecodeCellData(c.Type, c.N, enc)
+		if err != nil || n != len(enc) {
+			t.Fatalf("%+v: err=%v n=%d len=%d", c, err, n, len(enc))
+		}
+		if got.U != c.U || got.F != c.F || !bytes.Equal(got.B, c.B) {
+			t.Fatalf("roundtrip %+v → %+v", c, got)
+		}
+		tagged := AppendTaggedCell(nil, c)
+		got2, n2, err := DecodeTaggedCell(tagged)
+		if err != nil || n2 != len(tagged) || got2.Type != c.Type || got2.N != c.N {
+			t.Fatalf("tagged %+v: %+v %v", c, got2, err)
+		}
+	}
+}
+
+func TestCellDataTruncationAndBadTag(t *testing.T) {
+	if _, _, err := DecodeCellData(OperateTypeU32, 0, []byte{1, 2}); err == nil {
+		t.Fatal("truncated U32 accepted")
+	}
+	if _, _, err := DecodeCellData(OperateTypeFixed, 4, []byte{1, 2}); err == nil {
+		t.Fatal("truncated FIXED accepted")
+	}
+	if _, _, err := DecodeCellData(OperateTypeBytes, 0, []byte{0x05, 1}); err == nil {
+		t.Fatal("truncated BYTES accepted")
+	}
+	if _, _, err := DecodeCellData(OperateTypeUVarint, 0, []byte{0x80}); err == nil {
+		t.Fatal("truncated varint accepted")
+	}
+	if _, _, err := DecodeTaggedCell([]byte{OperateTypeCount}); err == nil {
+		t.Fatal("unknown tag accepted")
+	}
+	if _, _, err := DecodeTaggedCell([]byte{OperateTypeTable}); err == nil {
+		t.Fatal("table tag accepted as a cell")
+	}
+}
+
+func TestCanonFloat(t *testing.T) {
+	if CanonFloat(OperateTypeF32, 0.1) != float64(float32(0.1)) {
+		t.Fatal("F32 not rounded")
+	}
+	nan := math.Float64frombits(0x7FF8DEADBEEF0001)
+	if math.Float64bits(CanonFloat(OperateTypeF64, nan)) != 0x7FF8000000000000 {
+		t.Fatal("NaN not canonical")
+	}
+	if math.Float32bits(float32(CanonFloat(OperateTypeF32, nan))) != 0x7FC00000 {
+		t.Fatal("F32 NaN not canonical")
+	}
+}

--- a/sdk/wire/operate_cell_test.go
+++ b/sdk/wire/operate_cell_test.go
@@ -4,6 +4,7 @@ package wire
 
 import (
 	"bytes"
+	"encoding/binary"
 	"math"
 	"testing"
 )
@@ -84,5 +85,46 @@ func TestCanonFloat(t *testing.T) {
 	}
 	if math.Float32bits(float32(CanonFloat(OperateTypeF32, nan))) != 0x7FC00000 {
 		t.Fatal("F32 NaN not canonical")
+	}
+}
+
+// TestAppendCellDataCanonicalizesNaN pins design doc §2.5 on the ENCODE
+// side: whatever NaN bit pattern a caller hands in, the bytes that go to
+// storage are the canonical quiet NaN (and an F32 is narrowed through
+// float32 on the way). Without this, a payload NaN reaching AppendCellData
+// from a hand-built Cell would be stored verbatim and then rejected by
+// DecodeRecord's canonical-bytes check as a malformed record.
+func TestAppendCellDataCanonicalizesNaN(t *testing.T) {
+	payload := math.Float64frombits(0x7FF8000000000123) // quiet NaN, payload 0x123
+	signaling := math.Float64frombits(0x7FF0000000000001)
+
+	for _, f := range []float64{payload, signaling, math.NaN()} {
+		got := AppendCellData(nil, Cell{Type: OperateTypeF64, F: f})
+		if len(got) != 8 || binary.LittleEndian.Uint64(got) != 0x7FF8000000000000 {
+			t.Fatalf("F64 NaN encoded as %x, want the canonical quiet NaN", got)
+		}
+		got32 := AppendCellData(nil, Cell{Type: OperateTypeF32, F: f})
+		if len(got32) != 4 || binary.LittleEndian.Uint32(got32) != 0x7FC00000 {
+			t.Fatalf("F32 NaN encoded as %x, want the canonical quiet NaN", got32)
+		}
+	}
+
+	// The canonical pattern round-trips: decode it and it re-encodes to the
+	// same bytes, which is what keeps DecodeRecord's identity intact.
+	canon := AppendCellData(nil, Cell{Type: OperateTypeF64, F: math.NaN()})
+	c, n, err := DecodeCellData(OperateTypeF64, 0, canon)
+	if err != nil || n != 8 || !math.IsNaN(c.F) {
+		t.Fatalf("decode canonical NaN: %+v n=%d err=%v", c, n, err)
+	}
+	if !bytes.Equal(AppendCellData(nil, c), canon) {
+		t.Fatal("canonical NaN did not re-encode to itself")
+	}
+
+	// Finite floats are untouched, negative zero included.
+	for _, f := range []float64{0, math.Copysign(0, -1), 1.5, -3.25, math.Inf(1), math.Inf(-1)} {
+		got := AppendCellData(nil, Cell{Type: OperateTypeF64, F: f})
+		if binary.LittleEndian.Uint64(got) != math.Float64bits(f) {
+			t.Fatalf("finite F64 %v encoded as %x", f, got)
+		}
 	}
 }

--- a/sdk/wire/operate_const.go
+++ b/sdk/wire/operate_const.go
@@ -1,0 +1,94 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package wire
+
+import "errors"
+
+// Operate scalar type tags (design doc §2.1). A stored cell carries no type of
+// its own — the type lives once, in the schema (schema mode) or beside the
+// name (dynamic mode) — these tags are the wire vocabulary shared by both.
+//
+//	0–7  U8 U16 U32 U64 I8 I16 I32 I64   fixed width 1/2/4/8, little-endian,
+//	                                     arithmetic saturates
+//	8–9  F32 F64                        IEEE, canonical NaN
+//	10–11 UVARINT IVARINT               LEB128 (IVARINT zigzagged); record
+//	                                     fields only, never a table column
+//	12   BYTES                          [len uvarint][data], ≤ OperateMaxBytesLen
+//	13   FIXED(n)                       n raw bytes (1–255); allowed as a column
+//	                                     and as a row key
+//	14   TABLE                          record fields only; not a cell itself
+//	15   UNSET                          0 bytes; a declared-but-never-written slot
+const (
+	OperateTypeU8 uint8 = iota
+	OperateTypeU16
+	OperateTypeU32
+	OperateTypeU64
+	OperateTypeI8
+	OperateTypeI16
+	OperateTypeI32
+	OperateTypeI64
+	OperateTypeF32
+	OperateTypeF64
+	OperateTypeUVarint
+	OperateTypeIVarint
+	OperateTypeBytes
+	OperateTypeFixed
+	OperateTypeTable
+	OperateTypeUnset
+
+	// OperateTypeCount is one past the last valid type tag; any tag >= this is
+	// unknown and rejected by the decoders.
+	OperateTypeCount = 16
+
+	// OperateTypeFromSchema marks an op's type byte as "whatever the schema (or,
+	// in dynamic mode, the existing field) already says" rather than a type to
+	// create with. It is never a value stored on the wire, only an op operand.
+	OperateTypeFromSchema uint8 = 0xFF
+)
+
+// Caps (design doc §2.7): hard, DoS-defensive ceilings enforced before any
+// allocation, all-or-nothing. Hitting one is an error with the record left
+// unchanged — never an implicit eviction.
+const (
+	OperateMaxFields      = 65535   // a schema declaring more fields is rejected
+	OperateMaxCols        = 65535   // a table declaring more columns is rejected
+	OperateMaxSchemaBytes = 4096    // bounds schema parsing and the offset-cache entry
+	OperateMaxRows        = 1 << 20 // per table; a hostile cap above it is clamped
+	OperateMaxRowWidth    = 4096    // bounds FIXED(n) columns × count, in bytes
+	OperateMaxKeyLen      = 255     // u8; FIXED(n) keys (schema mode) or any key (dynamic mode)
+	OperateMaxNameLen     = 255     // u8; dynamic-mode field/column names
+	OperateMaxBytesLen    = 65535   // u16 on the wire, per BYTES field
+	OperateMaxNameBytes   = 4096    // per record; names are stored once
+	OperateMaxOps         = 4096    // per call; bounds CPU per apply
+	OperateMaxRet         = 4096    // per call; bounds CPU per apply
+)
+
+// Errors returned by the operate wire codec and, downstream, its apply engine.
+var (
+	// ErrOperateType marks an op whose type byte does not match the domain
+	// (int/float/bytes) of the field or column it targets, or an op that
+	// cannot apply to that domain at all (e.g. a shift on a float).
+	ErrOperateType = errors.New("wire: operate type not applicable")
+	// ErrOperatePath marks a path that does not resolve against the record: an
+	// out-of-range position, an unknown name, a row path into a non-table
+	// field, or a scalar op on a table field.
+	ErrOperatePath = errors.New("wire: operate path does not fit the record")
+	// ErrOperateOpcode marks an unknown opcode, or a table opcode used where a
+	// scalar opcode is expected (and vice versa).
+	ErrOperateOpcode = errors.New("wire: operate unknown opcode")
+	// ErrOperateCmp marks an unknown comparator in a CHECK/IF op.
+	ErrOperateCmp = errors.New("wire: operate unknown comparator")
+	// ErrOperateSchema marks a schema blob that fails to decode or validate.
+	ErrOperateSchema = errors.New("wire: operate schema invalid")
+	// ErrOperateSchemaVersion marks a call whose schema version does not match
+	// the version already stored on the record.
+	ErrOperateSchemaVersion = errors.New("wire: operate schema version mismatch")
+	// ErrOperateMode marks a call whose Create mode does not match the mode
+	// (schema vs. dynamic) byte already stored on the record.
+	ErrOperateMode = errors.New("wire: operate record mode mismatch")
+	// ErrOperateCap marks a call that would exceed one of the caps above.
+	ErrOperateCap = errors.New("wire: operate cap exceeded")
+	// ErrOperateRecord marks a stored record whose bytes are malformed
+	// (hostile or corrupt) rather than a call whose input is invalid.
+	ErrOperateRecord = errors.New("wire: operate stored record malformed")
+)

--- a/sdk/wire/operate_const.go
+++ b/sdk/wire/operate_const.go
@@ -167,17 +167,47 @@ const OperateMigrateDropExtra uint8 = 1
 // allocation, all-or-nothing. Hitting one is an error with the record left
 // unchanged — never an implicit eviction.
 const (
-	OperateMaxFields      = 65535   // a schema declaring more fields is rejected
-	OperateMaxCols        = 65535   // a table declaring more columns is rejected
-	OperateMaxSchemaBytes = 4096    // bounds schema parsing and the offset-cache entry
-	OperateMaxRows        = 1 << 20 // per table; a hostile cap above it is clamped
-	OperateMaxRowWidth    = 4096    // bounds FIXED(n) columns × count, in bytes
-	OperateMaxKeyLen      = 255     // u8; FIXED(n) keys (schema mode) or any key (dynamic mode)
-	OperateMaxNameLen     = 255     // u8; dynamic-mode field/column names
-	OperateMaxBytesLen    = 65535   // u16 on the wire, per BYTES field
-	OperateMaxNameBytes   = 4096    // per record; names are stored once
-	OperateMaxOps         = 4096    // per call; bounds CPU per apply
-	OperateMaxRet         = 4096    // per call; bounds CPU per apply
+	// OperateMaxFields bounds a schema's field count and a dynamic record's;
+	// a declaration above it is rejected.
+	OperateMaxFields = 65535
+	// OperateMaxCols bounds one table's column count; a declaration above it
+	// is rejected.
+	OperateMaxCols = 65535
+	// OperateMaxSchemaBytes bounds the encoded schema blob, the offset-cache
+	// entry built from it, and — because every field and column costs at
+	// least one byte of that blob — the field and column counts DecodeSchema
+	// will allocate for, checked BEFORE the allocation rather than after it.
+	OperateMaxSchemaBytes = 4096
+	// OperateMaxRows bounds one table's rows. A declared cap above it is
+	// rejected outright: Schema.Validate refuses a TableDef.Cap over it and
+	// checkRowCap refuses a CONFIG/TRIM operand over it, so an over-cap cap
+	// is an error, never a silently clamped one. On the decode side the row
+	// and column counts of every table in a record are charged against one
+	// shared budget of this size, so a record cannot dodge it by spreading
+	// rows across many tables.
+	OperateMaxRows = 1 << 20
+	// OperateMaxRowWidth bounds one table row's stored bytes: key plus every
+	// column, FIXED(n) widths included.
+	OperateMaxRowWidth = 4096
+	// OperateMaxKeyLen bounds a row key: a u8 length, so FIXED(n) keys in
+	// schema mode and any key in dynamic mode.
+	OperateMaxKeyLen = 255
+	// OperateMaxNameLen bounds one dynamic-mode field or column name (a u8
+	// length prefix), and one name in a schema blob's names section.
+	OperateMaxNameLen = 255
+	// OperateMaxBytesLen bounds one BYTES value; it is a u16 on the wire.
+	OperateMaxBytesLen = 65535
+	// OperateMaxNameBytes bounds the SCHEMA BLOB's names section only — the
+	// one place names are stored per record, since a schema is stored inline
+	// in front of its values. It says nothing about dynamic mode, whose
+	// names are bounded individually by OperateMaxNameLen and collectively
+	// only by the record-size cap (there is no names section to bound).
+	OperateMaxNameBytes = 4096
+	// OperateMaxOps bounds a call's op list; it bounds CPU per apply.
+	OperateMaxOps = 4096
+	// OperateMaxRet bounds a call's return-spec list, and with it the value
+	// count a result frame may carry; it bounds CPU per apply.
+	OperateMaxRet = 4096
 )
 
 // Errors returned by the operate wire codec and, downstream, its apply engine.

--- a/sdk/wire/operate_const.go
+++ b/sdk/wire/operate_const.go
@@ -52,8 +52,15 @@ const (
 // or abort a run of the other ops. Groups are numbered with gaps so a later
 // revision can add an op to a group without renumbering the others.
 const (
-	OperateOpSET   uint8 = 1  // write a (int/float) or bytes (bytes/fixed)
-	OperateOpDEL   uint8 = 2  // field -> UNSET; row -> removed; table -> emptied; record -> deleted
+	OperateOpSET uint8 = 1 // write a (int/float) or bytes (bytes/fixed)
+	// DEL's effect on a FIELD differs by mode, because only one of the two
+	// has a declaration to fall back on: schema mode ZEROES the field to its
+	// schema-declared type (the slot is still declared, so it still occupies
+	// its bytes and still reads as that type's zero), while dynamic mode
+	// REMOVES it outright (nothing declares it, and losing the last field
+	// deletes the record). Row -> removed; table -> emptied; record ->
+	// deleted, in both modes.
+	OperateOpDEL   uint8 = 2
 	OperateOpADD   uint8 = 3  // x += a, saturating (int) / IEEE (float)
 	OperateOpMUL   uint8 = 4  // x *= a, saturating (int) / IEEE (float)
 	OperateOpMIN   uint8 = 5  // x = min(x, v); int, float, bytes/fixed (bytewise)
@@ -186,8 +193,15 @@ const (
 	// shared budget of this size, so a record cannot dodge it by spreading
 	// rows across many tables.
 	OperateMaxRows = 1 << 20
-	// OperateMaxRowWidth bounds one table row's stored bytes: key plus every
-	// column, FIXED(n) widths included.
+	// OperateMaxRowWidth bounds one SCHEMA-mode table row's stored bytes: key
+	// plus every column, FIXED(n) widths included. Schema.Validate computes
+	// that width from the TableDef and refuses a schema over it, which it can
+	// do because a schema-mode row is fixed-width by construction. A
+	// dynamic-mode row has no declared width to check, so it is bounded
+	// instead by what its parts are individually capped at
+	// (OperateMaxNameLen per column name, OperateMaxKeyLen per key,
+	// OperateMaxBytesLen per BYTES value, OperateMaxCols columns) and, in
+	// aggregate, by the record-size cap.
 	OperateMaxRowWidth = 4096
 	// OperateMaxKeyLen bounds a row key: a u8 length, so FIXED(n) keys in
 	// schema mode and any key in dynamic mode.

--- a/sdk/wire/operate_const.go
+++ b/sdk/wire/operate_const.go
@@ -46,6 +46,123 @@ const (
 	OperateTypeFromSchema uint8 = 0xFF
 )
 
+// Operate opcodes (design doc §3.1–§3.3): the byte carried in an OperateOp's
+// Opcode field. Scalar ops (§3.1) apply to a record field or row column;
+// table ops (§3.2) apply to the table field itself; control ops (§3.3) gate
+// or abort a run of the other ops. Groups are numbered with gaps so a later
+// revision can add an op to a group without renumbering the others.
+const (
+	OperateOpSET   uint8 = 1  // write a (int/float) or bytes (bytes/fixed)
+	OperateOpDEL   uint8 = 2  // field -> UNSET; row -> removed; table -> emptied; record -> deleted
+	OperateOpADD   uint8 = 3  // x += a, saturating (int) / IEEE (float)
+	OperateOpMUL   uint8 = 4  // x *= a, saturating (int) / IEEE (float)
+	OperateOpMIN   uint8 = 5  // x = min(x, v); int, float, bytes/fixed (bytewise)
+	OperateOpMAX   uint8 = 6  // x = max(x, v); int, float, bytes/fixed (bytewise)
+	OperateOpAND   uint8 = 7  // bitwise, masked to the field width; fixed-width int only
+	OperateOpOR    uint8 = 8  // bitwise, masked to the field width; fixed-width int only
+	OperateOpXOR   uint8 = 9  // bitwise, masked to the field width; fixed-width int only
+	OperateOpSHL   uint8 = 10 // shift 0..64, masked to the field width; fixed-width int only
+	OperateOpSHR   uint8 = 11 // shift 0..64; arithmetic for signed, logical for unsigned
+	OperateOpSTAMP uint8 = 12 // x = tx.applyStamp() in aux's unit (OperateStamp*), saturating; int only
+
+	OperateOpMIGRATE uint8 = 20 // must be the first op: append-only schema evolution or dynamic freeze
+	OperateOpCONFIG  uint8 = 21 // dynamic mode only: set the table's eviction triple at path
+	OperateOpTRIM    uint8 = 22 // one-off shrink of the table at path to a.Keep rows
+
+	OperateOpIF    uint8 = 30 // if node(path) cmp v is false, skip the next b ops
+	OperateOpCHECK uint8 = 31 // if node(path) cmp v is false, abort the whole list (CHECK_FAILED)
+)
+
+// OperateCmp* are the comparators usable by IF, CHECK, and CompareCell /
+// CompareCount (design doc §3.3): a scalar compares in its domain (an absent
+// numeric cell compares as zero; bytes compare bytewise); a table compares
+// by its row count. EXISTS/ABSENT ignore the operand and test presence.
+const (
+	OperateCmpEQ uint8 = iota
+	OperateCmpNE
+	OperateCmpLT
+	OperateCmpLE
+	OperateCmpGT
+	OperateCmpGE
+	OperateCmpExists
+	OperateCmpAbsent
+)
+
+// OperatePolicy* selects which row CONFIG/TRIM (or a full table) evicts:
+// the row with the smallest/largest row key, or the smallest/largest value
+// in the table's configured eviction column (design doc §3.2, "cap, policy,
+// byCol").
+const (
+	OperatePolicyNone uint8 = iota
+	OperatePolicyMinKey
+	OperatePolicyMaxKey
+	OperatePolicyMinCol
+	OperatePolicyMaxCol
+)
+
+// OperateMode* is the record's stored mode byte (design doc §2.2/§2.9): the
+// first byte of every stored operate record, distinguishing schema mode
+// from self-describing dynamic mode.
+const (
+	OperateModeSchema  uint8 = 1
+	OperateModeDynamic uint8 = 2
+)
+
+// OperateCreate* is a call's `create` parameter (design doc §3.5): whether
+// (and how) an absent record may be created by this call.
+const (
+	OperateCreateNone uint8 = iota
+	OperateCreateSchema
+	OperateCreateDynamic
+)
+
+// OperateTTL* is a call's `ttlMode` parameter (design doc §3.5): how the
+// call's ttlMs affects the record's expiry.
+const (
+	OperateTTLKeep uint8 = iota
+	OperateTTLSet
+	OperateTTLCreateOnly
+)
+
+// OperateStatus* is the result frame's status byte (design doc §3.4).
+const (
+	OperateStatusOK uint8 = iota
+	OperateStatusCheckFailed
+)
+
+// OperateRet* selects a return spec's mode (design doc §3.4): the full,
+// self-describing value, or just a count.
+const (
+	OperateRetValue uint8 = iota
+	OperateRetCount
+)
+
+// OperateStamp* is STAMP's aux unit (design doc §3.1): the transaction
+// timestamp is written in milliseconds or seconds, saturating to the
+// field's stored type.
+const (
+	OperateStampMs uint8 = iota
+	OperateStampS
+)
+
+// OperatePath* is a path's Kind byte (design doc §2.4): which of the
+// record, a field, a table row, or a table column the path resolves to.
+const (
+	OperatePathRecord uint8 = iota
+	OperatePathField
+	OperatePathRow
+	OperatePathCol
+)
+
+// OperateMigrateFromDynamic marks a MIGRATE op's `a` (from-version) operand
+// as "the existing record is dynamic mode", distinguishing it from every
+// non-negative schema version (design doc §2.8/§2.9).
+const OperateMigrateFromDynamic int64 = -1
+
+// OperateMigrateDropExtra is a bit in a MIGRATE op's aux byte: when set,
+// fields/columns the new schema drops are discarded rather than rejected.
+const OperateMigrateDropExtra uint8 = 1
+
 // Caps (design doc §2.7): hard, DoS-defensive ceilings enforced before any
 // allocation, all-or-nothing. Hitting one is an error with the record left
 // unchanged — never an implicit eviction.

--- a/sdk/wire/operate_math.go
+++ b/sdk/wire/operate_math.go
@@ -292,8 +292,12 @@ func cloneBytes(b []byte) []byte {
 // present alone; every other comparator compares in c's domain — numeric
 // (an absent cell reads as zero, per §2.4) or bytewise for BYTES/FIXED. For
 // an unsigned cell, a negative operand is below every unsigned value (it
-// cannot be represented in that domain). An unknown comparator (or one
-// applied to a domain it does not support) returns ErrOperateCmp.
+// cannot be represented in that domain). A float comparison against NaN
+// (either c or the operand) is neither < nor >, so it falls to floatCompare's
+// equal case: EQ reports true and LT/GT report false for a NaN cell against
+// any operand, including another NaN — a deliberate, deterministic choice,
+// not IEEE 754 unordered semantics. An unknown comparator (or one applied to
+// a domain it does not support) returns ErrOperateCmp.
 func CompareCell(cmp uint8, c Cell, present bool, op Operand) (bool, error) {
 	switch cmp {
 	case OperateCmpExists:

--- a/sdk/wire/operate_math.go
+++ b/sdk/wire/operate_math.go
@@ -1,0 +1,551 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package wire
+
+import (
+	"bytes"
+	"math"
+	"math/bits"
+)
+
+// Operand carries a scalar op's operand fields (design doc §3, "Every op is
+// (opcode, type, aux, path, a i64, b i64, bytes)"): A holds an int operand or
+// the IEEE bit pattern of a float operand, per the field's stored type; Aux
+// selects STAMP's unit (OperateStamp*); Bytes carries a BYTES/FIXED operand;
+// StampMs is the transaction timestamp STAMP writes (already resolved by the
+// caller, e.g. from the applying transaction), independent of A/Bytes.
+type Operand struct {
+	A       int64
+	Aux     uint8
+	Bytes   []byte
+	StampMs int64
+}
+
+// ApplyScalar applies opcode to c using op, returning the new cell (design
+// doc §3.1). present reflects whether the path resolved to an existing value
+// before this call — the "absent reads as zero" rule (§2.4) means c is
+// already ZeroCell(c.Type, c.N) in that case, so present itself does not
+// change the arithmetic here; it exists for callers/comparators that need it
+// (see CompareCell). An opcode not valid for c.Type's domain, or unknown
+// outright, returns ErrOperateType / ErrOperateOpcode and a zero Cell.
+func ApplyScalar(opcode uint8, c Cell, present bool, op Operand) (Cell, error) { //nolint:revive // present kept for API symmetry with CompareCell; unused here by design, see doc comment
+	switch {
+	case TypeIsFloat(c.Type):
+		return applyFloat(opcode, c, op)
+	case TypeIsInt(c.Type):
+		return applyInt(opcode, c, op)
+	case TypeIsBytes(c.Type):
+		return applyBytes(opcode, c, op)
+	default:
+		return Cell{}, ErrOperateType
+	}
+}
+
+// applyInt implements the integer scalar ops (design doc §3.1) for the eight
+// fixed-width int types and the two varint types. ADD/MUL saturate at the
+// stored type's range; MIN/MAX clamp the operand into that range first, then
+// compare; AND/OR/XOR/SHL/SHR require a fixed-width type (varints have no
+// fixed bit width to mask or shift within) and operate on the field's raw
+// bits, masked to its width and sign-extended back for a signed type; STAMP
+// writes the transaction timestamp in its aux unit, saturating.
+func applyInt(opcode uint8, c Cell, op Operand) (Cell, error) {
+	unsigned := TypeIsUnsigned(c.Type)
+	switch opcode {
+	case OperateOpSET:
+		c.U = storeIntOperand(c.Type, unsigned, op.A)
+		return c, nil
+
+	case OperateOpADD:
+		if unsigned {
+			c.U = addSatUnsigned(c.U, op.A, typeUMax(c.Type))
+		} else {
+			lo, hi := typeSignedRange(c.Type)
+			cur := signExtend(c.U, typeBits(c.Type))
+			c.U = uint64(addSatSigned(cur, op.A, lo, hi)) //nolint:gosec // reinterpret store convention
+		}
+		return c, nil
+
+	case OperateOpMUL:
+		if unsigned {
+			c.U = mulSatUnsigned(c.U, op.A, typeUMax(c.Type))
+		} else {
+			lo, hi := typeSignedRange(c.Type)
+			cur := signExtend(c.U, typeBits(c.Type))
+			c.U = uint64(mulSatSigned(cur, op.A, lo, hi)) //nolint:gosec // reinterpret store convention
+		}
+		return c, nil
+
+	case OperateOpMIN, OperateOpMAX:
+		wantMin := opcode == OperateOpMIN
+		if unsigned {
+			v := clampUnsigned(op.A, typeUMax(c.Type))
+			if wantMin == (v < c.U) {
+				c.U = v
+			}
+		} else {
+			lo, hi := typeSignedRange(c.Type)
+			v := clampSigned(op.A, lo, hi)
+			cur := signExtend(c.U, typeBits(c.Type))
+			if wantMin == (v < cur) {
+				c.U = uint64(v) //nolint:gosec // reinterpret store convention
+			}
+		}
+		return c, nil
+
+	case OperateOpAND, OperateOpOR, OperateOpXOR, OperateOpSHL, OperateOpSHR:
+		return applyBitOp(opcode, c, unsigned, op.A)
+
+	case OperateOpSTAMP:
+		ms := op.StampMs
+		if op.Aux == OperateStampS {
+			ms /= 1000
+		}
+		c.U = storeIntOperand(c.Type, unsigned, ms)
+		return c, nil
+
+	default:
+		return Cell{}, ErrOperateOpcode
+	}
+}
+
+// applyBitOp implements AND/OR/XOR/SHL/SHR (design doc §3.1): all five
+// require a fixed-width int type — varints have no fixed bit width to mask
+// or shift within. The field's current bits are taken low-width-bits-only
+// (c.U & mask; upper bits are just this convention's sign/zero extension),
+// combined or shifted within that width, then written back zero-extended
+// (unsigned) or sign-extended (signed) per Cell.U's storage convention.
+func applyBitOp(opcode uint8, c Cell, unsigned bool, a int64) (Cell, error) {
+	if !TypeIsFixedInt(c.Type) {
+		return Cell{}, ErrOperateType
+	}
+	w := typeBits(c.Type)
+	mask := widthMask(w)
+	cur := c.U & mask
+
+	var raw uint64
+	switch opcode {
+	case OperateOpAND:
+		raw = cur & (uint64(a) & mask) //nolint:gosec // bit pattern reinterpret, per field convention
+	case OperateOpOR:
+		raw = cur | (uint64(a) & mask) //nolint:gosec // bit pattern reinterpret
+	case OperateOpXOR:
+		raw = cur ^ (uint64(a) & mask) //nolint:gosec // bit pattern reinterpret
+	case OperateOpSHL:
+		if a < 0 || a > 64 {
+			return Cell{}, ErrOperateType
+		}
+		if uint64(a) >= uint64(w) { //nolint:gosec // a checked >= 0 above
+			raw = 0
+		} else {
+			raw = (cur << uint(a)) & mask //nolint:gosec // a in [0,64)
+		}
+	case OperateOpSHR:
+		if a < 0 || a > 64 {
+			return Cell{}, ErrOperateType
+		}
+		switch {
+		case unsigned:
+			if uint64(a) >= uint64(w) { //nolint:gosec // a checked >= 0 above
+				raw = 0
+			} else {
+				raw = cur >> uint(a) //nolint:gosec // a in [0,64)
+			}
+		default:
+			signedCur := signExtend(c.U, w)
+			if uint64(a) >= uint64(w) { //nolint:gosec // a checked >= 0 above
+				if signedCur < 0 {
+					raw = mask // full shift-out of a negative value is all-ones (-1) within the width
+				} else {
+					raw = 0
+				}
+			} else {
+				raw = uint64(signedCur>>uint(a)) & mask //nolint:gosec // arithmetic shift, then re-mask to width
+			}
+		}
+	}
+
+	if unsigned {
+		c.U = raw
+	} else {
+		c.U = uint64(signExtend(raw, w)) //nolint:gosec // reinterpret store convention
+	}
+	return c, nil
+}
+
+// storeIntOperand clamps/truncates operand v into c's declared type and
+// returns it in Cell.U's storage convention (zero-extended for unsigned,
+// sign-extended for signed), for SET and STAMP.
+func storeIntOperand(t uint8, unsigned bool, v int64) uint64 {
+	if unsigned {
+		return clampUnsigned(v, typeUMax(t))
+	}
+	lo, hi := typeSignedRange(t)
+	return uint64(clampSigned(v, lo, hi)) //nolint:gosec // reinterpret store convention
+}
+
+// applyFloat implements the float scalar ops (design doc §3.1) for F32/F64.
+// The operand is the IEEE bit pattern of a float64 (or, for F32, the low 32
+// bits of a float32 pattern), per §3 ("a carries ... the IEEE bit pattern of
+// a float operand"). Every result is canonicalized via CanonFloat so a NaN
+// is always the canonical quiet NaN and F32 storage round-trips exactly.
+// MIN/MAX use a plain IEEE comparison, so a NaN operand never replaces the
+// stored value (NaN compares false against everything).
+func applyFloat(opcode uint8, c Cell, op Operand) (Cell, error) {
+	switch opcode {
+	case OperateOpSET:
+		c.F = CanonFloat(c.Type, floatOperand(c.Type, op.A))
+	case OperateOpADD:
+		c.F = CanonFloat(c.Type, c.F+floatOperand(c.Type, op.A))
+	case OperateOpMUL:
+		c.F = CanonFloat(c.Type, c.F*floatOperand(c.Type, op.A))
+	case OperateOpMIN:
+		if v := floatOperand(c.Type, op.A); v < c.F {
+			c.F = CanonFloat(c.Type, v)
+		}
+	case OperateOpMAX:
+		if v := floatOperand(c.Type, op.A); v > c.F {
+			c.F = CanonFloat(c.Type, v)
+		}
+	default:
+		return Cell{}, ErrOperateType
+	}
+	return c, nil
+}
+
+// floatOperand reinterprets a as the IEEE-754 bit pattern of a float64
+// operand (design doc §3: "a carries ... the IEEE bit pattern of a float
+// operand"). This is uniform across F32 and F64 fields — the operand always
+// travels as a double; a field's own stored width (4 bytes for F32) is a
+// property of Cell's wire encoding, not of how its operands are carried. The
+// result is rounded back down through CanonFloat by the caller when t is
+// OperateTypeF32.
+func floatOperand(_ uint8, a int64) float64 {
+	return math.Float64frombits(uint64(a)) //nolint:gosec // 64-bit IEEE pattern
+}
+
+// applyBytes implements the BYTES/FIXED scalar ops: SET, MIN, and MAX,
+// compared bytewise via bytes.Compare (design doc §3.1). A FIXED cell's
+// operand length must equal c.N; a BYTES operand is bounded by
+// OperateMaxBytesLen (design doc §2.7). The result never aliases op.Bytes.
+func applyBytes(opcode uint8, c Cell, op Operand) (Cell, error) {
+	if c.Type == OperateTypeFixed {
+		if len(op.Bytes) != int(c.N) {
+			return Cell{}, ErrOperateType
+		}
+	} else if len(op.Bytes) > OperateMaxBytesLen {
+		return Cell{}, ErrOperateCap
+	}
+
+	switch opcode {
+	case OperateOpSET:
+		c.B = cloneBytes(op.Bytes)
+	case OperateOpMIN:
+		if bytes.Compare(op.Bytes, c.B) < 0 {
+			c.B = cloneBytes(op.Bytes)
+		}
+	case OperateOpMAX:
+		if bytes.Compare(op.Bytes, c.B) > 0 {
+			c.B = cloneBytes(op.Bytes)
+		}
+	default:
+		return Cell{}, ErrOperateType
+	}
+	return c, nil
+}
+
+// cloneBytes returns an independent copy of b so a returned Cell never
+// aliases a caller-owned operand slice.
+func cloneBytes(b []byte) []byte {
+	out := make([]byte, len(b))
+	copy(out, b)
+	return out
+}
+
+// CompareCell evaluates cmp against c (design doc §3.3): EXISTS/ABSENT test
+// present alone; every other comparator compares in c's domain — numeric
+// (an absent cell reads as zero, per §2.4) or bytewise for BYTES/FIXED. For
+// an unsigned cell, a negative operand is below every unsigned value (it
+// cannot be represented in that domain). An unknown comparator (or one
+// applied to a domain it does not support) returns ErrOperateCmp.
+func CompareCell(cmp uint8, c Cell, present bool, op Operand) (bool, error) {
+	switch cmp {
+	case OperateCmpExists:
+		return present, nil
+	case OperateCmpAbsent:
+		return !present, nil
+	}
+
+	var order int
+	switch {
+	case TypeIsFloat(c.Type):
+		v := floatOperand(c.Type, op.A)
+		order = floatCompare(c.F, v)
+	case TypeIsInt(c.Type):
+		if TypeIsUnsigned(c.Type) {
+			if op.A < 0 {
+				order = 1 // every unsigned value is above a negative operand
+			} else {
+				order = uint64Compare(c.U, uint64(op.A)) //nolint:gosec // op.A >= 0 checked above
+			}
+		} else {
+			order = int64Compare(signExtend(c.U, typeBits(c.Type)), op.A)
+		}
+	case TypeIsBytes(c.Type):
+		order = bytes.Compare(c.B, op.Bytes)
+	default:
+		return false, ErrOperateCmp
+	}
+	return compareOrder(cmp, order)
+}
+
+// CompareCount evaluates cmp against a table's row count n (design doc
+// §3.3, "a table compares by its row count"): an unsigned comparison of n
+// against op.A, where a negative op.A is below every count. EXISTS/ABSENT
+// test present alone, same as CompareCell.
+func CompareCount(cmp uint8, n uint64, present bool, op Operand) (bool, error) {
+	switch cmp {
+	case OperateCmpExists:
+		return present, nil
+	case OperateCmpAbsent:
+		return !present, nil
+	}
+	var order int
+	if op.A < 0 {
+		order = 1 // every count is above a negative operand
+	} else {
+		order = uint64Compare(n, uint64(op.A)) //nolint:gosec // op.A >= 0 checked above
+	}
+	return compareOrder(cmp, order)
+}
+
+// compareOrder maps a three-way order (-1/0/1) to the EQ/NE/LT/LE/GT/GE
+// result for cmp, rejecting any comparator not in that set (EXISTS/ABSENT
+// are handled by the caller before order is ever computed).
+func compareOrder(cmp uint8, order int) (bool, error) {
+	switch cmp {
+	case OperateCmpEQ:
+		return order == 0, nil
+	case OperateCmpNE:
+		return order != 0, nil
+	case OperateCmpLT:
+		return order < 0, nil
+	case OperateCmpLE:
+		return order <= 0, nil
+	case OperateCmpGT:
+		return order > 0, nil
+	case OperateCmpGE:
+		return order >= 0, nil
+	default:
+		return false, ErrOperateCmp
+	}
+}
+
+func floatCompare(a, b float64) int {
+	switch {
+	case a < b:
+		return -1
+	case a > b:
+		return 1
+	default:
+		return 0
+	}
+}
+
+func uint64Compare(a, b uint64) int {
+	switch {
+	case a < b:
+		return -1
+	case a > b:
+		return 1
+	default:
+		return 0
+	}
+}
+
+func int64Compare(a, b int64) int {
+	switch {
+	case a < b:
+		return -1
+	case a > b:
+		return 1
+	default:
+		return 0
+	}
+}
+
+// --- v1 helpers (ports of ops/operate.go, unchanged behavior) --------------
+
+// typeUMax returns the maximum value of unsigned type t (U8/U16/U32 exactly;
+// U64 and UVARINT both saturate at the u64 boundary).
+func typeUMax(t uint8) uint64 {
+	switch t {
+	case OperateTypeU8:
+		return math.MaxUint8
+	case OperateTypeU16:
+		return math.MaxUint16
+	case OperateTypeU32:
+		return math.MaxUint32
+	default: // U64, UVARINT
+		return math.MaxUint64
+	}
+}
+
+// typeSignedRange returns the [lo, hi] range of signed type t (I8/I16/I32
+// exactly; I64 and IVARINT both saturate at the i64 boundary).
+func typeSignedRange(t uint8) (lo, hi int64) {
+	switch t {
+	case OperateTypeI8:
+		return math.MinInt8, math.MaxInt8
+	case OperateTypeI16:
+		return math.MinInt16, math.MaxInt16
+	case OperateTypeI32:
+		return math.MinInt32, math.MaxInt32
+	default: // I64, IVARINT
+		return math.MinInt64, math.MaxInt64
+	}
+}
+
+// typeBits returns the fixed bit width of a fixed-width int type (U8..I64).
+// It is only meaningful for TypeIsFixedInt(t); varints have no fixed width.
+func typeBits(t uint8) int {
+	switch t {
+	case OperateTypeU8, OperateTypeI8:
+		return 8
+	case OperateTypeU16, OperateTypeI16:
+		return 16
+	case OperateTypeU32, OperateTypeI32:
+		return 32
+	default:
+		return 64
+	}
+}
+
+// widthMask returns a mask with the low bits bits set (all 64 bits for
+// bits >= 64).
+func widthMask(bits int) uint64 {
+	if bits >= 64 {
+		return math.MaxUint64
+	}
+	return (uint64(1) << uint(bits)) - 1
+}
+
+// signExtend reinterprets the low bits bits of v as a signed integer of that
+// width, sign-extended to int64.
+func signExtend(v uint64, bits int) int64 {
+	if bits >= 64 {
+		return int64(v) //nolint:gosec // full width
+	}
+	shift := uint(64 - bits)
+	return int64(v<<shift) >> shift //nolint:gosec // arithmetic shift sign-extends
+}
+
+// clampUnsigned clamps a into [0, max]: negative saturates to 0.
+func clampUnsigned(a int64, max uint64) uint64 {
+	if a < 0 {
+		return 0
+	}
+	ua := uint64(a) //nolint:gosec // a >= 0 checked above
+	if ua > max {
+		return max
+	}
+	return ua
+}
+
+// clampSigned clamps a into [lo, hi].
+func clampSigned(a, lo, hi int64) int64 {
+	switch {
+	case a < lo:
+		return lo
+	case a > hi:
+		return hi
+	default:
+		return a
+	}
+}
+
+// addSatUnsigned adds a signed delta to an unsigned value, saturating at
+// [0, max] (never wrapping). uint64(-delta) yields the correct magnitude
+// even for MinInt64 (two's-complement negation wraps back to the same bit
+// pattern, which reinterpreted as uint64 is exactly |MinInt64|).
+func addSatUnsigned(cur uint64, delta int64, max uint64) uint64 {
+	if delta >= 0 {
+		d := uint64(delta) //nolint:gosec // delta >= 0 checked above
+		if d > max-cur {
+			return max
+		}
+		return cur + d
+	}
+	d := uint64(-delta) //nolint:gosec // magnitude; correct even at MinInt64
+	if d > cur {
+		return 0
+	}
+	return cur - d
+}
+
+// addSatSigned adds delta to cur, saturating at [lo, hi] and detecting the
+// int64 wrap first (so I64 saturates at the int64 boundary instead of
+// wrapping).
+func addSatSigned(cur, delta, lo, hi int64) int64 {
+	sum := cur + delta
+	switch {
+	case delta > 0 && sum < cur:
+		return hi // overflowed positive
+	case delta < 0 && sum > cur:
+		return lo // overflowed negative
+	case sum < lo:
+		return lo
+	case sum > hi:
+		return hi
+	default:
+		return sum
+	}
+}
+
+// absU64 returns the magnitude of x as a uint64, correct even for
+// math.MinInt64 (whose negation overflows int64 but wraps, via two's
+// complement, back to a bit pattern that reinterpreted as uint64 is exactly
+// the true magnitude, 1<<63).
+func absU64(x int64) uint64 {
+	if x < 0 {
+		return uint64(-x) //nolint:gosec // two's-complement magnitude, correct even at MinInt64
+	}
+	return uint64(x)
+}
+
+// mulSatUnsigned multiplies cur by a signed delta, saturating at [0, max].
+// A negative a has no meaning for an unsigned value, so it saturates to 0
+// (matching addSatUnsigned's floor).
+func mulSatUnsigned(cur uint64, a int64, max uint64) uint64 {
+	if a < 0 {
+		return 0
+	}
+	hi, lo := bits.Mul64(cur, uint64(a)) //nolint:gosec // a >= 0 checked above
+	if hi != 0 || lo > max {
+		return max
+	}
+	return lo
+}
+
+// mulSatSigned multiplies cur by a, saturating at [lo, hi]. It multiplies
+// magnitudes with bits.Mul64 (a 64x64->128 multiply, so no product can
+// silently wrap) and reattaches the sign, checking the magnitude against
+// whichever bound (|lo| or hi) the result's sign would saturate toward.
+func mulSatSigned(cur, a, lo, hi int64) int64 {
+	if cur == 0 || a == 0 {
+		return 0
+	}
+	neg := (cur < 0) != (a < 0)
+	hiBits, loBits := bits.Mul64(absU64(cur), absU64(a))
+	if neg {
+		magLo := absU64(lo)
+		if hiBits != 0 || loBits > magLo {
+			return lo
+		}
+		return -int64(loBits) //nolint:gosec // magnitude bounded by |lo|; two's complement handles MinInt64 exactly
+	}
+	magHi := uint64(hi) //nolint:gosec // hi is non-negative for every signed range here
+	if hiBits != 0 || loBits > magHi {
+		return hi
+	}
+	return int64(loBits) //nolint:gosec // magnitude bounded by hi
+}

--- a/sdk/wire/operate_math.go
+++ b/sdk/wire/operate_math.go
@@ -29,6 +29,14 @@ type Operand struct {
 // (see CompareCell). An opcode not valid for c.Type's domain, or unknown
 // outright, returns ErrOperateType / ErrOperateOpcode and a zero Cell.
 func ApplyScalar(opcode uint8, c Cell, present bool, op Operand) (Cell, error) { //nolint:revive // present kept for API symmetry with CompareCell; unused here by design, see doc comment
+	if !isScalarOpcode(opcode) {
+		// An opcode outside the whole scalar vocabulary (e.g. DEL, a table/
+		// control opcode, or garbage) is unknown regardless of the target's
+		// type — never conflate this with a real-but-domain-inapplicable
+		// opcode (e.g. SHL on a float), which the per-domain functions below
+		// report as ErrOperateType.
+		return Cell{}, ErrOperateOpcode
+	}
 	switch {
 	case TypeIsFloat(c.Type):
 		return applyFloat(opcode, c, op)
@@ -38,6 +46,20 @@ func ApplyScalar(opcode uint8, c Cell, present bool, op Operand) (Cell, error) {
 		return applyBytes(opcode, c, op)
 	default:
 		return Cell{}, ErrOperateType
+	}
+}
+
+// isScalarOpcode reports whether opcode is one of the scalar ops (design doc
+// §3.1) ApplyScalar can ever apply — regardless of whether it is valid for
+// any particular field's type. DEL (a structural op handled by the tree
+// engine, not by scalar math) and every table/control opcode are excluded.
+func isScalarOpcode(opcode uint8) bool {
+	switch opcode {
+	case OperateOpSET, OperateOpADD, OperateOpMUL, OperateOpMIN, OperateOpMAX,
+		OperateOpAND, OperateOpOR, OperateOpXOR, OperateOpSHL, OperateOpSHR, OperateOpSTAMP:
+		return true
+	default:
+		return false
 	}
 }
 
@@ -97,8 +119,13 @@ func applyInt(opcode uint8, c Cell, op Operand) (Cell, error) {
 
 	case OperateOpSTAMP:
 		ms := op.StampMs
-		if op.Aux == OperateStampS {
+		switch op.Aux {
+		case OperateStampMs:
+			// ms is already in milliseconds
+		case OperateStampS:
 			ms /= 1000
+		default:
+			return Cell{}, ErrOperateType
 		}
 		c.U = storeIntOperand(c.Type, unsigned, ms)
 		return c, nil

--- a/sdk/wire/operate_math_test.go
+++ b/sdk/wire/operate_math_test.go
@@ -1,0 +1,124 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package wire
+
+import (
+	"math"
+	"testing"
+)
+
+// f64 reinterprets a float64 as its IEEE bit pattern at RUNTIME, mirroring
+// su64 in operate_cell_test.go (same package): math.Float64bits(x) is not a
+// constant expression, so this needs no special-casing, but the helper
+// keeps call sites uniform with su64.
+func f64(x float64) int64 { return int64(math.Float64bits(x)) } //nolint:gosec // reinterpret bits
+
+func TestApplyScalarSaturates(t *testing.T) {
+	cases := []struct {
+		typ   uint8
+		start uint64
+		op    uint8
+		a     int64
+		want  uint64
+	}{
+		{OperateTypeU8, 250, OperateOpADD, 10, 255},
+		{OperateTypeU8, 3, OperateOpADD, -10, 0},
+		{OperateTypeI8, 120, OperateOpADD, 10, 127},
+		{OperateTypeI8, su64(-120), OperateOpADD, -10, su64(-128)},
+		{OperateTypeU64, math.MaxUint64 - 1, OperateOpADD, 5, math.MaxUint64},
+		{OperateTypeI64, math.MaxInt64, OperateOpADD, 1, math.MaxInt64},
+		{OperateTypeU16, 60000, OperateOpMUL, 2, 65535},
+		{OperateTypeI16, su64(-30000), OperateOpMUL, 2, su64(-32768)},
+		{OperateTypeU32, 7, OperateOpMAX, 9, 9}, {OperateTypeU32, 7, OperateOpMAX, -9, 7},
+		{OperateTypeI32, 7, OperateOpMIN, -9, su64(-9)},
+		{OperateTypeU8, 0b1010, OperateOpAND, 0b0110, 0b0010}, {OperateTypeU8, 0b1010, OperateOpOR, 0b0101, 0b1111}, {OperateTypeU8, 0b1010, OperateOpXOR, 0b1111, 0b0101},
+		{OperateTypeU8, 0b1000_0001, OperateOpSHL, 1, 0b0000_0010}, // masked to 8 bits
+		{OperateTypeI8, su64(-128), OperateOpSHR, 1, su64(-64)},    // arithmetic
+		{OperateTypeU8, 0x80, OperateOpSHR, 1, 0x40},               // logical
+		{OperateTypeU8, 1, OperateOpSHL, 64, 0},
+		{OperateTypeUVarint, 1 << 40, OperateOpADD, 1, 1<<40 + 1},
+	}
+	for _, c := range cases {
+		got, err := ApplyScalar(c.op, Cell{Type: c.typ, U: c.start}, true, Operand{A: c.a})
+		if err != nil || got.U != c.want {
+			t.Errorf("%+v: got %d (%v) want %d", c, got.U, err, c.want)
+		}
+	}
+}
+
+func TestApplyScalarFloatsAndBytes(t *testing.T) {
+	got, _ := ApplyScalar(OperateOpADD, Cell{Type: OperateTypeF32, F: 1.5}, true, Operand{A: f64(0.25)})
+	if got.F != 1.75 {
+		t.Fatal(got.F)
+	}
+	got, _ = ApplyScalar(OperateOpMUL, Cell{Type: OperateTypeF64, F: 8}, true, Operand{A: f64(0.5)})
+	if got.F != 4 {
+		t.Fatal(got.F)
+	}
+	got, _ = ApplyScalar(OperateOpMAX, Cell{Type: OperateTypeF64, F: 8}, true, Operand{A: f64(math.NaN())})
+	if got.F != 8 {
+		t.Fatal("NaN replaced a value")
+	}
+	got, _ = ApplyScalar(OperateOpMAX, Cell{Type: OperateTypeBytes, B: []byte("abc")}, true, Operand{Bytes: []byte("abd")})
+	if string(got.B) != "abd" {
+		t.Fatal(string(got.B))
+	}
+	got, _ = ApplyScalar(OperateOpSET, Cell{Type: OperateTypeFixed, N: 2, B: []byte("DE")}, true, Operand{Bytes: []byte("FR")})
+	if string(got.B) != "FR" {
+		t.Fatal(string(got.B))
+	}
+	if _, err := ApplyScalar(OperateOpSET, Cell{Type: OperateTypeFixed, N: 2}, true, Operand{Bytes: []byte("FRA")}); err == nil {
+		t.Fatal("wrong FIXED length accepted")
+	}
+}
+
+func TestApplyScalarRejects(t *testing.T) {
+	bad := []struct{ typ, op uint8 }{
+		{OperateTypeF32, OperateOpSHL}, {OperateTypeF64, OperateOpAND}, {OperateTypeUVarint, OperateOpSHL},
+		{OperateTypeBytes, OperateOpADD}, {OperateTypeU8, 99},
+	}
+	for _, b := range bad {
+		if _, err := ApplyScalar(b.op, ZeroCell(b.typ, 0), true, Operand{A: 1}); err == nil {
+			t.Errorf("%+v accepted", b)
+		}
+	}
+	if _, err := ApplyScalar(OperateOpSHL, Cell{Type: OperateTypeU8}, true, Operand{A: -1}); err == nil {
+		t.Fatal("negative shift accepted")
+	}
+}
+
+func TestApplyScalarStamp(t *testing.T) {
+	got, _ := ApplyScalar(OperateOpSTAMP, ZeroCell(OperateTypeU32, 0), false, Operand{Aux: OperateStampS, StampMs: 1_700_000_000_123})
+	if got.U != 1_700_000_000 {
+		t.Fatal(got.U)
+	}
+	got, _ = ApplyScalar(OperateOpSTAMP, ZeroCell(OperateTypeU16, 0), false, Operand{Aux: OperateStampMs, StampMs: 1_700_000_000_123})
+	if got.U != 65535 {
+		t.Fatal("stamp did not saturate")
+	}
+}
+
+func TestCompareCell(t *testing.T) {
+	c := Cell{Type: OperateTypeI32, U: su64(-3)}
+	for cmp, want := range map[uint8]bool{OperateCmpLT: true, OperateCmpGE: false, OperateCmpEQ: false, OperateCmpNE: true, OperateCmpExists: true, OperateCmpAbsent: false} {
+		if got, _ := CompareCell(cmp, c, true, Operand{A: 0}); got != want {
+			t.Errorf("cmp %d: %v", cmp, got)
+		}
+	}
+	// absent numeric compares as zero
+	if got, _ := CompareCell(OperateCmpLT, ZeroCell(OperateTypeU32, 0), false, Operand{A: 100}); !got {
+		t.Fatal("absent<100 should hold")
+	}
+	if got, _ := CompareCell(OperateCmpExists, ZeroCell(OperateTypeU32, 0), false, Operand{}); got {
+		t.Fatal("absent exists")
+	}
+	if got, _ := CompareCell(OperateCmpGT, Cell{Type: OperateTypeBytes, B: []byte("b")}, true, Operand{Bytes: []byte("a")}); !got {
+		t.Fatal("bytes cmp")
+	}
+	if got, _ := CompareCount(OperateCmpGE, 100, true, Operand{A: 100}); !got {
+		t.Fatal("count cmp")
+	}
+	if _, err := CompareCell(99, c, true, Operand{}); err == nil {
+		t.Fatal("bad cmp accepted")
+	}
+}

--- a/sdk/wire/operate_math_test.go
+++ b/sdk/wire/operate_math_test.go
@@ -135,3 +135,23 @@ func TestCompareCell(t *testing.T) {
 		t.Fatal("bad cmp accepted")
 	}
 }
+
+// TestCompareCellNaN pins the documented, deterministic (not IEEE 754
+// unordered) NaN behavior of CompareCell/floatCompare: a NaN cell is
+// neither < nor > any operand, including another NaN, so it falls to the
+// equal case — EQ reports true, LT and GT report false.
+func TestCompareCellNaN(t *testing.T) {
+	nan := Cell{Type: OperateTypeF64, F: math.NaN()}
+	if got, _ := CompareCell(OperateCmpEQ, nan, true, Operand{A: f64(math.NaN())}); !got {
+		t.Fatal("NaN EQ NaN should be true (deterministic, not IEEE unordered)")
+	}
+	if got, _ := CompareCell(OperateCmpEQ, nan, true, Operand{A: f64(1)}); !got {
+		t.Fatal("NaN EQ 1 should be true (deterministic, not IEEE unordered)")
+	}
+	if got, _ := CompareCell(OperateCmpLT, nan, true, Operand{A: f64(1)}); got {
+		t.Fatal("NaN LT 1 should be false")
+	}
+	if got, _ := CompareCell(OperateCmpGT, nan, true, Operand{A: f64(1)}); got {
+		t.Fatal("NaN GT 1 should be false")
+	}
+}

--- a/sdk/wire/operate_math_test.go
+++ b/sdk/wire/operate_math_test.go
@@ -3,6 +3,7 @@
 package wire
 
 import (
+	"errors"
 	"math"
 	"testing"
 )
@@ -36,6 +37,7 @@ func TestApplyScalarSaturates(t *testing.T) {
 		{OperateTypeI8, su64(-128), OperateOpSHR, 1, su64(-64)},    // arithmetic
 		{OperateTypeU8, 0x80, OperateOpSHR, 1, 0x40},               // logical
 		{OperateTypeU8, 1, OperateOpSHL, 64, 0},
+		{OperateTypeI8, su64(-5), OperateOpSHR, 64, su64(-1)}, // negative signed, full shift-out -> -1
 		{OperateTypeUVarint, 1 << 40, OperateOpADD, 1, 1<<40 + 1},
 	}
 	for _, c := range cases {
@@ -75,7 +77,7 @@ func TestApplyScalarFloatsAndBytes(t *testing.T) {
 func TestApplyScalarRejects(t *testing.T) {
 	bad := []struct{ typ, op uint8 }{
 		{OperateTypeF32, OperateOpSHL}, {OperateTypeF64, OperateOpAND}, {OperateTypeUVarint, OperateOpSHL},
-		{OperateTypeBytes, OperateOpADD}, {OperateTypeU8, 99},
+		{OperateTypeBytes, OperateOpADD},
 	}
 	for _, b := range bad {
 		if _, err := ApplyScalar(b.op, ZeroCell(b.typ, 0), true, Operand{A: 1}); err == nil {
@@ -84,6 +86,14 @@ func TestApplyScalarRejects(t *testing.T) {
 	}
 	if _, err := ApplyScalar(OperateOpSHL, Cell{Type: OperateTypeU8}, true, Operand{A: -1}); err == nil {
 		t.Fatal("negative shift accepted")
+	}
+	// An unknown opcode is ErrOperateOpcode in EVERY domain, not just int —
+	// it must never be reported as ErrOperateType just because the target
+	// field happens to be a float or bytes cell.
+	for _, typ := range []uint8{OperateTypeU8, OperateTypeF64, OperateTypeBytes} {
+		if _, err := ApplyScalar(99, ZeroCell(typ, 0), true, Operand{A: 1}); !errors.Is(err, ErrOperateOpcode) {
+			t.Errorf("type %d: unknown opcode: got %v want ErrOperateOpcode", typ, err)
+		}
 	}
 }
 
@@ -95,6 +105,9 @@ func TestApplyScalarStamp(t *testing.T) {
 	got, _ = ApplyScalar(OperateOpSTAMP, ZeroCell(OperateTypeU16, 0), false, Operand{Aux: OperateStampMs, StampMs: 1_700_000_000_123})
 	if got.U != 65535 {
 		t.Fatal("stamp did not saturate")
+	}
+	if _, err := ApplyScalar(OperateOpSTAMP, ZeroCell(OperateTypeU32, 0), false, Operand{Aux: 99, StampMs: 1}); !errors.Is(err, ErrOperateType) {
+		t.Fatalf("bad stamp aux: got %v want ErrOperateType", err)
 	}
 }
 

--- a/sdk/wire/operate_record.go
+++ b/sdk/wire/operate_record.go
@@ -549,7 +549,8 @@ func decodeDynamicRecord(b []byte) (*Record, error) {
 // decodeDynamicTable reads a dynamic-mode table value ([byteLen uvarint]
 // [cap uvarint][policy u8][byColLen u8][byColName][nRows uvarint]{rows}*,
 // design doc §2.9) from the front of b. byteLen must fit the remaining
-// bytes and the parse of the fields it covers must consume it exactly.
+// bytes and the parse of the fields it covers must consume it exactly, and
+// a MIN_COL/MAX_COL policy must name the column it evicts by.
 // budget accumulates every field, row, and column decoded anywhere in the
 // record against OperateMaxRows.
 func decodeDynamicTable(b []byte, budget *int) (*Table, int, error) {
@@ -596,6 +597,15 @@ func decodeDynamicTable(b []byte, budget *int) (*Table, int, error) {
 	}
 	byColName := string(inner[ioff : ioff+byColLen])
 	ioff += byColLen
+	// A MIN_COL/MAX_COL policy evicts by the value in a named column, so it
+	// is meaningless without the name (design doc §3.2). Nothing that writes
+	// a table produces this pairing — CONFIG rejects it with
+	// wire.ErrOperatePath before it stores anything — so a record carrying
+	// it is malformed, and accepting it would leave the eviction victim
+	// undefined.
+	if (policy == OperatePolicyMinCol || policy == OperatePolicyMaxCol) && byColLen == 0 {
+		return nil, 0, ErrOperateRecord
+	}
 
 	nRows, m3, err := decodeCanonicalUvarint(inner[ioff:])
 	if err != nil {

--- a/sdk/wire/operate_record.go
+++ b/sdk/wire/operate_record.go
@@ -100,33 +100,52 @@ func (r *Record) encodeSchema() []byte {
 			continue
 		}
 		f := &s.Fields[i]
-		cell := Cell{}
+		var tree Cell
 		if i < len(r.Fields) {
-			cell = r.Fields[i].Cell
+			tree = r.Fields[i].Cell
 		}
-		if cell.Type == OperateTypeUnset {
-			cell = ZeroCell(f.Type, f.N)
-		}
-		b = AppendCellData(b, cell)
+		b = AppendCellData(b, schemaCellOrZero(tree, i < len(r.Fields), f.Type, f.N))
 	}
 
 	for _, i := range layout.VarTail {
 		f := &s.Fields[i]
 		var tree Field
-		if i < len(r.Fields) {
+		present := i < len(r.Fields)
+		if present {
 			tree = r.Fields[i]
 		}
 		if f.Type == OperateTypeTable {
 			b = appendSchemaTable(b, f.Table, tree.Table)
 			continue
 		}
-		cell := tree.Cell
-		if cell.Type == OperateTypeUnset {
-			cell = ZeroCell(f.Type, f.N)
-		}
-		b = AppendCellData(b, cell)
+		b = AppendCellData(b, schemaCellOrZero(tree.Cell, present, f.Type, f.N))
 	}
 	return b
+}
+
+// schemaCellOrZero returns tree's payload (U/F/B) re-typed at the schema's
+// declared type and width (typ, n): in schema mode the SCHEMA, never the
+// tree cell's own Type, determines how AppendCellData interprets a field or
+// column (design doc §2.2 — "no tag stored"). tree.Type is otherwise
+// ignored, because OperateTypeU8 is also Go's zero value for uint8 — a
+// freshly zero-valued Cell{} (e.g. from a tree whose Fields slice is shorter
+// than the schema) is bit-for-bit indistinguishable from an explicit
+// Cell{Type: OperateTypeU8}, so branching on tree.Type alone would encode
+// every never-touched non-U8 field as a 1-byte U8 zero instead of its real
+// width, corrupting every fixed-offset field after it. A field that is
+// absent, explicitly OperateTypeUnset, or the Go zero value in every other
+// regard encodes as ZeroCell(typ, n) — for OperateTypeFixed this is n zero
+// bytes, not zero bytes, which matters just as much.
+func schemaCellOrZero(tree Cell, present bool, typ, n uint8) Cell {
+	if !present || tree.Type == OperateTypeUnset || isZeroCell(tree) {
+		return ZeroCell(typ, n)
+	}
+	return Cell{Type: typ, N: n, U: tree.U, F: tree.F, B: tree.B}
+}
+
+// isZeroCell reports whether c is the Go zero value of Cell in every field.
+func isZeroCell(c Cell) bool {
+	return c.Type == 0 && c.N == 0 && c.U == 0 && c.F == 0 && len(c.B) == 0
 }
 
 // appendSchemaTable appends a schema-mode table's value area (design doc
@@ -145,14 +164,12 @@ func appendSchemaTable(b []byte, tdef *TableDef, tbl *Table) []byte {
 		b = append(b, row.Key...)
 		for c := range tdef.Cols {
 			cd := &tdef.Cols[c]
-			var cell Cell
-			if c < len(row.Cols) {
-				cell = row.Cols[c].Cell
+			var tree Cell
+			present := c < len(row.Cols)
+			if present {
+				tree = row.Cols[c].Cell
 			}
-			if cell.Type == OperateTypeUnset {
-				cell = ZeroCell(cd.Type, cd.N)
-			}
-			b = AppendCellData(b, cell)
+			b = AppendCellData(b, schemaCellOrZero(tree, present, cd.Type, cd.N))
 		}
 	}
 	return b
@@ -215,7 +232,10 @@ func appendDynamicTable(dst []byte, t *Table) []byte {
 
 // appendDynamicRow appends one dynamic-mode row's content (everything after
 // its rowLen prefix): [klen u8][key][nCols uvarint]{cols}*, columns sorted
-// by name.
+// by name. Encode assumes a well-formed tree (design doc §2.4: a dynamic
+// row key is 1-255 bytes); a row with an empty Key encodes a klen of 0,
+// which DecodeRecord — the hardened side of this codec — will then reject,
+// so such a tree cannot round-trip. Encode does not itself guard against it.
 func appendDynamicRow(dst []byte, row Row) []byte {
 	dst = append(dst, byte(len(row.Key))) //nolint:gosec // bounded by OperateMaxKeyLen on a well-formed tree
 	dst = append(dst, row.Key...)
@@ -265,23 +285,41 @@ func compareLE(a, b []byte) int {
 	}
 }
 
-// decodeCellDataCanonical wraps DecodeCellData with a re-encode check.
-// DecodeCellData (Task 1) accepts any length-legal varint or BYTES-length
-// encoding, not necessarily the minimal one AppendCellData would produce
-// (e.g. a two-byte over-long encoding of the value 1, [0x81, 0x00]) — fine
-// for the op-args wire format, but a record byte stream carrying such an
-// encoding would decode successfully yet not re-encode identically,
-// breaking the decode-encode identity DecodeRecord's hostile decoder must
-// uphold (FuzzDecodeRecord). Rejecting a non-canonical encoding here, at
-// every cell read, keeps DecodeRecord(b).Encode() == b for every b it
-// accepts, without changing Task 1's cell codec.
+// decodeCellDataCanonical wraps DecodeCellData with a re-encode check for
+// the value shapes that can be spelled non-canonically:
+//
+//   - UVARINT/IVARINT and BYTES's length prefix: DecodeCellData (Task 1)
+//     accepts any length-legal LEB128 encoding, not necessarily the minimal
+//     one AppendCellData would produce (e.g. a two-byte over-long encoding
+//     of the value 1, [0x81, 0x00]) — fine for the op-args wire format, but
+//     a record byte stream carrying such an encoding would decode
+//     successfully yet not re-encode identically.
+//   - F32: Cell always holds a float64 (F), so decoding an F32 widens
+//     through float64 and encoding narrows back. On common hardware that
+//     widen/narrow round trip sets a signaling NaN's quiet bit even though
+//     it is a pure format conversion — so a stored signaling-NaN F32 bit
+//     pattern (which a correctly canonicalizing writer never produces,
+//     design doc §2.5, but a hostile or corrupt stream could contain)
+//     decodes fine yet re-encodes to a different, now-quiet bit pattern.
+//     F64 has no such conversion (DecodeCellData reads its bits directly
+//     into Cell.F) and is not affected.
+//
+// Rejecting a non-canonical encoding here, at every such read, keeps
+// DecodeRecord(b).Encode() == b for every b it accepts (the identity
+// FuzzDecodeRecord checks), without changing Task 1's cell codec. Every
+// other type is fixed-width raw bytes with exactly one possible encoding
+// (or, for F64, a lossless one), so the re-encode-and-compare would always
+// trivially pass — skipped for those.
 func decodeCellDataCanonical(t uint8, n uint8, b []byte) (Cell, int, error) {
 	c, m, err := DecodeCellData(t, n, b)
 	if err != nil {
 		return Cell{}, 0, err
 	}
-	if !bytes.Equal(AppendCellData(nil, c), b[:m]) {
-		return Cell{}, 0, ErrOperateRecord
+	switch t {
+	case OperateTypeUVarint, OperateTypeIVarint, OperateTypeBytes, OperateTypeF32:
+		if !bytes.Equal(AppendCellData(nil, c), b[:m]) {
+			return Cell{}, 0, ErrOperateRecord
+		}
 	}
 	return c, m, nil
 }
@@ -441,10 +479,9 @@ func decodeDynamicRecord(b []byte) (*Record, error) {
 	if !CountFitsIn(int(nFields), len(b)-off, 3) {
 		return nil, ErrOperateRecord
 	}
+	// nFields is already bounded by OperateMaxFields (65535) above, well
+	// under OperateMaxRows (1<<20): no separate cap check is reachable here.
 	budget := int(nFields)
-	if budget > OperateMaxRows {
-		return nil, ErrOperateRecord
-	}
 
 	fields := make([]Field, nFields)
 	var prevName string
@@ -616,7 +653,7 @@ func decodeDynamicRow(b []byte, budget *int) (Row, int, error) {
 	}
 	klen := int(b[0])
 	off := 1
-	if klen > OperateMaxKeyLen {
+	if klen == 0 || klen > OperateMaxKeyLen {
 		return Row{}, 0, ErrOperateRecord
 	}
 	if len(b)-off < klen {

--- a/sdk/wire/operate_record.go
+++ b/sdk/wire/operate_record.go
@@ -1,0 +1,686 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package wire
+
+import (
+	"bytes"
+	"encoding/binary"
+	"sort"
+)
+
+// Record is the decoded tree form of a stored operate record (design doc
+// §2.2/§2.9), in either mode. It is the reference representation: the
+// server's byte-level apply engines (which patch stored bytes directly, per
+// §2.6) must produce exactly the bytes DecodeRecord/Encode agree on, and
+// clients decode a `get` result with this type.
+//
+// In schema mode, Fields[i] corresponds to Schema.Fields[i] by position; a
+// TABLE field's Table is filled from the schema's TableDef (Cap/Policy/ByCol
+// are informational copies — Encode ignores them and rebuilds them from
+// Schema). In dynamic mode, Schema is nil and Fields is logically a set kept
+// sorted by Name.
+type Record struct {
+	Mode   uint8
+	Schema *Schema
+	Fields []Field
+}
+
+// Field is one field of a Record tree. Cell.Type == OperateTypeTable implies
+// Table != nil (and, in schema mode, means the schema at this position
+// declares a TABLE field; in dynamic mode, Name carries the field's name and
+// Cell.Type is otherwise the field's own stored type).
+type Field struct {
+	Name  string
+	Cell  Cell
+	Table *Table
+}
+
+// Table is a table field's rows plus its eviction triple (design doc §2.3).
+// Rows are kept sorted by Key: numeric key types (U8..U64) compare as
+// integers (the bytes are little-endian), OperateTypeFixed keys compare
+// bytewise. In schema mode ByColName is unused (ByCol, a schema-relative
+// column position, carries the information, and Cap/Policy/ByCol are
+// informational — see Record's doc comment); in dynamic mode ByCol is
+// unused (ByColName, a column name, carries the information).
+type Table struct {
+	Cap       uint32
+	Policy    uint8
+	ByCol     uint16
+	ByColName string
+	Rows      []Row
+}
+
+// Row is one row of a Table. In schema mode, Cols is addressed by position
+// (Cols[i] is the schema's i'th column) and Name is unused; in dynamic mode
+// Cols is kept sorted by Name.
+type Row struct {
+	Key  []byte
+	Cols []Col
+}
+
+// Col is one column value of a Row. Name is used only in dynamic mode.
+type Col struct {
+	Name string
+	Cell Cell
+}
+
+// Encode serializes r in the stored wire format (design doc §2.2 for schema
+// mode, §2.9 for dynamic mode). It is deterministic: rows are sorted by key
+// and, in dynamic mode, fields and columns are sorted by name, regardless of
+// the order they appear in r — so op order and Go map/slice iteration never
+// leak into stored bytes (design doc §2.5).
+//
+// Encode assumes r is a well-formed tree matching its Schema (schema mode):
+// a wrong column count, a key of the wrong width, or an invalid Mode may
+// produce garbage bytes or panic. DecodeRecord, not Encode, is the hardened
+// side of this codec — it is the one exposed to untrusted (stored) bytes.
+func (r *Record) Encode() []byte {
+	switch r.Mode {
+	case OperateModeSchema:
+		return r.encodeSchema()
+	case OperateModeDynamic:
+		return r.encodeDynamic()
+	default:
+		return nil
+	}
+}
+
+func (r *Record) encodeSchema() []byte {
+	s := r.Schema
+	layout, err := s.Layout()
+	if err != nil {
+		return nil
+	}
+	b := make([]byte, 0, 64)
+	b = append(b, OperateModeSchema)
+	b = append(b, s.Encode()...)
+
+	for i := range s.Fields {
+		if layout.FixedOff[i] < 0 {
+			continue
+		}
+		f := &s.Fields[i]
+		cell := Cell{}
+		if i < len(r.Fields) {
+			cell = r.Fields[i].Cell
+		}
+		if cell.Type == OperateTypeUnset {
+			cell = ZeroCell(f.Type, f.N)
+		}
+		b = AppendCellData(b, cell)
+	}
+
+	for _, i := range layout.VarTail {
+		f := &s.Fields[i]
+		var tree Field
+		if i < len(r.Fields) {
+			tree = r.Fields[i]
+		}
+		if f.Type == OperateTypeTable {
+			b = appendSchemaTable(b, f.Table, tree.Table)
+			continue
+		}
+		cell := tree.Cell
+		if cell.Type == OperateTypeUnset {
+			cell = ZeroCell(f.Type, f.N)
+		}
+		b = AppendCellData(b, cell)
+	}
+	return b
+}
+
+// appendSchemaTable appends a schema-mode table's value area (design doc
+// §2.3): [nRows uvarint]{key col₀ col₁ …}*, rows sorted by key per tdef's key
+// type. tbl may be nil (an unset TABLE field encodes as zero rows).
+func appendSchemaTable(b []byte, tdef *TableDef, tbl *Table) []byte {
+	var rows []Row
+	if tbl != nil {
+		rows = append([]Row(nil), tbl.Rows...)
+	}
+	sort.Slice(rows, func(i, j int) bool {
+		return compareKey(rows[i].Key, rows[j].Key, tdef.KeyType) < 0
+	})
+	b = binary.AppendUvarint(b, uint64(len(rows))) //nolint:gosec // bounded by OperateMaxRows on a well-formed tree
+	for _, row := range rows {
+		b = append(b, row.Key...)
+		for c := range tdef.Cols {
+			cd := &tdef.Cols[c]
+			var cell Cell
+			if c < len(row.Cols) {
+				cell = row.Cols[c].Cell
+			}
+			if cell.Type == OperateTypeUnset {
+				cell = ZeroCell(cd.Type, cd.N)
+			}
+			b = AppendCellData(b, cell)
+		}
+	}
+	return b
+}
+
+func (r *Record) encodeDynamic() []byte {
+	fields := append([]Field(nil), r.Fields...)
+	sort.Slice(fields, func(i, j int) bool { return fields[i].Name < fields[j].Name })
+
+	b := []byte{OperateModeDynamic}
+	b = binary.AppendUvarint(b, uint64(len(fields))) //nolint:gosec // bounded by OperateMaxFields on a well-formed tree
+	for _, f := range fields {
+		b = append(b, byte(len(f.Name))) //nolint:gosec // bounded by OperateMaxNameLen on a well-formed tree
+		b = append(b, f.Name...)
+		if f.Cell.Type == OperateTypeTable {
+			b = append(b, OperateTypeTable)
+			b = appendDynamicTable(b, f.Table)
+			continue
+		}
+		b = append(b, f.Cell.Type)
+		if f.Cell.Type == OperateTypeFixed {
+			b = append(b, f.Cell.N)
+		}
+		b = AppendCellData(b, f.Cell)
+	}
+	return b
+}
+
+// appendDynamicTable appends a dynamic-mode table's value (design doc §2.9):
+// [byteLen uvarint][cap uvarint][policy u8][byColLen u8][byColName]
+// [nRows uvarint]{rows}*, byteLen covering everything after itself to the
+// end of the table. t may be nil (an unset TABLE field encodes as an empty,
+// zero-eviction table).
+func appendDynamicTable(dst []byte, t *Table) []byte {
+	var capV uint32
+	var policy uint8
+	var byColName string
+	var rows []Row
+	if t != nil {
+		capV, policy, byColName = t.Cap, t.Policy, t.ByColName
+		rows = append([]Row(nil), t.Rows...)
+	}
+	sort.Slice(rows, func(i, j int) bool { return bytes.Compare(rows[i].Key, rows[j].Key) < 0 })
+
+	inner := make([]byte, 0, 32)
+	inner = binary.AppendUvarint(inner, uint64(capV))
+	inner = append(inner, policy)
+	inner = append(inner, byte(len(byColName))) //nolint:gosec // bounded by OperateMaxNameLen on a well-formed tree
+	inner = append(inner, byColName...)
+	inner = binary.AppendUvarint(inner, uint64(len(rows))) //nolint:gosec // bounded by OperateMaxRows on a well-formed tree
+	for _, row := range rows {
+		rowBytes := appendDynamicRow(nil, row)
+		inner = binary.AppendUvarint(inner, uint64(len(rowBytes))) //nolint:gosec // bounded by construction
+		inner = append(inner, rowBytes...)
+	}
+
+	dst = binary.AppendUvarint(dst, uint64(len(inner))) //nolint:gosec // bounded by construction
+	return append(dst, inner...)
+}
+
+// appendDynamicRow appends one dynamic-mode row's content (everything after
+// its rowLen prefix): [klen u8][key][nCols uvarint]{cols}*, columns sorted
+// by name.
+func appendDynamicRow(dst []byte, row Row) []byte {
+	dst = append(dst, byte(len(row.Key))) //nolint:gosec // bounded by OperateMaxKeyLen on a well-formed tree
+	dst = append(dst, row.Key...)
+
+	cols := append([]Col(nil), row.Cols...)
+	sort.Slice(cols, func(i, j int) bool { return cols[i].Name < cols[j].Name })
+	dst = binary.AppendUvarint(dst, uint64(len(cols))) //nolint:gosec // bounded by OperateMaxCols on a well-formed tree
+	for _, c := range cols {
+		dst = append(dst, byte(len(c.Name))) //nolint:gosec // bounded by OperateMaxNameLen on a well-formed tree
+		dst = append(dst, c.Name...)
+		dst = append(dst, c.Cell.Type)
+		if c.Cell.Type == OperateTypeFixed {
+			dst = append(dst, c.Cell.N)
+		}
+		dst = AppendCellData(dst, c.Cell)
+	}
+	return dst
+}
+
+// compareKey compares two table row keys the way the design mandates
+// (§2.3): OperateTypeFixed keys bytewise, every other legal key type
+// (U8..U64) as a little-endian-encoded unsigned integer.
+func compareKey(a, b []byte, keyType uint8) int {
+	if keyType == OperateTypeFixed {
+		return bytes.Compare(a, b)
+	}
+	return compareLE(a, b)
+}
+
+// compareLE compares two little-endian byte strings (at most 8 bytes, per
+// CellWidth's fixed-width int types) as unsigned integers.
+func compareLE(a, b []byte) int {
+	var av, bv uint64
+	for i := len(a) - 1; i >= 0; i-- {
+		av = av<<8 | uint64(a[i])
+	}
+	for i := len(b) - 1; i >= 0; i-- {
+		bv = bv<<8 | uint64(b[i])
+	}
+	switch {
+	case av < bv:
+		return -1
+	case av > bv:
+		return 1
+	default:
+		return 0
+	}
+}
+
+// decodeCellDataCanonical wraps DecodeCellData with a re-encode check.
+// DecodeCellData (Task 1) accepts any length-legal varint or BYTES-length
+// encoding, not necessarily the minimal one AppendCellData would produce
+// (e.g. a two-byte over-long encoding of the value 1, [0x81, 0x00]) — fine
+// for the op-args wire format, but a record byte stream carrying such an
+// encoding would decode successfully yet not re-encode identically,
+// breaking the decode-encode identity DecodeRecord's hostile decoder must
+// uphold (FuzzDecodeRecord). Rejecting a non-canonical encoding here, at
+// every cell read, keeps DecodeRecord(b).Encode() == b for every b it
+// accepts, without changing Task 1's cell codec.
+func decodeCellDataCanonical(t uint8, n uint8, b []byte) (Cell, int, error) {
+	c, m, err := DecodeCellData(t, n, b)
+	if err != nil {
+		return Cell{}, 0, err
+	}
+	if !bytes.Equal(AppendCellData(nil, c), b[:m]) {
+		return Cell{}, 0, ErrOperateRecord
+	}
+	return c, m, nil
+}
+
+// fitsRemaining reports whether a decoded byte-length n (as opposed to an
+// element count — CountFitsIn is for those) fits within remaining bytes,
+// without ever narrowing n to int: n can be an arbitrary attacker-controlled
+// uvarint up to 2^64-1, and converting it to int first (as CountFitsIn does
+// for element counts, after bounding them against a small cap) would wrap on
+// a 32-bit int and defeat the check.
+func fitsRemaining(n uint64, remaining int) bool {
+	if remaining < 0 {
+		return false
+	}
+	return n <= uint64(remaining) //nolint:gosec // remaining >= 0 checked above
+}
+
+// DecodeRecord reads one Encode-formatted record from the front of b,
+// returning the decoded tree. b must be consumed exactly (trailing bytes are
+// an error), so a successfully decoded record always satisfies
+// bytes.Equal(r.Encode(), b) — the identity FuzzDecodeRecord checks.
+//
+// Every count (field, row, column) is bounded against the remaining input
+// with CountFitsIn (or, for byte-length prefixes that are not element
+// counts, fitsRemaining) before it is trusted to size an allocation; rows
+// must arrive strictly ascending by key and, in dynamic mode, fields and
+// columns strictly ascending by name — the invariant a follower's Encode
+// would itself produce, checked here on the untrusted read side. A mode byte
+// of 0 or greater than 2 is ErrOperateRecord. No input drives DecodeRecord to
+// panic.
+func DecodeRecord(b []byte) (*Record, error) {
+	if len(b) < 1 {
+		return nil, ErrOperateRecord
+	}
+	switch b[0] {
+	case OperateModeSchema:
+		return decodeSchemaRecord(b[1:])
+	case OperateModeDynamic:
+		return decodeDynamicRecord(b[1:])
+	default:
+		return nil, ErrOperateRecord
+	}
+}
+
+func decodeSchemaRecord(b []byte) (*Record, error) {
+	schema, n, err := DecodeSchema(b)
+	if err != nil {
+		return nil, err
+	}
+	off := n
+	layout, err := schema.Layout()
+	if err != nil {
+		return nil, err
+	}
+
+	fields := make([]Field, len(schema.Fields))
+	for i := range schema.Fields {
+		if layout.FixedOff[i] < 0 {
+			continue
+		}
+		f := &schema.Fields[i]
+		cell, m, cerr := decodeCellDataCanonical(f.Type, f.N, b[off:])
+		if cerr != nil {
+			return nil, cerr
+		}
+		off += m
+		fields[i].Cell = cell
+	}
+
+	budget := 0
+	for _, i := range layout.VarTail {
+		f := &schema.Fields[i]
+		if f.Type == OperateTypeTable {
+			tbl, m, terr := decodeSchemaTable(f.Table, layout.Tables[i], b[off:], &budget)
+			if terr != nil {
+				return nil, terr
+			}
+			off += m
+			fields[i].Cell = Cell{Type: OperateTypeTable}
+			fields[i].Table = tbl
+			continue
+		}
+		cell, m, cerr := decodeCellDataCanonical(f.Type, f.N, b[off:])
+		if cerr != nil {
+			return nil, cerr
+		}
+		off += m
+		fields[i].Cell = cell
+	}
+
+	if off != len(b) {
+		return nil, ErrOperateRecord
+	}
+	return &Record{Mode: OperateModeSchema, Schema: schema, Fields: fields}, nil
+}
+
+// decodeSchemaTable reads a schema-mode table value ([nRows uvarint]{key
+// col₀ col₁ …}* nRows, design doc §2.3) from the front of b, returning the
+// decoded table and bytes consumed. budget accumulates every row decoded
+// anywhere in the record (across every TABLE field) against OperateMaxRows,
+// bounding total allocation even when several tables each stay under the
+// per-table cap.
+func decodeSchemaTable(tdef *TableDef, tl *TableLayout, b []byte, budget *int) (*Table, int, error) {
+	nRows, m, err := decodeCanonicalUvarint(b)
+	if err != nil {
+		return nil, 0, err
+	}
+	off := m
+	if nRows > OperateMaxRows {
+		return nil, 0, ErrOperateRecord
+	}
+	if !CountFitsIn(int(nRows), len(b)-off, tl.RowWidth) {
+		return nil, 0, ErrOperateRecord
+	}
+	*budget += int(nRows)
+	if *budget > OperateMaxRows {
+		return nil, 0, ErrOperateRecord
+	}
+
+	rows := make([]Row, nRows)
+	var prevKey []byte
+	for r := range rows {
+		if len(b)-off < tl.KeyWidth {
+			return nil, 0, ErrShortArgs
+		}
+		key := append([]byte(nil), b[off:off+tl.KeyWidth]...)
+		off += tl.KeyWidth
+		if r > 0 && compareKey(prevKey, key, tdef.KeyType) >= 0 {
+			return nil, 0, ErrOperateRecord
+		}
+		prevKey = key
+
+		cols := make([]Col, len(tdef.Cols))
+		for c := range tdef.Cols {
+			cd := &tdef.Cols[c]
+			cell, m2, cerr := decodeCellDataCanonical(cd.Type, cd.N, b[off:])
+			if cerr != nil {
+				return nil, 0, cerr
+			}
+			off += m2
+			cols[c] = Col{Cell: cell}
+		}
+		rows[r] = Row{Key: key, Cols: cols}
+	}
+	return &Table{Cap: tdef.Cap, Policy: tdef.Policy, ByCol: tdef.ByCol, Rows: rows}, off, nil
+}
+
+func decodeDynamicRecord(b []byte) (*Record, error) {
+	nFields, m, err := decodeCanonicalUvarint(b)
+	if err != nil {
+		return nil, err
+	}
+	off := m
+	if nFields > OperateMaxFields {
+		return nil, ErrOperateRecord
+	}
+	if !CountFitsIn(int(nFields), len(b)-off, 3) {
+		return nil, ErrOperateRecord
+	}
+	budget := int(nFields)
+	if budget > OperateMaxRows {
+		return nil, ErrOperateRecord
+	}
+
+	fields := make([]Field, nFields)
+	var prevName string
+	for i := range fields {
+		if len(b)-off < 1 {
+			return nil, ErrShortArgs
+		}
+		nlen := int(b[off])
+		off++
+		if nlen > OperateMaxNameLen {
+			return nil, ErrOperateRecord
+		}
+		if len(b)-off < nlen {
+			return nil, ErrShortArgs
+		}
+		name := string(b[off : off+nlen])
+		off += nlen
+		if i > 0 && name <= prevName {
+			return nil, ErrOperateRecord
+		}
+		prevName = name
+
+		if len(b)-off < 1 {
+			return nil, ErrShortArgs
+		}
+		typ := b[off]
+		off++
+
+		if typ == OperateTypeTable {
+			tbl, m2, terr := decodeDynamicTable(b[off:], &budget)
+			if terr != nil {
+				return nil, terr
+			}
+			off += m2
+			fields[i] = Field{Name: name, Cell: Cell{Type: OperateTypeTable}, Table: tbl}
+			continue
+		}
+
+		var n uint8
+		if typ == OperateTypeFixed {
+			if len(b)-off < 1 {
+				return nil, ErrShortArgs
+			}
+			n = b[off]
+			off++
+		}
+		cell, m2, cerr := decodeCellDataCanonical(typ, n, b[off:])
+		if cerr != nil {
+			return nil, cerr
+		}
+		off += m2
+		fields[i] = Field{Name: name, Cell: cell}
+	}
+
+	if off != len(b) {
+		return nil, ErrOperateRecord
+	}
+	return &Record{Mode: OperateModeDynamic, Fields: fields}, nil
+}
+
+// decodeDynamicTable reads a dynamic-mode table value ([byteLen uvarint]
+// [cap uvarint][policy u8][byColLen u8][byColName][nRows uvarint]{rows}*,
+// design doc §2.9) from the front of b. byteLen must fit the remaining
+// bytes and the parse of the fields it covers must consume it exactly.
+// budget accumulates every field, row, and column decoded anywhere in the
+// record against OperateMaxRows.
+func decodeDynamicTable(b []byte, budget *int) (*Table, int, error) {
+	byteLen, m, err := decodeCanonicalUvarint(b)
+	if err != nil {
+		return nil, 0, err
+	}
+	off := m
+	if !fitsRemaining(byteLen, len(b)-off) {
+		return nil, 0, ErrOperateRecord
+	}
+	inner := b[off : off+int(byteLen)]
+	off += int(byteLen)
+
+	ioff := 0
+	capV, m2, err := decodeCanonicalUvarint(inner[ioff:])
+	if err != nil {
+		return nil, 0, err
+	}
+	ioff += m2
+	if capV > OperateMaxRows {
+		return nil, 0, ErrOperateRecord
+	}
+
+	if len(inner)-ioff < 1 {
+		return nil, 0, ErrShortArgs
+	}
+	policy := inner[ioff]
+	ioff++
+	if policy > OperatePolicyMaxCol {
+		return nil, 0, ErrOperateRecord
+	}
+
+	if len(inner)-ioff < 1 {
+		return nil, 0, ErrShortArgs
+	}
+	byColLen := int(inner[ioff])
+	ioff++
+	if byColLen > OperateMaxNameLen {
+		return nil, 0, ErrOperateRecord
+	}
+	if len(inner)-ioff < byColLen {
+		return nil, 0, ErrShortArgs
+	}
+	byColName := string(inner[ioff : ioff+byColLen])
+	ioff += byColLen
+
+	nRows, m3, err := decodeCanonicalUvarint(inner[ioff:])
+	if err != nil {
+		return nil, 0, err
+	}
+	ioff += m3
+	if nRows > OperateMaxRows {
+		return nil, 0, ErrOperateRecord
+	}
+	if !CountFitsIn(int(nRows), len(inner)-ioff, 3) {
+		return nil, 0, ErrOperateRecord
+	}
+	*budget += int(nRows)
+	if *budget > OperateMaxRows {
+		return nil, 0, ErrOperateRecord
+	}
+
+	rows := make([]Row, nRows)
+	var prevKey []byte
+	for r := range rows {
+		rowLen, m4, rerr := decodeCanonicalUvarint(inner[ioff:])
+		if rerr != nil {
+			return nil, 0, rerr
+		}
+		ioff += m4
+		if !fitsRemaining(rowLen, len(inner)-ioff) {
+			return nil, 0, ErrOperateRecord
+		}
+		rowBuf := inner[ioff : ioff+int(rowLen)]
+		ioff += int(rowLen)
+
+		row, consumed, rowErr := decodeDynamicRow(rowBuf, budget)
+		if rowErr != nil {
+			return nil, 0, rowErr
+		}
+		if consumed != len(rowBuf) {
+			return nil, 0, ErrOperateRecord
+		}
+		if r > 0 && bytes.Compare(prevKey, row.Key) >= 0 {
+			return nil, 0, ErrOperateRecord
+		}
+		prevKey = row.Key
+		rows[r] = row
+	}
+
+	if ioff != len(inner) {
+		return nil, 0, ErrOperateRecord
+	}
+	return &Table{Cap: uint32(capV), Policy: policy, ByColName: byColName, Rows: rows}, off, nil //nolint:gosec // capV bounded by OperateMaxRows above
+}
+
+// decodeDynamicRow reads one dynamic-mode row's content (everything after
+// its rowLen prefix, which the caller has already sliced exactly): [klen
+// u8][key][nCols uvarint]{[nlen u8][name][type u8][n u8 iff FIXED][data]}*,
+// columns strictly ascending by name.
+func decodeDynamicRow(b []byte, budget *int) (Row, int, error) {
+	if len(b) < 1 {
+		return Row{}, 0, ErrShortArgs
+	}
+	klen := int(b[0])
+	off := 1
+	if klen > OperateMaxKeyLen {
+		return Row{}, 0, ErrOperateRecord
+	}
+	if len(b)-off < klen {
+		return Row{}, 0, ErrShortArgs
+	}
+	key := append([]byte(nil), b[off:off+klen]...)
+	off += klen
+
+	nCols, m, err := decodeCanonicalUvarint(b[off:])
+	if err != nil {
+		return Row{}, 0, err
+	}
+	off += m
+	if nCols > OperateMaxCols {
+		return Row{}, 0, ErrOperateRecord
+	}
+	if !CountFitsIn(int(nCols), len(b)-off, 3) {
+		return Row{}, 0, ErrOperateRecord
+	}
+	*budget += int(nCols)
+	if *budget > OperateMaxRows {
+		return Row{}, 0, ErrOperateRecord
+	}
+
+	cols := make([]Col, nCols)
+	var prevName string
+	for c := range cols {
+		if len(b)-off < 1 {
+			return Row{}, 0, ErrShortArgs
+		}
+		nlen := int(b[off])
+		off++
+		if nlen > OperateMaxNameLen {
+			return Row{}, 0, ErrOperateRecord
+		}
+		if len(b)-off < nlen {
+			return Row{}, 0, ErrShortArgs
+		}
+		name := string(b[off : off+nlen])
+		off += nlen
+		if c > 0 && name <= prevName {
+			return Row{}, 0, ErrOperateRecord
+		}
+		prevName = name
+
+		if len(b)-off < 1 {
+			return Row{}, 0, ErrShortArgs
+		}
+		typ := b[off]
+		off++
+		var n uint8
+		if typ == OperateTypeFixed {
+			if len(b)-off < 1 {
+				return Row{}, 0, ErrShortArgs
+			}
+			n = b[off]
+			off++
+		}
+		cell, m2, cerr := decodeCellDataCanonical(typ, n, b[off:])
+		if cerr != nil {
+			return Row{}, 0, cerr
+		}
+		off += m2
+		cols[c] = Col{Name: name, Cell: cell}
+	}
+	return Row{Key: key, Cols: cols}, off, nil
+}

--- a/sdk/wire/operate_record.go
+++ b/sdk/wire/operate_record.go
@@ -156,7 +156,7 @@ func appendSchemaTable(b []byte, tdef *TableDef, tbl *Table) []byte {
 	if tbl != nil {
 		rows = append([]Row(nil), tbl.Rows...)
 	}
-	sort.Slice(rows, func(i, j int) bool {
+	sort.SliceStable(rows, func(i, j int) bool {
 		return compareKey(rows[i].Key, rows[j].Key, tdef.KeyType) < 0
 	})
 	b = binary.AppendUvarint(b, uint64(len(rows))) //nolint:gosec // bounded by OperateMaxRows on a well-formed tree
@@ -177,7 +177,7 @@ func appendSchemaTable(b []byte, tdef *TableDef, tbl *Table) []byte {
 
 func (r *Record) encodeDynamic() []byte {
 	fields := append([]Field(nil), r.Fields...)
-	sort.Slice(fields, func(i, j int) bool { return fields[i].Name < fields[j].Name })
+	sort.SliceStable(fields, func(i, j int) bool { return fields[i].Name < fields[j].Name })
 
 	b := []byte{OperateModeDynamic}
 	b = binary.AppendUvarint(b, uint64(len(fields))) //nolint:gosec // bounded by OperateMaxFields on a well-formed tree
@@ -212,7 +212,7 @@ func appendDynamicTable(dst []byte, t *Table) []byte {
 		capV, policy, byColName = t.Cap, t.Policy, t.ByColName
 		rows = append([]Row(nil), t.Rows...)
 	}
-	sort.Slice(rows, func(i, j int) bool { return bytes.Compare(rows[i].Key, rows[j].Key) < 0 })
+	sort.SliceStable(rows, func(i, j int) bool { return bytes.Compare(rows[i].Key, rows[j].Key) < 0 })
 
 	inner := make([]byte, 0, 32)
 	inner = binary.AppendUvarint(inner, uint64(capV))
@@ -241,7 +241,7 @@ func appendDynamicRow(dst []byte, row Row) []byte {
 	dst = append(dst, row.Key...)
 
 	cols := append([]Col(nil), row.Cols...)
-	sort.Slice(cols, func(i, j int) bool { return cols[i].Name < cols[j].Name })
+	sort.SliceStable(cols, func(i, j int) bool { return cols[i].Name < cols[j].Name })
 	dst = binary.AppendUvarint(dst, uint64(len(cols))) //nolint:gosec // bounded by OperateMaxCols on a well-formed tree
 	for _, c := range cols {
 		dst = append(dst, byte(len(c.Name))) //nolint:gosec // bounded by OperateMaxNameLen on a well-formed tree
@@ -491,7 +491,7 @@ func decodeDynamicRecord(b []byte) (*Record, error) {
 		}
 		nlen := int(b[off])
 		off++
-		if nlen > OperateMaxNameLen {
+		if nlen == 0 || nlen > OperateMaxNameLen {
 			return nil, ErrOperateRecord
 		}
 		if len(b)-off < nlen {
@@ -686,7 +686,7 @@ func decodeDynamicRow(b []byte, budget *int) (Row, int, error) {
 		}
 		nlen := int(b[off])
 		off++
-		if nlen > OperateMaxNameLen {
+		if nlen == 0 || nlen > OperateMaxNameLen {
 			return Row{}, 0, ErrOperateRecord
 		}
 		if len(b)-off < nlen {

--- a/sdk/wire/operate_record.go
+++ b/sdk/wire/operate_record.go
@@ -294,29 +294,28 @@ func compareLE(a, b []byte) int {
 //     of the value 1, [0x81, 0x00]) — fine for the op-args wire format, but
 //     a record byte stream carrying such an encoding would decode
 //     successfully yet not re-encode identically.
-//   - F32: Cell always holds a float64 (F), so decoding an F32 widens
-//     through float64 and encoding narrows back. On common hardware that
-//     widen/narrow round trip sets a signaling NaN's quiet bit even though
-//     it is a pure format conversion — so a stored signaling-NaN F32 bit
-//     pattern (which a correctly canonicalizing writer never produces,
-//     design doc §2.5, but a hostile or corrupt stream could contain)
-//     decodes fine yet re-encodes to a different, now-quiet bit pattern.
-//     F64 has no such conversion (DecodeCellData reads its bits directly
-//     into Cell.F) and is not affected.
+//   - F32 and F64: AppendCellData canonicalizes every NaN to the quiet NaN
+//     of design doc §2.5 (and narrows an F32 through float32), so exactly
+//     one NaN bit pattern per float type re-encodes to itself. A stored NaN
+//     spelled any other way — a signaling NaN, or a quiet NaN with a
+//     non-zero payload, neither of which a correctly canonicalizing writer
+//     produces, though a hostile or corrupt stream could contain one —
+//     decodes fine yet re-encodes to different bytes. Non-NaN floats are
+//     unaffected: an F64 keeps its bits verbatim and an F32 survives the
+//     float64 widen/narrow round trip exactly.
 //
 // Rejecting a non-canonical encoding here, at every such read, keeps
 // DecodeRecord(b).Encode() == b for every b it accepts (the identity
 // FuzzDecodeRecord checks), without changing Task 1's cell codec. Every
-// other type is fixed-width raw bytes with exactly one possible encoding
-// (or, for F64, a lossless one), so the re-encode-and-compare would always
-// trivially pass — skipped for those.
+// other type is fixed-width raw bytes with exactly one possible encoding, so
+// the re-encode-and-compare would always trivially pass — skipped for those.
 func decodeCellDataCanonical(t uint8, n uint8, b []byte) (Cell, int, error) {
 	c, m, err := DecodeCellData(t, n, b)
 	if err != nil {
 		return Cell{}, 0, err
 	}
 	switch t {
-	case OperateTypeUVarint, OperateTypeIVarint, OperateTypeBytes, OperateTypeF32:
+	case OperateTypeUVarint, OperateTypeIVarint, OperateTypeBytes, OperateTypeF32, OperateTypeF64:
 		if !bytes.Equal(AppendCellData(nil, c), b[:m]) {
 			return Cell{}, 0, ErrOperateRecord
 		}
@@ -527,6 +526,11 @@ func decodeDynamicRecord(b []byte) (*Record, error) {
 			}
 			n = b[off]
 			off++
+			// FIXED's declared width is 1-255 (design doc §2.1); a stored 0
+			// is a malformed record, not a zero-width value.
+			if n == 0 {
+				return nil, ErrOperateRecord
+			}
 		}
 		cell, m2, cerr := decodeCellDataCanonical(typ, n, b[off:])
 		if cerr != nil {
@@ -711,6 +715,10 @@ func decodeDynamicRow(b []byte, budget *int) (Row, int, error) {
 			}
 			n = b[off]
 			off++
+			// Same rule as a dynamic field header: FIXED(0) is not a width.
+			if n == 0 {
+				return Row{}, 0, ErrOperateRecord
+			}
 		}
 		cell, m2, cerr := decodeCellDataCanonical(typ, n, b[off:])
 		if cerr != nil {

--- a/sdk/wire/operate_record_test.go
+++ b/sdk/wire/operate_record_test.go
@@ -1,0 +1,109 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package wire
+
+import (
+	"bytes"
+	"encoding/binary"
+	"testing"
+)
+
+func sessionRecord() *Record {
+	s := sessionSchema()
+	r := &Record{Mode: OperateModeSchema, Schema: s, Fields: make([]Field, 4)}
+	r.Fields[0].Cell = Cell{Type: OperateTypeU8, U: 7}
+	r.Fields[1].Cell = Cell{Type: OperateTypeU8, U: 1}
+	r.Fields[2].Cell = Cell{Type: OperateTypeU32, U: 0b1011}
+	r.Fields[3].Cell = Cell{Type: OperateTypeTable}
+	r.Fields[3].Table = &Table{Cap: 1024, Policy: OperatePolicyMinCol, ByCol: 2}
+	for _, k := range []uint64{900, 3, 42} {
+		key := make([]byte, 8)
+		binary.LittleEndian.PutUint64(key, k)
+		r.Fields[3].Table.Rows = append(r.Fields[3].Table.Rows, Row{Key: key, Cols: []Col{
+			{Cell: Cell{Type: OperateTypeU16, U: uint64(k)}}, {Cell: Cell{Type: OperateTypeI64, U: su64(-1)}}, {Cell: Cell{Type: OperateTypeU32, U: 1000 + uint64(k)}}}})
+	}
+	return r
+}
+
+func TestRecordSchemaModeRoundtripAndSize(t *testing.T) {
+	r := sessionRecord()
+	b := r.Encode()
+	schemaLen := len(sessionSchema().Encode())
+	// 1 mode + schema + 1+1+4 fixed + nRows(1) + 3 rows × (8 key + 2 + 8 + 4)
+	if want := 1 + schemaLen + 6 + 1 + 3*22; len(b) != want {
+		t.Fatalf("encoded %d bytes, want %d", len(b), want)
+	}
+	got, err := DecodeRecord(b)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(got.Encode(), b) {
+		t.Fatal("decode∘encode unstable")
+	}
+	rows := got.Fields[3].Table.Rows
+	if len(rows) != 3 || binary.LittleEndian.Uint64(rows[0].Key) != 3 {
+		t.Fatal("rows not sorted by key on encode")
+	}
+}
+
+func TestRecordDynamicModeRoundtrip(t *testing.T) {
+	r := &Record{Mode: OperateModeDynamic, Fields: []Field{
+		{Name: "name", Cell: Cell{Type: OperateTypeBytes, B: []byte("vahid")}},
+		{Name: "hits", Cell: Cell{Type: OperateTypeI64, U: 5}},
+		{Name: "ev", Cell: Cell{Type: OperateTypeTable}, Table: &Table{Cap: 100, Policy: OperatePolicyMinKey, Rows: []Row{
+			{Key: []byte("k2"), Cols: []Col{{Name: "p", Cell: Cell{Type: OperateTypeFixed, N: 2, B: []byte("xy")}}}},
+			{Key: []byte("k1"), Cols: []Col{{Name: "z", Cell: Cell{Type: OperateTypeU8, U: 1}}, {Name: "a", Cell: Cell{Type: OperateTypeUVarint, U: 999}}}},
+		}}},
+	}}
+	b := r.Encode()
+	got, err := DecodeRecord(b)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Fields[0].Name != "ev" || got.Fields[2].Name != "name" {
+		t.Fatal("fields not sorted by name")
+	}
+	if rows := got.Fields[0].Table.Rows; string(rows[0].Key) != "k1" || rows[0].Cols[0].Name != "a" {
+		t.Fatal("rows/cols not sorted")
+	}
+	if !bytes.Equal(got.Encode(), b) {
+		t.Fatal("unstable")
+	}
+}
+
+func TestRecordEncodeDeterministic(t *testing.T) {
+	want := sessionRecord().Encode()
+	for i := 0; i < 20; i++ {
+		r := sessionRecord()
+		rows := r.Fields[3].Table.Rows
+		rows[0], rows[2] = rows[2], rows[0]
+		if !bytes.Equal(r.Encode(), want) {
+			t.Fatal("row order leaked into bytes")
+		}
+	}
+}
+
+func TestDecodeRecordHostile(t *testing.T) {
+	cases := [][]byte{{}, {0}, {3}, {1}, {2}, {1, 1, 0, 0, 1, OperateTypeU8}, {2, 0xFF, 0xFF, 0xFF, 0xFF, 0x0F},
+		append([]byte{1}, append(sessionSchema().Encode(), 1, 2, 3, 4, 5, 6, 0xFF, 0xFF, 0xFF, 0xFF, 0x0F)...), // nRows huge
+		{2, 1, 1, 'x', OperateTypeBytes, 0xFF, 0xFF, 0x03}}
+	for _, b := range cases {
+		if _, err := DecodeRecord(b); err == nil {
+			t.Errorf("%x accepted", b)
+		}
+	}
+}
+
+func FuzzDecodeRecord(f *testing.F) {
+	f.Add(sessionRecord().Encode())
+	f.Add((&Record{Mode: OperateModeDynamic, Fields: []Field{{Name: "a", Cell: Cell{Type: OperateTypeU8, U: 1}}}}).Encode())
+	f.Fuzz(func(t *testing.T, b []byte) {
+		r, err := DecodeRecord(b)
+		if err != nil {
+			return
+		}
+		if !bytes.Equal(r.Encode(), b) {
+			t.Fatal("decode∘encode not identity on accepted input")
+		}
+	})
+}

--- a/sdk/wire/operate_record_test.go
+++ b/sdk/wire/operate_record_test.go
@@ -87,7 +87,10 @@ func TestDecodeRecordHostile(t *testing.T) {
 	cases := [][]byte{{}, {0}, {3}, {1}, {2}, {1, 1, 0, 0, 1, OperateTypeU8}, {2, 0xFF, 0xFF, 0xFF, 0xFF, 0x0F},
 		append([]byte{1}, append(sessionSchema().Encode(), 1, 2, 3, 4, 5, 6, 0xFF, 0xFF, 0xFF, 0xFF, 0x0F)...), // nRows huge
 		{2, 1, 1, 'x', OperateTypeBytes, 0xFF, 0xFF, 0x03},
-		{2, 1, 1, 't', OperateTypeTable, 7, 0, 0, 0, 1, 2, 0, 0}} // dynamic row with a zero-length key
+		{2, 1, 1, 't', OperateTypeTable, 7, 0, 0, 0, 1, 2, 0, 0}, // dynamic row with a zero-length key
+		{2, 1, 0}, // dynamic field with a zero-length name
+		(&Record{Mode: OperateModeDynamic, Fields: []Field{{Name: "t", Cell: Cell{Type: OperateTypeTable}, Table: &Table{
+			Rows: []Row{{Key: []byte("k"), Cols: []Col{{Name: "", Cell: Cell{Type: OperateTypeU8}}}}}}}}}).Encode()} // dynamic column with a zero-length name
 	for _, b := range cases {
 		if _, err := DecodeRecord(b); err == nil {
 			t.Errorf("%x accepted", b)

--- a/sdk/wire/operate_record_test.go
+++ b/sdk/wire/operate_record_test.go
@@ -86,11 +86,109 @@ func TestRecordEncodeDeterministic(t *testing.T) {
 func TestDecodeRecordHostile(t *testing.T) {
 	cases := [][]byte{{}, {0}, {3}, {1}, {2}, {1, 1, 0, 0, 1, OperateTypeU8}, {2, 0xFF, 0xFF, 0xFF, 0xFF, 0x0F},
 		append([]byte{1}, append(sessionSchema().Encode(), 1, 2, 3, 4, 5, 6, 0xFF, 0xFF, 0xFF, 0xFF, 0x0F)...), // nRows huge
-		{2, 1, 1, 'x', OperateTypeBytes, 0xFF, 0xFF, 0x03}}
+		{2, 1, 1, 'x', OperateTypeBytes, 0xFF, 0xFF, 0x03},
+		{2, 1, 1, 't', OperateTypeTable, 7, 0, 0, 0, 1, 2, 0, 0}} // dynamic row with a zero-length key
 	for _, b := range cases {
 		if _, err := DecodeRecord(b); err == nil {
 			t.Errorf("%x accepted", b)
 		}
+	}
+}
+
+// TestRecordSchemaZeroValueUsesSchemaType guards against Cell{}'s zero
+// value (Type == OperateTypeU8, which is also Go's zero uint8) being
+// mistaken for the schema's type when a tree's Fields slice is shorter than
+// its schema: every never-touched fixed-width field and column must encode
+// at its own declared width, not as a 1-byte U8 zero.
+func TestRecordSchemaZeroValueUsesSchemaType(t *testing.T) {
+	s := &Schema{Version: 1, Fields: []FieldDef{
+		{Type: OperateTypeU8}, {Type: OperateTypeU32}, {Type: OperateTypeI64}, {Type: OperateTypeF64},
+		{Type: OperateTypeFixed, N: 3},
+		{Type: OperateTypeTable, Table: &TableDef{KeyType: OperateTypeU8, Cols: []ColumnDef{
+			{Type: OperateTypeU16}, {Type: OperateTypeF32},
+		}}},
+	}}
+	// Only field 0 is touched; Fields is shorter than the schema, so fields
+	// 1-5 fall back to Cell{} (the Go zero value), which has Type ==
+	// OperateTypeU8 despite the schema saying U32, I64, F64, FIXED(3), TABLE.
+	r := &Record{Mode: OperateModeSchema, Schema: s, Fields: []Field{{Cell: Cell{Type: OperateTypeU8, U: 9}}}}
+
+	b := r.Encode()
+	blob := s.Encode()
+	if want := 1 + len(blob) + (1 + 4 + 8 + 8 + 3) + 1; len(b) != want { // +1 for the empty table's nRows=0
+		t.Fatalf("encoded %d bytes, want %d", len(b), want)
+	}
+
+	got, err := DecodeRecord(b)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Fields[0].Cell.Type != OperateTypeU8 || got.Fields[0].Cell.U != 9 {
+		t.Fatalf("field0 = %+v", got.Fields[0].Cell)
+	}
+	if got.Fields[1].Cell.Type != OperateTypeU32 || got.Fields[1].Cell.U != 0 {
+		t.Fatalf("field1 = %+v", got.Fields[1].Cell)
+	}
+	if got.Fields[2].Cell.Type != OperateTypeI64 || got.Fields[2].Cell.U != 0 {
+		t.Fatalf("field2 = %+v", got.Fields[2].Cell)
+	}
+	if got.Fields[3].Cell.Type != OperateTypeF64 || got.Fields[3].Cell.F != 0 {
+		t.Fatalf("field3 = %+v", got.Fields[3].Cell)
+	}
+	if got.Fields[4].Cell.Type != OperateTypeFixed || len(got.Fields[4].Cell.B) != 3 {
+		t.Fatalf("field4 = %+v", got.Fields[4].Cell)
+	}
+	for _, bb := range got.Fields[4].Cell.B {
+		if bb != 0 {
+			t.Fatalf("FIXED field not zero-filled: %+v", got.Fields[4].Cell)
+		}
+	}
+	if got.Fields[5].Table == nil || len(got.Fields[5].Table.Rows) != 0 {
+		t.Fatalf("table = %+v", got.Fields[5].Table)
+	}
+	if !bytes.Equal(got.Encode(), b) {
+		t.Fatal("decode∘encode unstable")
+	}
+}
+
+// TestDecodeRecordRejectsNonCanonicalVarint and
+// TestDecodeRecordRejectsNonCanonicalBytesLength are regression tests for
+// the bug FuzzDecodeRecord found: DecodeCellData accepts any length-legal
+// LEB128 encoding (via binary.Uvarint), not only the minimal one
+// AppendCellData produces, so a non-canonical encoding would decode
+// successfully yet re-encode to different, shorter bytes.
+func TestDecodeRecordRejectsNonCanonicalVarint(t *testing.T) {
+	// mode=dynamic, 1 field, name "", type UVARINT, value = over-long
+	// two-byte encoding of 1 ([0x81, 0x00]; canonical is one byte, 0x01).
+	b := []byte{OperateModeDynamic, 1, 0, OperateTypeUVarint, 0x81, 0x00}
+	if _, err := DecodeRecord(b); err == nil {
+		t.Fatal("non-canonical UVARINT accepted")
+	}
+}
+
+func TestDecodeRecordRejectsNonCanonicalBytesLength(t *testing.T) {
+	// mode=dynamic, 1 field, name "", type BYTES, length = over-long
+	// two-byte encoding of 0 ([0x80, 0x00]; canonical is one byte, 0x00).
+	b := []byte{OperateModeDynamic, 1, 0, OperateTypeBytes, 0x80, 0x00}
+	if _, err := DecodeRecord(b); err == nil {
+		t.Fatal("non-canonical BYTES length accepted")
+	}
+}
+
+// TestDecodeRecordRejectsNonCanonicalF32 is a regression test for a second
+// bug fuzzing found: a schema-mode record whose sole F32 field holds a raw
+// SIGNALING NaN bit pattern (exponent all-ones, mantissa nonzero, quiet bit
+// clear). Decoding widens it through float64 and re-encoding narrows back;
+// on common hardware that round trip sets the quiet bit, so the re-encoded
+// bytes differ from the stored ones. A correctly canonicalizing writer never
+// produces a signaling NaN (design doc §2.5), so DecodeRecord must reject
+// one rather than accept it and silently mutate it on the next round trip.
+func TestDecodeRecordRejectsNonCanonicalF32(t *testing.T) {
+	s := &Schema{Version: 1, Fields: []FieldDef{{Type: OperateTypeF32}}}
+	b := append([]byte{OperateModeSchema}, s.Encode()...)
+	b = append(b, 0x30, 0x30, 0x80, 0xff) // LE bits 0xff803030: signaling NaN
+	if _, err := DecodeRecord(b); err == nil {
+		t.Fatal("non-canonical (signaling NaN) F32 accepted")
 	}
 }
 

--- a/sdk/wire/operate_record_test.go
+++ b/sdk/wire/operate_record_test.go
@@ -315,3 +315,42 @@ func FuzzDecodeRecord(f *testing.F) {
 		}
 	})
 }
+
+// dynTableRecord frames a one-field dynamic record whose single field "t" is
+// a table with the given cap/policy/byColName and no rows, so a header rule
+// can be exercised on bytes no encoder would produce.
+func dynTableRecord(policy uint8, byColName string) []byte {
+	inner := []byte{0, policy, byte(len(byColName))} // cap 0, policy, byColLen
+	inner = append(inner, byColName...)
+	inner = append(inner, 0) // nRows
+	b := []byte{OperateModeDynamic, 1, 1, 't', OperateTypeTable, byte(len(inner))}
+	return append(b, inner...)
+}
+
+// TestDecodeRecordRejectsColPolicyWithoutColumn covers a dynamic table header
+// whose policy evicts by a column but whose byColName is empty. MIN_COL and
+// MAX_COL pick their victim by the value in a named column (design doc §3.2),
+// so without the name the eviction victim is undefined. CONFIG refuses to
+// write the pairing, so a stored record carrying it is malformed.
+func TestDecodeRecordRejectsColPolicyWithoutColumn(t *testing.T) {
+	for _, policy := range []uint8{OperatePolicyMinCol, OperatePolicyMaxCol} {
+		if _, err := DecodeRecord(dynTableRecord(policy, "")); !errors.Is(err, ErrOperateRecord) {
+			t.Fatalf("policy %d with no byColName: err = %v, want ErrOperateRecord", policy, err)
+		}
+		// The same header naming a column decodes, so the case above is
+		// failing on the missing name and not on the frame.
+		got, err := DecodeRecord(dynTableRecord(policy, "c"))
+		if err != nil {
+			t.Fatalf("policy %d with a byColName: %v", policy, err)
+		}
+		if got.Fields[0].Table.ByColName != "c" {
+			t.Fatalf("byColName = %q", got.Fields[0].Table.ByColName)
+		}
+	}
+	// A policy that does not evict by a column needs no name.
+	for _, policy := range []uint8{OperatePolicyNone, OperatePolicyMinKey, OperatePolicyMaxKey} {
+		if _, err := DecodeRecord(dynTableRecord(policy, "")); err != nil {
+			t.Fatalf("policy %d with no byColName: %v", policy, err)
+		}
+	}
+}

--- a/sdk/wire/operate_record_test.go
+++ b/sdk/wire/operate_record_test.go
@@ -5,6 +5,8 @@ package wire
 import (
 	"bytes"
 	"encoding/binary"
+	"errors"
+	"math"
 	"testing"
 )
 
@@ -160,21 +162,43 @@ func TestRecordSchemaZeroValueUsesSchemaType(t *testing.T) {
 // LEB128 encoding (via binary.Uvarint), not only the minimal one
 // AppendCellData produces, so a non-canonical encoding would decode
 // successfully yet re-encode to different, shorter bytes.
+//
+// Both build their input with a ONE-BYTE field name. An earlier revision
+// used a zero-length name, which decodeDynamicRecord rejects at its nlen
+// check before it ever reads the value — so the tests passed without the
+// canonical check existing at all. Each one now asserts the canonically
+// spelled twin decodes, which is what proves the decoder reaches the value.
 func TestDecodeRecordRejectsNonCanonicalVarint(t *testing.T) {
-	// mode=dynamic, 1 field, name "", type UVARINT, value = over-long
+	// mode=dynamic, 1 field, name "a", type UVARINT, value = over-long
 	// two-byte encoding of 1 ([0x81, 0x00]; canonical is one byte, 0x01).
-	b := []byte{OperateModeDynamic, 1, 0, OperateTypeUVarint, 0x81, 0x00}
-	if _, err := DecodeRecord(b); err == nil {
-		t.Fatal("non-canonical UVARINT accepted")
+	b := []byte{OperateModeDynamic, 1, 1, 'a', OperateTypeUVarint, 0x81, 0x00}
+	if _, err := DecodeRecord(b); !errors.Is(err, ErrOperateRecord) {
+		t.Fatalf("non-canonical UVARINT: err = %v, want ErrOperateRecord", err)
+	}
+	canonical := []byte{OperateModeDynamic, 1, 1, 'a', OperateTypeUVarint, 0x01}
+	r, err := DecodeRecord(canonical)
+	if err != nil {
+		t.Fatalf("the canonical spelling must decode, or the case above never reaches the value: %v", err)
+	}
+	if len(r.Fields) != 1 || r.Fields[0].Cell.U != 1 {
+		t.Fatalf("canonical UVARINT decoded to %+v", r.Fields)
 	}
 }
 
 func TestDecodeRecordRejectsNonCanonicalBytesLength(t *testing.T) {
-	// mode=dynamic, 1 field, name "", type BYTES, length = over-long
+	// mode=dynamic, 1 field, name "a", type BYTES, length = over-long
 	// two-byte encoding of 0 ([0x80, 0x00]; canonical is one byte, 0x00).
-	b := []byte{OperateModeDynamic, 1, 0, OperateTypeBytes, 0x80, 0x00}
-	if _, err := DecodeRecord(b); err == nil {
-		t.Fatal("non-canonical BYTES length accepted")
+	b := []byte{OperateModeDynamic, 1, 1, 'a', OperateTypeBytes, 0x80, 0x00}
+	if _, err := DecodeRecord(b); !errors.Is(err, ErrOperateRecord) {
+		t.Fatalf("non-canonical BYTES length: err = %v, want ErrOperateRecord", err)
+	}
+	canonical := []byte{OperateModeDynamic, 1, 1, 'a', OperateTypeBytes, 0x00}
+	r, err := DecodeRecord(canonical)
+	if err != nil {
+		t.Fatalf("the canonical spelling must decode, or the case above never reaches the value: %v", err)
+	}
+	if len(r.Fields) != 1 || len(r.Fields[0].Cell.B) != 0 {
+		t.Fatalf("canonical BYTES decoded to %+v", r.Fields)
 	}
 }
 
@@ -190,8 +214,91 @@ func TestDecodeRecordRejectsNonCanonicalF32(t *testing.T) {
 	s := &Schema{Version: 1, Fields: []FieldDef{{Type: OperateTypeF32}}}
 	b := append([]byte{OperateModeSchema}, s.Encode()...)
 	b = append(b, 0x30, 0x30, 0x80, 0xff) // LE bits 0xff803030: signaling NaN
-	if _, err := DecodeRecord(b); err == nil {
-		t.Fatal("non-canonical (signaling NaN) F32 accepted")
+	if _, err := DecodeRecord(b); !errors.Is(err, ErrOperateRecord) {
+		t.Fatalf("non-canonical (signaling NaN) F32: err = %v, want ErrOperateRecord", err)
+	}
+	// The canonical quiet NaN (F32 bits 0x7FC00000) is the one spelling that
+	// must survive, which is also what proves the case above reaches the
+	// value rather than failing earlier in the frame.
+	ok := append([]byte{OperateModeSchema}, s.Encode()...)
+	ok = binary.LittleEndian.AppendUint32(ok, 0x7FC00000)
+	got, err := DecodeRecord(ok)
+	if err != nil {
+		t.Fatalf("canonical quiet-NaN F32 rejected: %v", err)
+	}
+	if !math.IsNaN(got.Fields[0].Cell.F) || !bytes.Equal(got.Encode(), ok) {
+		t.Fatalf("canonical NaN did not round-trip: %+v", got.Fields[0].Cell)
+	}
+}
+
+// TestDecodeRecordRejectsNonCanonicalF64 is the F64 half of the same rule:
+// AppendCellData canonicalizes every NaN (design doc §2.5), so a stored
+// quiet NaN with a non-zero payload decodes fine yet re-encodes to the
+// canonical pattern — DecodeRecord must reject it rather than silently
+// mutate it on the next round trip.
+func TestDecodeRecordRejectsNonCanonicalF64(t *testing.T) {
+	s := &Schema{Version: 1, Fields: []FieldDef{{Type: OperateTypeF64}}}
+	bad := append([]byte{OperateModeSchema}, s.Encode()...)
+	bad = binary.LittleEndian.AppendUint64(bad, 0x7FF8000000000001) // quiet NaN, payload 1
+	if _, err := DecodeRecord(bad); !errors.Is(err, ErrOperateRecord) {
+		t.Fatalf("non-canonical F64 NaN: err = %v, want ErrOperateRecord", err)
+	}
+	ok := append([]byte{OperateModeSchema}, s.Encode()...)
+	ok = binary.LittleEndian.AppendUint64(ok, 0x7FF8000000000000)
+	got, err := DecodeRecord(ok)
+	if err != nil {
+		t.Fatalf("canonical quiet-NaN F64 rejected: %v", err)
+	}
+	if !math.IsNaN(got.Fields[0].Cell.F) || !bytes.Equal(got.Encode(), ok) {
+		t.Fatalf("canonical NaN did not round-trip: %+v", got.Fields[0].Cell)
+	}
+	// A finite F64 keeps its bits verbatim: adding F64 to the canonical check
+	// must not cost the ordinary values anything.
+	fin := append([]byte{OperateModeSchema}, s.Encode()...)
+	fin = binary.LittleEndian.AppendUint64(fin, math.Float64bits(-0.5))
+	if _, err := DecodeRecord(fin); err != nil {
+		t.Fatalf("finite F64 rejected: %v", err)
+	}
+}
+
+// TestDecodeRecordRejectsFixedZeroWidth covers FIXED(0), which is not a
+// legal width (design doc §2.1: FIXED(n) is 1-255 bytes). A zero-width cell
+// would be a second spelling of UNSET — it encodes and decodes as no bytes
+// at all — so the codec rejects it wherever a width is stored: a dynamic
+// field header, a dynamic column header, and a bare tagged cell.
+func TestDecodeRecordRejectsFixedZeroWidth(t *testing.T) {
+	field := []byte{OperateModeDynamic, 1, 1, 'a', OperateTypeFixed, 0}
+	if _, err := DecodeRecord(field); !errors.Is(err, ErrOperateRecord) {
+		t.Fatalf("FIXED(0) field: err = %v, want ErrOperateRecord", err)
+	}
+	// The same record with a width of 1 and one data byte must decode, so the
+	// case above is failing on the width and not on the frame's shape.
+	okField := []byte{OperateModeDynamic, 1, 1, 'a', OperateTypeFixed, 1, 0x7A}
+	if _, err := DecodeRecord(okField); err != nil {
+		t.Fatalf("FIXED(1) field rejected: %v", err)
+	}
+
+	// A dynamic table holding one row with one FIXED(0) column:
+	// [byteLen][cap 0][policy 0][byColLen 0][nRows 1][rowLen][klen 1]['k']
+	// [nCols 1][nlen 1]['c'][type FIXED][n 0].
+	row := []byte{1, 'k', 1, 1, 'c', OperateTypeFixed, 0}
+	inner := append([]byte{0, 0, 0, 1, byte(len(row))}, row...)
+	col := append([]byte{OperateModeDynamic, 1, 1, 't', OperateTypeTable, byte(len(inner))}, inner...)
+	if _, err := DecodeRecord(col); !errors.Is(err, ErrOperateRecord) {
+		t.Fatalf("FIXED(0) column: err = %v, want ErrOperateRecord", err)
+	}
+	okRow := []byte{1, 'k', 1, 1, 'c', OperateTypeFixed, 1, 0x7A}
+	okInner := append([]byte{0, 0, 0, 1, byte(len(okRow))}, okRow...)
+	okCol := append([]byte{OperateModeDynamic, 1, 1, 't', OperateTypeTable, byte(len(okInner))}, okInner...)
+	if _, err := DecodeRecord(okCol); err != nil {
+		t.Fatalf("FIXED(1) column rejected: %v", err)
+	}
+
+	if _, _, err := DecodeTaggedCell([]byte{OperateTypeFixed, 0}); !errors.Is(err, ErrOperateType) {
+		t.Fatalf("DecodeTaggedCell FIXED(0): err = %v, want ErrOperateType", err)
+	}
+	if _, _, err := DecodeCellData(OperateTypeFixed, 0, []byte{1, 2, 3}); !errors.Is(err, ErrOperateType) {
+		t.Fatalf("DecodeCellData FIXED(0): err = %v, want ErrOperateType", err)
 	}
 }
 

--- a/sdk/wire/operate_schema.go
+++ b/sdk/wire/operate_schema.go
@@ -180,8 +180,9 @@ func appendName(dst []byte, name string) []byte {
 
 // DecodeSchema reads one Encode-formatted schema blob from the front of b,
 // returning the decoded schema and the number of bytes consumed. Every
-// count is bounded with CountFitsIn against the remaining input and the
-// relevant cap before it is trusted to size an allocation, and every read is
+// count is bounded with CountFitsIn against the remaining input, against the
+// relevant cap, and against OperateMaxSchemaBytes (the blob a schema must
+// fit in) before it is trusted to size an allocation, and every read is
 // truncation-checked, so DecodeSchema never panics or over-reads on hostile
 // input. A successfully decoded schema always passes Validate — DecodeSchema
 // runs it before returning.
@@ -206,7 +207,14 @@ func DecodeSchema(b []byte) (*Schema, int, error) {
 		return nil, 0, err
 	}
 	off += m
-	if nFields > OperateMaxFields {
+	// Two independent bounds, both before the allocation below. CountFitsIn
+	// bounds the count against the bytes actually left, but b is the whole
+	// stored record — up to 16 MiB — not just the schema blob, so on its own
+	// it would let a declared 65535 fields size a multi-megabyte slice out of
+	// a blob that can never legally exceed OperateMaxSchemaBytes. Every field
+	// costs at least one byte of that blob, so the count is bounded by the
+	// blob budget too.
+	if nFields > OperateMaxFields || nFields > OperateMaxSchemaBytes {
 		return nil, 0, ErrOperateSchema
 	}
 	if !CountFitsIn(int(nFields), len(b)-off, 1) {
@@ -251,7 +259,9 @@ func DecodeSchema(b []byte) (*Schema, int, error) {
 			return nil, 0, err
 		}
 		off += m2
-		if nCols > OperateMaxCols {
+		// Bounded by the blob budget as well as by the column cap, for the
+		// same reason nFields is: one byte of blob per column, minimum.
+		if nCols > OperateMaxCols || nCols > OperateMaxSchemaBytes {
 			return nil, 0, ErrOperateSchema
 		}
 		if !CountFitsIn(int(nCols), len(b)-off, 1) {

--- a/sdk/wire/operate_schema.go
+++ b/sdk/wire/operate_schema.go
@@ -207,16 +207,29 @@ func DecodeSchema(b []byte) (*Schema, int, error) {
 		return nil, 0, err
 	}
 	off += m
-	// Two independent bounds, both before the allocation below. CountFitsIn
-	// bounds the count against the bytes actually left, but b is the whole
-	// stored record — up to 16 MiB — not just the schema blob, so on its own
-	// it would let a declared 65535 fields size a multi-megabyte slice out of
-	// a blob that can never legally exceed OperateMaxSchemaBytes. Every field
-	// costs at least one byte of that blob, so the count is bounded by the
-	// blob budget too.
-	if nFields > OperateMaxFields || nFields > OperateMaxSchemaBytes {
+	// budget is what is left of OperateMaxSchemaBytes, and it is spent by
+	// every declaration in the blob rather than reset per declaration.
+	//
+	// CountFitsIn bounds a count against the bytes actually left, but b is
+	// the whole STORED record — up to maxRecordBytes, 16 MiB — not just the
+	// schema blob, and the 4 KiB blob cap is only checked by Validate, after
+	// the whole thing has been decoded. A per-declaration bound is therefore
+	// not a bound at all in aggregate: every one of thousands of table fields
+	// can declare thousands of columns, each passing its own check, while the
+	// sum sizes hundreds of megabytes of ColumnDef before anything says no.
+	//
+	// One running budget closes that. Every field costs at least its type
+	// byte, every column at least its own, and the names section costs its
+	// declared length, so a schema whose declarations sum past the blob cap
+	// cannot possibly encode within it — and the budget is spent BEFORE each
+	// make, so an over-declaration is rejected rather than allocated for. It
+	// never rejects a legal schema: len(Encode()) >= nFields + Σ nCols +
+	// nameBytes, and Validate already requires len(Encode()) <= the cap.
+	budget := uint64(OperateMaxSchemaBytes)
+	if nFields > OperateMaxFields || nFields > budget {
 		return nil, 0, ErrOperateSchema
 	}
+	budget -= nFields
 	if !CountFitsIn(int(nFields), len(b)-off, 1) {
 		return nil, 0, ErrShortArgs
 	}
@@ -259,11 +272,13 @@ func DecodeSchema(b []byte) (*Schema, int, error) {
 			return nil, 0, err
 		}
 		off += m2
-		// Bounded by the blob budget as well as by the column cap, for the
-		// same reason nFields is: one byte of blob per column, minimum.
-		if nCols > OperateMaxCols || nCols > OperateMaxSchemaBytes {
+		// Charged against the same running budget the fields were, so the
+		// columns of every table in the blob are bounded in aggregate and
+		// not merely one table at a time.
+		if nCols > OperateMaxCols || nCols > budget {
 			return nil, 0, ErrOperateSchema
 		}
+		budget -= nCols
 		if !CountFitsIn(int(nCols), len(b)-off, 1) {
 			return nil, 0, ErrShortArgs
 		}
@@ -321,7 +336,9 @@ func DecodeSchema(b []byte) (*Schema, int, error) {
 		return nil, 0, err
 	}
 	off += m5
-	if nameBytes > OperateMaxNameBytes {
+	// The last charge against the budget: the names section is the rest of
+	// what a blob spends its 4 KiB on.
+	if nameBytes > OperateMaxNameBytes || nameBytes > budget {
 		return nil, 0, ErrOperateSchema
 	}
 	if !CountFitsIn(int(nameBytes), len(b)-off, 1) {
@@ -556,8 +573,11 @@ func (s *Schema) Layout() (*Layout, error) {
 
 // Extends reports whether newer is a valid append-only evolution of s
 // (design doc §2.8): a strictly greater version; every existing field kept
-// at its position with an unchanged type and width (a table's key type/width
-// unchanged and its existing columns kept as an unchanged-type prefix, while
+// at its position with an unchanged type and, for OperateTypeFixed, an
+// unchanged width — N is compared only where it means something, since it is
+// ignored (and not even encoded) for every other type (a table's key
+// type/width unchanged and its existing columns kept as an unchanged-type
+// prefix, while
 // Cap/Policy/ByCol are free to change); new fields and columns may be
 // appended; a name already stored may not change (though a field/column that
 // had no name may gain one). Anything else is ErrOperateSchema.
@@ -571,7 +591,11 @@ func (s *Schema) Extends(newer *Schema) error {
 	for i := range s.Fields {
 		of := &s.Fields[i]
 		nf := &newer.Fields[i]
-		if nf.Type != of.Type || nf.N != of.N {
+		// N is the FIXED(n) width and is ignored for every other type
+		// (FieldDef.N's own doc says so), so comparing it unconditionally
+		// would refuse an otherwise identical schema over a byte nothing
+		// reads — Encode does not even write it.
+		if nf.Type != of.Type || (of.Type == OperateTypeFixed && nf.N != of.N) {
 			return ErrOperateSchema
 		}
 		if of.Name != "" && nf.Name != of.Name {
@@ -584,7 +608,8 @@ func (s *Schema) Extends(newer *Schema) error {
 			return ErrOperateSchema
 		}
 		ot, nt := of.Table, nf.Table
-		if ot.KeyType != nt.KeyType || ot.KeyN != nt.KeyN {
+		// KeyN, like N, is the FIXED key's width and ignored otherwise.
+		if ot.KeyType != nt.KeyType || (ot.KeyType == OperateTypeFixed && ot.KeyN != nt.KeyN) {
 			return ErrOperateSchema
 		}
 		if len(nt.Cols) < len(ot.Cols) {
@@ -592,7 +617,7 @@ func (s *Schema) Extends(newer *Schema) error {
 		}
 		for c := range ot.Cols {
 			oc, nc := &ot.Cols[c], &nt.Cols[c]
-			if nc.Type != oc.Type || nc.N != oc.N {
+			if nc.Type != oc.Type || (oc.Type == OperateTypeFixed && nc.N != oc.N) {
 				return ErrOperateSchema
 			}
 			if oc.Name != "" && nc.Name != oc.Name {

--- a/sdk/wire/operate_schema.go
+++ b/sdk/wire/operate_schema.go
@@ -1,0 +1,595 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package wire
+
+import "encoding/binary"
+
+// ColumnDef is one fixed-width column of a table field (design doc §2.3):
+// its type and, for OperateTypeFixed, declared width. Name is optional and
+// used only client-side (§2.2) unless the schema's StoreNames is set.
+type ColumnDef struct {
+	Name string
+	Type uint8
+	N    uint8 // OperateTypeFixed width only; ignored otherwise
+}
+
+// TableDef is a table field's header (design doc §2.3): its row key type,
+// its columns (fixed-width only), and its optional eviction policy. Cap == 0
+// means unbounded; Policy/ByCol select the eviction victim when the table is
+// full (OperatePolicy*).
+type TableDef struct {
+	KeyType uint8
+	KeyN    uint8 // OperateTypeFixed key width only; ignored otherwise
+	Cols    []ColumnDef
+	Cap     uint32
+	Policy  uint8
+	ByCol   uint16
+}
+
+// FieldDef is one field of a record's schema (design doc §2.2): its type
+// and, for OperateTypeFixed, declared width, or, for OperateTypeTable, the
+// table's header. Name is optional client-side metadata, stored on the wire
+// only when the owning Schema's StoreNames is set.
+type FieldDef struct {
+	Name  string
+	Type  uint8
+	N     uint8 // OperateTypeFixed width only; ignored otherwise
+	Table *TableDef
+}
+
+// Schema is a record's field layout (design doc §2.2/§2.8): a client-chosen
+// Version and an ordered list of fields. It is defined by the client,
+// versioned, and immutable per record — a record's schema is stored inline
+// in front of its values so the record is self-describing. StoreNames
+// controls whether field/column names ride the wire (costing bytes) or live
+// only in the client's in-memory Schema object.
+type Schema struct {
+	Version    uint16
+	StoreNames bool
+	Fields     []FieldDef
+}
+
+// TableLayout is the precomputed byte layout of one table field (design doc
+// §2.3): the key's width, the width of one full row (key + columns), and
+// each column's byte offset within a row.
+type TableLayout struct {
+	KeyWidth int
+	RowWidth int
+	ColOff   []int
+}
+
+// Layout is a schema's precomputed byte layout (design doc §2.2): the
+// fixed-width fields are packed first, in schema order, at constant offsets;
+// the variable-length fields (BYTES, UVARINT, IVARINT, TABLE) follow in the
+// "tail" and must be read to skip. FixedOff[i] is the byte offset of field i
+// among the fixed-width fields, or -1 if field i is variable-length.
+// Tables[i] is non-nil exactly when field i is an OperateTypeTable field.
+type Layout struct {
+	FixedOff []int
+	FixedLen int
+	VarTail  []int
+	Tables   []*TableLayout
+}
+
+// schemaFlagStoreNames is bit 0 of a schema blob's flags byte: whether the
+// names section at the end of the blob is present (design doc §2.2).
+const schemaFlagStoreNames uint8 = 1 << 0
+
+// minUvarintLen returns the number of bytes binary.AppendUvarint would use to
+// encode v: the canonical (minimal) LEB128 length.
+func minUvarintLen(v uint64) int {
+	n := 1
+	for v >= 0x80 {
+		v >>= 7
+		n++
+	}
+	return n
+}
+
+// decodeCanonicalUvarint reads one uvarint from the front of b, rejecting a
+// truncated encoding and also a non-canonical (zero-padded) one: LEB128
+// allows the same value to be spelled with extra all-continuation-bit-set,
+// zero-value bytes (e.g. 0x80 0x00 for 0), which would decode fine but never
+// be produced by Encode — accepting it would break the
+// Encode(DecodeSchema(b)) == b identity hardened decoding requires.
+func decodeCanonicalUvarint(b []byte) (uint64, int, error) {
+	v, m := binary.Uvarint(b)
+	if m <= 0 {
+		return 0, 0, ErrShortArgs
+	}
+	if m != minUvarintLen(v) {
+		return 0, 0, ErrOperateSchema
+	}
+	return v, m, nil
+}
+
+// Encode writes s in the wire format (design doc §2.2/§2.3):
+//
+//	[version u16 LE][flags u8][nFields uvarint]
+//	  per field: [type u8][n u8 iff FIXED]
+//	             iff TABLE: [keyType u8][keyN u8 iff FIXED][nCols uvarint]
+//	                        {[type u8][n u8 iff FIXED]}* [cap uvarint][policy u8][byCol uvarint]
+//	[nameBytes uvarint]
+//	  iff StoreNames: per field [len u8][name], then per table's columns [len u8][name], in field order
+//
+// nameBytes is the byte length of the names section that follows it (0 when
+// StoreNames is false, or trivially when there are no fields). Encode
+// assumes s is well-formed (Validate has been, or will be, checked
+// separately); it does not itself return an error.
+func (s *Schema) Encode() []byte {
+	b := make([]byte, 0, 32)
+	b = binary.LittleEndian.AppendUint16(b, s.Version)
+	var flags uint8
+	if s.StoreNames {
+		flags |= schemaFlagStoreNames
+	}
+	b = append(b, flags)
+	b = binary.AppendUvarint(b, uint64(len(s.Fields))) //nolint:gosec // bounded by OperateMaxFields on validated schemas
+
+	for i := range s.Fields {
+		f := &s.Fields[i]
+		b = append(b, f.Type)
+		if f.Type == OperateTypeFixed {
+			b = append(b, f.N)
+		}
+		if f.Type == OperateTypeTable && f.Table != nil {
+			t := f.Table
+			b = append(b, t.KeyType)
+			if t.KeyType == OperateTypeFixed {
+				b = append(b, t.KeyN)
+			}
+			b = binary.AppendUvarint(b, uint64(len(t.Cols))) //nolint:gosec // bounded by OperateMaxCols on validated schemas
+			for _, c := range t.Cols {
+				b = append(b, c.Type)
+				if c.Type == OperateTypeFixed {
+					b = append(b, c.N)
+				}
+			}
+			b = binary.AppendUvarint(b, uint64(t.Cap))
+			b = append(b, t.Policy)
+			b = binary.AppendUvarint(b, uint64(t.ByCol))
+		}
+	}
+
+	if !s.StoreNames {
+		return binary.AppendUvarint(b, 0)
+	}
+
+	var names []byte
+	for i := range s.Fields {
+		names = appendName(names, s.Fields[i].Name)
+	}
+	for i := range s.Fields {
+		f := &s.Fields[i]
+		if f.Type == OperateTypeTable && f.Table != nil {
+			for _, c := range f.Table.Cols {
+				names = appendName(names, c.Name)
+			}
+		}
+	}
+	b = binary.AppendUvarint(b, uint64(len(names))) //nolint:gosec // bounded by OperateMaxNameBytes on validated schemas
+	return append(b, names...)
+}
+
+// appendName appends one [len u8][name] entry. Callers are responsible for
+// keeping name within OperateMaxNameLen (Validate enforces this).
+func appendName(dst []byte, name string) []byte {
+	dst = append(dst, byte(len(name))) //nolint:gosec // bounded by OperateMaxNameLen on validated schemas
+	return append(dst, name...)
+}
+
+// DecodeSchema reads one Encode-formatted schema blob from the front of b,
+// returning the decoded schema and the number of bytes consumed. Every
+// count is bounded with CountFitsIn against the remaining input and the
+// relevant cap before it is trusted to size an allocation, and every read is
+// truncation-checked, so DecodeSchema never panics or over-reads on hostile
+// input. A successfully decoded schema always passes Validate — DecodeSchema
+// runs it before returning.
+func DecodeSchema(b []byte) (*Schema, int, error) {
+	if len(b) < 4 {
+		return nil, 0, ErrShortArgs
+	}
+	s := &Schema{Version: binary.LittleEndian.Uint16(b[0:2])}
+	flags := b[2]
+	if flags&^schemaFlagStoreNames != 0 {
+		// Reserved flag bits set: either a future format this decoder does
+		// not understand, or hostile input. Either way, silently accepting
+		// and then re-encoding would drop those bits, breaking the
+		// Encode(DecodeSchema(b)) == b identity — reject instead.
+		return nil, 0, ErrOperateSchema
+	}
+	s.StoreNames = flags&schemaFlagStoreNames != 0
+	off := 3
+
+	nFields, m, err := decodeCanonicalUvarint(b[off:])
+	if err != nil {
+		return nil, 0, err
+	}
+	off += m
+	if nFields > OperateMaxFields {
+		return nil, 0, ErrOperateSchema
+	}
+	if !CountFitsIn(int(nFields), len(b)-off, 1) {
+		return nil, 0, ErrShortArgs
+	}
+
+	fields := make([]FieldDef, nFields)
+	for i := range fields {
+		if len(b)-off < 1 {
+			return nil, 0, ErrShortArgs
+		}
+		typ := b[off]
+		off++
+		fields[i].Type = typ
+		if typ == OperateTypeFixed {
+			if len(b)-off < 1 {
+				return nil, 0, ErrShortArgs
+			}
+			fields[i].N = b[off]
+			off++
+		}
+		if typ != OperateTypeTable {
+			continue
+		}
+
+		td := &TableDef{}
+		if len(b)-off < 1 {
+			return nil, 0, ErrShortArgs
+		}
+		td.KeyType = b[off]
+		off++
+		if td.KeyType == OperateTypeFixed {
+			if len(b)-off < 1 {
+				return nil, 0, ErrShortArgs
+			}
+			td.KeyN = b[off]
+			off++
+		}
+
+		nCols, m2, err := decodeCanonicalUvarint(b[off:])
+		if err != nil {
+			return nil, 0, err
+		}
+		off += m2
+		if nCols > OperateMaxCols {
+			return nil, 0, ErrOperateSchema
+		}
+		if !CountFitsIn(int(nCols), len(b)-off, 1) {
+			return nil, 0, ErrShortArgs
+		}
+
+		cols := make([]ColumnDef, nCols)
+		for j := range cols {
+			if len(b)-off < 1 {
+				return nil, 0, ErrShortArgs
+			}
+			ctyp := b[off]
+			off++
+			cols[j].Type = ctyp
+			if ctyp == OperateTypeFixed {
+				if len(b)-off < 1 {
+					return nil, 0, ErrShortArgs
+				}
+				cols[j].N = b[off]
+				off++
+			}
+		}
+		td.Cols = cols
+
+		capV, m3, err := decodeCanonicalUvarint(b[off:])
+		if err != nil {
+			return nil, 0, err
+		}
+		off += m3
+		if capV > OperateMaxRows {
+			return nil, 0, ErrOperateSchema
+		}
+		td.Cap = uint32(capV) //nolint:gosec // bounded by OperateMaxRows above
+
+		if len(b)-off < 1 {
+			return nil, 0, ErrShortArgs
+		}
+		td.Policy = b[off]
+		off++
+
+		byColV, m4, err := decodeCanonicalUvarint(b[off:])
+		if err != nil {
+			return nil, 0, err
+		}
+		off += m4
+		if byColV > OperateMaxCols {
+			return nil, 0, ErrOperateSchema
+		}
+		td.ByCol = uint16(byColV) //nolint:gosec // bounded by OperateMaxCols above
+
+		fields[i].Table = td
+	}
+	s.Fields = fields
+
+	nameBytes, m5, err := decodeCanonicalUvarint(b[off:])
+	if err != nil {
+		return nil, 0, err
+	}
+	off += m5
+	if nameBytes > OperateMaxNameBytes {
+		return nil, 0, ErrOperateSchema
+	}
+	if !CountFitsIn(int(nameBytes), len(b)-off, 1) {
+		return nil, 0, ErrShortArgs
+	}
+
+	if !s.StoreNames {
+		if nameBytes != 0 {
+			return nil, 0, ErrOperateSchema
+		}
+	} else {
+		end := off + int(nameBytes)
+		buf := b[off:end]
+		pos := 0
+		readName := func() (string, error) {
+			if len(buf)-pos < 1 {
+				return "", ErrShortArgs
+			}
+			ln := int(buf[pos])
+			pos++
+			if ln > OperateMaxNameLen {
+				return "", ErrOperateSchema
+			}
+			if len(buf)-pos < ln {
+				return "", ErrShortArgs
+			}
+			name := string(buf[pos : pos+ln])
+			pos += ln
+			return name, nil
+		}
+		for i := range s.Fields {
+			name, err := readName()
+			if err != nil {
+				return nil, 0, err
+			}
+			s.Fields[i].Name = name
+		}
+		for i := range s.Fields {
+			f := &s.Fields[i]
+			if f.Type == OperateTypeTable && f.Table != nil {
+				for j := range f.Table.Cols {
+					name, err := readName()
+					if err != nil {
+						return nil, 0, err
+					}
+					f.Table.Cols[j].Name = name
+				}
+			}
+		}
+		if pos != len(buf) {
+			return nil, 0, ErrOperateSchema
+		}
+		off = end
+	}
+
+	if err := s.Validate(); err != nil {
+		return nil, 0, err
+	}
+	return s, off, nil
+}
+
+// validOperateKeyType reports whether t is a legal table row-key type
+// (design doc §2.3): one of the unsigned fixed-width integer types or
+// OperateTypeFixed. Signed integers, floats, and every variable-length type
+// are not legal keys.
+func validOperateKeyType(t uint8) bool {
+	switch t {
+	case OperateTypeU8, OperateTypeU16, OperateTypeU32, OperateTypeU64, OperateTypeFixed:
+		return true
+	default:
+		return false
+	}
+}
+
+// Validate checks s against every structural rule the design imposes
+// (§2.2/§2.3/§2.7/§2.8): known, non-UNSET types; FIXED widths >= 1; table
+// columns fixed-width only; a legal key type; row width, field/column
+// counts, cap, and total encoded size within the hard caps (§2.7); *_COL
+// eviction policies pointing at a real column; and unique names among
+// fields, and among one table's own columns, when names are present. A
+// schema that fails Validate must never be stored or acted on.
+func (s *Schema) Validate() error {
+	if len(s.Fields) > OperateMaxFields {
+		return ErrOperateSchema
+	}
+
+	fieldNames := make(map[string]struct{}, len(s.Fields))
+	for i := range s.Fields {
+		f := &s.Fields[i]
+		if f.Type >= OperateTypeCount || f.Type == OperateTypeUnset {
+			return ErrOperateSchema
+		}
+		if f.Type == OperateTypeFixed && f.N < 1 {
+			return ErrOperateSchema
+		}
+		if f.Name != "" {
+			if len(f.Name) > OperateMaxNameLen {
+				return ErrOperateSchema
+			}
+			if _, dup := fieldNames[f.Name]; dup {
+				return ErrOperateSchema
+			}
+			fieldNames[f.Name] = struct{}{}
+		}
+
+		if f.Type != OperateTypeTable {
+			continue
+		}
+		if f.Table == nil {
+			return ErrOperateSchema
+		}
+		t := f.Table
+		if !validOperateKeyType(t.KeyType) {
+			return ErrOperateSchema
+		}
+		if t.KeyType == OperateTypeFixed && t.KeyN < 1 {
+			return ErrOperateSchema
+		}
+		if len(t.Cols) > OperateMaxCols {
+			return ErrOperateSchema
+		}
+		if t.Cap > OperateMaxRows {
+			return ErrOperateSchema
+		}
+		if t.Policy > OperatePolicyMaxCol {
+			return ErrOperateSchema
+		}
+		if (t.Policy == OperatePolicyMinCol || t.Policy == OperatePolicyMaxCol) && int(t.ByCol) >= len(t.Cols) {
+			return ErrOperateSchema
+		}
+
+		rowWidth := CellWidth(t.KeyType, t.KeyN)
+		if rowWidth < 1 {
+			return ErrOperateSchema
+		}
+		colNames := make(map[string]struct{}, len(t.Cols))
+		for _, c := range t.Cols {
+			if c.Type >= OperateTypeCount {
+				return ErrOperateSchema
+			}
+			w := CellWidth(c.Type, c.N)
+			if w < 1 {
+				return ErrOperateSchema
+			}
+			rowWidth += w
+			if c.Name != "" {
+				if len(c.Name) > OperateMaxNameLen {
+					return ErrOperateSchema
+				}
+				if _, dup := colNames[c.Name]; dup {
+					return ErrOperateSchema
+				}
+				colNames[c.Name] = struct{}{}
+			}
+		}
+		if rowWidth > OperateMaxRowWidth {
+			return ErrOperateSchema
+		}
+	}
+
+	if len(s.Encode()) > OperateMaxSchemaBytes {
+		return ErrOperateSchema
+	}
+	return nil
+}
+
+// FieldPos returns the schema position of the field named name, and whether
+// it was found. It is a client-side convenience (design doc §2.2): the wire
+// never carries names, only positions.
+func (s *Schema) FieldPos(name string) (int, bool) {
+	if name == "" {
+		return 0, false
+	}
+	for i := range s.Fields {
+		if s.Fields[i].Name == name {
+			return i, true
+		}
+	}
+	return 0, false
+}
+
+// Layout computes s's byte layout (design doc §2.2/§2.3): fixed-width
+// fields packed first in schema order, then the variable-length tail. It
+// returns an error rather than panicking if s contains a structural
+// impossibility (a table field with a nil Table, or a key/column whose
+// width cannot be determined) — callers normally call this only on an
+// already-Validate'd schema, for which it cannot fail.
+func (s *Schema) Layout() (*Layout, error) {
+	l := &Layout{
+		FixedOff: make([]int, len(s.Fields)),
+		Tables:   make([]*TableLayout, len(s.Fields)),
+	}
+	off := 0
+	for i := range s.Fields {
+		f := &s.Fields[i]
+		if f.Type == OperateTypeFixed && f.N < 1 {
+			return nil, ErrOperateSchema
+		}
+		w := CellWidth(f.Type, f.N)
+		if w < 0 {
+			l.FixedOff[i] = -1
+			l.VarTail = append(l.VarTail, i)
+			if f.Type == OperateTypeTable {
+				if f.Table == nil {
+					return nil, ErrOperateSchema
+				}
+				t := f.Table
+				kw := CellWidth(t.KeyType, t.KeyN)
+				if kw < 1 {
+					return nil, ErrOperateSchema
+				}
+				colOff := make([]int, len(t.Cols))
+				rowWidth := kw
+				for c := range t.Cols {
+					cw := CellWidth(t.Cols[c].Type, t.Cols[c].N)
+					if cw < 1 {
+						return nil, ErrOperateSchema
+					}
+					colOff[c] = rowWidth
+					rowWidth += cw
+				}
+				l.Tables[i] = &TableLayout{KeyWidth: kw, RowWidth: rowWidth, ColOff: colOff}
+			}
+			continue
+		}
+		l.FixedOff[i] = off
+		off += w
+	}
+	l.FixedLen = off
+	return l, nil
+}
+
+// Extends reports whether newer is a valid append-only evolution of s
+// (design doc §2.8): a strictly greater version; every existing field kept
+// at its position with an unchanged type and width (a table's key type/width
+// unchanged and its existing columns kept as an unchanged-type prefix, while
+// Cap/Policy/ByCol are free to change); new fields and columns may be
+// appended; a name already stored may not change (though a field/column that
+// had no name may gain one). Anything else is ErrOperateSchema.
+func (s *Schema) Extends(newer *Schema) error {
+	if newer.Version <= s.Version {
+		return ErrOperateSchema
+	}
+	if len(newer.Fields) < len(s.Fields) {
+		return ErrOperateSchema
+	}
+	for i := range s.Fields {
+		of := &s.Fields[i]
+		nf := &newer.Fields[i]
+		if nf.Type != of.Type || nf.N != of.N {
+			return ErrOperateSchema
+		}
+		if of.Name != "" && nf.Name != of.Name {
+			return ErrOperateSchema
+		}
+		if of.Type != OperateTypeTable {
+			continue
+		}
+		if of.Table == nil || nf.Table == nil {
+			return ErrOperateSchema
+		}
+		ot, nt := of.Table, nf.Table
+		if ot.KeyType != nt.KeyType || ot.KeyN != nt.KeyN {
+			return ErrOperateSchema
+		}
+		if len(nt.Cols) < len(ot.Cols) {
+			return ErrOperateSchema
+		}
+		for c := range ot.Cols {
+			oc, nc := &ot.Cols[c], &nt.Cols[c]
+			if nc.Type != oc.Type || nc.N != oc.N {
+				return ErrOperateSchema
+			}
+			if oc.Name != "" && nc.Name != oc.Name {
+				return ErrOperateSchema
+			}
+		}
+		// Cap, Policy, and ByCol may change freely.
+	}
+	return nil
+}

--- a/sdk/wire/operate_schema_test.go
+++ b/sdk/wire/operate_schema_test.go
@@ -189,3 +189,122 @@ func TestDecodeSchemaHostileCounts(t *testing.T) {
 		t.Fatalf("a legal 1000-field schema must decode: %v (n=%d)", err, n)
 	}
 }
+
+// declaredTablesBlob builds a schema blob header that declares nTables TABLE
+// fields, each declaring nCols columns, with enough trailing filler that
+// every CountFitsIn bound is satisfied. It is not a legal schema — it is the
+// shape a hostile STORED record can carry, since the 4 KiB blob cap is only
+// checked by Validate, after the whole thing has been decoded.
+func declaredTablesBlob(nTables, nCols int) []byte {
+	b := []byte{1, 0, 0} // version 1, no flags
+	b = binary.AppendUvarint(b, uint64(nTables))
+	for i := 0; i < nTables; i++ {
+		b = append(b, OperateTypeTable, OperateTypeU8) // field type, key type
+		b = binary.AppendUvarint(b, uint64(nCols))
+		b = append(b, make([]byte, nCols)...) // nCols U8 column type bytes
+		b = append(b, 0, 0, 0)                // cap, policy, byCol
+	}
+	return append(b, 0) // nameBytes
+}
+
+// TestDecodeSchemaAggregateBudget covers the schema-blob budget IN
+// AGGREGATE. A per-declaration bound is not a bound at all here: every one of
+// many table fields can declare a column count that passes its own check
+// while the sum sizes far more ColumnDef than a 4 KiB blob could ever hold.
+// DecodeSchema is handed the whole stored record, up to maxRecordBytes, and
+// the blob cap is only checked by Validate once decoding is done, so the
+// budget has to be spent as it goes.
+func TestDecodeSchemaAggregateBudget(t *testing.T) {
+	// Three tables of 2000 columns each: 2000 passes any per-table bound
+	// (it is under both OperateMaxCols and OperateMaxSchemaBytes), while
+	// 3 + 6000 declared bytes is well past the 4096-byte blob.
+	blob := declaredTablesBlob(3, 2000)
+	if _, _, err := DecodeSchema(blob); !errors.Is(err, ErrOperateSchema) {
+		t.Fatalf("3 tables x 2000 columns: err = %v, want ErrOperateSchema", err)
+	}
+
+	// The same shape at scale: 200 tables of 4000 columns is 800,000 declared
+	// columns, ~19 MB of ColumnDef if every count were honoured. 4000 is
+	// under both OperateMaxCols and OperateMaxSchemaBytes, so no
+	// per-declaration bound stops it — only the running budget does, and it
+	// does so at the FIRST table (200 fields leave 3896 bytes, less than the
+	// 4000 that table asks for), before the make. Three allocations reach
+	// that point: the Schema, the field slice, and the first TableDef.
+	big := declaredTablesBlob(200, 4000)
+	if _, _, err := DecodeSchema(big); !errors.Is(err, ErrOperateSchema) {
+		t.Fatalf("200 tables x 4000 columns: err = %v, want ErrOperateSchema", err)
+	}
+	if n := testing.AllocsPerRun(10, func() { _, _, _ = DecodeSchema(big) }); n > 4 {
+		t.Fatalf("declared 800000 columns allocated %v times; the budget must be spent before each make", n)
+	}
+
+	// The aggregate bound must not cost a legal schema anything. This one
+	// spends most of the blob on columns spread over several tables, which is
+	// exactly the shape the budget charges.
+	s := &Schema{Version: 1}
+	for i := 0; i < 4; i++ {
+		td := &TableDef{KeyType: OperateTypeU64}
+		for c := 0; c < 300; c++ {
+			td.Cols = append(td.Cols, ColumnDef{Type: OperateTypeU8})
+		}
+		s.Fields = append(s.Fields, FieldDef{Type: OperateTypeTable, Table: td})
+	}
+	enc := s.Encode()
+	if len(enc) > OperateMaxSchemaBytes {
+		t.Fatalf("fixture blob is %d bytes, over the %d-byte cap", len(enc), OperateMaxSchemaBytes)
+	}
+	got, n, err := DecodeSchema(enc)
+	if err != nil || n != len(enc) || len(got.Fields) != 4 || len(got.Fields[3].Table.Cols) != 300 {
+		t.Fatalf("a legal 4-table, 1200-column schema must decode: %v (n=%d)", err, n)
+	}
+}
+
+// TestExtendsComparesWidthOnlyForFixed covers Extends's width rule. N is the
+// FIXED(n) width and is ignored — not even encoded — for every other type,
+// so comparing it unconditionally refused an evolution over a byte nothing
+// reads.
+func TestExtendsComparesWidthOnlyForFixed(t *testing.T) {
+	base := &Schema{Version: 1, Fields: []FieldDef{
+		{Name: "n", Type: OperateTypeU32, N: 0},
+		{Name: "t", Type: OperateTypeTable, Table: &TableDef{
+			KeyType: OperateTypeU64, KeyN: 0,
+			Cols: []ColumnDef{{Name: "c", Type: OperateTypeU16, N: 0}},
+		}},
+	}}
+	// Identical but for three N values none of these types reads.
+	newer := &Schema{Version: 2, Fields: []FieldDef{
+		{Name: "n", Type: OperateTypeU32, N: 7},
+		{Name: "t", Type: OperateTypeTable, Table: &TableDef{
+			KeyType: OperateTypeU64, KeyN: 9,
+			Cols: []ColumnDef{{Name: "c", Type: OperateTypeU16, N: 5}},
+		}},
+	}}
+	if err := base.Extends(newer); err != nil {
+		t.Fatalf("an ignored N blocked an otherwise identical evolution: %v", err)
+	}
+	// The blobs are in fact identical, which is why the widths cannot matter.
+	if !bytes.Equal(base.Encode()[2:], newer.Encode()[2:]) { // [2:] skips the version
+		t.Fatal("fixture schemas do not encode identically; the test would prove nothing")
+	}
+
+	// Where N does mean something, a change is still refused.
+	fixedBase := &Schema{Version: 1, Fields: []FieldDef{{Name: "f", Type: OperateTypeFixed, N: 4}}}
+	fixedNewer := &Schema{Version: 2, Fields: []FieldDef{{Name: "f", Type: OperateTypeFixed, N: 5}}}
+	if err := fixedBase.Extends(fixedNewer); !errors.Is(err, ErrOperateSchema) {
+		t.Fatalf("a changed FIXED width: err = %v, want ErrOperateSchema", err)
+	}
+	keyBase := &Schema{Version: 1, Fields: []FieldDef{{Name: "t", Type: OperateTypeTable,
+		Table: &TableDef{KeyType: OperateTypeFixed, KeyN: 4}}}}
+	keyNewer := &Schema{Version: 2, Fields: []FieldDef{{Name: "t", Type: OperateTypeTable,
+		Table: &TableDef{KeyType: OperateTypeFixed, KeyN: 5}}}}
+	if err := keyBase.Extends(keyNewer); !errors.Is(err, ErrOperateSchema) {
+		t.Fatalf("a changed FIXED key width: err = %v, want ErrOperateSchema", err)
+	}
+	colBase := &Schema{Version: 1, Fields: []FieldDef{{Name: "t", Type: OperateTypeTable,
+		Table: &TableDef{KeyType: OperateTypeU8, Cols: []ColumnDef{{Type: OperateTypeFixed, N: 4}}}}}}
+	colNewer := &Schema{Version: 2, Fields: []FieldDef{{Name: "t", Type: OperateTypeTable,
+		Table: &TableDef{KeyType: OperateTypeU8, Cols: []ColumnDef{{Type: OperateTypeFixed, N: 5}}}}}}
+	if err := colBase.Extends(colNewer); !errors.Is(err, ErrOperateSchema) {
+		t.Fatalf("a changed FIXED column width: err = %v, want ErrOperateSchema", err)
+	}
+}

--- a/sdk/wire/operate_schema_test.go
+++ b/sdk/wire/operate_schema_test.go
@@ -1,0 +1,139 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package wire
+
+import (
+	"bytes"
+	"reflect"
+	"testing"
+)
+
+func sessionSchema() *Schema {
+	return &Schema{Version: 1, Fields: []FieldDef{
+		{Name: "rc", Type: OperateTypeU8}, {Name: "bc", Type: OperateTypeU8}, {Name: "hist", Type: OperateTypeU32},
+		{Name: "b", Type: OperateTypeTable, Table: &TableDef{KeyType: OperateTypeU64, Cols: []ColumnDef{
+			{Name: "c", Type: OperateTypeU16}, {Name: "hi", Type: OperateTypeI64}, {Name: "t", Type: OperateTypeU32}},
+			Cap: 1024, Policy: OperatePolicyMinCol, ByCol: 2}},
+	}}
+}
+
+func TestSchemaRoundtripAndSize(t *testing.T) {
+	s := sessionSchema()
+	b := s.Encode()
+	if len(b) > 20 {
+		t.Fatalf("session schema is %d bytes, expected ≤ 20", len(b))
+	}
+	got, n, err := DecodeSchema(b)
+	if err != nil || n != len(b) {
+		t.Fatal(err, n)
+	}
+	if got.Version != 1 || len(got.Fields) != 4 || got.Fields[3].Table.Cap != 1024 || got.Fields[3].Table.ByCol != 2 {
+		t.Fatalf("%+v", got)
+	}
+	if got.Fields[0].Name != "" {
+		t.Fatal("names stored without StoreNames")
+	}
+	s.StoreNames = true
+	got, _, _ = DecodeSchema(s.Encode())
+	if got.Fields[3].Table.Cols[2].Name != "t" {
+		t.Fatal("names not stored")
+	}
+}
+
+func TestSchemaLayout(t *testing.T) {
+	s := &Schema{Version: 1, Fields: []FieldDef{
+		{Type: OperateTypeU8}, {Type: OperateTypeBytes}, {Type: OperateTypeU32}, {Type: OperateTypeFixed, N: 3},
+		{Type: OperateTypeTable, Table: &TableDef{KeyType: OperateTypeFixed, KeyN: 2, Cols: []ColumnDef{{Type: OperateTypeU16}, {Type: OperateTypeF64}}}},
+		{Type: OperateTypeUVarint},
+	}}
+	l, err := s.Layout()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(l.FixedOff, []int{0, -1, 1, 5, -1, -1}) || l.FixedLen != 8 {
+		t.Fatalf("%+v", l)
+	}
+	if !reflect.DeepEqual(l.VarTail, []int{1, 4, 5}) {
+		t.Fatalf("tail %v", l.VarTail)
+	}
+	if tl := l.Tables[4]; tl.KeyWidth != 2 || tl.RowWidth != 12 || !reflect.DeepEqual(tl.ColOff, []int{2, 4}) {
+		t.Fatalf("%+v", tl)
+	}
+}
+
+func TestSchemaValidate(t *testing.T) {
+	bad := []*Schema{
+		{Fields: []FieldDef{{Type: OperateTypeTable, Table: &TableDef{KeyType: OperateTypeU64, Cols: []ColumnDef{{Type: OperateTypeBytes}}}}}}, // variable column
+		{Fields: []FieldDef{{Type: OperateTypeTable, Table: &TableDef{KeyType: OperateTypeBytes}}}},                                            // variable key
+		{Fields: []FieldDef{{Type: OperateTypeTable, Table: &TableDef{KeyType: OperateTypeU8, Policy: OperatePolicyMinCol, ByCol: 3}}}},        // byCol out of range
+		{Fields: []FieldDef{{Type: OperateTypeFixed, N: 0}}},                                                                                   // FIXED(0)
+		{Fields: []FieldDef{{Type: OperateTypeUnset}}},                                                                                         // UNSET declared
+		{Fields: []FieldDef{{Type: OperateTypeTable, Table: &TableDef{KeyType: OperateTypeU8, Cap: OperateMaxRows + 1}}}},                      // cap above hard max
+	}
+	for i, s := range bad {
+		if err := s.Validate(); err == nil {
+			t.Errorf("case %d accepted", i)
+		}
+	}
+	if err := sessionSchema().Validate(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestSchemaExtends(t *testing.T) {
+	old := sessionSchema()
+	ok := sessionSchema()
+	ok.Version = 2
+	ok.Fields = append(ok.Fields, FieldDef{Name: "x", Type: OperateTypeI16})
+	ok.Fields[3].Table.Cols = append(ok.Fields[3].Table.Cols, ColumnDef{Name: "n", Type: OperateTypeU8})
+	ok.Fields[3].Table.Cap = 512
+	if err := old.Extends(ok); err != nil {
+		t.Fatal(err)
+	}
+	for i, mut := range []func(s *Schema){
+		func(s *Schema) { s.Fields[0].Type = OperateTypeU16 },          // widened type
+		func(s *Schema) { s.Fields = s.Fields[:3] },                    // dropped field
+		func(s *Schema) { s.Fields[3].Table.KeyType = OperateTypeU32 }, // key type change
+		func(s *Schema) { s.Version = 1 },                              // version not increased
+	} {
+		n := sessionSchema()
+		n.Version = 2
+		mut(n)
+		if err := old.Extends(n); err == nil {
+			t.Errorf("mutation %d accepted", i)
+		}
+	}
+}
+
+func TestDecodeSchemaHostile(t *testing.T) {
+	for _, b := range [][]byte{{}, {1, 0}, {1, 0, 0, 0xFF}, {1, 0, 0, 1, OperateTypeTable, OperateTypeU8, 0xFF, 0xFF, 0xFF, 0xFF, 0x0F}} {
+		if _, _, err := DecodeSchema(b); err == nil {
+			t.Errorf("%x accepted", b)
+		}
+	}
+}
+
+func FuzzDecodeSchema(f *testing.F) {
+	f.Add(sessionSchema().Encode())
+	s := sessionSchema()
+	s.StoreNames = true
+	f.Add(s.Encode())
+	f.Fuzz(func(t *testing.T, b []byte) {
+		s, n, err := DecodeSchema(b)
+		if err != nil {
+			return
+		}
+		if n > len(b) {
+			t.Fatal("over-read")
+		}
+		if err := s.Validate(); err != nil {
+			t.Fatalf("decoded schema fails Validate: %v", err)
+		}
+		if _, err := s.Layout(); err != nil {
+			t.Fatal(err)
+		}
+		if !bytes.Equal(s.Encode(), b[:n]) {
+			t.Fatal("re-encode differs")
+		}
+	})
+}

--- a/sdk/wire/operate_schema_test.go
+++ b/sdk/wire/operate_schema_test.go
@@ -4,6 +4,8 @@ package wire
 
 import (
 	"bytes"
+	"encoding/binary"
+	"errors"
 	"reflect"
 	"testing"
 )
@@ -136,4 +138,54 @@ func FuzzDecodeSchema(f *testing.F) {
 			t.Fatal("re-encode differs")
 		}
 	})
+}
+
+// TestDecodeSchemaHostileCounts covers the field and column counts against
+// the schema-blob budget. DecodeSchema is handed the whole stored record —
+// up to maxRecordBytes — not just the blob, so CountFitsIn against the bytes
+// remaining is not on its own a bound: a declared 65535 fields inside a
+// megabyte-long record passes it and sizes a multi-megabyte slice. Every
+// field and column costs at least one byte of a blob that can never legally
+// exceed OperateMaxSchemaBytes, so the count is bounded by that too, before
+// the allocation.
+func TestDecodeSchemaHostileCounts(t *testing.T) {
+	// [version u16][flags 0][nFields = 65535][65535+ filler bytes], every
+	// filler byte a valid U8 field type, so nothing but the budget check
+	// stops this from being parsed in full.
+	blob := []byte{1, 0, 0}
+	blob = binary.AppendUvarint(blob, OperateMaxFields)
+	blob = append(blob, make([]byte, OperateMaxFields+16)...)
+	if _, _, err := DecodeSchema(blob); !errors.Is(err, ErrOperateSchema) {
+		t.Fatalf("hostile nFields: err = %v, want ErrOperateSchema", err)
+	}
+	if n := testing.AllocsPerRun(20, func() { _, _, _ = DecodeSchema(blob) }); n > 2 {
+		t.Fatalf("hostile nFields allocated %v times; the count must be bounded before the make", n)
+	}
+
+	// The same shape one level down: one TABLE field declaring 65535
+	// columns, with enough filler to satisfy CountFitsIn.
+	cols := []byte{1, 0, 0, 1, OperateTypeTable, OperateTypeU8}
+	cols = binary.AppendUvarint(cols, OperateMaxCols)
+	cols = append(cols, make([]byte, OperateMaxCols+16)...)
+	if _, _, err := DecodeSchema(cols); !errors.Is(err, ErrOperateSchema) {
+		t.Fatalf("hostile nCols: err = %v, want ErrOperateSchema", err)
+	}
+	if n := testing.AllocsPerRun(20, func() { _, _, _ = DecodeSchema(cols) }); n > 3 {
+		t.Fatalf("hostile nCols allocated %v times; the count must be bounded before the make", n)
+	}
+
+	// A schema at the far side of the budget still decodes: the bound is the
+	// blob budget, not a smaller number picked to make the test pass.
+	s := &Schema{Version: 3, Fields: make([]FieldDef, 1000)}
+	for i := range s.Fields {
+		s.Fields[i].Type = OperateTypeU8
+	}
+	enc := s.Encode()
+	if len(enc) > OperateMaxSchemaBytes {
+		t.Fatalf("fixture schema is %d bytes, over the %d-byte budget", len(enc), OperateMaxSchemaBytes)
+	}
+	got, n, err := DecodeSchema(enc)
+	if err != nil || n != len(enc) || len(got.Fields) != 1000 {
+		t.Fatalf("a legal 1000-field schema must decode: %v (n=%d)", err, n)
+	}
 }

--- a/sdk/wire/operate_test.go
+++ b/sdk/wire/operate_test.go
@@ -265,3 +265,58 @@ func TestDecodeOperateArgsErrorIdentity(t *testing.T) {
 		t.Fatalf("nRet within the cap but past the byte budget: err = %v, want ErrShortArgs", err)
 	}
 }
+
+// TestOperateRetModeValidated covers the return-spec mode byte at both ends
+// of the codec. The apply engine has no branch for a mode outside
+// OperateRet*, so encoding one would ship a frame that can only be rejected
+// server side, and accepting one on decode would hand the caller a spec it
+// cannot act on — and break the decode/re-encode identity, since the encoder
+// now refuses what the decoder produced.
+func TestOperateRetModeValidated(t *testing.T) {
+	a := sampleArgs()
+	a.Rets = []OperateRet{{Mode: OperateRetCount + 1, Path: OperatePath{Kind: OperatePathRecord}}}
+	if _, err := EncodeOperateArgs(a); !errors.Is(err, ErrOperateArgs) {
+		t.Fatalf("encode: err = %v, want ErrOperateArgs", err)
+	}
+	for _, mode := range []uint8{OperateRetValue, OperateRetCount} {
+		a.Rets[0].Mode = mode
+		if _, err := EncodeOperateArgs(a); err != nil {
+			t.Fatalf("encode mode %d: %v", mode, err)
+		}
+	}
+
+	// Decode: patch the ret mode byte of a well-formed frame in place. The
+	// rets are last, and a record-path ret is two bytes, so the mode byte is
+	// the second-to-last.
+	a.Rets[0].Mode = OperateRetCount
+	b, err := EncodeOperateArgs(a)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := DecodeOperateArgs(b); err != nil {
+		t.Fatalf("the unpatched frame must decode: %v", err)
+	}
+	b[len(b)-2] = OperateRetCount + 1
+	if _, err := DecodeOperateArgs(b); !errors.Is(err, ErrOperateArgs) {
+		t.Fatalf("decode: err = %v, want ErrOperateArgs", err)
+	}
+}
+
+// TestDecodeOperateResultCountErrors covers the result frame's declared
+// count, split the same way DecodeOperateArgs splits its own: over the cap is
+// a frame declaring more values than a call may return, over the byte budget
+// is a truncated or lying frame.
+func TestDecodeOperateResultCountErrors(t *testing.T) {
+	over := []byte{OperateStatusOK, 0, 0}
+	binary.BigEndian.PutUint16(over[1:], OperateMaxRet+1)
+	over = append(over, make([]byte, (OperateMaxRet+1)*4)...)
+	if _, err := DecodeOperateResult(over); !errors.Is(err, ErrOperateCap) {
+		t.Fatalf("nRet over the cap: err = %v, want ErrOperateCap", err)
+	}
+
+	short := []byte{OperateStatusOK, 0, 0}
+	binary.BigEndian.PutUint16(short[1:], OperateMaxRet)
+	if _, err := DecodeOperateResult(short); !errors.Is(err, ErrShortArgs) {
+		t.Fatalf("nRet within the cap but past the byte budget: err = %v, want ErrShortArgs", err)
+	}
+}

--- a/sdk/wire/operate_test.go
+++ b/sdk/wire/operate_test.go
@@ -1,0 +1,117 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package wire
+
+import (
+	"encoding/binary"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+)
+
+func sampleArgs() *OperateArgs {
+	return &OperateArgs{Key: []byte("session:42"), TTL: 90 * time.Second, TTLMode: OperateTTLCreateOnly, Create: OperateCreateSchema,
+		Schema: sessionSchema().Encode(),
+		Ops: []OperateOp{
+			{Opcode: OperateOpIF, Aux: OperateCmpGE, Path: OperatePath{Kind: OperatePathField, Field: OperateSeg{Pos: 0}}, A: 255, B: 2},
+			{Opcode: OperateOpSHR, Type: OperateTypeFromSchema, Path: OperatePath{Kind: OperatePathField, Field: OperateSeg{Pos: 0}}, A: 1},
+			{Opcode: OperateOpADD, Type: OperateTypeFromSchema, Path: OperatePath{Kind: OperatePathCol, Field: OperateSeg{Pos: 3}, Key: []byte{1, 0, 0, 0, 0, 0, 0, 0}, Col: OperateSeg{Pos: 0}}, A: 1},
+			{Opcode: OperateOpSET, Type: OperateTypeBytes, Path: OperatePath{Kind: OperatePathField, Field: OperateSeg{ByName: true, Name: "name"}}, Bytes: []byte("v")},
+		},
+		Rets: []OperateRet{{Mode: OperateRetValue, Path: OperatePath{Kind: OperatePathRecord}}, {Mode: OperateRetCount, Path: OperatePath{Kind: OperatePathField, Field: OperateSeg{Pos: 3}}}}}
+}
+
+func TestOperateArgsRoundtrip(t *testing.T) {
+	a := sampleArgs()
+	b, err := EncodeOperateArgs(a)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, err := DecodeOperateArgs(b)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(got, a) {
+		t.Fatalf("\n got %+v\nwant %+v", got, a)
+	}
+}
+
+func TestOperateArgsLimits(t *testing.T) {
+	a := sampleArgs()
+	a.Ops = make([]OperateOp, OperateMaxOps+1)
+	if _, err := EncodeOperateArgs(a); err == nil {
+		t.Fatal("too many ops encoded")
+	}
+	a = sampleArgs()
+	a.Ops[0].Path.Field = OperateSeg{ByName: true, Name: strings.Repeat("x", 256)}
+	if _, err := EncodeOperateArgs(a); err == nil {
+		t.Fatal("long name encoded")
+	}
+	a = sampleArgs()
+	a.Ops[0].Bytes = make([]byte, 65536)
+	if _, err := EncodeOperateArgs(a); err == nil {
+		t.Fatal("long bytes encoded")
+	}
+}
+
+func TestDecodeOperateArgsTruncation(t *testing.T) {
+	b, _ := EncodeOperateArgs(sampleArgs())
+	for i := 0; i < len(b); i++ {
+		if _, err := DecodeOperateArgs(b[:i]); err == nil {
+			t.Fatalf("prefix %d accepted", i)
+		}
+	}
+}
+
+func TestDecodeOperateArgsHostileCounts(t *testing.T) {
+	b, _ := EncodeOperateArgs(&OperateArgs{Key: []byte("k"), Create: OperateCreateDynamic})
+	// nOps sits after key(3)+ttl(8)+ttlMode(1)+create(1)+schemaLen(2)
+	off := 2 + 1 + 8 + 1 + 1 + 2
+	binary.BigEndian.PutUint16(b[off:], 0xFFFF)
+	if _, err := DecodeOperateArgs(b); err == nil {
+		t.Fatal("hostile nOps accepted")
+	}
+	b, _ = EncodeOperateArgs(&OperateArgs{Key: []byte("k"), Create: OperateCreateDynamic})
+	b[2+1+8+1] = 5 // the create byte (after keyLen, key, ttlMs, ttlMode)
+	if _, err := DecodeOperateArgs(b); err == nil {
+		t.Fatal("bad create accepted")
+	}
+}
+
+func TestOperateResultRoundtrip(t *testing.T) {
+	r := &OperateResult{Status: OperateStatusCheckFailed, FailedOp: 3, Values: [][]byte{AppendTaggedCell(nil, Cell{Type: OperateTypeU8, U: 9}), {OperateTypeUnset}}}
+	got, err := DecodeOperateResult(EncodeOperateResult(r))
+	if err != nil || !reflect.DeepEqual(got, r) {
+		t.Fatalf("%+v %v", got, err)
+	}
+	ok := &OperateResult{Status: OperateStatusOK, Values: [][]byte{}}
+	got, _ = DecodeOperateResult(EncodeOperateResult(ok))
+	if got.Status != OperateStatusOK || got.FailedOp != 0 {
+		t.Fatal(got)
+	}
+	if _, err := DecodeOperateResult([]byte{OperateStatusOK, 0xFF, 0xFF}); err == nil {
+		t.Fatal("hostile nRet accepted")
+	}
+}
+
+func FuzzDecodeOperateArgs(f *testing.F) {
+	b, _ := EncodeOperateArgs(sampleArgs())
+	f.Add(b)
+	f.Add([]byte{})
+	f.Add([]byte{0, 1})
+	f.Fuzz(func(t *testing.T, b []byte) {
+		a, err := DecodeOperateArgs(b)
+		if err != nil {
+			return
+		}
+		b2, err := EncodeOperateArgs(a)
+		if err != nil {
+			t.Fatal("decoded args do not re-encode:", err)
+		}
+		a2, err := DecodeOperateArgs(b2)
+		if err != nil || !reflect.DeepEqual(a, a2) {
+			t.Fatal("not stable")
+		}
+	})
+}

--- a/sdk/wire/operate_test.go
+++ b/sdk/wire/operate_test.go
@@ -4,6 +4,7 @@ package wire
 
 import (
 	"encoding/binary"
+	"errors"
 	"reflect"
 	"strings"
 	"testing"
@@ -81,12 +82,20 @@ func TestDecodeOperateArgsHostileCounts(t *testing.T) {
 
 func TestOperateResultRoundtrip(t *testing.T) {
 	r := &OperateResult{Status: OperateStatusCheckFailed, FailedOp: 3, Values: [][]byte{AppendTaggedCell(nil, Cell{Type: OperateTypeU8, U: 9}), {OperateTypeUnset}}}
-	got, err := DecodeOperateResult(EncodeOperateResult(r))
+	enc, err := EncodeOperateResult(r)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, err := DecodeOperateResult(enc)
 	if err != nil || !reflect.DeepEqual(got, r) {
 		t.Fatalf("%+v %v", got, err)
 	}
 	ok := &OperateResult{Status: OperateStatusOK, Values: [][]byte{}}
-	got, _ = DecodeOperateResult(EncodeOperateResult(ok))
+	enc, err = EncodeOperateResult(ok)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, _ = DecodeOperateResult(enc)
 	if got.Status != OperateStatusOK || got.FailedOp != 0 {
 		t.Fatal(got)
 	}
@@ -114,4 +123,71 @@ func FuzzDecodeOperateArgs(f *testing.F) {
 			t.Fatal("not stable")
 		}
 	})
+}
+
+// TestEncodeOperateArgsNegativeTTL covers a negative duration, which has no
+// wire encoding: ttlMs is an unsigned 64-bit millisecond count, so
+// converting one would wrap into a ~584-million-year TTL rather than the
+// expiry the caller asked for.
+func TestEncodeOperateArgsNegativeTTL(t *testing.T) {
+	a := sampleArgs()
+	a.TTL = -time.Second
+	if _, err := EncodeOperateArgs(a); !errors.Is(err, ErrOperateArgs) {
+		t.Fatalf("err = %v, want ErrOperateArgs", err)
+	}
+	a.TTL = 0
+	if _, err := EncodeOperateArgs(a); err != nil {
+		t.Fatalf("a zero TTL must still encode: %v", err)
+	}
+	// A sub-millisecond positive duration truncates to zero rather than
+	// erroring — it is representable, just rounded.
+	a.TTL = time.Microsecond
+	if _, err := EncodeOperateArgs(a); err != nil {
+		t.Fatalf("a sub-millisecond TTL must still encode: %v", err)
+	}
+}
+
+// TestEncodeOperateResultLimits covers the two frames the result encoder
+// cannot honestly represent: more values than nRet's uint16 (and
+// OperateMaxRet) can count, and a status byte DecodeOperateResult would not
+// accept back.
+func TestEncodeOperateResultLimits(t *testing.T) {
+	over := &OperateResult{Status: OperateStatusOK, Values: make([][]byte, OperateMaxRet+1)}
+	if _, err := EncodeOperateResult(over); !errors.Is(err, ErrOperateCap) {
+		t.Fatalf("err = %v, want ErrOperateCap", err)
+	}
+	at := &OperateResult{Status: OperateStatusOK, Values: make([][]byte, OperateMaxRet)}
+	b, err := EncodeOperateResult(at)
+	if err != nil {
+		t.Fatalf("exactly OperateMaxRet values must encode: %v", err)
+	}
+	got, err := DecodeOperateResult(b)
+	if err != nil || len(got.Values) != OperateMaxRet {
+		t.Fatalf("round trip at the cap: %+v %v", got, err)
+	}
+	if _, err := EncodeOperateResult(&OperateResult{Status: 7}); !errors.Is(err, ErrOperateArgs) {
+		t.Fatalf("unknown status encoded: err = %v, want ErrOperateArgs", err)
+	}
+}
+
+// TestDecodeOperateResultUnknownStatus covers the decode side of the same
+// rule. The status byte selects the frame's shape — only
+// OperateStatusCheckFailed carries failedOp — so an unknown one cannot be
+// parsed past, and accepting it would hand the caller a status it has no
+// branch for.
+func TestDecodeOperateResultUnknownStatus(t *testing.T) {
+	for _, status := range []byte{2, 3, 0xFF} {
+		if _, err := DecodeOperateResult([]byte{status, 0, 0}); !errors.Is(err, ErrOperateArgs) {
+			t.Fatalf("status %d: err = %v, want ErrOperateArgs", status, err)
+		}
+	}
+	for _, status := range []uint8{OperateStatusOK, OperateStatusCheckFailed} {
+		b, err := EncodeOperateResult(&OperateResult{Status: status})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if _, err := DecodeOperateResult(b); err != nil {
+			t.Fatalf("status %d rejected: %v", status, err)
+		}
+	}
 }

--- a/sdk/wire/operate_test.go
+++ b/sdk/wire/operate_test.go
@@ -5,6 +5,7 @@ package wire
 import (
 	"encoding/binary"
 	"errors"
+	"math"
 	"reflect"
 	"strings"
 	"testing"
@@ -189,5 +190,78 @@ func TestDecodeOperateResultUnknownStatus(t *testing.T) {
 		if _, err := DecodeOperateResult(b); err != nil {
 			t.Fatalf("status %d rejected: %v", status, err)
 		}
+	}
+}
+
+// TestDecodeOperateArgsErrorIdentity pins which error each rejection
+// reports. The client turns these into a status the caller branches on, so
+// "over a cap" and "the frame is short" must not collapse into one another:
+//
+//   - a path position past the uint32 an OperateSeg addresses with is
+//     ErrOperateArgs (the frame is complete, its content is out of range),
+//   - nOps/nRet over OperateMaxOps/OperateMaxRet is ErrOperateCap,
+//   - nOps/nRet the remaining bytes cannot hold is still ErrShortArgs.
+func TestDecodeOperateArgsErrorIdentity(t *testing.T) {
+	// One op whose field seg is a by-position segment holding 2^32, which is
+	// one past the largest addressable position.
+	frame := func(pos uint64) []byte {
+		b := binary.BigEndian.AppendUint16(nil, 1) // keyLen
+		b = append(b, 'k')
+		b = binary.BigEndian.AppendUint64(b, 0)          // ttlMs
+		b = append(b, OperateTTLKeep, OperateCreateNone) // ttlMode, create
+		b = binary.BigEndian.AppendUint16(b, 0)          // schemaLen
+		b = binary.BigEndian.AppendUint16(b, 1)          // nOps
+		b = append(b, OperateOpADD, OperateTypeU64, 0)   // opcode, type, aux
+		b = append(b, OperatePathField, 0)               // path kind, seg kind = by position
+		b = binary.AppendUvarint(b, pos)
+		b = binary.BigEndian.AppendUint64(b, 1)    // a
+		b = binary.BigEndian.AppendUint64(b, 0)    // b
+		b = binary.BigEndian.AppendUint16(b, 0)    // blen
+		return binary.BigEndian.AppendUint16(b, 0) // nRet
+	}
+	if _, err := DecodeOperateArgs(frame(math.MaxUint32 + 1)); !errors.Is(err, ErrOperateArgs) {
+		t.Fatalf("out-of-range seg position: err = %v, want ErrOperateArgs", err)
+	}
+	// The largest position that IS addressable decodes, so the case above is
+	// failing on the range and not on the frame.
+	got, err := DecodeOperateArgs(frame(math.MaxUint32))
+	if err != nil {
+		t.Fatalf("seg position at MaxUint32: %v", err)
+	}
+	if got.Ops[0].Path.Field.Pos != math.MaxUint32 {
+		t.Fatalf("pos = %d", got.Ops[0].Path.Field.Pos)
+	}
+
+	// nOps and nRet over their caps, each in a frame long enough that
+	// CountFitsIn would otherwise be satisfied. An over-cap count is
+	// unencodable — EncodeOperateArgs refuses it — so it only ever arrives in
+	// hostile input, which is exactly why the error has to say "cap".
+	base, err := EncodeOperateArgs(&OperateArgs{Key: []byte("k"), Create: OperateCreateDynamic})
+	if err != nil {
+		t.Fatal(err)
+	}
+	nOpsOff := 2 + 1 + 8 + 1 + 1 + 2
+	over := append(append([]byte(nil), base...), make([]byte, (OperateMaxOps+1)*minOpBytes)...)
+	binary.BigEndian.PutUint16(over[nOpsOff:], OperateMaxOps+1)
+	if _, err := DecodeOperateArgs(over); !errors.Is(err, ErrOperateCap) {
+		t.Fatalf("nOps over the cap: err = %v, want ErrOperateCap", err)
+	}
+	overRet := append(append([]byte(nil), base...), make([]byte, (OperateMaxRet+1)*minRetBytes)...)
+	binary.BigEndian.PutUint16(overRet[nOpsOff+2:], OperateMaxRet+1) // nRet, with nOps = 0 before it
+	if _, err := DecodeOperateArgs(overRet); !errors.Is(err, ErrOperateCap) {
+		t.Fatalf("nRet over the cap: err = %v, want ErrOperateCap", err)
+	}
+
+	// A count under the cap that the remaining bytes cannot hold is still a
+	// short frame, not a cap hit.
+	short := append([]byte(nil), base...)
+	binary.BigEndian.PutUint16(short[nOpsOff:], OperateMaxOps)
+	if _, err := DecodeOperateArgs(short); !errors.Is(err, ErrShortArgs) {
+		t.Fatalf("nOps within the cap but past the byte budget: err = %v, want ErrShortArgs", err)
+	}
+	shortRet := append([]byte(nil), base...)
+	binary.BigEndian.PutUint16(shortRet[nOpsOff+2:], OperateMaxRet)
+	if _, err := DecodeOperateArgs(shortRet); !errors.Is(err, ErrShortArgs) {
+		t.Fatalf("nRet within the cap but past the byte budget: err = %v, want ErrShortArgs", err)
 	}
 }


### PR DESCRIPTION
## Summary

`operate` is a built-in KV op that applies a list of typed field updates to one record atomically, server-side, in a single round-trip — the primitive for a hot key that many callers update in parallel, where a client CAS-retry loop livelocks. The op-list is data, so the update logic stays in the application and adding a counter never rebuilds Rostam.

This supersedes the draft in #96 (v1), whose record model and opcodes were shaped around one session-cache workload. v2 is general-purpose: a record + table value model in two per-record encodings, a small composable op vocabulary, and a byte-patching apply path that never materializes a tree.

## Data model

- A record is a struct of typed fields; a field may be a **table** of keyed, fixed-width rows sharing one row schema. Depth is exactly record → table → row → column.
- **Schema mode**: a client-defined, versioned schema is stored once; values are packed with nothing per value; rows are sorted and binary-searchable. 22–24 bytes per session row versus 40 in v1. Evolution is an explicit append-only `MIGRATE`; a version mismatch is an error.
- **Dynamic mode**: every field and column is stored as `[name][type][data]`; anything can be added by name at any time; `MIGRATE` can freeze a dynamic record into a schema.
- Eviction is an explicit, optional table property (`cap` + `MIN_KEY`/`MAX_KEY`/`MIN_COL`/`MAX_COL`), which gives LRU, LFU, top-N and FIFO as recipes; `cap = 0` is unbounded. Caps error, never evict.

## Ops

`SET DEL ADD MUL MIN MAX AND OR XOR SHL SHR STAMP` on any field or row column (ints saturate, bit ops mask to width, `STAMP` writes the leader apply clock), `MIGRATE CONFIG TRIM` on tables, and `IF`/`CHECK` for conditional application and server-side compare-and-update. Returns are typed and self-describing. `ttlMode` is `KEEP` / `SET` / `CREATE_ONLY`.

## Determinism and hardening

The only clock is `tx.applyStamp()`; stored bytes are a pure function of the record (sorted rows and names, canonical varints, canonical NaN); integer math saturates. Every decoder bounds counts before allocation and truncation-checks every read; the engines validate stored bytes structurally and never panic on hostile input (a plain `put` can store anything under the key); all size math is 64-bit before a cap check.

## Implementation

- `sdk/wire` (engine-free leaf): constants, typed cell codec, scalar math, schema blob/layout/`Extends`, record tree codec, args/result codec.
- `ops`: a test-only **tree oracle** defines the semantics (`Ruling:` comments); a generic apply loop over an `engine` interface; schema-mode and dynamic-mode byte engines; `applyRecordBytes`; the `handleOperate` handler with TTL modes; registration in both builtin tables; hostile-sweep entries.
- `client`: `Client.Operate` and a typed op-list builder (`client.NewOperate(key).WithSchema(s).Add(...)`).
- `docs/kv/overview.md` section + `custom-ops.md` pointer; changelog entry.

## Verification

- Both byte engines are held to the oracle by property tests that compare results, bytes, and **error identity** (2000×5 in CI; 200k×5 ad hoc, zero divergence), plus a cross-mode equivalence test and the semantics suite run through the real handler.
- Hostile-bytes no-panic tests over every prefix and every single-byte mutation of valid records; three fuzzers; linux/386 and `-race -short` lanes; full suite green.
- Allocation guards: 2 allocs per in-place call. Benchmarks (laptop, `-cpu 1`): schema in-place 4.3 µs, insert+evict 11 µs, dynamic 52 µs, tree strategy 297 µs / 2,097 allocs.

## Notes for review

- Closes the design gap in #96; #96 can be closed once this merges.
- Two pre-existing `golangci-lint` findings in `client/client.go:213/745` are untouched.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the built-in `operate` op for atomic multi-field updates on a single record, with schema and dynamic storage modes. This supersedes the draft operate v1 and includes a Go client API.

**New Features**
- Applies counters, conditional checks, and table operations (including eviction policies) atomically under the shard lock in one round trip.
- Dynamic mode stores fields self-describing, so any op can add a new named field; `MIGRATE` can freeze a dynamic record into schema mode.
- Go client gains `Client.Operate` and a typed op-list builder (`client.NewOperate(key).WithSchema(s).Add(...)`).

**Behavior changes**
- `operate` is non-replayable like `incr_ex`, so ambiguous post-commit failures surface an error instead of double-applying increments on blind replay.
- Malformed inputs — invalid FIXED widths, non-canonical NaN, negative TTLs, oversized stored records — fail before allocation; schema decode bounds aggregate allocation, and `MIGRATE` validates its schema client-side.
- Schema evolution compares FIXED width only where it's meaningful, and dynamic tables with a column eviction policy must name the eviction column.
- The client builder rejects mixing schema and dynamic modes, requires `MIGRATE` first, and rejects a column path without a row key.
- Wire decoding returns distinct contract errors for out-of-range values versus over-limit op/return counts.

<sup>Written for commit fead29509c40edfb900c5b712d0825e3643f4e3b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rostamlabs/rostam/pull/97?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the `operate` operation for atomic multi-field record updates.
  * Supports scalar and table updates, counters, conditionals, compare-and-swap checks, TTLs, eviction policies, value/count returns, and record deletion.
  * Added schema-based and dynamic records, including migration from dynamic to schema mode.
  * Added Go client builders and wire support for constructing and decoding operate requests and results.
* **Bug Fixes**
  * Prevented automatic retries of non-idempotent `operate` requests after ambiguous failures.
* **Documentation**
  * Added comprehensive `operate` usage and behavior documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->