### PR TITLE
fix(raft/logstore): reject trailing bytes in decodeInto

### DIFF
--- a/raft/logstore/codec.go
+++ b/raft/logstore/codec.go
@@ -118,6 +118,14 @@ func decodeInto(payload []byte, out *hraft.Log) error {
 	} else {
 		out.Extensions = append(out.Extensions[:0], p[:el]...)
 	}
+	p = p[el:]
+	// A record is sealed by its recLen frame + crc, so a well-formed payload ends
+	// exactly here. Any remaining bytes mean a misframed or corrupt record; reject
+	// it rather than silently dropping the tail — matching the trailing-bytes
+	// checks the wire decoders elsewhere already make (e.g. decodeReplicateGroup).
+	if len(p) != 0 {
+		return errCorrupt
+	}
 	return nil
 }
 

--- a/raft/logstore/codec_fuzz_test.go
+++ b/raft/logstore/codec_fuzz_test.go
@@ -36,16 +36,10 @@ func FuzzDecodeInto(f *testing.F) {
 		if err := decodeInto(payload, &out); err != nil {
 			return
 		}
-		// Re-encoding the decoded entry must reproduce a PREFIX of the payload.
-		// NOTE decodeInto does NOT reject trailing bytes after the extensions
-		// field (unlike every other decoder in the tree — cf. decodeReplicateGroup's
-		// "trailing bytes" check), so a payload with junk past the last field
-		// decodes "successfully" and silently drops it. In production the recLen
-		// framing + crc seal each record, so this path never sees trailing bytes;
-		// this is a defense-in-depth / consistency gap, not an exploitable bug, so
-		// the invariant asserts a faithful prefix rather than full equality.
+		// decodeInto consumes the WHOLE payload (it rejects trailing bytes), so a
+		// payload it accepts must re-encode to exactly those bytes.
 		re := appendRecord(nil, &out)[frameHdr:]
-		if len(re) > len(payload) || !bytes.Equal(re, payload[:len(re)]) {
+		if !bytes.Equal(re, payload) {
 			t.Fatalf("decodeInto round-trip mismatch: in=%x out=%x", payload, re)
 		}
 	})

--- a/raft/logstore/codec_test.go
+++ b/raft/logstore/codec_test.go
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package logstore
+
+import (
+	"errors"
+	"testing"
+
+	hraft "github.com/hashicorp/raft"
+)
+
+// TestDecodeIntoRejectsTrailingBytes pins that decodeInto rejects a payload with
+// bytes past the last field rather than silently dropping them. A record is
+// sealed by its recLen frame + crc, so a well-formed payload ends exactly at the
+// extensions field; trailing bytes mean a misframed/corrupt record, and the
+// decoder must fail closed like the other wire decoders in the tree.
+func TestDecodeIntoRejectsTrailingBytes(t *testing.T) {
+	enc := appendRecord(nil, &hraft.Log{Index: 7, Term: 3, Type: hraft.LogCommand, Data: []byte("hi"), Extensions: []byte("x")})
+	payload := enc[frameHdr:] // strip recLen+crc; decodeInto takes the payload only
+
+	var out hraft.Log
+	if err := decodeInto(payload, &out); err != nil {
+		t.Fatalf("valid payload must decode: %v", err)
+	}
+
+	// One junk byte past the extensions field.
+	if err := decodeInto(append(append([]byte(nil), payload...), 0x00), &out); !errors.Is(err, errCorrupt) {
+		t.Fatalf("trailing byte: want errCorrupt, got %v", err)
+	}
+}


### PR DESCRIPTION
The `decodeInto` trailing-bytes follow-up you asked for in #98.

`decodeInto` accepted a record payload with bytes past the `extensions` field and silently dropped them — unlike every other wire decoder in the tree (cf. `decodeReplicateGroup`'s trailing-bytes check). A record is sealed by its `recLen` frame + crc, so a well-formed payload ends exactly at the extensions field; trailing bytes mean a misframed/corrupt record. It now rejects them with `errCorrupt`.

Not exploitable on its own — the only caller (`GetLog`) hands it a slice sized exactly by `recLen`, so this path never sees trailing bytes in practice — so this is defense-in-depth / consistency, not a bug fix. No legitimate record carries trailing bytes, so no stored log is affected: the full existing `raft/logstore` suite passes unchanged.

Also flips the `FuzzDecodeInto` invariant back to strict `encode(decode(b))==b` (the decoder now consumes the whole payload) and adds a small regression test.

I left the changelog untouched since this isn't user-visible behavior — happy to add an entry if you'd prefer one.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Log record decoding now rejects corrupted payloads containing unexpected trailing bytes instead of silently ignoring them.
  - Improved consistency between in-memory and write-ahead log decoding behavior.

- **Tests**
  - Added coverage for trailing-byte corruption.
  - Strengthened round-trip validation to require decoded records to re-encode to exactly the original data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes `decodeInto` reject record payloads with trailing bytes past the `extensions` field instead of silently dropping them, matching the trailing-bytes checks other wire decoders already make. This is defense-in-depth/consistency — `GetLog` always passes a slice sized exactly by `recLen`, so no stored log is affected.

**Changes**
- Restores the `FuzzDecodeInto` invariant to strict `encode(decode(b))==b`.
- Adds a regression test for the rejection.

<sup>Written for commit 29b8fa8614783791276c64d78eb0c7e121fc4bc2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rostamlabs/rostam/pull/100?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

