### PR TITLE
test(shard/pbisr): seed the group-count cap; fix stale comments

### DIFF
--- a/shard/pbisr/pb_frame.go
+++ b/shard/pbisr/pb_frame.go
@@ -192,10 +192,9 @@ func (fr *pbFrameReader) read() (pbFrame, error) {
 	return f, nil
 }
 
-// Slim payload codecs for the batched transport: unlike net_codec.go's
-// encodeReplicateReq/decodeReplicateReq (which prefix the shard onto the
-// payload for the old unbatched transport), these omit the shard since it now
-// lives in the frame header. Layout (v2):
+// Slim payload codecs for the batched transport. These omit the shard from the
+// payload — it lives in the frame header (see pbFrame) rather than being
+// prefixed onto every message body. Layout (v2):
 // epoch(8) seq(8) prevSeq(8) prevEpoch(8) dataLen(4) data.
 
 // pbReplicateHdrSize is the fixed header of a single-write replicate payload.

--- a/shard/pbisr/pb_frame_fuzz_test.go
+++ b/shard/pbisr/pb_frame_fuzz_test.go
@@ -42,9 +42,11 @@ func FuzzPBDecodeReplicateGroup(f *testing.F) {
 		{Epoch: 3, Seq: 10, PrevSeq: 9, PrevEpoch: 3, Data: []byte("a")},
 		{Epoch: 3, Seq: 11, PrevSeq: 10, PrevEpoch: 3, Data: []byte("bb")},
 	}))
-	// A hostile count with no records behind it must be rejected, not allocated.
+	// A hostile count far above pbGroupCountMax, with no records behind it, must
+	// be rejected outright rather than driving an allocation. count is the
+	// big-endian u32 at [32:36] of the group header.
 	big := make([]byte, pbGroupHdrSize)
-	big[35] = 0xff // count low byte; header is big-endian so this is a small count, still
+	binary.BigEndian.PutUint32(big[32:36], pbGroupCountMax+1)
 	f.Add(big)
 	f.Fuzz(func(t *testing.T, b []byte) {
 		msgs, err := decodeReplicateGroup(b)


### PR DESCRIPTION
Two follow-ups from #98 — one comment fix and one real test-seed fix.

- `pb_frame.go` referenced `net_codec.go`, which no longer exists in the tree. Reworded to explain why the slim payload codecs omit the shard (it lives in the frame header) without pointing at a deleted file. (comment only)

- The `FuzzPBDecodeReplicateGroup` "hostile count" seed set only the low byte of the big-endian count `u32`, so it exercised `count=255` — a valid, under-limit count that never reached the `pbGroupCountMax` cap-rejection branch. It now sets the whole `u32` to `pbGroupCountMax+1`, so the seed actually drives that branch. This changes what the fuzz corpus explores, so it is a behavior-affecting test change, not comment-only.
