### PR TITLE
test(ops): skip the operate allocation-budget tests under -race

### DIFF
--- a/ops/norace_detect_test.go
+++ b/ops/norace_detect_test.go
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build !race
+
+package ops
+
+// raceEnabled is false in normal (non -race) builds.
+const raceEnabled = false

--- a/ops/operate_dynamic_engine_test.go
+++ b/ops/operate_dynamic_engine_test.go
@@ -277,7 +277,19 @@ func dynamicArgsFor(key []byte) *wire.OperateArgs {
 // exactly the cost the byte engine exists to avoid. The bound is the measured
 // figure, not a round number above it: slack here is coverage given away,
 // since a new per-call allocation would slip in under it unnoticed.
+//
+// Skipped under -race: the engine comes from dynamicEnginePool (sync.Pool),
+// and the race detector's sync.Pool.Put randomly drops about a quarter of
+// puts on the floor by design (see sync/pool.go's "Randomly drop x on floor",
+// gated on race.Enabled) specifically so pool-reliant code can't assume
+// retention. That is not a GC or timing flake this test can wait out — the
+// stdlib does it on purpose every run — so the budget is meaningless under
+// -race and is checked only in normal builds, where Get reliably returns
+// what the prior call Put back.
 func TestDynamicEngineAllocs(t *testing.T) {
+	if raceEnabled {
+		t.Skip("sync.Pool.Put randomly drops items under -race by design, which defeats this allocation budget; see race_detect_test.go")
+	}
 	rec := bigDynamicRecord(t, 1024)
 	a := dynamicArgsFor(keyU64(512))
 	a.Rets = nil

--- a/ops/operate_schema_engine_test.go
+++ b/ops/operate_schema_engine_test.go
@@ -115,7 +115,19 @@ func sessionArgsFor(key []byte) *wire.OperateArgs {
 // path: one allocation for the record copy and one for the result frame. A
 // regression here means the engine started building something per call —
 // exactly the cost the byte engine exists to avoid.
+//
+// Skipped under -race: the engine comes from schemaEnginePool (sync.Pool),
+// and the race detector's sync.Pool.Put randomly drops about a quarter of
+// puts on the floor by design (see sync/pool.go's "Randomly drop x on floor",
+// gated on race.Enabled) specifically so pool-reliant code can't assume
+// retention. That is not a GC or timing flake this test can wait out — the
+// stdlib does it on purpose every run — so the budget is meaningless under
+// -race and is checked only in normal builds, where Get reliably returns
+// what the prior call Put back.
 func TestSchemaEngineAllocs(t *testing.T) {
+	if raceEnabled {
+		t.Skip("sync.Pool.Put randomly drops items under -race by design, which defeats this allocation budget; see race_detect_test.go")
+	}
 	rec := bigSessionRecord(t, 1024)
 	a := sessionArgsFor(keyU64(512))
 	a.Rets = nil

--- a/ops/race_detect_test.go
+++ b/ops/race_detect_test.go
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build race
+
+package ops
+
+// raceEnabled is true in -race builds. The race detector's own sync.Pool.Put
+// randomly drops ~1/4 of items on the floor (see sync/pool.go) specifically
+// so pool-reliant code cannot assume retention across a Get/Put pair — which
+// is exactly what the operate allocation-budget tests rely on. See
+// TestDynamicEngineAllocs and TestSchemaEngineAllocs.
+const raceEnabled = true


### PR DESCRIPTION
`TestDynamicEngineAllocs` and `TestSchemaEngineAllocs` fail intermittently under the race detector (about 1 in 3 locally; 3/3 reruns on #98's race lane). Both measure the `operate` engines' allocation budget with `testing.AllocsPerRun`, and both engines come from a `sync.Pool`.

The cause is not GC timing: instrumenting the pool showed no GC during the measured window. Go's `sync.Pool.Put` intentionally drops about a quarter of puts on the floor when the race detector is enabled (`sync/pool.go`, gated on `race.Enabled`) so pool-reliant code cannot assume retention across a Get/Put pair. Every dropped put costs one `New()` on the next call, which is a third allocation the budget correctly rejects. Pinning GC off cannot change that; it happens on purpose every run.

This skips both tests under `-race` using the `raceEnabled` build-tag pattern the root, server, httpapi, inttest, shard and cluster packages already use, with a comment explaining why. The `<= 2` bound is unchanged and still enforced in the normal and 32-bit lanes, where `Get` reliably returns what the previous call put back.

Verification: `go test -race ./ops/ -run Allocs -count=20` 20/20 (skipped); `go test ./ops/ -run Allocs -count=5` and `GOARCH=386 … -count=3` all pass and still log "allocations per apply: 2"; vet and golangci-lint clean. Test-only, no changelog entry (ops/ is outside the changelog check's watched paths).


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes intermittent failures of `TestDynamicEngineAllocs` and `TestSchemaEngineAllocs` under `-race` by skipping them in that mode. The race detector intentionally drops items from `sync.Pool`, which makes the allocation budget meaningless, so the tests are now skipped there while still enforcing the `<= 2` bound in normal builds.

<sup>Written for commit 4491c079380519990108b692f65e948550f97ded. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rostamlabs/rostam/pull/99?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

