### PR TITLE
feat: record search in vector payloads (operate records as a payload kind, filter paths, auto-index)

### DIFF
--- a/client/vector_search.go
+++ b/client/vector_search.go
@@ -246,6 +246,11 @@ func rawGroupKeyToString(raw json.RawMessage) (string, error) {
 	case vtypes.ValueBool:
 		return strconv.FormatBool(v.Bool), nil
 	default:
+		// ValueRecord considered: falls here too — vector/group.go's groupKeyString
+		// already declines records upstream (a byte blob has no single-string
+		// bucket identity), so a record can never actually arrive as a group key
+		// wire value. The raw-JSON fallback is kept generic rather than special-
+		// cased so it degrades safely for any future kind, record included.
 		return string(raw), nil
 	}
 }

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -5,6 +5,19 @@ Notable user-visible changes. Entries that alter existing behaviour are marked
 
 ## Unreleased
 
+- **Filter and index `operate` records stored in vector payloads.** A payload
+  value of kind `record` (the bytes `operate` writes) can now be addressed
+  directly by filters: a path like `session/rc`, `session/b/42/hi`, or
+  `session/b#count` resolves into the record, and two new leaf ops,
+  `row_exists` and `row_absent`, test table-row presence. A collection
+  auto-indexes every top-level scalar field and table row count for `eq`/
+  `in`/range acceleration; row/column/positional paths and
+  `contains`/`match`/`regex`/`row_exists`/`row_absent` are always evaluated
+  against the live record. A point whose stored record is malformed fails
+  the whole payload key closed (evaluated live, still correct) until it is
+  repaired or reclaimed. See
+  [record paths in filters](vector/filtering.md#record-paths).
+
 - **`operate`: server-side atomic multi-field updates on a record.** A new
   built-in op updates several fields of one record atomically, in one round
   trip, against a hot key — the way you'd reach for a Redis hash command or

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -15,8 +15,12 @@ Notable user-visible changes. Entries that alter existing behaviour are marked
   `contains`/`match`/`regex`/`row_exists`/`row_absent` are always evaluated
   against the live record. A point whose stored record is malformed fails
   the whole payload key closed (evaluated live, still correct) until it is
-  repaired or reclaimed. See
-  [record paths in filters](vector/filtering.md#record-paths).
+  repaired or reclaimed. `row_exists` and `row_absent` follow the same
+  exact-payload-key-first rule as every other op — a literal key such as
+  `"session/b/42"` wins over splitting, and makes both ops false — and
+  `row_absent` is true only when the named field really is a table on that
+  point, so a record with no such field at all answers false rather than
+  true. See [record paths in filters](vector/filtering.md#record-paths).
 
 - **`operate`: server-side atomic multi-field updates on a record.** A new
   built-in op updates several fields of one record atomically, in one round

--- a/docs/kv/overview.md
+++ b/docs/kv/overview.md
@@ -412,6 +412,16 @@ wire args. The stored **record and cell data themselves are little-endian**
 (fixed-width ints, table row keys) — the wire args format and the on-disk
 record format are independent conventions.
 
+### Searching operate records from vector payloads
+
+A record `operate` writes can also be stored verbatim as a vector point's
+payload value (kind `record`) and filtered on directly — `session/rc`,
+`session/b/42/hi`, `session/b#count`, and the `row_exists`/`row_absent`
+presence ops all address the same paths this section describes, against the
+same stored bytes. See
+[record paths in filters](../vector/filtering.md#record-paths) for the path
+grammar, value mapping, and what a collection auto-indexes.
+
 ## TTL semantics
 
 TTLs are absolute deadlines computed at write time. Expiry is enforced lazily on

--- a/docs/vector/filtering.md
+++ b/docs/vector/filtering.md
@@ -245,11 +245,20 @@ SDK encoder, never by hand.
   string field literally named `"a/b"`) still resolves and indexes exactly —
   but the planner decides whether to accelerate a filter purely from the
   field *name*'s shape, which cannot tell a literal key from a record path
-  apart. Such a key gets full `eq`/`in`/range acceleration but not
-  `match`/`contains`/geo acceleration, even though the underlying value is
-  an ordinary string. This is a deliberate, accepted phase-1 cost: the
-  filter still answers correctly, just via the graph-traversal fallback
-  instead of the payload index for those operators.
+  apart. How much acceleration such a key loses depends on the shape its
+  tail parses as:
+    - **One indexed segment** (`a/b`, `a/b#count`) — keeps `eq`, `in` and
+      range acceleration, loses `match`/`contains`/geo.
+    - **Anything else that still parses as a path** — a multi-segment tail
+      (`metrics/q1/42`, a row or a cell) or a positional segment
+      (`a/#0`) — loses index acceleration for **every** operator, `eq` and
+      range included, because those shapes are not posted at all.
+    - **A tail that is not a valid path** (e.g. `metrics/2024/q1`, whose
+      middle segment is not a legal row key) is treated as an ordinary
+      literal key and keeps full acceleration.
+  This is a deliberate, accepted phase-1 cost. In every case the filter
+  still answers **correctly**; it just falls back to graph traversal instead
+  of the payload index for the operators it cannot narrow.
 - A positional field (`#N`) is always evaluated live, regardless of
   selectivity, per the indexing rule above.
 

--- a/docs/vector/filtering.md
+++ b/docs/vector/filtering.md
@@ -118,6 +118,13 @@ verbatim as a payload value of kind `record`:
 never hand-built. A record value is never `is_empty`/`is_null` unless it is
 literally absent or zero-length; a present, non-empty record is neither.
 
+Over HTTP, gRPC or the binary protocol the record you read back is a copy the
+codec wrote, and it is yours. In the **in-process Go API** it is not: a payload
+returned by a read shares its bytes with the stored record, exactly as a
+list-valued payload shares its slice. Read it, never write through it — mutating
+it changes the live record while the index still describes the old bytes. Copy
+the slice if you need to keep or edit it.
+
 ### Path grammar
 
 A filter's `field` string is tried as an exact payload key first. Only when

--- a/docs/vector/filtering.md
+++ b/docs/vector/filtering.md
@@ -34,6 +34,7 @@ Over HTTP the same filter is JSON, with operators as lowercase names:
 | Presence | `is_empty`, `is_null` |
 | Datetime | `dt_gt`, `dt_gte`, `dt_lt`, `dt_lte` (RFC 3339 bounds) |
 | Geo | `geo_radius`, `geo_bounding_box`, `geo_polygon` |
+| Record | `row_exists`, `row_absent` (table-row presence inside a [record payload value](#record-paths)) |
 
 Geo filters take a `geo` condition object instead of `value`:
 `geo_radius` → `{center_lat, center_lon, radius_m}`; `geo_bounding_box` →
@@ -99,6 +100,158 @@ an ordering, and inventing one leaves `x >= 3 AND x <= 2` matching a NaN row.
     different rows depending on which query path ran; the new rule is what makes
     both paths answer the same question. To keep such points matchable, write a
     real sentinel value instead of NaN.
+
+## Record paths
+
+`operate` (the KV store's server-side atomic multi-field update op, see
+[the KV overview](../kv/overview.md#atomic-multi-field-updates-operate))
+writes a **record**: a struct of scalar fields where a field may be a table
+of keyed rows of columns. A vector payload can carry one of these records
+verbatim as a payload value of kind `record`:
+
+```json
+{"kind": "record", "rec": "<base64 of the operate record bytes>"}
+```
+
+`rec` is exactly the bytes `operate` stores for the key — copy them in as-is
+(e.g. from a KV `get`'s raw value, or the Go client's typed operate result),
+never hand-built. A record value is never `is_empty`/`is_null` unless it is
+literally absent or zero-length; a present, non-empty record is neither.
+
+### Path grammar
+
+A filter's `field` string is tried as an exact payload key first. Only when
+there is no exact match, and the field contains a `/`, is it split at the
+**first** `/` into a payload key and a path into that key's record (a literal
+payload key that itself contains `/` — including one that happens to look
+like a path, e.g. `"a/b"` — always wins over this splitting). The path is
+1-3 `/`-separated segments:
+
+| Segment | Form | Names |
+|---|---|---|
+| field | `name` or `#N` | a top-level record field, by name or position (`N` ≤ 65535) |
+| row key | decimal digits, or `"…"` | a table row: decimal for an integer key type, quoted (`\"`/`\\` escapes) for a `FIXED` key type |
+| column | `name` or `#N` | one column of the row named by the previous segment |
+
+A field segment may instead end in `#count` (e.g. `session/b#count`), which
+must be the only segment — it reports a table field's row count and does not
+compose with a row or column segment.
+
+For a **dynamic**-mode record, table row keys have no declared width: a
+decimal segment denotes the 8-byte little-endian encoding of the number (what
+the Go client's `client.KeyU64` produces), and a quoted segment denotes its
+unescaped bytes verbatim. For a **schema**-mode record, the row key's type and
+width come from the schema, and a decimal segment denotes that width's
+little-endian encoding.
+
+A path that cannot apply — an unknown field, an absent row or column, a
+row/column segment against a scalar field, a position against a schema that
+stores no names, or a payload key that holds something other than a record —
+evaluates as "no such field": no match, never a filter error. `row_exists`
+and `row_absent` are the one exception: their `field` string's path **shape**
+is validated once, at filter-compile time (see below), because that shape
+depends only on the string, never on any point's data.
+
+### Example
+
+```
+payload {"session": <record>}
+  #0 rc   U8    = 7
+  #1 bc   U8    = 3
+  #2 hist U32   = 1234
+  #3 bal  I32   = -5
+  #4 tag  BYTES = "de"
+  #5 b    TABLE(key U64; hi U32, lo U32) = {42: (hi=500, lo=1), 99: (hi=7, lo=2)}
+```
+
+```json
+{"op": "gt", "field": "session/rc", "value": {"kind": "int", "int": 5}}
+{"op": "eq", "field": "session/b/42/hi", "value": {"kind": "int", "int": 500}}
+{"op": "gte", "field": "session/b#count", "value": {"kind": "int", "int": 1}}
+{"op": "row_exists", "field": "session/b/42"}
+{"op": "row_absent", "field": "session/b/7"}
+```
+
+### `row_exists` / `row_absent`
+
+Both take a `field` whose path names exactly a table row — a field segment
+then a row segment (`table/rowKey`), nothing shorter or longer; `CompileFilter`
+rejects any other shape (a bare field, a `#count`, or a row **and** column) as
+a compile error, since that shape never depends on the data. `row_exists` is
+true iff the row is present. `row_absent` is **not** simply "not
+`row_exists`": it is true only when the row is affirmatively missing from a
+real table on that point (the payload key holds a record and the named field
+really is a table). A missing payload key, a payload key holding something
+other than a record, or a path that cannot apply to that point's record
+shape (e.g. the field is a scalar, not a table) makes **both** ops false —
+"the row is absent" presupposes a table to search, and a point that cannot
+even be asked the question is not in a position to assert that.
+
+### Value mapping
+
+A resolved cell (or a `#count`) maps to a payload value the same comparators
+`eq`/`ne`/`gt`/`gte`/`lt`/`lte`/`in` use everywhere else:
+
+| Stored type | Payload kind |
+|---|---|
+| `U8`/`U16`/`U32`/`I8`/`I16`/`I32`/`I64`/`IVARINT`, and `U64`/`UVARINT` up to `MaxInt64` | `int` |
+| `U64`/`UVARINT` above `MaxInt64` | `float` (lossy — the only wider payload kind) |
+| `F32`/`F64` | `float` |
+| `BYTES`/`FIXED` | `string` (the raw bytes) |
+| `#count` (a table's row count) | `int` |
+
+`contains`, `match`, and `regex` read a record path's resolved **string**
+cell (`BYTES`/`FIXED`) the same way they read any string payload field, via
+the live record — they have no index of their own over record content (see
+below).
+
+### What's indexed
+
+A collection auto-indexes, for every point whose payload carries a record —
+no configuration needed — each top-level **scalar** field by name and each
+table field's row count, as synthetic payload fields `<payloadKey>/<field>`
+and `<payloadKey>/<table>#count`, with the same `eq`/`in`/range acceleration
+a literal payload field gets.
+
+**Not indexed** — always evaluated against the live record instead, still
+correct, just not accelerated:
+
+- a positional field (`session/#0`) — even when the record's schema would
+  resolve it, since one collection can mix a names-carrying schema (indexed
+  by name) and a names-less one (indexed positionally), and a field string
+  alone can't say which a given point uses;
+- a table row, a table column, or the table field itself (`session/b`,
+  `session/b/42`, `session/b/42/hi`);
+- `contains`, `match`, `regex`, `row_exists`, and `row_absent` on any record
+  path — a record's scalars post whole-value **equality** keys only, never
+  tokens, contains-elements, or geo cells.
+
+### Fail-closed indexing
+
+If any live point stores a **malformed** record under a payload key —
+bytes that fail to enumerate in full, even though some of its fields would
+still resolve individually — every path under that payload key stops using
+the index for **every point**, for as long as the malformed record survives:
+filtered search and delete/scroll selection fall back to evaluating the live
+record, which stays correct. The key regains acceleration automatically once
+the malformed point's payload is repaired, cleared, or the point itself is
+reclaimed; it is a tracked state, not a one-way trip. Since a hand-crafted
+byte string can trigger this, produce records only through `operate` or its
+SDK encoder, never by hand.
+
+### Known limits
+
+- A literal payload key whose name merely **looks like** a path (e.g. a
+  string field literally named `"a/b"`) still resolves and indexes exactly —
+  but the planner decides whether to accelerate a filter purely from the
+  field *name*'s shape, which cannot tell a literal key from a record path
+  apart. Such a key gets full `eq`/`in`/range acceleration but not
+  `match`/`contains`/geo acceleration, even though the underlying value is
+  an ordinary string. This is a deliberate, accepted phase-1 cost: the
+  filter still answers correctly, just via the graph-traversal fallback
+  instead of the payload index for those operators.
+- A positional field (`#N`) is always evaluated live, regardless of
+  selectivity, per the indexing rule above.
 
 ## Building filters from Python
 

--- a/docs/vector/filtering.md
+++ b/docs/vector/filtering.md
@@ -144,10 +144,17 @@ unescaped bytes verbatim. For a **schema**-mode record, the row key's type and
 width come from the schema, and a decimal segment denotes that width's
 little-endian encoding.
 
+Which spelling applies follows the record: a **schema**-mode record always
+accepts positions (`session/#0`, `session/#5/42/#1`), and accepts names only
+when its schema stores them — a names-less schema is addressable by position
+alone. A **dynamic**-mode record is the mirror image: names only, never a
+position, since it has no schema to number its fields against.
+
 A path that cannot apply — an unknown field, an absent row or column, a
-row/column segment against a scalar field, a position against a schema that
-stores no names, or a payload key that holds something other than a record —
-evaluates as "no such field": no match, never a filter error. `row_exists`
+row/column segment against a scalar field, a *name* against a schema that
+stores no names, a *position* against a dynamic record, or a payload key that
+holds something other than a record — evaluates as "no such field": no match,
+never a filter error. `row_exists`
 and `row_absent` are the one exception: their `field` string's path **shape**
 is validated once, at filter-compile time (see below), because that shape
 depends only on the string, never on any point's data.

--- a/docs/vector/filtering.md
+++ b/docs/vector/filtering.md
@@ -129,7 +129,7 @@ like a path, e.g. `"a/b"` — always wins over this splitting). The path is
 
 | Segment | Form | Names |
 |---|---|---|
-| field | `name` or `#N` | a top-level record field, by name or position (`N` ≤ 65535) |
+| field | `name` or `#N` | a top-level record field, by name or position (`N` ≤ 65535, written canonically: at most 5 digits, no leading zeros except `#0`) |
 | row key | decimal digits, or `"…"` | a table row: decimal for an integer key type, quoted (`\"`/`\\` escapes) for a `FIXED` key type |
 | column | `name` or `#N` | one column of the row named by the previous segment |
 

--- a/docs/vector/filtering.md
+++ b/docs/vector/filtering.md
@@ -181,10 +181,17 @@ a compile error, since that shape never depends on the data. `row_exists` is
 true iff the row is present. `row_absent` is **not** simply "not
 `row_exists`": it is true only when the row is affirmatively missing from a
 real table on that point (the payload key holds a record and the named field
-really is a table). A missing payload key, a payload key holding something
-other than a record, or a path that cannot apply to that point's record
-shape (e.g. the field is a scalar, not a table) makes **both** ops false —
-"the row is absent" presupposes a table to search, and a point that cannot
+really is a table). All of the following make **both** ops false:
+
+- the field string matches an **exact payload key** on that point — a literal
+  key wins over splitting, exactly as it does for every other op;
+- the payload key is missing, or holds something other than a record;
+- that point's record has **no such field at all**: an unknown field name, or
+  a position past the end of its schema;
+- the path cannot apply to that point's record shape, e.g. the field holds a
+  scalar, not a table.
+
+"The row is absent" presupposes a table to search, and a point that cannot
 even be asked the question is not in a position to assert that.
 
 ### Value mapping

--- a/docs/vector/filtering.md
+++ b/docs/vector/filtering.md
@@ -203,7 +203,12 @@ really is a table). All of the following make **both** ops false:
 - that point's record has **no such field at all**: an unknown field name, or
   a position past the end of its schema;
 - the path cannot apply to that point's record shape, e.g. the field holds a
-  scalar, not a table.
+  scalar, not a table;
+- the record is **malformed** where it matters — for `row_absent`, a table
+  whose rows are not in the ascending key order the format requires. Absence is
+  proved by walking the table, not inferred from an ordering the bytes merely
+  claim, so a damaged table asserts nothing. (`row_exists` needs no such check:
+  a matched row is proof of itself.)
 
 "The row is absent" presupposes a table to search, and a point that cannot
 even be asked the question is not in a position to assert that.

--- a/grpcapi/error_findings_test.go
+++ b/grpcapi/error_findings_test.go
@@ -4,6 +4,7 @@ package grpcapi
 
 import (
 	"errors"
+	"fmt"
 	"testing"
 
 	"google.golang.org/grpc/codes"
@@ -58,5 +59,38 @@ func TestGrpcErrorLeaderlessIsRetryable(t *testing.T) {
 		if got := status.Code(grpcError(tc.err)); got != codes.Unavailable {
 			t.Errorf("%s: grpcError = %v, want Unavailable (retryable)", tc.name, got)
 		}
+	}
+}
+
+// TestGrpcErrorRecordTooLarge pins vector.ErrRecordTooLarge as a CLIENT error on
+// the gRPC front end. It was classified by neither errIs list, so an oversize
+// record payload came back as codes.Internal — a server fault, which standard
+// gRPC retry policies retry and which tells the caller nothing about the one
+// thing they can fix.
+//
+// Three arms, because the sentinel does not survive every path it can take:
+// the sentinel itself, a wrapped one (%w through the op layer), and the
+// stringified one a clustered apply produces, where shard.decodePBResult
+// rebuilds the error with errors.New(string(payload)) and errors.Is stops
+// matching. The stringified arm is built from the sentinel's own .Error() so it
+// cannot drift from the classifier's substring.
+func TestGrpcErrorRecordTooLarge(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+	}{
+		{"sentinel", vector.ErrRecordTooLarge},
+		{"wrapped", fmt.Errorf("vector_insert: %w: payload key %q holds a 20000000-byte record, the cap is 16777216 bytes", vector.ErrRecordTooLarge, "session")},
+		{"stringified", errors.New(vector.ErrRecordTooLarge.Error() + ": payload key \"session\" holds a 20000000-byte record, the cap is 16777216 bytes")},
+	}
+	for _, tc := range cases {
+		if got := status.Code(grpcError(tc.err)); got != codes.InvalidArgument {
+			t.Errorf("%s: grpcError = %v, want InvalidArgument", tc.name, got)
+		}
+	}
+	// The negative control: an unrelated internal fault must still be Internal,
+	// so the new arm is not classifying by accident.
+	if got := status.Code(grpcError(errors.New("open /var/lib/rostam/shard-7: no such file"))); got != codes.Internal {
+		t.Errorf("unrelated fault = %v, want Internal", got)
 	}
 }

--- a/grpcapi/error_findings_test.go
+++ b/grpcapi/error_findings_test.go
@@ -68,29 +68,48 @@ func TestGrpcErrorLeaderlessIsRetryable(t *testing.T) {
 // gRPC retry policies retry and which tells the caller nothing about the one
 // thing they can fix.
 //
-// Three arms, because the sentinel does not survive every path it can take:
-// the sentinel itself, a wrapped one (%w through the op layer), and the
-// stringified one a clustered apply produces, where shard.decodePBResult
-// rebuilds the error with errors.New(string(payload)) and errors.Is stops
-// matching. The stringified arm is built from the sentinel's own .Error() so it
-// cannot drift from the classifier's substring.
+// The sentinel does not survive every path it can take, so this covers both
+// the in-process shapes (single-payload and bulk, %w-wrapped so errors.Is
+// still finds the sentinel) and the stringified ones a clustered apply
+// produces, where shard.decodePBResult rebuilds the error with
+// errors.New(string(payload)) and errors.Is stops matching — recognized
+// instead by vector.IsRecordTooLargeMessage, an exact-shape matcher.
 func TestGrpcErrorRecordTooLarge(t *testing.T) {
+	single := fmt.Errorf("%w: payload key %q holds a 20000000-byte record, the cap is 16777216 bytes",
+		vector.ErrRecordTooLarge, "session")
+	bulk := fmt.Errorf("payload %d: %w", 3, single)
 	cases := []struct {
 		name string
 		err  error
 	}{
 		{"sentinel", vector.ErrRecordTooLarge},
-		{"wrapped", fmt.Errorf("vector_insert: %w: payload key %q holds a 20000000-byte record, the cap is 16777216 bytes", vector.ErrRecordTooLarge, "session")},
-		{"stringified", errors.New(vector.ErrRecordTooLarge.Error() + ": payload key \"session\" holds a 20000000-byte record, the cap is 16777216 bytes")},
+		{"single-payload form (%w wrapped)", single},
+		{"bulk form (%w wrapped, real shape checkRecordValuesAll produces)", bulk},
+		{"single-payload form, stringified across replication", errors.New(single.Error())},
+		{"bulk form, stringified across replication", errors.New(bulk.Error())},
 	}
 	for _, tc := range cases {
 		if got := status.Code(grpcError(tc.err)); got != codes.InvalidArgument {
 			t.Errorf("%s: grpcError = %v, want InvalidArgument", tc.name, got)
 		}
 	}
-	// The negative control: an unrelated internal fault must still be Internal,
-	// so the new arm is not classifying by accident.
-	if got := status.Code(grpcError(errors.New("open /var/lib/rostam/shard-7: no such file"))); got != codes.Internal {
-		t.Errorf("unrelated fault = %v, want Internal", got)
+	// Negative controls: an unrelated internal fault must still be Internal,
+	// including one that merely CONTAINS the sentinel text inside an unrelated
+	// wrapper — the exact bug a bare strings.Contains classifier would
+	// reintroduce (it would leak the WAL path below to the caller).
+	negatives := []struct {
+		name string
+		err  error
+	}{
+		{"unrelated fault, no sentinel text", errors.New("open /var/lib/rostam/shard-7: no such file")},
+		{"unrelated fault wrapping the sentinel (%v)",
+			fmt.Errorf("wal append failed at /var/lib/rostam/x: %v", vector.ErrRecordTooLarge)},
+		{"unrelated fault stringified across replication",
+			errors.New(fmt.Errorf("wal append failed at /var/lib/rostam/x: %v", vector.ErrRecordTooLarge).Error())},
+	}
+	for _, tc := range negatives {
+		if got := status.Code(grpcError(tc.err)); got != codes.Internal {
+			t.Errorf("%s: grpcError = %v, want Internal", tc.name, got)
+		}
 	}
 }

--- a/grpcapi/server.go
+++ b/grpcapi/server.go
@@ -219,12 +219,14 @@ func grpcError(err error) error {
 		// same sentinel. Unclassified it fell to codes.Internal, which reads as a
 		// server fault and which standard gRPC retry policies hammer.
 		//
-		// Matched by sentinel AND by string: shard.decodePBResult rebuilds an op
-		// error with errors.New(string(payload)) across replication, so a
-		// clustered apply loses errors.Is identity — the same reason the other two
-		// classifiers carry string fallbacks. Comparing against the sentinel's own
-		// .Error() text cannot drift from it.
-		strings.Contains(err.Error(), vector.ErrRecordTooLarge.Error()):
+		// Matched by sentinel AND by exact message shape: shard.decodePBResult
+		// rebuilds an op error with errors.New(string(payload)) across
+		// replication, so a clustered apply loses errors.Is identity — the same
+		// reason the other two classifiers carry a message-shape fallback. The
+		// fallback uses vector.IsRecordTooLargeMessage, NOT strings.Contains — a
+		// bare substring check would also match an unrelated internal error that
+		// merely wraps the sentinel, leaking it to the caller unredacted.
+		vector.IsRecordTooLargeMessage(err.Error()):
 		return status.Error(codes.InvalidArgument, err.Error())
 	case errIs(err, vector.ErrAPIKeyExists):
 		// Online key-admin: KeysAdd of an already-registered token. AlreadyExists

--- a/grpcapi/server.go
+++ b/grpcapi/server.go
@@ -210,6 +210,22 @@ func grpcError(err error) error {
 		// in the root rostam package (un-importable here without a cycle), so match
 		// the message prefix rather than the sentinel.
 		return status.Error(codes.InvalidArgument, err.Error())
+	case errIs(err, vector.ErrRecordTooLarge),
+		// vector.ErrRecordTooLarge: a payload carrying a record value above the
+		// storage cap. A caller mistake with a clear remedy (send a smaller
+		// record) whose message names only the payload key and the two sizes,
+		// all of which the caller sent — so InvalidArgument, mirroring
+		// server.clientFacingErr and httpapi.statusForError's 400 bucket for the
+		// same sentinel. Unclassified it fell to codes.Internal, which reads as a
+		// server fault and which standard gRPC retry policies hammer.
+		//
+		// Matched by sentinel AND by string: shard.decodePBResult rebuilds an op
+		// error with errors.New(string(payload)) across replication, so a
+		// clustered apply loses errors.Is identity — the same reason the other two
+		// classifiers carry string fallbacks. Comparing against the sentinel's own
+		// .Error() text cannot drift from it.
+		strings.Contains(err.Error(), vector.ErrRecordTooLarge.Error()):
+		return status.Error(codes.InvalidArgument, err.Error())
 	case errIs(err, vector.ErrAPIKeyExists):
 		// Online key-admin: KeysAdd of an already-registered token. AlreadyExists
 		// (the etcd/gRPC create-conflict code) — the caller revokes first or picks a

--- a/httpapi/error_findings_test.go
+++ b/httpapi/error_findings_test.go
@@ -4,6 +4,7 @@ package httpapi
 
 import (
 	"errors"
+	"fmt"
 	"net/http"
 	"strings"
 	"testing"
@@ -270,5 +271,42 @@ func TestStatusForErrorAlreadyPartitioned(t *testing.T) {
 	if got := statusForError(err); got != http.StatusConflict {
 		t.Fatalf("statusForError(already partitioned) = %d, want %d (409 Conflict)",
 			got, http.StatusConflict)
+	}
+}
+
+// TestStatusForErrorRecordTooLarge pins the HTTP status for an oversize record
+// payload at 400 in all three shapes the sentinel can arrive in. The sentinel
+// and wrapped arms were already classified; the STRINGIFIED arm is the shape a
+// clustered write produces (shard.decodePBResult rebuilds an op error with
+// errors.New across replication, so errors.Is stops matching), and unclassified
+// it fell through to the redacted 500 bucket — a server fault for a mistake the
+// caller can fix by sending a smaller record.
+func TestStatusForErrorRecordTooLarge(t *testing.T) {
+	const detail = ": payload key \"session\" holds a 20000000-byte record, the cap is 16777216 bytes"
+	cases := []struct {
+		name string
+		err  error
+	}{
+		{"sentinel", vector.ErrRecordTooLarge},
+		{"wrapped", fmt.Errorf("vector_insert: %w"+detail, vector.ErrRecordTooLarge)},
+		{"stringified", errors.New(vector.ErrRecordTooLarge.Error() + detail)},
+	}
+	for _, tc := range cases {
+		if got := statusForError(tc.err); got != http.StatusBadRequest {
+			t.Errorf("%s: statusForError = %d, want 400", tc.name, got)
+		}
+		// A 4xx must keep its descriptive message: it names only the caller's own
+		// payload key and the two sizes.
+		status, msg := clientError("vector_insert", tc.err)
+		if status == http.StatusInternalServerError || msg == "internal error" {
+			t.Errorf("%s: clientError redacted a client-facing error: status=%d msg=%q", tc.name, status, msg)
+		}
+		if !strings.Contains(msg, "exceeds the storage cap") {
+			t.Errorf("%s: message lost the cap text: %q", tc.name, msg)
+		}
+	}
+	// Negative control: an unrelated fault is still a redacted 500.
+	if got := statusForError(errors.New("open /var/lib/rostam/shard-7: no such file")); got != http.StatusInternalServerError {
+		t.Errorf("unrelated fault = %d, want 500", got)
 	}
 }

--- a/httpapi/error_findings_test.go
+++ b/httpapi/error_findings_test.go
@@ -275,21 +275,30 @@ func TestStatusForErrorAlreadyPartitioned(t *testing.T) {
 }
 
 // TestStatusForErrorRecordTooLarge pins the HTTP status for an oversize record
-// payload at 400 in all three shapes the sentinel can arrive in. The sentinel
-// and wrapped arms were already classified; the STRINGIFIED arm is the shape a
-// clustered write produces (shard.decodePBResult rebuilds an op error with
-// errors.New across replication, so errors.Is stops matching), and unclassified
-// it fell through to the redacted 500 bucket — a server fault for a mistake the
-// caller can fix by sending a smaller record.
+// payload at 400 in every shape the sentinel can arrive in. The sentinel arm
+// was already classified; the message-shape arm (vector.IsRecordTooLargeMessage)
+// is what recognizes the STRINGIFIED forms — the shape a clustered write
+// produces (shard.decodePBResult rebuilds an op error with errors.New across
+// replication, so errors.Is stops matching) — and unclassified it fell through
+// to the redacted 500 bucket, a server fault for a mistake the caller can fix
+// by sending a smaller record.
+//
+// The message-shape arm is an exact-shape matcher, not a bare strings.Contains:
+// the negative controls assert that an unrelated internal error whose message
+// merely contains the sentinel text is still redacted as a 500.
 func TestStatusForErrorRecordTooLarge(t *testing.T) {
-	const detail = ": payload key \"session\" holds a 20000000-byte record, the cap is 16777216 bytes"
+	single := fmt.Errorf("%w: payload key %q holds a 20000000-byte record, the cap is 16777216 bytes",
+		vector.ErrRecordTooLarge, "session")
+	bulk := fmt.Errorf("payload %d: %w", 3, single)
 	cases := []struct {
 		name string
 		err  error
 	}{
 		{"sentinel", vector.ErrRecordTooLarge},
-		{"wrapped", fmt.Errorf("vector_insert: %w"+detail, vector.ErrRecordTooLarge)},
-		{"stringified", errors.New(vector.ErrRecordTooLarge.Error() + detail)},
+		{"single-payload form (%w wrapped)", single},
+		{"bulk form (%w wrapped, real shape checkRecordValuesAll produces)", bulk},
+		{"single-payload form, stringified across replication", errors.New(single.Error())},
+		{"bulk form, stringified across replication", errors.New(bulk.Error())},
 	}
 	for _, tc := range cases {
 		if got := statusForError(tc.err); got != http.StatusBadRequest {
@@ -305,8 +314,22 @@ func TestStatusForErrorRecordTooLarge(t *testing.T) {
 			t.Errorf("%s: message lost the cap text: %q", tc.name, msg)
 		}
 	}
-	// Negative control: an unrelated fault is still a redacted 500.
-	if got := statusForError(errors.New("open /var/lib/rostam/shard-7: no such file")); got != http.StatusInternalServerError {
-		t.Errorf("unrelated fault = %d, want 500", got)
+	// Negative controls: an unrelated fault is still a redacted 500, including
+	// one that merely CONTAINS the sentinel text inside an unrelated wrapper —
+	// the exact bug a bare strings.Contains classifier would reintroduce.
+	negatives := []struct {
+		name string
+		err  error
+	}{
+		{"unrelated fault, no sentinel text", errors.New("open /var/lib/rostam/shard-7: no such file")},
+		{"unrelated fault wrapping the sentinel (%v)",
+			fmt.Errorf("wal append failed at /var/lib/rostam/x: %v", vector.ErrRecordTooLarge)},
+		{"unrelated fault stringified across replication",
+			errors.New(fmt.Errorf("wal append failed at /var/lib/rostam/x: %v", vector.ErrRecordTooLarge).Error())},
+	}
+	for _, tc := range negatives {
+		if got := statusForError(tc.err); got != http.StatusInternalServerError {
+			t.Errorf("%s: statusForError = %d, want 500", tc.name, got)
+		}
 	}
 }

--- a/httpapi/httpapi.go
+++ b/httpapi/httpapi.go
@@ -496,7 +496,14 @@ func statusForError(err error) int {
 		// acking something that can never be made durable; refusing it is a
 		// client-fixable mistake and the message is the caller's own data.
 		// Keeps this classifier in sync with server.clientFacingErr.
+		//
+		// Matched by sentinel AND by string: a clustered apply rebuilds the op
+		// error with errors.New across the replication boundary
+		// (shard.decodePBResult), so errors.Is alone loses it there and the error
+		// would fall through to the redacted 500 bucket. Comparing against the
+		// sentinel's own .Error() text cannot drift from it.
 		errors.Is(err, vector.ErrRecordTooLarge),
+		strings.Contains(err.Error(), vector.ErrRecordTooLarge.Error()),
 		errors.Is(err, vector.ErrEmptyFilter),
 		errors.Is(err, vector.ErrEmptyGroupBy),
 		errors.Is(err, vector.ErrSparseMismatch),

--- a/httpapi/httpapi.go
+++ b/httpapi/httpapi.go
@@ -491,6 +491,12 @@ func writeInternalError(w http.ResponseWriter, ctx string, err error) {
 func statusForError(err error) int {
 	switch {
 	case errors.Is(err, vector.ErrDimMismatch),
+		// A payload carrying a record value above the storage cap: 400, not 500.
+		// The cap is the snapshot/WAL codec's, so accepting the write would mean
+		// acking something that can never be made durable; refusing it is a
+		// client-fixable mistake and the message is the caller's own data.
+		// Keeps this classifier in sync with server.clientFacingErr.
+		errors.Is(err, vector.ErrRecordTooLarge),
 		errors.Is(err, vector.ErrEmptyFilter),
 		errors.Is(err, vector.ErrEmptyGroupBy),
 		errors.Is(err, vector.ErrSparseMismatch),

--- a/httpapi/httpapi.go
+++ b/httpapi/httpapi.go
@@ -497,13 +497,15 @@ func statusForError(err error) int {
 		// client-fixable mistake and the message is the caller's own data.
 		// Keeps this classifier in sync with server.clientFacingErr.
 		//
-		// Matched by sentinel AND by string: a clustered apply rebuilds the op
-		// error with errors.New across the replication boundary
+		// Matched by sentinel AND by exact message shape: a clustered apply
+		// rebuilds the op error with errors.New across the replication boundary
 		// (shard.decodePBResult), so errors.Is alone loses it there and the error
-		// would fall through to the redacted 500 bucket. Comparing against the
-		// sentinel's own .Error() text cannot drift from it.
+		// would fall through to the redacted 500 bucket. The message-shape arm
+		// uses vector.IsRecordTooLargeMessage, NOT strings.Contains — a bare
+		// substring check would also match an unrelated internal error that
+		// merely wraps the sentinel, leaking it to the caller unredacted.
 		errors.Is(err, vector.ErrRecordTooLarge),
-		strings.Contains(err.Error(), vector.ErrRecordTooLarge.Error()),
+		vector.IsRecordTooLargeMessage(err.Error()),
 		errors.Is(err, vector.ErrEmptyFilter),
 		errors.Is(err, vector.ErrEmptyGroupBy),
 		errors.Is(err, vector.ErrSparseMismatch),

--- a/mcp/values.go
+++ b/mcp/values.go
@@ -300,6 +300,12 @@ func metadataToJSON(m rostam.VectorMetadata) map[string]any {
 			out[key] = v.Flts
 		case vector.ValueGeo:
 			out[key] = map[string]float64{"lat": v.Lat, "lon": v.Lon}
+		case vector.ValueRecord:
+			// Pass-through, not a new MCP feature: v.Rec is raw bytes, which
+			// encoding/json already renders as base64 for any []byte value — the
+			// same representation vtypes.Value's own JSON tag produces. Without
+			// this case the key would silently vanish from tool output instead.
+			out[key] = v.Rec
 		}
 	}
 	return out

--- a/ops/mv_batch_record_oversize_test.go
+++ b/ops/mv_batch_record_oversize_test.go
@@ -1,0 +1,128 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package ops
+
+import (
+	"errors"
+	"io"
+	"testing"
+
+	"github.com/rostamlabs/rostam/sdk/vtypes"
+	"github.com/rostamlabs/rostam/vector"
+)
+
+// mvBatchTx creates a fresh TxContext with one MV collection named "mv".
+func mvBatchTx(t *testing.T) *TxContext {
+	t.Helper()
+	tx := newVecTx(t)
+	cfg := vector.MultiVectorConfig{Dim: 2, M: 8, EfConstruction: 50, EfSearch: 32, Seed: 1}
+	if _, err := handleMVCreate(tx, EncodeMVCreateArgs("mv", cfg)); err != nil {
+		t.Fatalf("create MV collection: %v", err)
+	}
+	return tx
+}
+
+func mvRec(id uint64, meta vtypes.Metadata) vtypes.MultiScanRecord {
+	return vtypes.MultiScanRecord{ID: id, Tokens: [][]float32{{1, 0}, {0, 1}}, Metadata: meta, Version: 1}
+}
+
+// TestMVAddBatchOversizeRecordRejectedOnBothPaths is the regression for the gap
+// the deep review found: vector_mv_add_batch has TWO downstream paths and only
+// one of them was bounded.
+//
+// handleMVAddBatch calls MultiBulkBuild as the FAST PATH whenever the target
+// index is empty, falling through to the gated MultiRestoreAddSparse only once
+// documents exist. MultiBulkBuild validated tokens, dimension and sparse but not
+// records, so the same wire op was gated or ungated depending purely on the
+// target's emptiness — and the ungated case, a fresh partition, is exactly the
+// one an offline MV resplit drives.
+//
+// The damage is durability, not memory: MultiBulkBuild does not WAL-log
+// (durability rides the replicated batch op), so an oversize record simply goes
+// live and then every snapshot of the collection fails for as long as the
+// document stays live. Both branches must answer the same way, so the test
+// drives both through the real op handler.
+func TestMVAddBatchOversizeRecordRejectedOnBothPaths(t *testing.T) {
+	oversize := vtypes.Metadata{"session": vtypes.NewRecord(make([]byte, overCapRecordBytes))}
+
+	t.Run("empty target (MultiBulkBuild fast path)", func(t *testing.T) {
+		tx := mvBatchTx(t)
+		_, err := handleMVAddBatch(tx, EncodeMVAddBatchArgs("mv", []vtypes.MultiScanRecord{
+			mvRec(1, vtypes.Metadata{"rc": vtypes.NewInt(1)}),
+			mvRec(2, oversize),
+		}))
+		if err == nil {
+			t.Fatal("batch with a 16 MiB+1 record into an EMPTY index: got nil error, want ErrRecordTooLarge")
+		}
+		if !errors.Is(err, vector.ErrRecordTooLarge) {
+			t.Fatalf("err = %v, want vector.ErrRecordTooLarge", err)
+		}
+
+		// The WHOLE batch is refused, including the good record that preceded the
+		// bad one: validation runs before the index lock is taken, so nothing was
+		// half-built.
+		for _, id := range []uint64{1, 2} {
+			eb, eerr := handleMVExists(tx, EncodeMVExistsArgs("mv", id))
+			if eerr != nil {
+				t.Fatalf("mv exists %d: %v", id, eerr)
+			}
+			if ex, _ := DecodeExistsResult(eb); ex {
+				t.Fatalf("rejected batch still created document %d", id)
+			}
+		}
+
+		// The consequence the bound exists for: the collection is still
+		// snapshottable. An oversize record stored here would make writeValue
+		// fail for every snapshot while the document stayed live.
+		if err := tx.Vectors().SnapshotAll(io.Discard); err != nil {
+			t.Fatalf("snapshot after the rejected batch: %v, want nil", err)
+		}
+
+		// And the index is still EMPTY, so a legitimate batch still takes the
+		// fast path it was built for.
+		if _, err := handleMVAddBatch(tx, EncodeMVAddBatchArgs("mv", []vtypes.MultiScanRecord{
+			mvRec(3, vtypes.Metadata{"rc": vtypes.NewInt(2)}),
+		})); err != nil {
+			t.Fatalf("legitimate batch after the rejected one: %v, want nil", err)
+		}
+		eb, eerr := handleMVExists(tx, EncodeMVExistsArgs("mv", 3))
+		if eerr != nil {
+			t.Fatalf("mv exists 3: %v", eerr)
+		}
+		if ex, _ := DecodeExistsResult(eb); !ex {
+			t.Fatal("the legitimate batch did not land")
+		}
+		if err := tx.Vectors().SnapshotAll(io.Discard); err != nil {
+			t.Fatalf("snapshot after the legitimate batch: %v, want nil", err)
+		}
+	})
+
+	t.Run("non-empty target (MultiRestoreAddSparse path)", func(t *testing.T) {
+		tx := mvBatchTx(t)
+		// Seed one document so the fast path declines and the batch falls
+		// through to the per-record path, which was already gated. Both
+		// branches must agree.
+		if _, err := handleMVAddBatch(tx, EncodeMVAddBatchArgs("mv", []vtypes.MultiScanRecord{
+			mvRec(1, vtypes.Metadata{"rc": vtypes.NewInt(1)}),
+		})); err != nil {
+			t.Fatalf("seed batch: %v", err)
+		}
+		_, err := handleMVAddBatch(tx, EncodeMVAddBatchArgs("mv", []vtypes.MultiScanRecord{mvRec(2, oversize)}))
+		if err == nil {
+			t.Fatal("batch with a 16 MiB+1 record into a NON-EMPTY index: got nil error, want ErrRecordTooLarge")
+		}
+		if !errors.Is(err, vector.ErrRecordTooLarge) {
+			t.Fatalf("err = %v, want vector.ErrRecordTooLarge", err)
+		}
+		eb, eerr := handleMVExists(tx, EncodeMVExistsArgs("mv", 2))
+		if eerr != nil {
+			t.Fatalf("mv exists 2: %v", eerr)
+		}
+		if ex, _ := DecodeExistsResult(eb); ex {
+			t.Fatal("rejected batch still created document 2")
+		}
+		if err := tx.Vectors().SnapshotAll(io.Discard); err != nil {
+			t.Fatalf("snapshot after the rejected batch: %v, want nil", err)
+		}
+	})
+}

--- a/ops/record_oversize_test.go
+++ b/ops/record_oversize_test.go
@@ -1,0 +1,85 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package ops
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/rostamlabs/rostam/sdk/vtypes"
+	"github.com/rostamlabs/rostam/vector"
+)
+
+// overCapRecordBytes is one byte past the engine's ValueRecord cap
+// (vector's unexported maxRecordValueBytes, 16 MiB — the snapshot/WAL codec's
+// limit). Spelled out rather than imported because the constant is internal to
+// the vector package; if it ever moves, this test fails loudly by ACCEPTING the
+// insert, which is the direction that matters.
+const overCapRecordBytes = 16<<20 + 1
+
+// TestVectorInsertOversizeRecordRejectedOnBothWirePaths is the regression for the
+// gap the scoped re-review found: handleVectorInsert has TWO downstream paths,
+// and only one of them was bounded.
+//
+// A non-zero `version` in the decoded wire args routes the insert to
+// Collection.RestoreInsert/RestoreInsertAt — the version-preserving reinsert the
+// reshard backfill uses — instead of InsertCASKeyTTL. That branch carries the
+// CALLER's metadata, so it is an ingest path reachable from any client that sets
+// a version, not the replay-only primitive its doc comment reads like. It used to
+// accept a 16 MiB+1 record that the ordinary insert refused, and because
+// Collection.RestoreInsert applies to the index BEFORE it appends to the WAL, the
+// point went live and the append then failed — after which the collection could
+// no longer be snapshotted.
+//
+// Both branches must answer the same way, so the test drives both through the
+// real op handler.
+func TestVectorInsertOversizeRecordRejectedOnBothWirePaths(t *testing.T) {
+	tx := newVecTx(t)
+	cfg := vector.Config{Dim: 2, M: 4, EfConstruction: 10, EfSearch: 10, Seed: 1, Metric: vector.L2}
+	if _, err := handleVectorCreateCollection(tx, EncodeCreateCollectionArgs("docs", cfg)); err != nil {
+		t.Fatalf("create collection: %v", err)
+	}
+	oversize := vtypes.Metadata{"session": vtypes.NewRecord(make([]byte, overCapRecordBytes))}
+	vec := []float32{1, 0}
+
+	for _, tc := range []struct {
+		name    string
+		id      uint64
+		version uint64
+	}{
+		{"ordinary insert (version 0)", 1, 0},
+		{"version-preserving reinsert (version != 0)", 2, 7},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := handleVectorInsert(tx, EncodeVectorInsertArgsVersioned(
+				"docs", tc.id, vec, 0, oversize, vtypes.SparseVector{}, tc.version))
+			if err == nil {
+				t.Fatal("insert with a 16 MiB+1 record: got nil error, want ErrRecordTooLarge")
+			}
+			if !errors.Is(err, vector.ErrRecordTooLarge) {
+				t.Fatalf("err = %v, want vector.ErrRecordTooLarge", err)
+			}
+			eb, eerr := handleVectorExists(tx, EncodeExistsArgs("docs", tc.id))
+			if eerr != nil {
+				t.Fatalf("exists: %v", eerr)
+			}
+			if ex, _ := DecodeExistsResult(eb); ex {
+				t.Fatalf("rejected insert still created point %d", tc.id)
+			}
+		})
+	}
+
+	// The consequence the bound exists for: an ordinary insert alongside the
+	// rejected ones still works, and the collection is still writable.
+	if _, err := handleVectorInsert(tx, EncodeVectorInsertArgsVersioned(
+		"docs", 3, vec, 0, vtypes.Metadata{"rc": vtypes.NewInt(1)}, vtypes.SparseVector{}, 7)); err != nil {
+		t.Fatalf("version-preserving reinsert with an ordinary payload: %v, want nil", err)
+	}
+	eb, err := handleVectorExists(tx, EncodeExistsArgs("docs", 3))
+	if err != nil {
+		t.Fatalf("exists: %v", err)
+	}
+	if ex, _ := DecodeExistsResult(eb); !ex {
+		t.Fatal("the legitimate version-preserving reinsert did not land")
+	}
+}

--- a/sdk/record/doc.go
+++ b/sdk/record/doc.go
@@ -1,0 +1,57 @@
+// SPDX-License-Identifier: Apache-2.0
+
+// Package record implements record paths and byte-level resolution for
+// `operate` records (design doc §2.2/§2.9), shared by the vector store's
+// record-typed payload cells and the KV store's operate records. It has no
+// dependency on either engine: it operates purely on decoded record trees
+// (sdk/wire) and produces payload-shaped values (sdk/vtypes) so filter and
+// index code on both sides can treat a resolved record cell like any other
+// payload value.
+//
+// # Path grammar
+//
+// A filter or index `field` string is first tried as an exact payload key
+// (a key that itself contains "/" keeps working); otherwise SplitField
+// divides it at the first "/" into a payload key and a record path, and the
+// payload key must hold a record. ParsePath then parses the record path
+// into 1-3 "/"-separated segments:
+//
+//	seg1        a field: a name, or "#N" for a position (N <= 65535)
+//	seg2        a row key: decimal digits ([0-9]+, <= 20 digits, must fit
+//	            uint64) for an integer key type, or a quoted string "..."
+//	            (with \" and \\ escapes) for a FIXED key type
+//	seg3        a column: a name, or "#N" for a position
+//
+// A field segment may end with "#count" (e.g. "b#count"), in which case it
+// must be the only segment in the path — "#count" reports a table field's
+// row count and does not compose with a row or column segment.
+//
+// Names are 1-255 bytes and may not contain '/', '#', or '"'. Any path that
+// does not fit this grammar is rejected with an error wrapping ErrPath.
+//
+// # Determinism
+//
+// ParsePath and SplitField are pure functions of their input string: same
+// bytes in, same result out, on every platform and Go version this module
+// supports. Nothing in this package consults the clock, environment,
+// filesystem, or any other ambient state. A later resolver built on top of
+// this grammar (Task 3) must hold to the same rule: it is a pure function of
+// the record bytes and the parsed Path, and any schema cache it keeps must
+// be keyed by the schema blob's bytes so a cache hit can never change the
+// answer.
+//
+// # Hardening
+//
+// A stored record's `set_payload` bytes are attacker-influenced: a client
+// can store arbitrary bytes under any key, including bytes shaped to look
+// like a record but crafted to defeat a careless decoder. ParsePath and
+// SplitField only ever see the path string (never record bytes) and are
+// therefore straightforward to keep panic-free: every length is checked
+// before slicing, every numeric parse is bounds-checked before the value is
+// trusted (position <= 65535, row-key digit count <= 20 and must fit
+// uint64), and no segment is treated as well-formed until it has been fully
+// validated. A resolver built on this grammar (Task 3, mirroring
+// sdk/wire/operate_record.go) must extend the same discipline to the record
+// bytes themselves: every offset bounds-checked before use, every count
+// bounded before allocation, and only canonical uvarints accepted.
+package record

--- a/sdk/record/doc.go
+++ b/sdk/record/doc.go
@@ -31,6 +31,12 @@
 // Names are 1-255 bytes and may not contain '/', '#', or '"'. Any path that
 // does not fit this grammar is rejected with an error wrapping ErrPath.
 //
+// The grammar bounds the whole string as well as its segments: three
+// segments of at most 255 bytes each, with a quoted row key of at most
+// 2+2*wire.OperateMaxKeyLen raw bytes, is 1024 bytes. ParsePath checks that
+// total FIRST, before it splits, so a hostile field costs one length
+// comparison rather than one allocation per '/'.
+//
 // # Determinism
 //
 // ParsePath and SplitField are pure functions of their input string: same

--- a/sdk/record/doc.go
+++ b/sdk/record/doc.go
@@ -19,7 +19,9 @@
 //	seg1        a field: a name, or "#N" for a position (N <= 65535)
 //	seg2        a row key: decimal digits ([0-9]+, <= 20 digits, must fit
 //	            uint64) for an integer key type, or a quoted string "..."
-//	            (with \" and \\ escapes) for a FIXED key type
+//	            (with \" and \\ escapes) for a FIXED key type, whose
+//	            UNESCAPED length must be <= 255 bytes (wire.OperateMaxKeyLen,
+//	            the widest row key any record can encode)
 //	seg3        a column: a name, or "#N" for a position
 //
 // A field segment may end with "#count" (e.g. "b#count"), in which case it
@@ -49,7 +51,10 @@
 // before slicing, every numeric parse is bounds-checked before the value is
 // trusted (position <= 65535, row-key digit count <= 20 and must fit
 // uint64), and no segment is treated as well-formed until it has been fully
-// validated. Resolver.Resolve extends the same discipline to the record
+// validated. The quoted row key is bounded before it is unescaped, not
+// after, so a hostile path cannot drive a large allocation on a parse that
+// is going to be rejected anyway. Resolver.Resolve extends the same
+// discipline to the record
 // bytes themselves, mirroring sdk/wire/operate_record.go: every offset
 // bounds-checked before use, every count bounded before allocation, and
 // only canonical uvarints accepted.

--- a/sdk/record/doc.go
+++ b/sdk/record/doc.go
@@ -3,10 +3,10 @@
 // Package record implements record paths and byte-level resolution for
 // `operate` records (design doc §2.2/§2.9), shared by the vector store's
 // record-typed payload cells and the KV store's operate records. It has no
-// dependency on either engine: it operates purely on decoded record trees
-// (sdk/wire) and produces payload-shaped values (sdk/vtypes) so filter and
-// index code on both sides can treat a resolved record cell like any other
-// payload value.
+// dependency on either engine: it reads stored record bytes with the wire
+// format's own vocabulary (sdk/wire) and produces payload-shaped values
+// (sdk/vtypes) so filter and index code on both sides can treat a resolved
+// record cell like any other payload value.
 //
 // # Path grammar
 //
@@ -34,11 +34,10 @@
 // ParsePath and SplitField are pure functions of their input string: same
 // bytes in, same result out, on every platform and Go version this module
 // supports. Nothing in this package consults the clock, environment,
-// filesystem, or any other ambient state. A later resolver built on top of
-// this grammar (Task 3) must hold to the same rule: it is a pure function of
-// the record bytes and the parsed Path, and any schema cache it keeps must
-// be keyed by the schema blob's bytes so a cache hit can never change the
-// answer.
+// filesystem, or any other ambient state. Resolver.Resolve holds to the
+// same rule: it is a pure function of the record bytes and the parsed Path,
+// and its schema cache is keyed by the schema blob's bytes so a cache hit
+// can never change the answer.
 //
 // # Hardening
 //
@@ -50,8 +49,8 @@
 // before slicing, every numeric parse is bounds-checked before the value is
 // trusted (position <= 65535, row-key digit count <= 20 and must fit
 // uint64), and no segment is treated as well-formed until it has been fully
-// validated. A resolver built on this grammar (Task 3, mirroring
-// sdk/wire/operate_record.go) must extend the same discipline to the record
-// bytes themselves: every offset bounds-checked before use, every count
-// bounded before allocation, and only canonical uvarints accepted.
+// validated. Resolver.Resolve extends the same discipline to the record
+// bytes themselves, mirroring sdk/wire/operate_record.go: every offset
+// bounds-checked before use, every count bounded before allocation, and
+// only canonical uvarints accepted.
 package record

--- a/sdk/record/doc.go
+++ b/sdk/record/doc.go
@@ -16,13 +16,16 @@
 // payload key must hold a record. ParsePath then parses the record path
 // into 1-3 "/"-separated segments:
 //
-//	seg1        a field: a name, or "#N" for a position (N <= 65535)
+//	seg1        a field: a name, or "#N" for a position (N <= 65535,
+//	            written canonically: at most 5 digits, no leading zeros
+//	            except "#0" itself)
 //	seg2        a row key: decimal digits ([0-9]+, <= 20 digits, must fit
 //	            uint64) for an integer key type, or a quoted string "..."
 //	            (with \" and \\ escapes) for a FIXED key type, whose
 //	            UNESCAPED length must be <= 255 bytes (wire.OperateMaxKeyLen,
 //	            the widest row key any record can encode)
-//	seg3        a column: a name, or "#N" for a position
+//	seg3        a column: a name, or "#N" for a position, in the same
+//	            canonical form as seg1
 //
 // A field segment may end with "#count" (e.g. "b#count"), in which case it
 // must be the only segment in the path — "#count" reports a table field's
@@ -55,8 +58,9 @@
 // SplitField only ever see the path string (never record bytes) and are
 // therefore straightforward to keep panic-free: every length is checked
 // before slicing, every numeric parse is bounds-checked before the value is
-// trusted (position <= 65535, row-key digit count <= 20 and must fit
-// uint64), and no segment is treated as well-formed until it has been fully
+// trusted (position <= 65535 and canonically spelled, row-key digit count
+// <= 20 and must fit uint64), and no segment is treated as well-formed
+// until it has been fully
 // validated. The quoted row key is bounded before it is unescaped, not
 // after, so a hostile path cannot drive a large allocation on a parse that
 // is going to be rejected anyway. Resolver.Resolve extends the same

--- a/sdk/record/fuzz_test.go
+++ b/sdk/record/fuzz_test.go
@@ -1,0 +1,219 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package record
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/rostamlabs/rostam/sdk/wire"
+)
+
+// fuzzPaths is the fixed set of paths FuzzResolve checks against every
+// record wire.DecodeRecord accepts out of the fuzzer's corpus. It is drawn
+// from the two seed fixtures' own field/row/column names — the session
+// example (rc, bc, hist, bal, tag, b/hi/lo) and the dynamic example
+// (cnt, raw, t/hi/lo) — plus deliberate near-misses: an absent name (zz), an
+// out-of-range position (#9), a #count on a field that may not be a table,
+// a row on a field that may not be one, and a row+column on a field that may
+// not have a row at that key. The set is FIXED rather than randomly drawn
+// (contrast oracle_test.go's randomPath) because the fuzzer already varies
+// the record bytes; adding a second axis of randomness would make a
+// discovered crasher harder to reproduce from its saved corpus entry.
+var fuzzPaths = mustParsePaths([]string{
+	"rc", "bc", "hist", "bal", "tag", "b", "cnt", "raw", "t", "zz",
+	"#0", "#1", "#5", "#9",
+	"b#count", "t#count", "rc#count", "zz#count",
+	"b/42", "b/99", "b/7", `b/"DE"`, `b/"XX"`,
+	"t/42", "t/7", `t/"DE"`, `t/"XX"`,
+	"b/42/hi", "b/42/lo", "b/42/#0", "b/42/#9", "b/42/zz",
+	"t/42/hi", "t/42/lo", `t/"DE"/hi`, `t/"DE"/lo`,
+	"#5/42/#0", "#0/42",
+})
+
+// mustParsePaths parses every path string in ss, panicking on the first
+// failure. Called only from a package-level var initializer with a fixed,
+// hand-checked literal list, so a panic here is a bug in this file, not
+// something a test run needs to recover from.
+func mustParsePaths(ss []string) []Path {
+	paths := make([]Path, 0, len(ss))
+	for _, s := range ss {
+		p, err := ParsePath(s)
+		if err != nil {
+			panic("fuzzPaths: " + s + ": " + err.Error())
+		}
+		paths = append(paths, p)
+	}
+	return paths
+}
+
+// fuzzLEKey encodes v as an 8-byte little-endian table row key — what
+// client.KeyU64 (and a decimal row-key segment, in both schema and dynamic
+// mode) produce — for the seed fixtures below.
+func fuzzLEKey(v uint64) []byte {
+	b := make([]byte, 8)
+	for i := range b {
+		b[i] = byte(v >> (8 * uint(i)))
+	}
+	return b
+}
+
+// fuzzSessionSeed builds the same schema-mode session record
+// resolve_test.go's sessionRecord(t, true) and record_filter_test.go's
+// sessionRecordBytes build, without needing a *testing.T (f.Add seeding runs
+// before any subtest exists):
+//
+//	#0 rc   U8      = 7
+//	#1 bc   U8      = 3
+//	#2 hist U32     = 1234
+//	#3 bal  I32     = -5
+//	#4 tag  BYTES   = "de"
+//	#5 b    TABLE(key U64; c0 "hi" U32, c1 "lo" U32) = {42: (500, 1), 99: (7, 2)}
+func fuzzSessionSeed(f *testing.F) []byte {
+	s := &wire.Schema{
+		Version:    3,
+		StoreNames: true,
+		Fields: []wire.FieldDef{
+			{Name: "rc", Type: wire.OperateTypeU8},
+			{Name: "bc", Type: wire.OperateTypeU8},
+			{Name: "hist", Type: wire.OperateTypeU32},
+			{Name: "bal", Type: wire.OperateTypeI32},
+			{Name: "tag", Type: wire.OperateTypeBytes},
+			{Name: "b", Type: wire.OperateTypeTable, Table: &wire.TableDef{
+				KeyType: wire.OperateTypeU64,
+				Cols: []wire.ColumnDef{
+					{Name: "hi", Type: wire.OperateTypeU32},
+					{Name: "lo", Type: wire.OperateTypeU32},
+				},
+			}},
+		},
+	}
+	if err := s.Validate(); err != nil {
+		f.Fatalf("session seed schema invalid: %v", err)
+	}
+	rec := &wire.Record{Mode: wire.OperateModeSchema, Schema: s, Fields: []wire.Field{
+		{Cell: wire.Cell{Type: wire.OperateTypeU8, U: 7}},
+		{Cell: wire.Cell{Type: wire.OperateTypeU8, U: 3}},
+		{Cell: wire.Cell{Type: wire.OperateTypeU32, U: 1234}},
+		{Cell: wire.Cell{Type: wire.OperateTypeI32, U: su64(-5)}},
+		{Cell: wire.Cell{Type: wire.OperateTypeBytes, B: []byte("de")}},
+		{Cell: wire.Cell{Type: wire.OperateTypeTable}, Table: &wire.Table{Rows: []wire.Row{
+			{Key: fuzzLEKey(42), Cols: []wire.Col{
+				{Cell: wire.Cell{Type: wire.OperateTypeU32, U: 500}},
+				{Cell: wire.Cell{Type: wire.OperateTypeU32, U: 1}},
+			}},
+			{Key: fuzzLEKey(99), Cols: []wire.Col{
+				{Cell: wire.Cell{Type: wire.OperateTypeU32, U: 7}},
+				{Cell: wire.Cell{Type: wire.OperateTypeU32, U: 2}},
+			}},
+		}}},
+	}}
+	enc := rec.Encode()
+	if enc == nil {
+		f.Fatal("session seed failed to encode")
+	}
+	return enc
+}
+
+// fuzzDynamicSeed builds the same dynamic-mode record resolve_test.go's
+// dynamicRecord(t) builds, without needing a *testing.T:
+//
+//	cnt U32   = 9
+//	raw BYTES = "hi"
+//	t   TABLE: {LE(42): (hi=500, lo=1), "DE": (hi=7)}
+func fuzzDynamicSeed(f *testing.F) []byte {
+	rec := &wire.Record{Mode: wire.OperateModeDynamic, Fields: []wire.Field{
+		{Name: "cnt", Cell: wire.Cell{Type: wire.OperateTypeU32, U: 9}},
+		{Name: "raw", Cell: wire.Cell{Type: wire.OperateTypeBytes, B: []byte("hi")}},
+		{Name: "t", Cell: wire.Cell{Type: wire.OperateTypeTable}, Table: &wire.Table{Rows: []wire.Row{
+			{Key: fuzzLEKey(42), Cols: []wire.Col{
+				{Name: "hi", Cell: wire.Cell{Type: wire.OperateTypeU32, U: 500}},
+				{Name: "lo", Cell: wire.Cell{Type: wire.OperateTypeU8, U: 1}},
+			}},
+			{Key: []byte("DE"), Cols: []wire.Col{
+				{Name: "hi", Cell: wire.Cell{Type: wire.OperateTypeU32, U: 7}},
+			}},
+		}}},
+	}}
+	enc := rec.Encode()
+	if enc == nil {
+		f.Fatal("dynamic seed failed to encode")
+	}
+	return enc
+}
+
+// FuzzResolve is the hostile-input fuzz target for the record resolver.
+// Two properties hold for EVERY input, well-formed or not — the same ones
+// TestResolveHostileNeverPanics pins with a hand-built corpus:
+//
+//   - Resolve never panics (the fuzzing engine itself catches that) and
+//     never returns an error outside ErrPath/ErrRecord;
+//   - Resolve never mutates its input.
+//
+// A third property holds only when the fuzzed bytes really are a
+// well-formed record (wire.DecodeRecord accepts them): for every path in
+// fuzzPaths, Resolve must agree with the tree oracle (resolveTree,
+// oracle_test.go) — the same Result, or the same error class (ErrPath vs
+// ErrRecord, via errors.Is/errClass) — because on a well-formed record the
+// byte-level resolver and the decode-then-walk oracle are two
+// implementations of the identical rule and must never diverge.
+//
+// Seeded with the session (schema-mode) and dynamic-mode example records
+// (the same fixtures resolve_test.go's own tests use) plus a handful of
+// single-byte flips and truncations of each, so the corpus starts from
+// bytes already close to well-formed instead of making the mutator
+// rediscover record shape from nothing.
+func FuzzResolve(f *testing.F) {
+	sessEnc := fuzzSessionSeed(f)
+	dynEnc := fuzzDynamicSeed(f)
+	f.Add(sessEnc)
+	f.Add(dynEnc)
+
+	for _, base := range [][]byte{sessEnc, dynEnc} {
+		for _, off := range []int{0, 1, len(base) / 2, len(base) - 1} {
+			if off < 0 || off >= len(base) {
+				continue
+			}
+			mut := append([]byte(nil), base...)
+			mut[off] ^= 0xFF
+			f.Add(mut)
+		}
+		if len(base) > 1 {
+			f.Add(base[:len(base)-1])
+			f.Add(base[:len(base)/2])
+		}
+	}
+
+	r := NewResolver(16)
+	f.Fuzz(func(t *testing.T, b []byte) {
+		before := append([]byte(nil), b...)
+
+		for _, p := range fuzzPaths {
+			res, err := r.Resolve(b, p)
+			if err != nil && errClass(err) == "other" {
+				t.Fatalf("Resolve returned an error outside ErrPath/ErrRecord: %v", err)
+			}
+			if err != nil && !isZeroResult(res) {
+				t.Fatalf("error %v returned a non-zero result %+v", err, res)
+			}
+		}
+		if !bytes.Equal(before, b) {
+			t.Fatal("Resolve mutated its input")
+		}
+
+		dec, derr := wire.DecodeRecord(b)
+		if derr != nil {
+			return // not a well-formed record; the oracle has nothing to check.
+		}
+		for _, p := range fuzzPaths {
+			got, gerr := r.Resolve(b, p)
+			want, werr := resolveTree(dec, p)
+			if errClass(gerr) != errClass(werr) {
+				t.Fatalf("path %+v: error class %s (%v), oracle %s (%v)", p, errClass(gerr), gerr, errClass(werr), werr)
+			}
+			if gerr == nil && !resultsEqual(got, want) {
+				t.Fatalf("path %+v: got %+v, oracle %+v", p, got, want)
+			}
+		}
+	})
+}

--- a/sdk/record/fuzz_test.go
+++ b/sdk/record/fuzz_test.go
@@ -4,8 +4,11 @@ package record
 
 import (
 	"bytes"
+	"fmt"
+	"strings"
 	"testing"
 
+	"github.com/rostamlabs/rostam/sdk/vtypes"
 	"github.com/rostamlabs/rostam/sdk/wire"
 )
 
@@ -150,13 +153,22 @@ func fuzzDynamicSeed(f *testing.F) []byte {
 //     never returns an error outside ErrPath/ErrRecord;
 //   - Resolve never mutates its input.
 //
-// A third property holds only when the fuzzed bytes really are a
+// IndexEntries is fuzzed on the SAME inputs, and it has to be: it is the
+// other byte-level reader of a stored record, it runs on the WRITE path
+// (reindex) where a panic takes the collection down rather than one query,
+// and — unlike Resolve — it walks EVERY field of the record instead of
+// stopping on its own path, so it reaches decode states no path in fuzzPaths
+// can steer Resolve into. It holds the same three properties: no panic, an
+// error only ever wrapping ErrRecord/ErrPath, and no mutation of its input.
+//
+// A further property holds only when the fuzzed bytes really are a
 // well-formed record (wire.DecodeRecord accepts them): for every path in
 // fuzzPaths, Resolve must agree with the tree oracle (resolveTree,
 // oracle_test.go) — the same Result, or the same error class (ErrPath vs
-// ErrRecord, via errors.Is/errClass) — because on a well-formed record the
-// byte-level resolver and the decode-then-walk oracle are two
-// implementations of the identical rule and must never diverge.
+// ErrRecord, via errors.Is/errClass) — and IndexEntries must equal the
+// entries derived from that same decoded tree (indexEntriesTree). On a
+// well-formed record each byte-level reader and its decode-then-walk oracle
+// are two implementations of one rule and must never diverge.
 //
 // Seeded with the session (schema-mode) and dynamic-mode example records
 // (the same fixtures resolve_test.go's own tests use) plus a handful of
@@ -197,8 +209,15 @@ func FuzzResolve(f *testing.F) {
 				t.Fatalf("error %v returned a non-zero result %+v", err, res)
 			}
 		}
+		entries, ierr := r.IndexEntries(b)
+		if ierr != nil && errClass(ierr) == "other" {
+			t.Fatalf("IndexEntries returned an error outside ErrPath/ErrRecord: %v", ierr)
+		}
+		if ierr != nil && len(entries) != 0 {
+			t.Fatalf("IndexEntries error %v returned %d entries, want none", ierr, len(entries))
+		}
 		if !bytes.Equal(before, b) {
-			t.Fatal("Resolve mutated its input")
+			t.Fatal("Resolve or IndexEntries mutated its input")
 		}
 
 		dec, derr := wire.DecodeRecord(b)
@@ -215,5 +234,71 @@ func FuzzResolve(f *testing.F) {
 				t.Fatalf("path %+v: got %+v, oracle %+v", p, got, want)
 			}
 		}
+		if ierr != nil {
+			t.Fatalf("IndexEntries failed on a record wire.DecodeRecord accepts: %v", ierr)
+		}
+		if wantEntries := indexEntriesTree(dec); !entriesEqual(entries, wantEntries) {
+			t.Fatalf("IndexEntries = %v, oracle = %v", entriesString(entries), entriesString(wantEntries))
+		}
 	})
+}
+
+// indexEntriesTree is the decode-then-walk oracle for IndexEntries: it derives
+// the entries from the DECODED tree the same way the byte-level walk derives
+// them from the bytes. Kept deliberately dumb — a straight walk of the tree
+// with no offset arithmetic of its own — so that when the two disagree the
+// byte-level reader is the one under suspicion.
+//
+// It mirrors IndexEntries' documented rule exactly: one entry per top-level
+// scalar whose CellValue is defined and not NaN, one "<field>#count" entry per
+// top-level table, table columns never indexed, and schema-mode field names
+// spelled by schemaFieldLabel (the name, or "#N" for a names-less schema).
+func indexEntriesTree(rec *wire.Record) []Entry {
+	entries := make([]Entry, 0, len(rec.Fields))
+	for i := range rec.Fields {
+		f := &rec.Fields[i]
+		name := f.Name
+		if rec.Mode == wire.OperateModeSchema {
+			if rec.Schema == nil || i >= len(rec.Schema.Fields) {
+				return entries // a shape DecodeRecord would not have produced
+			}
+			name = schemaFieldLabel(rec.Schema.StoreNames, rec.Schema.Fields[i].Name, i)
+		}
+		if f.Cell.Type == wire.OperateTypeTable {
+			nRows := 0
+			if f.Table != nil {
+				nRows = len(f.Table.Rows)
+			}
+			entries = append(entries, Entry{Field: name + countSuffix, Value: vtypes.NewInt(int64(nRows))})
+			continue
+		}
+		if v, ok := CellValue(f.Cell); ok && !isNaNValue(v) {
+			entries = append(entries, Entry{Field: name, Value: v})
+		}
+	}
+	return entries
+}
+
+// entriesEqual compares two entry lists as ORDERED sequences: IndexEntries
+// promises a deterministic order (schema field order, or ascending stored name
+// order), so an order difference is a real divergence, not a formatting one.
+func entriesEqual(a, b []Entry) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i].Field != b[i].Field || !valuesEqual(a[i].Value, b[i].Value) {
+			return false
+		}
+	}
+	return true
+}
+
+// entriesString renders an entry list for a failure message.
+func entriesString(es []Entry) string {
+	parts := make([]string, 0, len(es))
+	for _, e := range es {
+		parts = append(parts, fmt.Sprintf("%s=%+v", e.Field, e.Value))
+	}
+	return "[" + strings.Join(parts, " ") + "]"
 }

--- a/sdk/record/oracle_test.go
+++ b/sdk/record/oracle_test.go
@@ -1,0 +1,719 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package record
+
+import (
+	"bytes"
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"math/rand"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/rostamlabs/rostam/sdk/wire"
+)
+
+// This file holds the ORACLE the byte-level resolver is held to: a second,
+// deliberately naive implementation of the same semantics over the decoded
+// record tree (wire.DecodeRecord), plus the random record and path
+// generators TestResolveMatchesOracle drives both with. The oracle walks
+// slices and maps; resolve.go walks stored bytes with offset arithmetic.
+// They must agree on every well-formed record.
+
+// resolveTree resolves p against the decoded record tree rec by the same
+// rules resolve.go implements over stored bytes. It is the reference
+// implementation, written for obviousness rather than speed.
+func resolveTree(rec *wire.Record, p Path) (Result, error) {
+	if len(p.Segs) == 0 || len(p.Segs) > 3 {
+		return Result{}, fmt.Errorf("%w: path has %d segments", ErrPath, len(p.Segs))
+	}
+	switch rec.Mode {
+	case wire.OperateModeSchema:
+		return resolveTreeSchema(rec, p)
+	case wire.OperateModeDynamic:
+		return resolveTreeDynamic(rec, p)
+	default:
+		return Result{}, fmt.Errorf("%w: unknown mode byte %d", ErrRecord, rec.Mode)
+	}
+}
+
+func resolveTreeSchema(rec *wire.Record, p Path) (Result, error) {
+	s := rec.Schema
+	seg := p.Segs[0]
+
+	var pos int
+	if seg.ByPos {
+		if int(seg.Pos) >= len(s.Fields) {
+			return Result{Kind: Absent}, nil
+		}
+		pos = int(seg.Pos)
+	} else {
+		if !s.StoreNames {
+			return Result{}, fmt.Errorf("%w: schema stores no names", ErrPath)
+		}
+		i, ok := s.FieldPos(seg.Name)
+		if !ok {
+			return Result{Kind: Absent}, nil
+		}
+		pos = i
+	}
+
+	fdef := &s.Fields[pos]
+	fld := &rec.Fields[pos]
+	isTable := fdef.Type == wire.OperateTypeTable
+
+	if seg.Kind == SegCount {
+		if !isTable {
+			return Result{}, fmt.Errorf("%w: #count on a non-table field", ErrPath)
+		}
+		return Result{Kind: Count, Count: uint64(len(fld.Table.Rows))}, nil
+	}
+	if len(p.Segs) == 1 {
+		if isTable {
+			return Result{Kind: Table}, nil
+		}
+		return Result{Kind: Scalar, Cell: fld.Cell}, nil
+	}
+	if !isTable {
+		return Result{}, fmt.Errorf("%w: row segment on a non-table field", ErrPath)
+	}
+
+	td := fdef.Table
+	kw := wire.CellWidth(td.KeyType, td.KeyN)
+	if kw < 1 {
+		return Result{}, fmt.Errorf("%w: table key has no width", ErrRecord)
+	}
+	key, ok := treeTargetKey(p.Segs[1], kw)
+	if !ok {
+		return Result{Kind: Absent}, nil
+	}
+	var row *wire.Row
+	for i := range fld.Table.Rows {
+		if bytes.Equal(fld.Table.Rows[i].Key, key) {
+			row = &fld.Table.Rows[i]
+			break
+		}
+	}
+	if row == nil {
+		return Result{Kind: Absent}, nil
+	}
+	if len(p.Segs) == 2 {
+		return Result{Kind: RowPresent}, nil
+	}
+
+	cseg := p.Segs[2]
+	var ci int
+	if cseg.ByPos {
+		if int(cseg.Pos) >= len(td.Cols) {
+			return Result{Kind: Absent}, nil
+		}
+		ci = int(cseg.Pos)
+	} else {
+		if !s.StoreNames {
+			return Result{}, fmt.Errorf("%w: schema stores no names", ErrPath)
+		}
+		found := -1
+		for i := range td.Cols {
+			if td.Cols[i].Name == cseg.Name {
+				found = i
+				break
+			}
+		}
+		if found < 0 {
+			return Result{Kind: Absent}, nil
+		}
+		ci = found
+	}
+	if ci >= len(row.Cols) {
+		return Result{Kind: Absent}, nil
+	}
+	return Result{Kind: Scalar, Cell: row.Cols[ci].Cell}, nil
+}
+
+func resolveTreeDynamic(rec *wire.Record, p Path) (Result, error) {
+	seg := p.Segs[0]
+	if seg.ByPos {
+		return Result{}, fmt.Errorf("%w: dynamic mode has no field positions", ErrPath)
+	}
+	idx := -1
+	for i := range rec.Fields {
+		if rec.Fields[i].Name == seg.Name {
+			idx = i
+			break
+		}
+	}
+	if idx < 0 {
+		return Result{Kind: Absent}, nil
+	}
+	fld := &rec.Fields[idx]
+	isTable := fld.Cell.Type == wire.OperateTypeTable
+
+	if seg.Kind == SegCount {
+		if !isTable {
+			return Result{}, fmt.Errorf("%w: #count on a non-table field", ErrPath)
+		}
+		return Result{Kind: Count, Count: uint64(len(fld.Table.Rows))}, nil
+	}
+	if len(p.Segs) == 1 {
+		if isTable {
+			return Result{Kind: Table}, nil
+		}
+		return Result{Kind: Scalar, Cell: fld.Cell}, nil
+	}
+	if !isTable {
+		return Result{}, fmt.Errorf("%w: row segment on a non-table field", ErrPath)
+	}
+
+	key, ok := treeDynamicKey(p.Segs[1])
+	if !ok {
+		return Result{Kind: Absent}, nil
+	}
+	var row *wire.Row
+	for i := range fld.Table.Rows {
+		if bytes.Equal(fld.Table.Rows[i].Key, key) {
+			row = &fld.Table.Rows[i]
+			break
+		}
+	}
+	if row == nil {
+		return Result{Kind: Absent}, nil
+	}
+	if len(p.Segs) == 2 {
+		return Result{Kind: RowPresent}, nil
+	}
+
+	cseg := p.Segs[2]
+	if cseg.ByPos {
+		return Result{}, fmt.Errorf("%w: dynamic mode has no column positions", ErrPath)
+	}
+	for i := range row.Cols {
+		if row.Cols[i].Name == cseg.Name {
+			return Result{Kind: Scalar, Cell: row.Cols[i].Cell}, nil
+		}
+	}
+	return Result{Kind: Absent}, nil
+}
+
+// treeTargetKey builds the schema-mode row key a row segment denotes at key
+// width kw, or reports that no row of that width can match.
+func treeTargetKey(seg Segment, kw int) ([]byte, bool) {
+	if seg.KeyQuoted {
+		if len(seg.Key) != kw {
+			return nil, false
+		}
+		return seg.Key, true
+	}
+	v, err := strconv.ParseUint(seg.KeyText, 10, 64)
+	if err != nil {
+		return nil, false
+	}
+	return leKeyBytes(v, kw)
+}
+
+// treeDynamicKey builds the dynamic-mode row key a row segment denotes: the
+// raw bytes of a quoted segment, or the 8-byte little-endian encoding of a
+// decimal one.
+func treeDynamicKey(seg Segment) ([]byte, bool) {
+	if seg.KeyQuoted {
+		return seg.Key, true
+	}
+	v, err := strconv.ParseUint(seg.KeyText, 10, 64)
+	if err != nil {
+		return nil, false
+	}
+	return leKeyBytes(v, 8)
+}
+
+// leKeyBytes encodes v as width little-endian bytes, reporting false when v
+// does not fit in that width.
+func leKeyBytes(v uint64, width int) ([]byte, bool) {
+	if width < 1 {
+		return nil, false
+	}
+	if width < 8 && v >= uint64(1)<<(8*uint(width)) {
+		return nil, false
+	}
+	b := make([]byte, width)
+	for i := 0; i < width && i < 8; i++ {
+		b[i] = byte(v >> (8 * uint(i)))
+	}
+	return b, true
+}
+
+// leValue decodes at most 8 little-endian bytes as an unsigned integer.
+func leValue(b []byte) uint64 {
+	var v uint64
+	for i := len(b) - 1; i >= 0; i-- {
+		v = v<<8 | uint64(b[i])
+	}
+	return v
+}
+
+// --- generators -----------------------------------------------------------
+
+var (
+	// schemaNamePool supplies unique, path-legal field names; a schema never
+	// has more fields than this pool has entries.
+	schemaNamePool = []string{"aa", "bb", "cc", "dd", "ee", "ff"}
+	// colNamePool supplies unique, path-legal column names.
+	colNamePool = []string{"c0", "c1", "c2", "c3"}
+	// dynNamePool supplies dynamic-mode field names.
+	dynNamePool = []string{"a", "bb", "ccc", "dd", "ee", "ff"}
+	// keyAlphabet is the byte alphabet FIXED and dynamic row keys are drawn
+	// from: path-safe (no '/', which ParsePath splits on before unquoting)
+	// but including the two bytes a quoted segment must escape.
+	keyAlphabet = []byte(`abcXY019"\`)
+
+	// scalarFieldTypes are the record-field types a generated schema draws
+	// from (TABLE is added separately; UNSET is not legal in a schema).
+	scalarFieldTypes = []uint8{
+		wire.OperateTypeU8, wire.OperateTypeU16, wire.OperateTypeU32, wire.OperateTypeU64,
+		wire.OperateTypeI8, wire.OperateTypeI16, wire.OperateTypeI32, wire.OperateTypeI64,
+		wire.OperateTypeF32, wire.OperateTypeF64,
+		wire.OperateTypeUVarint, wire.OperateTypeIVarint,
+		wire.OperateTypeBytes, wire.OperateTypeFixed,
+	}
+	// fixedWidthTypes are the types legal as a table column (fixed width only).
+	fixedWidthTypes = []uint8{
+		wire.OperateTypeU8, wire.OperateTypeU16, wire.OperateTypeU32, wire.OperateTypeU64,
+		wire.OperateTypeI8, wire.OperateTypeI16, wire.OperateTypeI32, wire.OperateTypeI64,
+		wire.OperateTypeF32, wire.OperateTypeF64, wire.OperateTypeFixed,
+	}
+	// keyTypes are the legal table row-key types.
+	keyTypes = []uint8{
+		wire.OperateTypeU8, wire.OperateTypeU16, wire.OperateTypeU32,
+		wire.OperateTypeU64, wire.OperateTypeFixed,
+	}
+	// dynFieldTypes are the dynamic-mode scalar field types (UNSET included:
+	// a dynamic field may legally carry no bytes at all).
+	dynFieldTypes = []uint8{
+		wire.OperateTypeU8, wire.OperateTypeU16, wire.OperateTypeU32, wire.OperateTypeU64,
+		wire.OperateTypeI8, wire.OperateTypeI16, wire.OperateTypeI32, wire.OperateTypeI64,
+		wire.OperateTypeF32, wire.OperateTypeF64,
+		wire.OperateTypeUVarint, wire.OperateTypeIVarint,
+		wire.OperateTypeBytes, wire.OperateTypeFixed, wire.OperateTypeUnset,
+	}
+)
+
+// randomSchemaRecord builds a random schema-mode record, encodes it, and
+// returns the stored bytes alongside the tree DecodeRecord reads back from
+// them. The DECODED tree — not the tree that was built — is the oracle's
+// input, so the oracle and the resolver see exactly the same record.
+func randomSchemaRecord(rng *rand.Rand) ([]byte, *wire.Record, error) {
+	s := &wire.Schema{
+		Version:    uint16(rng.Intn(4)),
+		StoreNames: rng.Intn(2) == 0,
+	}
+	n := 2 + rng.Intn(5) // 2..6
+	tables := 0
+	for i := 0; i < n; i++ {
+		fd := wire.FieldDef{Name: schemaNamePool[i]}
+		typ := scalarFieldTypes[rng.Intn(len(scalarFieldTypes))]
+		if tables < 2 && rng.Intn(3) == 0 {
+			typ = wire.OperateTypeTable
+		}
+		fd.Type = typ
+		switch typ {
+		case wire.OperateTypeFixed:
+			fd.N = uint8(1 + rng.Intn(4))
+		case wire.OperateTypeTable:
+			tables++
+			fd.Table = randomTableDef(rng)
+		}
+		s.Fields = append(s.Fields, fd)
+	}
+	if err := s.Validate(); err != nil {
+		return nil, nil, fmt.Errorf("generated schema invalid: %w", err)
+	}
+
+	rec := &wire.Record{Mode: wire.OperateModeSchema, Schema: s}
+	for i := range s.Fields {
+		f := &s.Fields[i]
+		if f.Type == wire.OperateTypeTable {
+			rec.Fields = append(rec.Fields, wire.Field{
+				Name:  f.Name,
+				Cell:  wire.Cell{Type: wire.OperateTypeTable},
+				Table: randomSchemaTable(rng, f.Table),
+			})
+			continue
+		}
+		rec.Fields = append(rec.Fields, wire.Field{Name: f.Name, Cell: randomCell(rng, f.Type, f.N)})
+	}
+
+	enc := rec.Encode()
+	if enc == nil {
+		return nil, nil, errors.New("generated record failed to encode")
+	}
+	dec, err := wire.DecodeRecord(enc)
+	if err != nil {
+		return nil, nil, fmt.Errorf("generated record failed to decode: %w", err)
+	}
+	return enc, dec, nil
+}
+
+func randomTableDef(rng *rand.Rand) *wire.TableDef {
+	td := &wire.TableDef{KeyType: keyTypes[rng.Intn(len(keyTypes))]}
+	if td.KeyType == wire.OperateTypeFixed {
+		td.KeyN = uint8(1 + rng.Intn(4))
+	}
+	nCols := 1 + rng.Intn(3)
+	for c := 0; c < nCols; c++ {
+		cd := wire.ColumnDef{Name: colNamePool[c], Type: fixedWidthTypes[rng.Intn(len(fixedWidthTypes))]}
+		if cd.Type == wire.OperateTypeFixed {
+			cd.N = uint8(1 + rng.Intn(3))
+		}
+		td.Cols = append(td.Cols, cd)
+	}
+	return td
+}
+
+func randomSchemaTable(rng *rand.Rand, td *wire.TableDef) *wire.Table {
+	kw := wire.CellWidth(td.KeyType, td.KeyN)
+	nRows := rng.Intn(6)
+	t := &wire.Table{}
+	seen := make(map[string]bool, nRows)
+	for attempts := 0; len(t.Rows) < nRows && attempts < 100; attempts++ {
+		var key []byte
+		if td.KeyType == wire.OperateTypeFixed {
+			key = randomKeyBytes(rng, kw)
+		} else {
+			v := uint64(rng.Intn(60))
+			key, _ = leKeyBytes(v, kw)
+		}
+		if seen[string(key)] {
+			continue
+		}
+		seen[string(key)] = true
+		row := wire.Row{Key: key}
+		for c := range td.Cols {
+			row.Cols = append(row.Cols, wire.Col{Cell: randomCell(rng, td.Cols[c].Type, td.Cols[c].N)})
+		}
+		t.Rows = append(t.Rows, row)
+	}
+	return t
+}
+
+// randomKeyBytes draws n bytes from keyAlphabet.
+func randomKeyBytes(rng *rand.Rand, n int) []byte {
+	b := make([]byte, n)
+	for i := range b {
+		b[i] = keyAlphabet[rng.Intn(len(keyAlphabet))]
+	}
+	return b
+}
+
+func randomCell(rng *rand.Rand, typ, n uint8) wire.Cell {
+	c := wire.Cell{Type: typ, N: n}
+	switch typ {
+	case wire.OperateTypeU8:
+		c.U = uint64(rng.Intn(256))
+	case wire.OperateTypeU16:
+		c.U = uint64(rng.Intn(65536))
+	case wire.OperateTypeU32:
+		c.U = uint64(rng.Uint32())
+	case wire.OperateTypeU64, wire.OperateTypeUVarint:
+		c.U = rng.Uint64() >> uint(rng.Intn(64))
+	case wire.OperateTypeI8:
+		c.U = su64(int64(int8(rng.Intn(256))))
+	case wire.OperateTypeI16:
+		c.U = su64(int64(int16(rng.Intn(65536))))
+	case wire.OperateTypeI32:
+		c.U = su64(int64(int32(rng.Uint32())))
+	case wire.OperateTypeI64, wire.OperateTypeIVarint:
+		c.U = su64(int64(rng.Uint64()) >> uint(rng.Intn(64)))
+	case wire.OperateTypeF32:
+		c.F = float64(float32(rng.NormFloat64()))
+	case wire.OperateTypeF64:
+		c.F = rng.NormFloat64()
+	case wire.OperateTypeBytes:
+		c.B = randomKeyBytes(rng, rng.Intn(6))
+	case wire.OperateTypeFixed:
+		c.B = randomKeyBytes(rng, int(n))
+	}
+	return c
+}
+
+// randomDynamicRecord builds a random dynamic-mode record, encodes it, and
+// returns the stored bytes alongside the decoded tree.
+func randomDynamicRecord(rng *rand.Rand) ([]byte, *wire.Record, error) {
+	rec := &wire.Record{Mode: wire.OperateModeDynamic}
+	n := 1 + rng.Intn(5)
+	used := make(map[string]bool, n)
+	for i := 0; i < n; i++ {
+		name := dynNamePool[rng.Intn(len(dynNamePool))]
+		if used[name] {
+			continue
+		}
+		used[name] = true
+		if rng.Intn(3) == 0 {
+			rec.Fields = append(rec.Fields, wire.Field{
+				Name:  name,
+				Cell:  wire.Cell{Type: wire.OperateTypeTable},
+				Table: randomDynamicTable(rng),
+			})
+			continue
+		}
+		typ := dynFieldTypes[rng.Intn(len(dynFieldTypes))]
+		var w uint8
+		if typ == wire.OperateTypeFixed {
+			w = uint8(1 + rng.Intn(4))
+		}
+		rec.Fields = append(rec.Fields, wire.Field{Name: name, Cell: randomCell(rng, typ, w)})
+	}
+	if len(rec.Fields) == 0 {
+		rec.Fields = append(rec.Fields, wire.Field{Name: "a", Cell: randomCell(rng, wire.OperateTypeU8, 0)})
+	}
+
+	enc := rec.Encode()
+	if enc == nil {
+		return nil, nil, errors.New("generated record failed to encode")
+	}
+	dec, err := wire.DecodeRecord(enc)
+	if err != nil {
+		return nil, nil, fmt.Errorf("generated record failed to decode: %w", err)
+	}
+	return enc, dec, nil
+}
+
+func randomDynamicTable(rng *rand.Rand) *wire.Table {
+	t := &wire.Table{Cap: uint32(rng.Intn(8))}
+	if rng.Intn(4) == 0 {
+		t.Policy = wire.OperatePolicyMinCol
+		t.ByColName = colNamePool[0]
+	} else {
+		t.Policy = uint8(rng.Intn(3)) // NONE, MIN_KEY, MAX_KEY
+	}
+	nRows := rng.Intn(5)
+	seen := make(map[string]bool, nRows)
+	for attempts := 0; len(t.Rows) < nRows && attempts < 100; attempts++ {
+		var key []byte
+		if rng.Intn(2) == 0 {
+			key, _ = leKeyBytes(uint64(rng.Intn(60)), 8)
+		} else {
+			key = randomKeyBytes(rng, 1+rng.Intn(4))
+		}
+		if seen[string(key)] {
+			continue
+		}
+		seen[string(key)] = true
+
+		row := wire.Row{Key: key}
+		nCols := rng.Intn(4)
+		usedCols := make(map[string]bool, nCols)
+		for c := 0; c < nCols; c++ {
+			name := colNamePool[rng.Intn(len(colNamePool))]
+			if usedCols[name] {
+				continue
+			}
+			usedCols[name] = true
+			typ := dynFieldTypes[rng.Intn(len(dynFieldTypes))]
+			var w uint8
+			if typ == wire.OperateTypeFixed {
+				w = uint8(1 + rng.Intn(3))
+			}
+			row.Cols = append(row.Cols, wire.Col{Name: name, Cell: randomCell(rng, typ, w)})
+		}
+		t.Rows = append(t.Rows, row)
+	}
+	return t
+}
+
+// randomPath draws a path string against rec: a mix of paths that resolve,
+// paths that are near misses (an absent name, an absent key, an
+// out-of-range position), and paths of the wrong shape for the field they
+// name (a row segment on a scalar, "#count" on a scalar). The caller runs
+// it through ParsePath; a string the grammar rejects is skipped.
+func randomPath(rng *rand.Rand, rec *wire.Record) string {
+	if rec.Mode == wire.OperateModeSchema {
+		return randomSchemaPath(rng, rec)
+	}
+	return randomDynamicPath(rng, rec)
+}
+
+func randomSchemaPath(rng *rand.Rand, rec *wire.Record) string {
+	s := rec.Schema
+	i := rng.Intn(len(s.Fields) + 1) // the last draw is out of range
+
+	var head string
+	switch {
+	case rng.Intn(2) == 0:
+		head = "#" + strconv.Itoa(i)
+	case rng.Intn(8) == 0:
+		head = "zz" // a name no generated schema uses
+	case i < len(s.Fields) && s.Fields[i].Name != "":
+		head = s.Fields[i].Name
+	default:
+		head = schemaNamePool[rng.Intn(len(schemaNamePool))]
+	}
+
+	switch rng.Intn(6) {
+	case 0:
+		return head + countSuffix
+	case 1, 2:
+		return head
+	}
+
+	var td *wire.TableDef
+	var tbl *wire.Table
+	if i < len(s.Fields) && s.Fields[i].Type == wire.OperateTypeTable {
+		td = s.Fields[i].Table
+		tbl = rec.Fields[i].Table
+	}
+	path := head + "/" + randomKeyText(rng, td, tbl)
+	if rng.Intn(2) == 0 {
+		return path
+	}
+	return path + "/" + randomColText(rng, td)
+}
+
+// randomKeyText renders a row-key segment: a real key of the table (when
+// there is one) half the time, a near miss otherwise.
+func randomKeyText(rng *rand.Rand, td *wire.TableDef, tbl *wire.Table) string {
+	if td != nil && tbl != nil && len(tbl.Rows) > 0 && rng.Intn(2) == 0 {
+		key := tbl.Rows[rng.Intn(len(tbl.Rows))].Key
+		if td.KeyType == wire.OperateTypeFixed {
+			return quoteKeyText(key)
+		}
+		return strconv.FormatUint(leValue(key), 10)
+	}
+	if rng.Intn(2) == 0 {
+		return strconv.FormatUint(uint64(rng.Intn(70)), 10)
+	}
+	return quoteKeyText(randomKeyBytes(rng, 1+rng.Intn(4)))
+}
+
+func randomColText(rng *rand.Rand, td *wire.TableDef) string {
+	if td != nil && len(td.Cols) > 0 && rng.Intn(2) == 0 {
+		c := rng.Intn(len(td.Cols))
+		if td.Cols[c].Name != "" && rng.Intn(2) == 0 {
+			return td.Cols[c].Name
+		}
+		return "#" + strconv.Itoa(c)
+	}
+	if rng.Intn(2) == 0 {
+		return "#" + strconv.Itoa(rng.Intn(5))
+	}
+	return colNamePool[rng.Intn(len(colNamePool))]
+}
+
+func randomDynamicPath(rng *rand.Rand, rec *wire.Record) string {
+	var head string
+	i := rng.Intn(len(rec.Fields) + 1)
+	switch {
+	case rng.Intn(8) == 0:
+		head = "#" + strconv.Itoa(i) // positions never apply in dynamic mode
+	case i < len(rec.Fields):
+		head = rec.Fields[i].Name
+	default:
+		head = dynNamePool[rng.Intn(len(dynNamePool))]
+	}
+
+	switch rng.Intn(6) {
+	case 0:
+		return head + countSuffix
+	case 1, 2:
+		return head
+	}
+
+	var tbl *wire.Table
+	if i < len(rec.Fields) {
+		tbl = rec.Fields[i].Table
+	}
+	path := head + "/" + randomDynamicKeyText(rng, tbl)
+	if rng.Intn(2) == 0 {
+		return path
+	}
+	if rng.Intn(8) == 0 {
+		return path + "/#0" // a column position never applies in dynamic mode
+	}
+	return path + "/" + colNamePool[rng.Intn(len(colNamePool))]
+}
+
+func randomDynamicKeyText(rng *rand.Rand, tbl *wire.Table) string {
+	if tbl != nil && len(tbl.Rows) > 0 && rng.Intn(2) == 0 {
+		key := tbl.Rows[rng.Intn(len(tbl.Rows))].Key
+		if len(key) == 8 {
+			return strconv.FormatUint(leValue(key), 10)
+		}
+		return quoteKeyText(key)
+	}
+	if rng.Intn(2) == 0 {
+		return strconv.FormatUint(uint64(rng.Intn(70)), 10)
+	}
+	return quoteKeyText(randomKeyBytes(rng, 1+rng.Intn(4)))
+}
+
+// quoteKeyText renders b as a quoted row-key segment, escaping the two
+// bytes the grammar escapes.
+func quoteKeyText(b []byte) string {
+	var sb strings.Builder
+	sb.WriteByte('"')
+	for _, c := range b {
+		if c == '"' || c == '\\' {
+			sb.WriteByte('\\')
+		}
+		sb.WriteByte(c)
+	}
+	sb.WriteByte('"')
+	return sb.String()
+}
+
+// TestOracleGeneratorsAreWellFormed checks the generators themselves: every
+// record they emit must round-trip through DecodeRecord (which is what
+// makes the oracle's tree the authority on the stored bytes), and a decent
+// share of the paths they draw must parse.
+func TestOracleGeneratorsAreWellFormed(t *testing.T) {
+	rng := rand.New(rand.NewSource(7))
+	parsed, total := 0, 0
+	for i := 0; i < 200; i++ {
+		var enc []byte
+		var dec *wire.Record
+		var err error
+		if i%2 == 0 {
+			enc, dec, err = randomSchemaRecord(rng)
+		} else {
+			enc, dec, err = randomDynamicRecord(rng)
+		}
+		if err != nil {
+			t.Fatalf("generator: %v", err)
+		}
+		if !bytes.Equal(dec.Encode(), enc) {
+			t.Fatalf("record %d does not re-encode identically", i)
+		}
+		for j := 0; j < 10; j++ {
+			total++
+			if _, perr := ParsePath(randomPath(rng, dec)); perr == nil {
+				parsed++
+			}
+		}
+	}
+	if parsed*2 < total {
+		t.Fatalf("only %d of %d generated paths parse; the generator is drifting from the grammar", parsed, total)
+	}
+}
+
+// TestLEKeyBytesRoundTrip checks the two helpers the oracle builds and
+// reads row keys with agree, and that the 8-byte form is exactly what
+// client.KeyU64 writes — the encoding a decimal row key denotes.
+func TestLEKeyBytesRoundTrip(t *testing.T) {
+	for _, v := range []uint64{0, 1, 255, 256, 65535, 1 << 32, ^uint64(0)} {
+		for _, w := range []int{1, 2, 4, 8} {
+			b, ok := leKeyBytes(v, w)
+			if !ok {
+				continue
+			}
+			if got := leValue(b); got != v {
+				t.Fatalf("leKeyBytes(%d, %d) round-tripped to %d", v, w, got)
+			}
+			if w == 8 {
+				var want [8]byte
+				binary.LittleEndian.PutUint64(want[:], v)
+				if !bytes.Equal(b, want[:]) {
+					t.Fatalf("leKeyBytes(%d, 8) = % x, want % x", v, b, want)
+				}
+			}
+		}
+	}
+}

--- a/sdk/record/oracle_test.go
+++ b/sdk/record/oracle_test.go
@@ -7,6 +7,7 @@ import (
 	"encoding/binary"
 	"errors"
 	"fmt"
+	"math"
 	"math/rand"
 	"strconv"
 	"strings"
@@ -242,6 +243,23 @@ func leKeyBytes(v uint64, width int) ([]byte, bool) {
 	return b, true
 }
 
+// decimalKeyFor renders key as a decimal row-key segment, reporting false
+// when no decimal segment can name it: a decimal denotes the key width's
+// little-endian encoding of a uint64, so every byte past the eighth must be
+// zero.
+func decimalKeyFor(key []byte) (string, bool) {
+	for i := 8; i < len(key); i++ {
+		if key[i] != 0 {
+			return "", false
+		}
+	}
+	n := len(key)
+	if n > 8 {
+		n = 8
+	}
+	return strconv.FormatUint(leValue(key[:n]), 10), true
+}
+
 // leValue decodes at most 8 little-endian bytes as an unsigned integer.
 func leValue(b []byte) uint64 {
 	var v uint64
@@ -356,7 +374,11 @@ func randomSchemaRecord(rng *rand.Rand) ([]byte, *wire.Record, error) {
 func randomTableDef(rng *rand.Rand) *wire.TableDef {
 	td := &wire.TableDef{KeyType: keyTypes[rng.Intn(len(keyTypes))]}
 	if td.KeyType == wire.OperateTypeFixed {
-		td.KeyN = uint8(1 + rng.Intn(4))
+		// 1..12, deliberately spanning 8: a FIXED key wider than a uint64
+		// is the only thing that exercises the zero-fill in the decimal
+		// key comparison (resolve.go's leByte past byte 7), and it must be
+		// drawn on both the matching and the near-miss side.
+		td.KeyN = uint8(1 + rng.Intn(12))
 	}
 	nCols := 1 + rng.Intn(3)
 	for c := 0; c < nCols; c++ {
@@ -378,6 +400,13 @@ func randomSchemaTable(rng *rand.Rand, td *wire.TableDef) *wire.Table {
 		var key []byte
 		if td.KeyType == wire.OperateTypeFixed {
 			key = randomKeyBytes(rng, kw)
+			// A third of FIXED keys are the little-endian encoding of a
+			// small number, so a decimal segment can actually MATCH a FIXED
+			// key (including one wider than 8 bytes, where the target is
+			// zero-filled past the eighth byte) and not only miss it.
+			if rng.Intn(3) == 0 {
+				key, _ = leKeyBytes(uint64(rng.Intn(60)), kw)
+			}
 		} else {
 			v := uint64(rng.Intn(60))
 			key, _ = leKeyBytes(v, kw)
@@ -393,6 +422,24 @@ func randomSchemaTable(rng *rand.Rand, td *wire.TableDef) *wire.Table {
 		t.Rows = append(t.Rows, row)
 	}
 	return t
+}
+
+// randomFloat draws a float value, one in eight of them a special: NaN and
+// the two infinities are what put the resolver's canonical-NaN check
+// (readCellAt's F32/F64 branches) under the oracle rather than only under
+// the hostile test. The encoder canonicalises the NaN it stores, so the
+// record still round-trips through DecodeRecord unchanged.
+func randomFloat(rng *rand.Rand) float64 {
+	switch rng.Intn(8) {
+	case 0:
+		return math.NaN()
+	case 1:
+		return math.Inf(1)
+	case 2:
+		return math.Inf(-1)
+	default:
+		return rng.NormFloat64()
+	}
 }
 
 // randomKeyBytes draws n bytes from keyAlphabet.
@@ -424,9 +471,9 @@ func randomCell(rng *rand.Rand, typ, n uint8) wire.Cell {
 	case wire.OperateTypeI64, wire.OperateTypeIVarint:
 		c.U = su64(int64(rng.Uint64()) >> uint(rng.Intn(64)))
 	case wire.OperateTypeF32:
-		c.F = float64(float32(rng.NormFloat64()))
+		c.F = float64(float32(randomFloat(rng)))
 	case wire.OperateTypeF64:
-		c.F = rng.NormFloat64()
+		c.F = randomFloat(rng)
 	case wire.OperateTypeBytes:
 		c.B = randomKeyBytes(rng, rng.Intn(6))
 	case wire.OperateTypeFixed:
@@ -574,6 +621,11 @@ func randomKeyText(rng *rand.Rand, td *wire.TableDef, tbl *wire.Table) string {
 	if td != nil && tbl != nil && len(tbl.Rows) > 0 && rng.Intn(2) == 0 {
 		key := tbl.Rows[rng.Intn(len(tbl.Rows))].Key
 		if td.KeyType == wire.OperateTypeFixed {
+			// A FIXED key that happens to be a little-endian number is
+			// addressable either way; draw both spellings.
+			if dec, ok := decimalKeyFor(key); ok && rng.Intn(2) == 0 {
+				return dec
+			}
 			return quoteKeyText(key)
 		}
 		return strconv.FormatUint(leValue(key), 10)
@@ -581,7 +633,7 @@ func randomKeyText(rng *rand.Rand, td *wire.TableDef, tbl *wire.Table) string {
 	if rng.Intn(2) == 0 {
 		return strconv.FormatUint(uint64(rng.Intn(70)), 10)
 	}
-	return quoteKeyText(randomKeyBytes(rng, 1+rng.Intn(4)))
+	return quoteKeyText(randomKeyBytes(rng, 1+rng.Intn(12)))
 }
 
 func randomColText(rng *rand.Rand, td *wire.TableDef) string {

--- a/sdk/record/path.go
+++ b/sdk/record/path.go
@@ -1,0 +1,286 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package record
+
+import (
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+// ErrPath is wrapped by every error ParsePath and its helpers return for a
+// path string that does not fit the grammar documented in the package
+// comment. Use errors.Is(err, ErrPath) to test for it.
+var ErrPath = errors.New("record: bad path")
+
+// ErrRecord is wrapped by every error a Resolver returns for record bytes
+// that cannot be decoded. Use errors.Is(err, ErrRecord) to test for it.
+var ErrRecord = errors.New("record: malformed record")
+
+// SegKind identifies the role a Segment plays in a Path.
+type SegKind uint8
+
+const (
+	// SegField is a Path's first segment: the record's top-level field,
+	// by name or by position.
+	SegField SegKind = iota
+	// SegRow is a Path's second segment: a table row key, by decimal
+	// value or by quoted FIXED text.
+	SegRow
+	// SegCol is a Path's third segment: a table column, by name or by
+	// position.
+	SegCol
+	// SegCount marks a Path whose sole segment is a field's "#count"
+	// suffix — the field's table row count.
+	SegCount
+)
+
+// Segment is one parsed component of a Path. Which fields are meaningful
+// depends on Kind:
+//
+//   - SegField, SegCount: Name (if !ByPos) or Pos (if ByPos) identifies the
+//     field.
+//   - SegRow: KeyText always holds the segment's original text. For a
+//     decimal key, KeyQuoted is false and Key is nil (a later stage encodes
+//     the decimal text to the key's on-disk width). For a quoted key,
+//     KeyQuoted is true and Key holds the unescaped bytes.
+//   - SegCol: Name (if !ByPos) or Pos (if ByPos) identifies the column.
+type Segment struct {
+	Kind      SegKind
+	Name      string
+	Pos       uint32
+	ByPos     bool
+	Key       []byte
+	KeyText   string
+	KeyQuoted bool
+}
+
+// Path is a parsed record path: 1-3 segments as documented in the package
+// comment. When Segs[0].Kind == SegCount it is the only segment.
+type Path struct {
+	Segs []Segment
+}
+
+// maxPos is the largest position a "#N" segment may name.
+const maxPos = 65535
+
+// maxRowKeyDigits is the longest decimal row key ParsePath accepts (a
+// uint64's maximum decimal representation is 20 digits).
+const maxRowKeyDigits = 20
+
+// countSuffix is the literal suffix that turns a field segment into a
+// SegCount path.
+const countSuffix = "#count"
+
+// ParsePath parses a record path — the part of a filter or index "field"
+// string that names a location inside a record's decoded fields, as
+// documented in the package comment. It never panics: every rejection
+// returns an error wrapping ErrPath.
+func ParsePath(s string) (Path, error) {
+	if s == "" {
+		return Path{}, fmt.Errorf("%w: empty path", ErrPath)
+	}
+
+	parts := strings.Split(s, "/")
+	if len(parts) > 3 {
+		return Path{}, fmt.Errorf("%w: too many segments in %q", ErrPath, s)
+	}
+	for _, p := range parts {
+		if p == "" {
+			return Path{}, fmt.Errorf("%w: empty segment in %q", ErrPath, s)
+		}
+	}
+
+	fieldSeg, isCount, err := parseFieldSeg(parts[0], len(parts) == 1)
+	if err != nil {
+		return Path{}, err
+	}
+	if isCount {
+		return Path{Segs: []Segment{fieldSeg}}, nil
+	}
+
+	segs := make([]Segment, 1, len(parts))
+	segs[0] = fieldSeg
+
+	if len(parts) >= 2 {
+		rowSeg, err := parseRowSeg(parts[1])
+		if err != nil {
+			return Path{}, err
+		}
+		segs = append(segs, rowSeg)
+	}
+	if len(parts) == 3 {
+		colSeg, err := parseColSeg(parts[2])
+		if err != nil {
+			return Path{}, err
+		}
+		segs = append(segs, colSeg)
+	}
+
+	return Path{Segs: segs}, nil
+}
+
+// SplitField splits field at its first '/' into a payload key and a record
+// path. ok is false when field contains no '/' (payloadKey and path are
+// both "" in that case; the caller should treat field itself as an exact
+// payload key). A leading '/' (e.g. "/x") yields an empty payloadKey with
+// ok == true — SplitField does not reject that itself; the caller is
+// expected to reject an empty payload key, since an exact-match payload key
+// of "" is never valid.
+func SplitField(field string) (payloadKey, path string, ok bool) {
+	idx := strings.IndexByte(field, '/')
+	if idx < 0 {
+		return "", "", false
+	}
+	return field[:idx], field[idx+1:], true
+}
+
+// parseFieldSeg parses a Path's first segment. onlySeg reports whether this
+// is the only segment in the path (required for a "#count" suffix to be
+// valid). isCount reports whether the segment was a "#count" form, in which
+// case the returned Segment already has Kind == SegCount.
+func parseFieldSeg(s string, onlySeg bool) (seg Segment, isCount bool, err error) {
+	if strings.HasSuffix(s, countSuffix) {
+		base := s[:len(s)-len(countSuffix)]
+		if base == "" {
+			return Segment{}, false, fmt.Errorf("%w: %q has no field before #count", ErrPath, s)
+		}
+		if !onlySeg {
+			return Segment{}, false, fmt.Errorf("%w: #count must be the only segment in %q", ErrPath, s)
+		}
+		name, pos, byPos, err := parseNameOrPos(base)
+		if err != nil {
+			return Segment{}, false, err
+		}
+		return Segment{Kind: SegCount, Name: name, Pos: pos, ByPos: byPos}, true, nil
+	}
+
+	name, pos, byPos, err := parseNameOrPos(s)
+	if err != nil {
+		return Segment{}, false, err
+	}
+	return Segment{Kind: SegField, Name: name, Pos: pos, ByPos: byPos}, false, nil
+}
+
+// parseColSeg parses a Path's third segment (a column: name or "#N").
+func parseColSeg(s string) (Segment, error) {
+	name, pos, byPos, err := parseNameOrPos(s)
+	if err != nil {
+		return Segment{}, err
+	}
+	return Segment{Kind: SegCol, Name: name, Pos: pos, ByPos: byPos}, nil
+}
+
+// parseNameOrPos parses a field or column segment: either a bare name, or
+// "#N" naming a position (N <= maxPos).
+func parseNameOrPos(s string) (name string, pos uint32, byPos bool, err error) {
+	if s == "" {
+		return "", 0, false, fmt.Errorf("%w: empty field or column segment", ErrPath)
+	}
+	if s[0] == '#' {
+		rest := s[1:]
+		if rest == "" || !isAllDigits(rest) {
+			return "", 0, false, fmt.Errorf("%w: malformed position %q", ErrPath, s)
+		}
+		v, perr := strconv.ParseUint(rest, 10, 32)
+		if perr != nil || v > maxPos {
+			return "", 0, false, fmt.Errorf("%w: position out of range %q", ErrPath, s)
+		}
+		return "", uint32(v), true, nil
+	}
+	if err := validateName(s); err != nil {
+		return "", 0, false, err
+	}
+	return s, 0, false, nil
+}
+
+// parseRowSeg parses a Path's second segment: a decimal row key or a
+// quoted FIXED row key.
+func parseRowSeg(s string) (Segment, error) {
+	if s[0] == '"' {
+		key, ok := unescapeQuoted(s)
+		if !ok {
+			return Segment{}, fmt.Errorf("%w: malformed quoted row key %q", ErrPath, s)
+		}
+		return Segment{Kind: SegRow, Key: key, KeyText: s, KeyQuoted: true}, nil
+	}
+	if s[0] == '#' {
+		return Segment{}, fmt.Errorf("%w: a position is not a valid row key %q", ErrPath, s)
+	}
+	if !isAllDigits(s) {
+		return Segment{}, fmt.Errorf("%w: row key is neither decimal nor quoted %q", ErrPath, s)
+	}
+	if len(s) > maxRowKeyDigits {
+		return Segment{}, fmt.Errorf("%w: row key too long %q", ErrPath, s)
+	}
+	if _, perr := strconv.ParseUint(s, 10, 64); perr != nil {
+		return Segment{}, fmt.Errorf("%w: row key does not fit uint64 %q", ErrPath, s)
+	}
+	return Segment{Kind: SegRow, KeyText: s}, nil
+}
+
+// validateName reports whether s is a valid field, row(-quoted excluded),
+// or column name: 1-255 bytes, containing none of '/', '#', '"'.
+func validateName(s string) error {
+	if len(s) < 1 || len(s) > 255 {
+		return fmt.Errorf("%w: name length out of range (1-255 bytes) %q", ErrPath, s)
+	}
+	for i := 0; i < len(s); i++ {
+		switch s[i] {
+		case '/', '#', '"':
+			return fmt.Errorf("%w: name contains an invalid character %q", ErrPath, s)
+		}
+	}
+	return nil
+}
+
+// isAllDigits reports whether s is non-empty and consists only of ASCII
+// digits.
+func isAllDigits(s string) bool {
+	if s == "" {
+		return false
+	}
+	for i := 0; i < len(s); i++ {
+		if s[i] < '0' || s[i] > '9' {
+			return false
+		}
+	}
+	return true
+}
+
+// unescapeQuoted parses a quoted row-key segment (including its
+// surrounding '"' characters) and returns its unescaped byte content. Only
+// \" and \\ are recognized escapes; any other backslash sequence, an
+// unescaped '"' before the closing quote, or a missing closing quote is
+// rejected.
+func unescapeQuoted(s string) (key []byte, ok bool) {
+	if len(s) < 2 || s[0] != '"' || s[len(s)-1] != '"' {
+		return nil, false
+	}
+	inner := s[1 : len(s)-1]
+	buf := make([]byte, 0, len(inner))
+	for i := 0; i < len(inner); {
+		c := inner[i]
+		switch c {
+		case '"':
+			// An unescaped quote before the segment's closing quote is
+			// malformed (it would have terminated the string early).
+			return nil, false
+		case '\\':
+			if i+1 >= len(inner) {
+				return nil, false
+			}
+			next := inner[i+1]
+			if next != '"' && next != '\\' {
+				return nil, false
+			}
+			buf = append(buf, next)
+			i += 2
+		default:
+			buf = append(buf, c)
+			i++
+		}
+	}
+	return buf, true
+}

--- a/sdk/record/path.go
+++ b/sdk/record/path.go
@@ -64,8 +64,21 @@ type Path struct {
 	Segs []Segment
 }
 
-// maxPos is the largest position a "#N" segment may name.
-const maxPos = 65535
+// maxPos is the largest position a "#N" segment may name. It is
+// wire.OperateMaxFields, the cap on a schema's field count and a table's
+// column count alike, so no legal position needs more digits than it has.
+const maxPos = wire.OperateMaxFields
+
+// maxPosDigits is the number of decimal digits maxPos takes, and therefore
+// the longest digit string a canonical "#N" segment may carry. The grammar
+// is CANONICAL: no leading zeros (except "#0" itself) and no more digits
+// than this. Without that rule "#N" would accept arbitrarily long digit
+// strings that merely happen to denote a small number ("#0000…01"), which
+// maxPathBytes then rejects for its length — two stages disagreeing about
+// the same path. Bounding the spelling here is what keeps them agreed, and
+// it costs nothing: a canonical position is at most 6 bytes, far inside the
+// 255-byte name bound maxPathBytes is derived from.
+const maxPosDigits = 5
 
 // maxRowKeyDigits is the longest decimal row key ParsePath accepts (a
 // uint64's maximum decimal representation is 20 digits).
@@ -226,6 +239,12 @@ func parseNameOrPos(s string) (name string, pos uint32, byPos bool, err error) {
 		rest := s[1:]
 		if rest == "" || !isAllDigits(rest) {
 			return "", 0, false, fmt.Errorf("%w: malformed position %q", ErrPath, s)
+		}
+		// Canonical spelling only — see maxPosDigits. "#0" is the one
+		// leading-zero form there is, because it is the only digit string
+		// that starts with '0' and is a single digit.
+		if len(rest) > maxPosDigits || (len(rest) > 1 && rest[0] == '0') {
+			return "", 0, false, fmt.Errorf("%w: non-canonical position %q (no leading zeros, at most %d digits)", ErrPath, s, maxPosDigits)
 		}
 		v, perr := strconv.ParseUint(rest, 10, 32)
 		if perr != nil || v > maxPos {

--- a/sdk/record/path.go
+++ b/sdk/record/path.go
@@ -7,6 +7,8 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
+
+	"github.com/rostamlabs/rostam/sdk/wire"
 )
 
 // ErrPath is wrapped by every error ParsePath and its helpers return for a
@@ -124,10 +126,14 @@ func ParsePath(s string) (Path, error) {
 // SplitField splits field at its first '/' into a payload key and a record
 // path. ok is false when field contains no '/' (payloadKey and path are
 // both "" in that case; the caller should treat field itself as an exact
-// payload key). A leading '/' (e.g. "/x") yields an empty payloadKey with
-// ok == true — SplitField does not reject that itself; the caller is
-// expected to reject an empty payload key, since an exact-match payload key
-// of "" is never valid.
+// payload key). A leading '/' (e.g. "/x") yields an EMPTY payloadKey with
+// ok == true, and that is a legal outcome, not one the caller must reject:
+// an empty payload key resolves against the metadata entry whose name is the
+// empty string, exactly as any other key resolves against its own entry.
+// vector.lookupPath relies on this — it looks up m[""] like any other key and
+// finds the record only if a point actually stored one under "" — and the
+// index side agrees, so the two never disagree about a "/x" field. Callers
+// that want to forbid an empty payload key must say so themselves.
 func SplitField(field string) (payloadKey, path string, ok bool) {
 	idx := strings.IndexByte(field, '/')
 	if idx < 0 {
@@ -199,9 +205,33 @@ func parseNameOrPos(s string) (name string, pos uint32, byPos bool, err error) {
 // quoted FIXED row key.
 func parseRowSeg(s string) (Segment, error) {
 	if s[0] == '"' {
+		// Bound the RAW inner length BEFORE unescaping. unescapeQuoted allocates
+		// len(inner) bytes, and this parse runs per point for a filter leaf that
+		// is not compiled (and once per compile for one that is), so an unbounded
+		// quoted key is a per-row allocation the caller controls: a filter field
+		// of session/"<30 MiB of x>"/col would allocate 30 MB for every point in
+		// the scan. Every escape is two bytes producing one, so an inner longer
+		// than 2*OperateMaxKeyLen cannot unescape to a legal key — checking the
+		// raw length first caps the unescape allocation at ~2*255 bytes, and the
+		// exact check below then holds the UNESCAPED key to the wire cap.
+		//
+		// The bound is semantically free: a key longer than OperateMaxKeyLen
+		// cannot name a row in any record. In schema mode findSchemaRow answers
+		// Absent on any key-width mismatch, and in dynamic mode a row key's
+		// length prefix is a u8 (sdk/wire/operate_record.go), so no encodable
+		// record has a longer key. Rejecting is therefore identical in meaning to
+		// resolving to Absent, and strictly cheaper.
+		if len(s) > 2+2*wire.OperateMaxKeyLen {
+			return Segment{}, fmt.Errorf("%w: quoted row key too long (%d raw bytes, cap is %d unescaped) %.64q",
+				ErrPath, len(s)-2, wire.OperateMaxKeyLen, s)
+		}
 		key, ok := unescapeQuoted(s)
 		if !ok {
 			return Segment{}, fmt.Errorf("%w: malformed quoted row key %q", ErrPath, s)
+		}
+		if len(key) > wire.OperateMaxKeyLen {
+			return Segment{}, fmt.Errorf("%w: quoted row key too long (%d bytes, cap is %d) %q",
+				ErrPath, len(key), wire.OperateMaxKeyLen, s)
 		}
 		return Segment{Kind: SegRow, Key: key, KeyText: s, KeyQuoted: true}, nil
 	}

--- a/sdk/record/path.go
+++ b/sdk/record/path.go
@@ -75,6 +75,37 @@ const maxRowKeyDigits = 20
 // SegCount path.
 const countSuffix = "#count"
 
+// maxNameLen is the longest field, column, or unquoted row-key name
+// validateName accepts.
+const maxNameLen = 255
+
+// maxPathBytes is the longest path string ParsePath can possibly accept, and
+// the bound it applies BEFORE strings.Split.
+//
+// WHY THE BOUND IS AHEAD OF THE SPLIT. strings.Split allocates one []string
+// header per segment (about 16 bytes each) and only then can the segment-count
+// check reject the input, so an unbounded field of '/' costs ~16x its own
+// length in transient headers before the rejection fires. The only outer limit
+// is the route body cap (httpapi's maxJSONBody, 32 MiB), which makes a
+// worst-case field cost roughly 512 MiB of headers — once per filter leaf per
+// request, multiplied by request concurrency. Segment-level bounds cannot help:
+// validateName's 255 and parseRowSeg's quoted-key cap both live in helpers that
+// run AFTER the split.
+//
+// DERIVATION. A path is at most three segments joined by two '/':
+//
+//	field:  a name of at most maxNameLen bytes (validateName), or "#65535";
+//	        the "#count" form is a name plus 6 bytes but must be the ONLY
+//	        segment, so 261 bytes total — well under the three-segment sum.
+//	row:    a quoted key of at most 2+2*wire.OperateMaxKeyLen RAW bytes (the
+//	        pre-unescape bound in parseRowSeg: every escape is two bytes
+//	        producing one), or at most maxRowKeyDigits decimal digits.
+//	column: a name of at most maxNameLen bytes.
+//
+// Nothing legal can exceed the sum, so the check rejects only inputs a later
+// stage would reject anyway — just without paying for the split first.
+const maxPathBytes = maxNameLen + 1 + (2 + 2*wire.OperateMaxKeyLen) + 1 + maxNameLen
+
 // ParsePath parses a record path — the part of a filter or index "field"
 // string that names a location inside a record's decoded fields, as
 // documented in the package comment. It never panics: every rejection
@@ -82,6 +113,13 @@ const countSuffix = "#count"
 func ParsePath(s string) (Path, error) {
 	if s == "" {
 		return Path{}, fmt.Errorf("%w: empty path", ErrPath)
+	}
+	// Ahead of the split, so a pathological field costs one length comparison
+	// instead of one []string header per '/'. See maxPathBytes. The message
+	// carries the length, never the input, so rejecting stays allocation-flat
+	// in the size of s.
+	if len(s) > maxPathBytes {
+		return Path{}, fmt.Errorf("%w: path too long (%d bytes, cap is %d)", ErrPath, len(s), maxPathBytes)
 	}
 
 	parts := strings.Split(s, "/")
@@ -253,8 +291,8 @@ func parseRowSeg(s string) (Segment, error) {
 // validateName reports whether s is a valid field, row(-quoted excluded),
 // or column name: 1-255 bytes, containing none of '/', '#', '"'.
 func validateName(s string) error {
-	if len(s) < 1 || len(s) > 255 {
-		return fmt.Errorf("%w: name length out of range (1-255 bytes) %q", ErrPath, s)
+	if len(s) < 1 || len(s) > maxNameLen {
+		return fmt.Errorf("%w: name length out of range (1-%d bytes) %q", ErrPath, maxNameLen, s)
 	}
 	for i := 0; i < len(s); i++ {
 		switch s[i] {

--- a/sdk/record/path_test.go
+++ b/sdk/record/path_test.go
@@ -1,0 +1,168 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package record
+
+import (
+	"errors"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func TestParsePathAccepted(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want Path
+	}{
+		{
+			name: "bare name field",
+			in:   "rc",
+			want: Path{Segs: []Segment{
+				{Kind: SegField, Name: "rc"},
+			}},
+		},
+		{
+			name: "positional field",
+			in:   "#2",
+			want: Path{Segs: []Segment{
+				{Kind: SegField, ByPos: true, Pos: 2},
+			}},
+		},
+		{
+			name: "field row col, decimal row key",
+			in:   "b/42/t",
+			want: Path{Segs: []Segment{
+				{Kind: SegField, Name: "b"},
+				{Kind: SegRow, KeyText: "42"},
+				{Kind: SegCol, Name: "t"},
+			}},
+		},
+		{
+			name: "field row col, quoted row key",
+			in:   `b/"DE"/hits`,
+			want: Path{Segs: []Segment{
+				{Kind: SegField, Name: "b"},
+				{Kind: SegRow, Key: []byte("DE"), KeyText: `"DE"`, KeyQuoted: true},
+				{Kind: SegCol, Name: "hits"},
+			}},
+		},
+		{
+			name: "field count",
+			in:   "b#count",
+			want: Path{Segs: []Segment{
+				{Kind: SegCount, Name: "b"},
+			}},
+		},
+		{
+			name: "field and row, no column",
+			in:   "b/42",
+			want: Path{Segs: []Segment{
+				{Kind: SegField, Name: "b"},
+				{Kind: SegRow, KeyText: "42"},
+			}},
+		},
+		{
+			name: "quoted row key with escapes",
+			in:   `a/"a\"b"/c`,
+			want: Path{Segs: []Segment{
+				{Kind: SegField, Name: "a"},
+				{Kind: SegRow, Key: []byte(`a"b`), KeyText: `"a\"b"`, KeyQuoted: true},
+				{Kind: SegCol, Name: "c"},
+			}},
+		},
+		{
+			name: "positional count",
+			in:   "#5#count",
+			want: Path{Segs: []Segment{
+				{Kind: SegCount, ByPos: true, Pos: 5},
+			}},
+		},
+		{
+			name: "max position value",
+			in:   "#65535",
+			want: Path{Segs: []Segment{
+				{Kind: SegField, ByPos: true, Pos: 65535},
+			}},
+		},
+		{
+			name: "max-length decimal row key (20 digits, fits uint64)",
+			in:   "a/18446744073709551615/c",
+			want: Path{Segs: []Segment{
+				{Kind: SegField, Name: "a"},
+				{Kind: SegRow, KeyText: "18446744073709551615"},
+				{Kind: SegCol, Name: "c"},
+			}},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := ParsePath(tc.in)
+			if err != nil {
+				t.Fatalf("ParsePath(%q) unexpected error: %v", tc.in, err)
+			}
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Fatalf("ParsePath(%q) = %+v, want %+v", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestParsePathRejected(t *testing.T) {
+	longName := strings.Repeat("x", 256)
+
+	cases := map[string]string{
+		"empty path":                         "",
+		"trailing slash":                     "a/",
+		"leading slash":                      "/a",
+		"too many segments":                  "a/b/c/d",
+		"count not sole segment":             "a#count/x",
+		"unterminated quote":                 `a/"unterminated`,
+		"row key neither decimal nor quoted": "a/x/y",
+		"position used as row key":           "a/#3",
+		"position out of range":              "#70000",
+		"256-byte name":                      longName,
+		"21-digit row key":                   "a/123456789012345678901/c",
+		"row key overflows uint64":           "a/18446744073709551616/c",
+		"name containing a quote":            `a"b`,
+	}
+
+	for name, in := range cases {
+		t.Run(name, func(t *testing.T) {
+			_, err := ParsePath(in)
+			if err == nil {
+				t.Fatalf("ParsePath(%q) expected error, got nil", in)
+			}
+			if !errors.Is(err, ErrPath) {
+				t.Fatalf("ParsePath(%q) error %v does not wrap ErrPath", in, err)
+			}
+		})
+	}
+}
+
+func TestSplitField(t *testing.T) {
+	cases := []struct {
+		name           string
+		in             string
+		wantPayloadKey string
+		wantPath       string
+		wantOK         bool
+	}{
+		{name: "field with path", in: "session/rc", wantPayloadKey: "session", wantPath: "rc", wantOK: true},
+		{name: "no slash", in: "plain", wantPayloadKey: "", wantPath: "", wantOK: false},
+		{name: "leading slash yields empty payload key", in: "/x", wantPayloadKey: "", wantPath: "x", wantOK: true},
+		{name: "empty string", in: "", wantPayloadKey: "", wantPath: "", wantOK: false},
+		{name: "splits at first slash only", in: "a/b/c", wantPayloadKey: "a", wantPath: "b/c", wantOK: true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			payloadKey, path, ok := SplitField(tc.in)
+			if payloadKey != tc.wantPayloadKey || path != tc.wantPath || ok != tc.wantOK {
+				t.Fatalf("SplitField(%q) = (%q, %q, %v), want (%q, %q, %v)",
+					tc.in, payloadKey, path, ok, tc.wantPayloadKey, tc.wantPath, tc.wantOK)
+			}
+		})
+	}
+}

--- a/sdk/record/path_test.go
+++ b/sdk/record/path_test.go
@@ -5,6 +5,7 @@ package record
 import (
 	"errors"
 	"reflect"
+	"runtime"
 	"strings"
 	"testing"
 )
@@ -227,4 +228,86 @@ func TestParsePathQuotedRowKeyLengthBound(t *testing.T) {
 			t.Fatalf("256 escaped pairs: err = %v, want an ErrPath", err)
 		}
 	})
+}
+
+// parsePathSink keeps the ParsePath results below from being optimized away.
+var parsePathSink error
+
+// TestParsePathLengthBoundBeforeSplit pins the bound ParsePath applies AHEAD of
+// strings.Split.
+//
+// Split allocates one []string header per segment and only then can the
+// segment-count check reject the input, so before this bound an input carrying
+// N slashes cost roughly 16N bytes of transient headers before rejection — once
+// per filter leaf per request, under a 32 MiB route body cap. The segment-level
+// bounds (validateName's 255, parseRowSeg's quoted-key cap) cannot help: both
+// live in helpers that run after the split.
+func TestParsePathLengthBoundBeforeSplit(t *testing.T) {
+	// The longest path the grammar allows, spelled out exactly: a 255-byte
+	// field name, a quoted row key at its raw cap (255 escaped pairs, 510 bytes
+	// inside the quotes, unescaping to a legal 255-byte key), and a 255-byte
+	// column name. This is the input a bound set one byte too low would break.
+	longest := strings.Repeat("f", maxNameLen) + `/"` + strings.Repeat(`\"`, 255) + `"/` + strings.Repeat("c", maxNameLen)
+	if len(longest) != maxPathBytes {
+		t.Fatalf("the longest legal path is %d bytes but maxPathBytes is %d — the derivation and the constant disagree",
+			len(longest), maxPathBytes)
+	}
+	p, err := ParsePath(longest)
+	if err != nil {
+		t.Fatalf("the longest legal path was rejected: %v", err)
+	}
+	if len(p.Segs) != 3 || len(p.Segs[1].Key) != 255 {
+		t.Fatalf("unexpected parse of the longest legal path: %+v", p)
+	}
+
+	// One byte over is rejected, and with an ErrPath like every other rejection.
+	if _, err := ParsePath(longest + "x"); err == nil || !errors.Is(err, ErrPath) {
+		t.Fatalf("maxPathBytes+1: err = %v, want an ErrPath", err)
+	}
+
+	// The hostile input: a 1 MiB field that is almost entirely '/'.
+	hostile := strings.Repeat("a/", 512<<10)
+	if _, err := ParsePath(hostile); err == nil || !errors.Is(err, ErrPath) {
+		t.Fatalf("a 1 MiB field of slashes: err = %v, want an ErrPath", err)
+	}
+
+	// The point of the fix, measured in BYTES rather than allocation count:
+	// strings.Split makes one big allocation for the whole []string, so the
+	// count barely moves while the bytes move by 16x the slash count. A 1 MiB
+	// field of slashes carries 512Ki segments, which is 8 MiB of headers.
+	small := strings.Repeat("a/", 32<<10) // 64 KiB, 32Ki slashes
+	smallBytes := bytesPerParse(small)
+	bigBytes := bytesPerParse(hostile)
+	const byteCeiling = 4 << 10 // the error value and its formatting; nothing per segment
+	if bigBytes > byteCeiling {
+		t.Errorf("rejecting a 1 MiB field allocated %d bytes, want at most %d — the split still runs first",
+			bigBytes, byteCeiling)
+	}
+	// And it does not scale: a 16x larger input must not cost 16x the bytes.
+	if bigBytes > smallBytes+byteCeiling {
+		t.Errorf("rejection bytes scale with input: %d for 64 KiB vs %d for 1 MiB", smallBytes, bigBytes)
+	}
+
+	// Allocation COUNT is asserted too, since a future rewrite could split into
+	// many small allocations instead of one big one.
+	const allocCeiling = 8 // the error value and its formatting
+	if got := testing.AllocsPerRun(50, func() { _, parsePathSink = ParsePath(hostile) }); got > allocCeiling {
+		t.Errorf("rejecting a 1 MiB field allocated %.0f times, want at most %d", got, allocCeiling)
+	}
+}
+
+// bytesPerParse reports the average heap bytes one rejected ParsePath call
+// allocates. runtime.MemStats rather than AllocsPerRun because the cost this
+// test is about is BYTES: strings.Split allocates the whole []string at once,
+// so a per-segment cost is invisible in the allocation count.
+func bytesPerParse(s string) uint64 {
+	const runs = 20
+	var before, after runtime.MemStats
+	runtime.GC()
+	runtime.ReadMemStats(&before)
+	for i := 0; i < runs; i++ {
+		_, parsePathSink = ParsePath(s)
+	}
+	runtime.ReadMemStats(&after)
+	return (after.TotalAlloc - before.TotalAlloc) / runs
 }

--- a/sdk/record/path_test.go
+++ b/sdk/record/path_test.go
@@ -166,3 +166,65 @@ func TestSplitField(t *testing.T) {
 		})
 	}
 }
+
+// TestParsePathQuotedRowKeyLengthBound pins the bound on a quoted row key.
+//
+// WHY IT IS A BOUND AND NOT JUST A VALIDATION. unescapeQuoted allocates the raw
+// inner length, and a filter's path is parsed against the record of every point
+// in a scan, so an unbounded quoted key is a per-row allocation the caller sizes:
+// a field of session/"<30 MiB of x>"/col cost ~30 MB per point. The raw length is
+// therefore checked BEFORE the unescape (every escape is two bytes producing one,
+// so 2*OperateMaxKeyLen raw is the widest input that could still be legal), and
+// the unescaped length is checked after.
+//
+// The bound is semantically free: a row key wider than OperateMaxKeyLen cannot
+// exist in any encodable record — schema mode answers Absent on a key-width
+// mismatch and a dynamic-mode key length is a u8 — so rejecting means exactly
+// what resolving would have meant.
+func TestParsePathQuotedRowKeyLengthBound(t *testing.T) {
+	quoted := func(n int) string { return `a/"` + strings.Repeat("k", n) + `"/c` }
+
+	t.Run("255 accepted", func(t *testing.T) {
+		p, err := ParsePath(quoted(255))
+		if err != nil {
+			t.Fatalf("ParsePath with a 255-byte quoted row key: %v, want nil", err)
+		}
+		if len(p.Segs) != 3 || p.Segs[1].Kind != SegRow || len(p.Segs[1].Key) != 255 {
+			t.Fatalf("unexpected parse: %+v", p)
+		}
+	})
+
+	t.Run("256 rejected", func(t *testing.T) {
+		_, err := ParsePath(quoted(256))
+		if err == nil || !errors.Is(err, ErrPath) {
+			t.Fatalf("ParsePath with a 256-byte quoted row key: err = %v, want an ErrPath", err)
+		}
+	})
+
+	// The hostile case: rejected on the RAW length, so nothing near this size is
+	// ever copied. A test that only asserted the error would pass even if the
+	// unescape still ran, so this one is the reason the raw check exists.
+	t.Run("1 MiB rejected", func(t *testing.T) {
+		_, err := ParsePath(quoted(1 << 20))
+		if err == nil || !errors.Is(err, ErrPath) {
+			t.Fatalf("ParsePath with a 1 MiB quoted row key: err = %v, want an ErrPath", err)
+		}
+	})
+
+	// Escapes count against the UNESCAPED length: 255 escaped pairs are 510 raw
+	// bytes and a legal 255-byte key, while 256 pairs are not. This is the case a
+	// raw-length-only bound would get wrong in both directions.
+	t.Run("escapes count unescaped", func(t *testing.T) {
+		esc := func(n int) string { return `a/"` + strings.Repeat(`\"`, n) + `"/c` }
+		p, err := ParsePath(esc(255))
+		if err != nil {
+			t.Fatalf("255 escaped pairs: %v, want nil", err)
+		}
+		if len(p.Segs[1].Key) != 255 {
+			t.Fatalf("unescaped key length = %d, want 255", len(p.Segs[1].Key))
+		}
+		if _, err := ParsePath(esc(256)); err == nil || !errors.Is(err, ErrPath) {
+			t.Fatalf("256 escaped pairs: err = %v, want an ErrPath", err)
+		}
+	})
+}

--- a/sdk/record/path_test.go
+++ b/sdk/record/path_test.go
@@ -87,6 +87,24 @@ func TestParsePathAccepted(t *testing.T) {
 			}},
 		},
 		{
+			// "#0" is the one position that legally starts with '0': a
+			// single digit is canonical by definition.
+			name: "zero position",
+			in:   "#0",
+			want: Path{Segs: []Segment{
+				{Kind: SegField, ByPos: true, Pos: 0},
+			}},
+		},
+		{
+			name: "canonical positional column",
+			in:   "a/1/#12345",
+			want: Path{Segs: []Segment{
+				{Kind: SegField, Name: "a"},
+				{Kind: SegRow, KeyText: "1"},
+				{Kind: SegCol, ByPos: true, Pos: 12345},
+			}},
+		},
+		{
 			name: "max-length decimal row key (20 digits, fits uint64)",
 			in:   "a/18446744073709551615/c",
 			want: Path{Segs: []Segment{
@@ -123,10 +141,19 @@ func TestParsePathRejected(t *testing.T) {
 		"row key neither decimal nor quoted": "a/x/y",
 		"position used as row key":           "a/#3",
 		"position out of range":              "#70000",
-		"256-byte name":                      longName,
-		"21-digit row key":                   "a/123456789012345678901/c",
-		"row key overflows uint64":           "a/18446744073709551616/c",
-		"name containing a quote":            `a"b`,
+		// Non-canonical spellings of positions that are in range. The value
+		// they denote is legal; the SPELLING is not, so that ParsePath's
+		// pre-split length bound and the "#N" grammar cannot disagree about
+		// the same string (a long enough run of leading zeros exceeded
+		// maxPathBytes while parseNameOrPos still accepted the digits).
+		"position with a leading zero":      "#01",
+		"position padded with zeros":        "#000001",
+		"position with six digits":          "#123456",
+		"positional column with a zero pad": "a/1/#01",
+		"256-byte name":                     longName,
+		"21-digit row key":                  "a/123456789012345678901/c",
+		"row key overflows uint64":          "a/18446744073709551616/c",
+		"name containing a quote":           `a"b`,
 	}
 
 	for name, in := range cases {

--- a/sdk/record/prove_test.go
+++ b/sdk/record/prove_test.go
@@ -1,0 +1,317 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package record
+
+import (
+	"errors"
+	"math/rand"
+	"testing"
+
+	"github.com/rostamlabs/rostam/sdk/wire"
+)
+
+// TestRowAbsentProvenMatchesOracle holds RowAbsentProven to the tree oracle on
+// well-formed records: for every field/row path the generators produce, it must
+// answer true exactly when the decoded tree says the field is a table AND the
+// row is not in it. Anything else — a present row, a scalar or missing field, a
+// path that cannot apply — is false.
+//
+// The stronger half of the property is the error class: on a record the
+// generators built and DecodeRecord accepted, the proof walk may never report
+// ErrRecord. A "prove it" operation that called well-formed records malformed
+// would answer false for rows that really are absent, which is a wrong answer in
+// the opposite direction from the one it exists to prevent.
+func TestRowAbsentProvenMatchesOracle(t *testing.T) {
+	records, paths := 1500, 24
+	if testing.Short() {
+		records, paths = 200, 10
+	}
+	rng := rand.New(rand.NewSource(20260909))
+	r := NewResolver(64)
+	seen := map[string]int{}
+	checked := 0
+	for i := 0; i < records; i++ {
+		var enc []byte
+		var dec *wire.Record
+		var err error
+		if i%2 == 0 {
+			enc, dec, err = randomSchemaRecord(rng)
+		} else {
+			enc, dec, err = randomDynamicRecord(rng)
+		}
+		if err != nil {
+			t.Fatalf("generator: %v", err)
+		}
+		for j := 0; j < paths; j++ {
+			p, perr := ParsePath(randomPath(rng, dec))
+			if perr != nil || len(p.Segs) != 2 || p.Segs[1].Kind != SegRow {
+				continue // only field/row paths are in this operation's domain
+			}
+			checked++
+			got, gerr := r.RowAbsentProven(enc, p)
+			if gerr != nil && errors.Is(gerr, ErrRecord) {
+				t.Fatalf("record %d: proof called a well-formed record malformed: %v", i, gerr)
+			}
+			// The oracle: the row is provably absent iff the tree resolves the
+			// field to a table and the row to Absent.
+			res, oerr := resolveTree(dec, p)
+			fres, ferr := resolveTree(dec, Path{Segs: p.Segs[:1:1]})
+			want := oerr == nil && ferr == nil && res.Kind == Absent && fres.Kind == Table
+			if got != want {
+				t.Fatalf("record %d path %+v: RowAbsentProven = (%v, %v), oracle wants %v (row %+v/%v, field %+v/%v)",
+					i, p.Segs, got, gerr, want, res, oerr, fres, ferr)
+			}
+			switch {
+			case want:
+				seen["proven-absent"]++
+			case oerr == nil && res.Kind == RowPresent:
+				seen["row-present"]++
+			case ferr == nil && fres.Kind == Table:
+				seen["table-but-not-absent"]++
+			default:
+				seen["not-a-table"]++
+			}
+		}
+	}
+	t.Logf("%d field/row paths checked: %v", checked, seen)
+	// A property test that only ever saw one outcome would prove nothing.
+	for _, k := range []string{"proven-absent", "row-present", "not-a-table"} {
+		if seen[k] == 0 {
+			t.Errorf("outcome %q never occurred; the generator stopped producing it", k)
+		}
+	}
+}
+
+// TestRowAbsentProvenRejectsUnorderedRows is the finding itself: a table whose
+// rows are NOT in ascending key order can answer Absent for a row that is
+// stored, because a schema-mode lookup is a binary search and a dynamic-mode
+// one stops at the first key greater than the target. Resolve documents that
+// leniency and keeps it — a filter leaf reads Absent as "no match", which is
+// safe. RowAbsentProven must refuse instead, because it turns Absent into a
+// positive claim about the point.
+//
+// Both modes are patched at the BYTE level, since the encoder sorts rows and
+// DecodeRecord rejects the result: this is a record only a hostile writer
+// produces, which is exactly the input the operation has to be right about.
+func TestRowAbsentProvenRejectsUnorderedRows(t *testing.T) {
+	t.Run("schema", func(t *testing.T) {
+		r := NewResolver(8)
+		enc, _ := sessionRecord(t, true)
+		// Precondition: with the rows in order, row 42 is present and row 7 is
+		// provably absent.
+		mustResolveKind(t, r, enc, "b/42", RowPresent)
+		if ok, err := r.RowAbsentProven(enc, mustPath(t, "b/7")); !ok || err != nil {
+			t.Fatalf("precondition: RowAbsentProven(b/7) = (%v, %v), want (true, nil)", ok, err)
+		}
+
+		swapSchemaRows(t, r, enc, 5, 0, 1)
+
+		// The documented leniency: the binary search now misses a row that is
+		// still there.
+		mustResolveKind(t, r, enc, "b/42", Absent)
+		for _, path := range []string{"b/42", "b/99", "b/7"} {
+			ok, err := r.RowAbsentProven(enc, mustPath(t, path))
+			if ok {
+				t.Errorf("RowAbsentProven(%s) = true on an out-of-order table, want false", path)
+			}
+			if !errors.Is(err, ErrRecord) {
+				t.Errorf("RowAbsentProven(%s) error = %v, want one wrapping ErrRecord", path, err)
+			}
+		}
+	})
+
+	t.Run("dynamic", func(t *testing.T) {
+		r := NewResolver(8)
+		enc, _ := dynamicRecord(t)
+		mustResolveKind(t, r, enc, "t/42", RowPresent)
+		if ok, err := r.RowAbsentProven(enc, mustPath(t, "t/7")); !ok || err != nil {
+			t.Fatalf("precondition: RowAbsentProven(t/7) = (%v, %v), want (true, nil)", ok, err)
+		}
+
+		swapDynamicRows(t, enc, "t", 0, 1)
+
+		mustResolveKind(t, r, enc, "t/42", Absent)
+		// The row that moved to the FRONT still matches on the first
+		// comparison, so it resolves RowPresent and needs no proof: row
+		// presence is proof of itself even on a damaged table.
+		mustResolveKind(t, r, enc, `t/"DE"`, RowPresent)
+		if ok, err := r.RowAbsentProven(enc, mustPath(t, `t/"DE"`)); ok || err != nil {
+			t.Errorf(`RowAbsentProven(t/"DE") = (%v, %v), want (false, nil)`, ok, err)
+		}
+		// Everything that resolved Absent must now be refused: the walk sees
+		// the disorder that made the early stop wrong.
+		for _, path := range []string{"t/42", "t/7"} {
+			ok, err := r.RowAbsentProven(enc, mustPath(t, path))
+			if ok {
+				t.Errorf("RowAbsentProven(%s) = true on an out-of-order table, want false", path)
+			}
+			if !errors.Is(err, ErrRecord) {
+				t.Errorf("RowAbsentProven(%s) error = %v, want one wrapping ErrRecord", path, err)
+			}
+		}
+	})
+}
+
+// TestRowAbsentProvenNonAbsentOutcomes pins the answers that need no walk: a
+// present row, a field that is not a table, a field the record does not have,
+// and a path of the wrong shape.
+func TestRowAbsentProvenNonAbsentOutcomes(t *testing.T) {
+	r := NewResolver(8)
+	enc, _ := sessionRecord(t, true)
+	for _, c := range []struct {
+		path    string
+		want    bool
+		wantErr error
+	}{
+		{path: "b/42", want: false},                   // present
+		{path: "b/7", want: true},                     // genuinely absent
+		{path: "rc/1", want: false, wantErr: ErrPath}, // a scalar, not a table
+		{path: "zzz/1", want: false},                  // no such field
+		{path: "#9/1", want: false},                   // position past the schema
+	} {
+		got, err := r.RowAbsentProven(enc, mustPath(t, c.path))
+		if got != c.want {
+			t.Errorf("RowAbsentProven(%s) = %v, want %v (err %v)", c.path, got, c.want, err)
+		}
+		if c.wantErr != nil && !errors.Is(err, c.wantErr) {
+			t.Errorf("RowAbsentProven(%s) error = %v, want one wrapping %v", c.path, err, c.wantErr)
+		}
+		if c.wantErr == nil && err != nil {
+			t.Errorf("RowAbsentProven(%s) unexpected error: %v", c.path, err)
+		}
+	}
+	// A path that is not field/row is a caller mistake, not a record fact.
+	if _, err := r.RowAbsentProven(enc, mustPath(t, "b/42/hi")); !errors.Is(err, ErrPath) {
+		t.Errorf("RowAbsentProven on a three-segment path error = %v, want one wrapping ErrPath", err)
+	}
+}
+
+func mustResolveKind(t *testing.T, r *Resolver, rec []byte, path string, want Kind) {
+	t.Helper()
+	got, err := r.Resolve(rec, mustPath(t, path))
+	if err != nil {
+		t.Fatalf("Resolve(%q): %v", path, err)
+	}
+	if got.Kind != want {
+		t.Fatalf("Resolve(%q).Kind = %v, want %v", path, got.Kind, want)
+	}
+}
+
+// swapSchemaRows swaps two fixed-width rows of a schema-mode table IN PLACE,
+// producing the out-of-order table DecodeRecord would refuse. It locates the
+// rows through the resolver's own offset arithmetic rather than hard-coded
+// offsets, so it keeps working if the fixture changes.
+func swapSchemaRows(t *testing.T, r *Resolver, rec []byte, fieldPos, i, j int) {
+	t.Helper()
+	e, err := r.schemaFor(rec)
+	if err != nil {
+		t.Fatalf("schemaFor: %v", err)
+	}
+	tl := e.layout.Tables[fieldPos]
+	off, err := schemaFieldOffset(rec, 1+e.blobLen, e.schema, e.layout, fieldPos)
+	if err != nil {
+		t.Fatalf("schemaFieldOffset: %v", err)
+	}
+	nRows, rowsOff, err := schemaTableHeader(rec, off, tl)
+	if err != nil {
+		t.Fatalf("schemaTableHeader: %v", err)
+	}
+	if i >= int(nRows) || j >= int(nRows) {
+		t.Fatalf("table has %d rows, cannot swap %d and %d", nRows, i, j)
+	}
+	a := rec[rowsOff+i*tl.RowWidth:][:tl.RowWidth]
+	b := rec[rowsOff+j*tl.RowWidth:][:tl.RowWidth]
+	tmp := append([]byte(nil), a...)
+	copy(a, b)
+	copy(b, tmp)
+}
+
+// swapDynamicRows swaps two whole [rowLen][row] units of a dynamic-mode table
+// IN PLACE. Swapping complete units keeps the table's byte length identical, so
+// no length prefix upstream has to be rewritten.
+func swapDynamicRows(t *testing.T, rec []byte, field string, i, j int) {
+	t.Helper()
+	inner, rowsOff := dynamicTableFor(t, rec, field)
+	spans := dynamicRowSpans(t, inner, rowsOff)
+	if i >= len(spans) || j >= len(spans) {
+		t.Fatalf("table has %d rows, cannot swap %d and %d", len(spans), i, j)
+	}
+	var out []byte
+	for k := range spans {
+		src := spans[k]
+		switch k {
+		case i:
+			src = spans[j]
+		case j:
+			src = spans[i]
+		}
+		out = append(out, inner[src[0]:src[1]]...)
+	}
+	if got, want := len(out), len(inner)-rowsOff; got != want {
+		t.Fatalf("rebuilt rows are %d bytes, want %d", got, want)
+	}
+	copy(inner[rowsOff:], out)
+}
+
+// dynamicTableFor returns the named dynamic field's table body (aliasing rec,
+// so writes through it patch the record) and the offset of its first row.
+func dynamicTableFor(t *testing.T, rec []byte, field string) ([]byte, int) {
+	t.Helper()
+	nFields, m, err := readCanonicalUvarint(rec, 1)
+	if err != nil {
+		t.Fatalf("field count: %v", err)
+	}
+	off := 1 + m
+	for i := uint64(0); i < nFields; i++ {
+		name, next, err := readName(rec, off)
+		if err != nil {
+			t.Fatalf("name: %v", err)
+		}
+		off = next
+		typ, n, valOff, err := readTypeTag(rec, off)
+		if err != nil {
+			t.Fatalf("type tag: %v", err)
+		}
+		if string(name) == field {
+			if typ != wire.OperateTypeTable {
+				t.Fatalf("field %q is not a table", field)
+			}
+			inner, _, err := dynamicTableInner(rec, valOff)
+			if err != nil {
+				t.Fatalf("table body: %v", err)
+			}
+			_, rowsOff, err := dynamicTableRows(inner)
+			if err != nil {
+				t.Fatalf("table rows: %v", err)
+			}
+			return inner, rowsOff
+		}
+		if off, err = skipDynamicValue(rec, valOff, typ, n); err != nil {
+			t.Fatalf("skip: %v", err)
+		}
+	}
+	t.Fatalf("no field %q in the record", field)
+	return nil, 0
+}
+
+// dynamicRowSpans returns each row unit's [start,end) inside inner, the unit
+// being its length prefix plus its body.
+func dynamicRowSpans(t *testing.T, inner []byte, rowsOff int) [][2]int {
+	t.Helper()
+	nRows, _, err := dynamicTableRows(inner)
+	if err != nil {
+		t.Fatalf("table rows: %v", err)
+	}
+	spans := make([][2]int, 0, nRows)
+	off := rowsOff
+	for i := uint64(0); i < nRows; i++ {
+		start := off
+		rowLen, m, err := readCanonicalUvarint(inner, off)
+		if err != nil {
+			t.Fatalf("row length: %v", err)
+		}
+		off += m + int(rowLen)
+		spans = append(spans, [2]int{start, off})
+	}
+	return spans
+}

--- a/sdk/record/resolve.go
+++ b/sdk/record/resolve.go
@@ -1120,6 +1120,13 @@ func readCanonicalUvarint(b []byte, off int) (uint64, int, error) {
 
 // minUvarintLen returns the number of bytes binary.AppendUvarint uses for
 // v: the canonical LEB128 length.
+//
+// TWIN of sdk/wire/operate_schema.go's minUvarintLen. The two must stay in
+// LOCKSTEP: they define what "canonical uvarint" means on the read side, and
+// this package's whole hardening story is that it rejects exactly the encodings
+// the wire encoder would never produce. It is duplicated rather than exported
+// so this leaf keeps its own copy of the rule it enforces; change one and you
+// must change the other.
 func minUvarintLen(v uint64) int {
 	n := 1
 	for v >= 0x80 {
@@ -1133,6 +1140,12 @@ func minUvarintLen(v uint64) int {
 // bytes, without narrowing it to int first: a length prefix is an arbitrary
 // attacker-controlled uvarint, and converting before comparing would wrap
 // on a 32-bit int.
+//
+// TWIN of sdk/wire/operate_record.go's fitsRemaining; keep the two in
+// LOCKSTEP. Note the deliberate asymmetry it encodes — byte LENGTHS come
+// here, element COUNTS go to wire.CountFitsIn — because only the count form
+// may be narrowed to int after being bounded. Diverging on that is how a
+// 32-bit overflow gets back in.
 func fitsRemaining(n uint64, remaining int) bool {
 	if remaining < 0 {
 		return false

--- a/sdk/record/resolve.go
+++ b/sdk/record/resolve.go
@@ -1,0 +1,1109 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package record
+
+import (
+	"bytes"
+	"encoding/binary"
+	"fmt"
+	"math"
+	"strconv"
+	"sync"
+
+	"github.com/rostamlabs/rostam/sdk/wire"
+)
+
+// Kind classifies what a Resolve found at the end of a path.
+type Kind uint8
+
+const (
+	// Absent means the path is well-formed for this record's shape but
+	// names nothing in it: an unknown field, a row key with no row, a
+	// column the table does not have. It is never an error — a filter over
+	// many records expects most of them not to have the field.
+	Absent Kind = iota
+	// Scalar means the path resolved to a value; Result.Cell holds it,
+	// typed as the schema (or, in dynamic mode, the stored tag) declares.
+	Scalar
+	// Count means the path ended in "#count" on a table field;
+	// Result.Count holds the table's row count.
+	Count
+	// RowPresent means the path named a table row that exists. The row's
+	// columns are not read (use a third segment for one).
+	RowPresent
+	// Table means the path named a table field with no row segment after
+	// it. Result carries no value: a table is not a scalar, and its row
+	// count is what "#count" is for.
+	Table
+)
+
+// Result is what Resolve found. Cell is meaningful only for Scalar and
+// Count only for Count; both are the zero value otherwise.
+type Result struct {
+	Kind  Kind
+	Cell  wire.Cell
+	Count uint64
+}
+
+// schemaEntry is one cached decoded schema: the schema itself, its
+// precomputed byte layout, and the length of the blob it was decoded from
+// (which is where a record's values begin).
+type schemaEntry struct {
+	schema  *wire.Schema
+	layout  *wire.Layout
+	blobLen int
+}
+
+// Resolver resolves paths against stored operate records (design doc
+// §2.2/§2.9) by walking the stored bytes, without decoding the record into
+// a tree. It caches decoded schemas so a schema-mode read of a fixed field,
+// or of a column of an existing row, costs offset arithmetic and one binary
+// search and allocates nothing.
+//
+// # Semantics
+//
+// Resolve is a pure function of the record bytes and the parsed Path. The
+// schema cache is keyed by the schema blob's exact bytes, so a hit and a
+// miss cannot produce different answers; nothing here consults the clock or
+// any other ambient state. A Resolver is safe for concurrent use — the
+// vector search path shares one across query goroutines.
+//
+// # Row keys
+//
+// A row-key segment names bytes, and how it does so depends on the mode:
+//
+//   - Schema mode: the table's key type and width come from the schema. A
+//     decimal segment denotes the key type's width in little-endian bytes
+//     (the encoding client.KeyU8/U16/U32/U64 produce); a value too large
+//     for that width resolves to Absent. A quoted segment denotes its
+//     unescaped bytes, which must be exactly the key width, else Absent.
+//   - Dynamic mode: keys are opaque byte strings with no declared width. A
+//     decimal segment denotes the 8-byte little-endian encoding of the
+//     number (what client.KeyU64 produces, the convention dynamic writers
+//     follow); a quoted segment denotes its unescaped bytes verbatim.
+//
+// # Errors
+//
+// Resolve returns an error only for record bytes it cannot read (wrapping
+// ErrRecord) or a path that cannot apply to this record's shape at all
+// (wrapping ErrPath): a row segment on a scalar field, "#count" on a
+// non-table, a name where the schema stores no names, a position in
+// dynamic mode. Anything merely missing is Result{Kind: Absent} with a nil
+// error.
+//
+// # Hardening
+//
+// Stored record bytes are attacker-influenced (a client can put anything
+// under a payload key), so every offset is bounds-checked before use, every
+// count is bounded before it is trusted, only canonical uvarints are
+// accepted, and BYTES/FIXED payloads are copied rather than aliased into
+// the caller's buffer. Resolve reads only the bytes its path touches, so it
+// is not a whole-record validator: it rejects everything wire.DecodeRecord
+// would reject along that path, and does not notice damage elsewhere. Two
+// deliberate consequences: a schema-mode table whose rows are not in the
+// ascending key order DecodeRecord enforces may resolve a present row to
+// Absent (binary search cannot see the disorder, and it never returns a row
+// whose key does not match), and a field with no further segment resolves
+// to Table without reading the table's bytes at all.
+type Resolver struct {
+	mu    sync.RWMutex
+	cache map[string]*schemaEntry
+	limit int
+}
+
+// NewResolver returns a Resolver whose schema cache holds at most
+// cacheSize entries (cleared wholesale when full — schemas are few and
+// long-lived, so an eviction policy would cost more than it saves). A
+// cacheSize below 1 disables caching: every call decodes the schema afresh,
+// which is slower but answers identically.
+func NewResolver(cacheSize int) *Resolver {
+	r := &Resolver{limit: cacheSize}
+	if cacheSize > 0 {
+		r.cache = make(map[string]*schemaEntry, cacheSize)
+	}
+	return r
+}
+
+// Resolve resolves p against the stored record rec.
+func (r *Resolver) Resolve(rec []byte, p Path) (Result, error) {
+	if err := checkPathShape(p); err != nil {
+		return Result{}, err
+	}
+	if len(rec) < 1 {
+		return Result{}, fmt.Errorf("%w: empty record", ErrRecord)
+	}
+	switch rec[0] {
+	case wire.OperateModeSchema:
+		return r.resolveSchema(rec, p)
+	case wire.OperateModeDynamic:
+		return resolveDynamic(rec, p)
+	default:
+		return Result{}, fmt.Errorf("%w: unknown mode byte %d", ErrRecord, rec[0])
+	}
+}
+
+// checkPathShape rejects a Path that ParsePath would never build. Resolve
+// is exported and Path is a plain struct, so a caller can hand over a
+// hand-assembled one; every later stage assumes the segment kinds line up.
+func checkPathShape(p Path) error {
+	if len(p.Segs) == 0 || len(p.Segs) > 3 {
+		return fmt.Errorf("%w: path has %d segments", ErrPath, len(p.Segs))
+	}
+	if k := p.Segs[0].Kind; k != SegField && k != SegCount {
+		return fmt.Errorf("%w: first segment is not a field", ErrPath)
+	}
+	if p.Segs[0].Kind == SegCount && len(p.Segs) != 1 {
+		return fmt.Errorf("%w: #count must be the only segment", ErrPath)
+	}
+	if len(p.Segs) >= 2 && p.Segs[1].Kind != SegRow {
+		return fmt.Errorf("%w: second segment is not a row key", ErrPath)
+	}
+	if len(p.Segs) == 3 && p.Segs[2].Kind != SegCol {
+		return fmt.Errorf("%w: third segment is not a column", ErrPath)
+	}
+	return nil
+}
+
+// --- schema mode ----------------------------------------------------------
+
+func (r *Resolver) resolveSchema(rec []byte, p Path) (Result, error) {
+	e, err := r.schemaFor(rec)
+	if err != nil {
+		return Result{}, err
+	}
+	s, l := e.schema, e.layout
+	base := 1 + e.blobLen
+	if base > len(rec) {
+		return Result{}, fmt.Errorf("%w: record ends inside its schema blob", ErrRecord)
+	}
+
+	seg := p.Segs[0]
+	var pos int
+	if seg.ByPos {
+		if uint64(seg.Pos) >= uint64(len(s.Fields)) {
+			return Result{Kind: Absent}, nil
+		}
+		pos = int(seg.Pos)
+	} else {
+		if !s.StoreNames {
+			return Result{}, fmt.Errorf("%w: schema stores no names, use a position", ErrPath)
+		}
+		i, ok := s.FieldPos(seg.Name)
+		if !ok {
+			return Result{Kind: Absent}, nil
+		}
+		pos = i
+	}
+
+	fdef := &s.Fields[pos]
+	isTable := fdef.Type == wire.OperateTypeTable
+
+	if seg.Kind == SegCount {
+		if !isTable {
+			return Result{}, fmt.Errorf("%w: #count on a non-table field", ErrPath)
+		}
+		off, err := schemaFieldOffset(rec, base, s, l, pos)
+		if err != nil {
+			return Result{}, err
+		}
+		nRows, _, err := schemaTableHeader(rec, off, l.Tables[pos])
+		if err != nil {
+			return Result{}, err
+		}
+		return Result{Kind: Count, Count: nRows}, nil
+	}
+
+	if len(p.Segs) == 1 {
+		if isTable {
+			return Result{Kind: Table}, nil
+		}
+		off, err := schemaFieldOffset(rec, base, s, l, pos)
+		if err != nil {
+			return Result{}, err
+		}
+		cell, err := readCellAt(rec, off, fdef.Type, fdef.N)
+		if err != nil {
+			return Result{}, err
+		}
+		return Result{Kind: Scalar, Cell: cell}, nil
+	}
+
+	if !isTable {
+		return Result{}, fmt.Errorf("%w: row segment on a non-table field", ErrPath)
+	}
+	tl := l.Tables[pos]
+	if tl == nil || fdef.Table == nil {
+		return Result{}, fmt.Errorf("%w: table field has no layout", ErrRecord)
+	}
+	off, err := schemaFieldOffset(rec, base, s, l, pos)
+	if err != nil {
+		return Result{}, err
+	}
+	nRows, rowsOff, err := schemaTableHeader(rec, off, tl)
+	if err != nil {
+		return Result{}, err
+	}
+	idx, found := findSchemaRow(rec, rowsOff, nRows, tl, fdef.Table.KeyType, p.Segs[1])
+	if !found {
+		return Result{Kind: Absent}, nil
+	}
+	if len(p.Segs) == 2 {
+		return Result{Kind: RowPresent}, nil
+	}
+
+	cseg := p.Segs[2]
+	cols := fdef.Table.Cols
+	var ci int
+	if cseg.ByPos {
+		if uint64(cseg.Pos) >= uint64(len(cols)) {
+			return Result{Kind: Absent}, nil
+		}
+		ci = int(cseg.Pos)
+	} else {
+		if !s.StoreNames {
+			return Result{}, fmt.Errorf("%w: schema stores no names, use a position", ErrPath)
+		}
+		found := -1
+		for i := range cols {
+			if cols[i].Name == cseg.Name {
+				found = i
+				break
+			}
+		}
+		if found < 0 {
+			return Result{Kind: Absent}, nil
+		}
+		ci = found
+	}
+	// idx < nRows and nRows*RowWidth was bounded against the remaining
+	// bytes by schemaTableHeader, so this product cannot overflow an int.
+	cellOff := rowsOff + idx*tl.RowWidth + tl.ColOff[ci]
+	cell, err := readCellAt(rec, cellOff, cols[ci].Type, cols[ci].N)
+	if err != nil {
+		return Result{}, err
+	}
+	return Result{Kind: Scalar, Cell: cell}, nil
+}
+
+// schemaFieldOffset returns the offset of field target's stored value. A
+// fixed-width field sits at a constant offset; a variable-length one has to
+// be walked to, skipping every tail field in front of it.
+func schemaFieldOffset(rec []byte, base int, s *wire.Schema, l *wire.Layout, target int) (int, error) {
+	if l.FixedOff[target] >= 0 {
+		off := base + l.FixedOff[target]
+		if off > len(rec) {
+			return 0, fmt.Errorf("%w: record ends before field %d", ErrRecord, target)
+		}
+		return off, nil
+	}
+	off := base + l.FixedLen
+	if off > len(rec) {
+		return 0, fmt.Errorf("%w: record ends inside its fixed fields", ErrRecord)
+	}
+	for _, i := range l.VarTail {
+		if i == target {
+			return off, nil
+		}
+		f := &s.Fields[i]
+		if f.Type == wire.OperateTypeTable {
+			nRows, rowsOff, err := schemaTableHeader(rec, off, l.Tables[i])
+			if err != nil {
+				return 0, err
+			}
+			off = rowsOff + int(nRows)*l.Tables[i].RowWidth
+			continue
+		}
+		n, err := cellDataLen(rec, off, f.Type, f.N)
+		if err != nil {
+			return 0, err
+		}
+		off += n
+	}
+	// Unreachable for a Layout built from this schema: every field is
+	// either fixed or in the tail.
+	return 0, fmt.Errorf("%w: field %d is in neither layout half", ErrRecord, target)
+}
+
+// schemaTableHeader reads a schema-mode table's row count from off and
+// returns it with the offset of the first row, having bounded the rows
+// against the bytes actually left (design doc §2.3).
+func schemaTableHeader(rec []byte, off int, tl *wire.TableLayout) (uint64, int, error) {
+	if tl == nil || tl.RowWidth < 1 {
+		return 0, 0, fmt.Errorf("%w: table has no row width", ErrRecord)
+	}
+	nRows, m, err := readCanonicalUvarint(rec, off)
+	if err != nil {
+		return 0, 0, err
+	}
+	if nRows > wire.OperateMaxRows {
+		return 0, 0, fmt.Errorf("%w: table declares %d rows", ErrRecord, nRows)
+	}
+	rowsOff := off + m
+	if !wire.CountFitsIn(int(nRows), len(rec)-rowsOff, tl.RowWidth) {
+		return 0, 0, fmt.Errorf("%w: table declares %d rows but the record is too short", ErrRecord, nRows)
+	}
+	return nRows, rowsOff, nil
+}
+
+// findSchemaRow binary-searches a schema-mode table's fixed-width rows for
+// the key seg names, returning its index. Rows are stored strictly
+// ascending by key (DecodeRecord enforces it), numeric keys ordered as
+// little-endian integers and FIXED keys bytewise.
+func findSchemaRow(rec []byte, rowsOff int, nRows uint64, tl *wire.TableLayout, keyType uint8, seg Segment) (int, bool) {
+	kw := tl.KeyWidth
+	var target []byte
+	var targetVal uint64
+	if seg.KeyQuoted {
+		if len(seg.Key) != kw {
+			// No row of this table can have a key of that length.
+			return 0, false
+		}
+		target = seg.Key
+	} else {
+		v, err := strconv.ParseUint(seg.KeyText, 10, 64)
+		if err != nil {
+			return 0, false
+		}
+		if kw < 8 && v >= uint64(1)<<(8*uint(kw)) {
+			return 0, false
+		}
+		targetVal = v
+	}
+
+	lo, hi := 0, int(nRows)
+	for lo < hi {
+		mid := int(uint(lo+hi) >> 1)
+		start := rowsOff + mid*tl.RowWidth
+		k := rec[start : start+kw]
+		var cmp int
+		if target != nil {
+			cmp = compareStoredKeyBytes(k, target, keyType)
+		} else {
+			cmp = compareStoredKeyValue(k, targetVal, keyType)
+		}
+		if cmp < 0 {
+			lo = mid + 1
+		} else {
+			hi = mid
+		}
+	}
+	if lo >= int(nRows) {
+		return 0, false
+	}
+	start := rowsOff + lo*tl.RowWidth
+	k := rec[start : start+kw]
+	if target != nil {
+		if compareStoredKeyBytes(k, target, keyType) != 0 {
+			return 0, false
+		}
+	} else if compareStoredKeyValue(k, targetVal, keyType) != 0 {
+		return 0, false
+	}
+	return lo, true
+}
+
+// compareStoredKeyBytes compares a stored key against target under the
+// table's key ordering: bytewise for FIXED, little-endian integer for every
+// other legal key type. Both are the table's key width.
+func compareStoredKeyBytes(k, target []byte, keyType uint8) int {
+	if keyType == wire.OperateTypeFixed {
+		return bytes.Compare(k, target)
+	}
+	return compareLEBytes(k, target)
+}
+
+// compareStoredKeyValue compares a stored key against the key a decimal
+// segment denotes, without materialising that key: for FIXED the target is
+// its little-endian bytes compared bytewise, otherwise it is the integer
+// itself.
+func compareStoredKeyValue(k []byte, v uint64, keyType uint8) int {
+	if keyType == wire.OperateTypeFixed {
+		for i := 0; i < len(k); i++ {
+			t := leByte(v, i)
+			if k[i] != t {
+				if k[i] < t {
+					return -1
+				}
+				return 1
+			}
+		}
+		return 0
+	}
+	kv := leValueOf(k)
+	switch {
+	case kv < v:
+		return -1
+	case kv > v:
+		return 1
+	default:
+		return 0
+	}
+}
+
+// leByte returns byte i of v's little-endian encoding, zero past its width.
+func leByte(v uint64, i int) byte {
+	if i >= 8 {
+		return 0
+	}
+	return byte(v >> (8 * uint(i)))
+}
+
+// leValueOf decodes at most 8 little-endian bytes as an unsigned integer.
+func leValueOf(b []byte) uint64 {
+	var v uint64
+	for i := len(b) - 1; i >= 0; i-- {
+		v = v<<8 | uint64(b[i])
+	}
+	return v
+}
+
+// compareLEBytes compares two equal-width little-endian byte strings as
+// unsigned integers.
+func compareLEBytes(a, b []byte) int {
+	av, bv := leValueOf(a), leValueOf(b)
+	switch {
+	case av < bv:
+		return -1
+	case av > bv:
+		return 1
+	default:
+		return 0
+	}
+}
+
+// --- schema cache ---------------------------------------------------------
+
+// schemaFor returns the decoded schema for rec, from the cache when the
+// blob is one already seen.
+func (r *Resolver) schemaFor(rec []byte) (*schemaEntry, error) {
+	blob := rec[1:]
+	if n, ok := schemaBlobLen(blob); ok {
+		// A cached key is a complete, valid schema blob. The stored format
+		// is parsed strictly front to back, so if those exact bytes are a
+		// prefix of this record's blob they ARE this record's blob — the
+		// scanner only proposes where to cut, the byte equality decides.
+		if e := r.lookup(blob[:n]); e != nil {
+			return e, nil
+		}
+	}
+	s, n, err := wire.DecodeSchema(blob)
+	if err != nil {
+		return nil, fmt.Errorf("%w: schema blob: %v", ErrRecord, err)
+	}
+	l, err := s.Layout()
+	if err != nil {
+		return nil, fmt.Errorf("%w: schema layout: %v", ErrRecord, err)
+	}
+	e := &schemaEntry{schema: s, layout: l, blobLen: n}
+	r.store(blob[:n], e)
+	return e, nil
+}
+
+func (r *Resolver) lookup(blob []byte) *schemaEntry {
+	if r.cache == nil {
+		return nil
+	}
+	r.mu.RLock()
+	// Written as a direct index of a string conversion so the compiler
+	// looks the key up without allocating it.
+	e := r.cache[string(blob)]
+	r.mu.RUnlock()
+	return e
+}
+
+func (r *Resolver) store(blob []byte, e *schemaEntry) {
+	if r.cache == nil {
+		return
+	}
+	r.mu.Lock()
+	if len(r.cache) >= r.limit {
+		clear(r.cache)
+	}
+	r.cache[string(blob)] = e
+	r.mu.Unlock()
+}
+
+// schemaBlobLen reports how many bytes the schema blob at the front of b
+// occupies, walking its declarations without decoding them (design doc
+// §2.2/§2.3). It is a cache-lookup optimisation only: it never decides
+// whether a blob is valid, and a false result — or a wrong one — costs a
+// cache miss and nothing else, because the cached entry is keyed by the
+// blob's exact bytes and wire.DecodeSchema is the authority on the miss
+// path.
+func schemaBlobLen(b []byte) (int, bool) {
+	if len(b) < 4 {
+		return 0, false
+	}
+	off := 3 // version u16 + flags u8
+	nFields, m, ok := scanUvarint(b, off)
+	if !ok || nFields > wire.OperateMaxFields {
+		return 0, false
+	}
+	off += m
+	for i := uint64(0); i < nFields; i++ {
+		if off >= len(b) {
+			return 0, false
+		}
+		typ := b[off]
+		off++
+		if typ == wire.OperateTypeFixed {
+			if off >= len(b) {
+				return 0, false
+			}
+			off++
+		}
+		if typ != wire.OperateTypeTable {
+			continue
+		}
+		if off >= len(b) {
+			return 0, false
+		}
+		keyType := b[off]
+		off++
+		if keyType == wire.OperateTypeFixed {
+			if off >= len(b) {
+				return 0, false
+			}
+			off++
+		}
+		nCols, m2, ok := scanUvarint(b, off)
+		if !ok || nCols > wire.OperateMaxCols {
+			return 0, false
+		}
+		off += m2
+		for c := uint64(0); c < nCols; c++ {
+			if off >= len(b) {
+				return 0, false
+			}
+			ct := b[off]
+			off++
+			if ct == wire.OperateTypeFixed {
+				if off >= len(b) {
+					return 0, false
+				}
+				off++
+			}
+		}
+		if _, m3, ok := scanUvarint(b, off); ok { // cap
+			off += m3
+		} else {
+			return 0, false
+		}
+		if off >= len(b) {
+			return 0, false
+		}
+		off++                                     // policy
+		if _, m4, ok := scanUvarint(b, off); ok { // byCol
+			off += m4
+		} else {
+			return 0, false
+		}
+	}
+	nameBytes, m5, ok := scanUvarint(b, off)
+	if !ok {
+		return 0, false
+	}
+	off += m5
+	if nameBytes > uint64(len(b)-off) {
+		return 0, false
+	}
+	return off + int(nameBytes), true
+}
+
+// scanUvarint reads one uvarint at off without the canonicality check
+// readCanonicalUvarint applies: schemaBlobLen only needs the length, and a
+// non-canonical blob is rejected by DecodeSchema on the cache-miss path.
+func scanUvarint(b []byte, off int) (uint64, int, bool) {
+	if off < 0 || off > len(b) {
+		return 0, 0, false
+	}
+	v, m := binary.Uvarint(b[off:])
+	if m <= 0 {
+		return 0, 0, false
+	}
+	return v, m, true
+}
+
+// --- dynamic mode ---------------------------------------------------------
+
+func resolveDynamic(rec []byte, p Path) (Result, error) {
+	seg := p.Segs[0]
+	if seg.ByPos {
+		return Result{}, fmt.Errorf("%w: dynamic records address fields by name, not position", ErrPath)
+	}
+
+	nFields, m, err := readCanonicalUvarint(rec, 1)
+	if err != nil {
+		return Result{}, err
+	}
+	off := 1 + m
+	if nFields > wire.OperateMaxFields {
+		return Result{}, fmt.Errorf("%w: record declares %d fields", ErrRecord, nFields)
+	}
+	if !wire.CountFitsIn(int(nFields), len(rec)-off, 3) {
+		return Result{}, fmt.Errorf("%w: record declares %d fields but is too short", ErrRecord, nFields)
+	}
+
+	var prevName []byte
+	for i := uint64(0); i < nFields; i++ {
+		name, next, err := readName(rec, off)
+		if err != nil {
+			return Result{}, err
+		}
+		off = next
+		// Fields are stored strictly ascending by name; checking it as we
+		// walk is what lets the walk stop early, and is the same invariant
+		// DecodeRecord enforces.
+		if prevName != nil && bytes.Compare(prevName, name) >= 0 {
+			return Result{}, fmt.Errorf("%w: fields out of order", ErrRecord)
+		}
+		prevName = name
+
+		cmp := compareBytesString(name, seg.Name)
+		if cmp > 0 {
+			return Result{Kind: Absent}, nil
+		}
+
+		typ, n, valOff, err := readTypeTag(rec, off)
+		if err != nil {
+			return Result{}, err
+		}
+		if cmp == 0 {
+			return resolveDynamicField(rec, valOff, typ, n, p)
+		}
+		off, err = skipDynamicValue(rec, valOff, typ, n)
+		if err != nil {
+			return Result{}, err
+		}
+	}
+	return Result{Kind: Absent}, nil
+}
+
+// resolveDynamicField finishes a dynamic-mode resolution once the named
+// field has been found at valOff with the stored type (typ, n).
+func resolveDynamicField(rec []byte, valOff int, typ, n uint8, p Path) (Result, error) {
+	isTable := typ == wire.OperateTypeTable
+
+	if p.Segs[0].Kind == SegCount {
+		if !isTable {
+			return Result{}, fmt.Errorf("%w: #count on a non-table field", ErrPath)
+		}
+		inner, _, err := dynamicTableInner(rec, valOff)
+		if err != nil {
+			return Result{}, err
+		}
+		nRows, _, err := dynamicTableRows(inner)
+		if err != nil {
+			return Result{}, err
+		}
+		return Result{Kind: Count, Count: nRows}, nil
+	}
+	if len(p.Segs) == 1 {
+		if isTable {
+			return Result{Kind: Table}, nil
+		}
+		cell, err := readCellAt(rec, valOff, typ, n)
+		if err != nil {
+			return Result{}, err
+		}
+		return Result{Kind: Scalar, Cell: cell}, nil
+	}
+	if !isTable {
+		return Result{}, fmt.Errorf("%w: row segment on a non-table field", ErrPath)
+	}
+
+	inner, _, err := dynamicTableInner(rec, valOff)
+	if err != nil {
+		return Result{}, err
+	}
+	nRows, rowsOff, err := dynamicTableRows(inner)
+	if err != nil {
+		return Result{}, err
+	}
+
+	seg := p.Segs[1]
+	var keyBuf [8]byte
+	target := seg.Key
+	if !seg.KeyQuoted {
+		v, perr := strconv.ParseUint(seg.KeyText, 10, 64)
+		if perr != nil {
+			return Result{Kind: Absent}, nil
+		}
+		binary.LittleEndian.PutUint64(keyBuf[:], v)
+		target = keyBuf[:]
+	}
+
+	off := rowsOff
+	var prevKey []byte
+	for i := uint64(0); i < nRows; i++ {
+		rowLen, m, err := readCanonicalUvarint(inner, off)
+		if err != nil {
+			return Result{}, err
+		}
+		off += m
+		if !fitsRemaining(rowLen, len(inner)-off) {
+			return Result{}, fmt.Errorf("%w: row runs past its table", ErrRecord)
+		}
+		row := inner[off : off+int(rowLen)]
+		off += int(rowLen)
+
+		if len(row) < 1 {
+			return Result{}, fmt.Errorf("%w: empty row", ErrRecord)
+		}
+		klen := int(row[0])
+		if klen == 0 || klen > wire.OperateMaxKeyLen {
+			return Result{}, fmt.Errorf("%w: row key length %d", ErrRecord, klen)
+		}
+		if len(row)-1 < klen {
+			return Result{}, fmt.Errorf("%w: row ends inside its key", ErrRecord)
+		}
+		key := row[1 : 1+klen]
+		// Rows are stored strictly ascending by key bytes, the invariant
+		// DecodeRecord enforces and the one the early stop below rests on.
+		if prevKey != nil && bytes.Compare(prevKey, key) >= 0 {
+			return Result{}, fmt.Errorf("%w: rows out of order", ErrRecord)
+		}
+		prevKey = key
+
+		switch bytes.Compare(key, target) {
+		case 1:
+			return Result{Kind: Absent}, nil
+		case 0:
+			return resolveDynamicRow(row[1+klen:], p)
+		}
+	}
+	return Result{Kind: Absent}, nil
+}
+
+// resolveDynamicRow finishes a dynamic-mode resolution inside the row whose
+// key matched; b is the row's content after its key.
+func resolveDynamicRow(b []byte, p Path) (Result, error) {
+	if len(p.Segs) == 2 {
+		return Result{Kind: RowPresent}, nil
+	}
+	cseg := p.Segs[2]
+	if cseg.ByPos {
+		return Result{}, fmt.Errorf("%w: dynamic rows address columns by name, not position", ErrPath)
+	}
+
+	nCols, m, err := readCanonicalUvarint(b, 0)
+	if err != nil {
+		return Result{}, err
+	}
+	off := m
+	if nCols > wire.OperateMaxCols {
+		return Result{}, fmt.Errorf("%w: row declares %d columns", ErrRecord, nCols)
+	}
+	if !wire.CountFitsIn(int(nCols), len(b)-off, 3) {
+		return Result{}, fmt.Errorf("%w: row declares %d columns but is too short", ErrRecord, nCols)
+	}
+
+	var prevName []byte
+	for i := uint64(0); i < nCols; i++ {
+		name, next, err := readName(b, off)
+		if err != nil {
+			return Result{}, err
+		}
+		off = next
+		if prevName != nil && bytes.Compare(prevName, name) >= 0 {
+			return Result{}, fmt.Errorf("%w: columns out of order", ErrRecord)
+		}
+		prevName = name
+
+		cmp := compareBytesString(name, cseg.Name)
+		if cmp > 0 {
+			return Result{Kind: Absent}, nil
+		}
+		typ, n, valOff, err := readTypeTag(b, off)
+		if err != nil {
+			return Result{}, err
+		}
+		if typ == wire.OperateTypeTable {
+			// A table is never a column value (design doc §2.9).
+			return Result{}, fmt.Errorf("%w: column holds a table", ErrRecord)
+		}
+		if cmp == 0 {
+			cell, cerr := readCellAt(b, valOff, typ, n)
+			if cerr != nil {
+				return Result{}, cerr
+			}
+			return Result{Kind: Scalar, Cell: cell}, nil
+		}
+		ln, lerr := cellDataLen(b, valOff, typ, n)
+		if lerr != nil {
+			return Result{}, lerr
+		}
+		off = valOff + ln
+	}
+	return Result{Kind: Absent}, nil
+}
+
+// dynamicTableInner slices a dynamic-mode table's byteLen-delimited body
+// (design doc §2.9) and reports where the field's value ends.
+func dynamicTableInner(rec []byte, off int) ([]byte, int, error) {
+	byteLen, m, err := readCanonicalUvarint(rec, off)
+	if err != nil {
+		return nil, 0, err
+	}
+	start := off + m
+	if !fitsRemaining(byteLen, len(rec)-start) {
+		return nil, 0, fmt.Errorf("%w: table runs past the record", ErrRecord)
+	}
+	end := start + int(byteLen)
+	return rec[start:end], end, nil
+}
+
+// dynamicTableRows reads a dynamic-mode table body's eviction triple and
+// row count, returning the count and the offset of the first row within
+// inner.
+func dynamicTableRows(inner []byte) (uint64, int, error) {
+	capV, m, err := readCanonicalUvarint(inner, 0)
+	if err != nil {
+		return 0, 0, err
+	}
+	off := m
+	if capV > wire.OperateMaxRows {
+		return 0, 0, fmt.Errorf("%w: table cap %d", ErrRecord, capV)
+	}
+	if len(inner)-off < 1 {
+		return 0, 0, fmt.Errorf("%w: table ends before its policy", ErrRecord)
+	}
+	policy := inner[off]
+	off++
+	if policy > wire.OperatePolicyMaxCol {
+		return 0, 0, fmt.Errorf("%w: unknown eviction policy %d", ErrRecord, policy)
+	}
+	if len(inner)-off < 1 {
+		return 0, 0, fmt.Errorf("%w: table ends before its eviction column", ErrRecord)
+	}
+	byColLen := int(inner[off])
+	off++
+	if len(inner)-off < byColLen {
+		return 0, 0, fmt.Errorf("%w: table ends inside its eviction column name", ErrRecord)
+	}
+	off += byColLen
+	// A *_COL policy evicts by a named column, so it is malformed without
+	// the name — the same pairing DecodeRecord refuses.
+	if (policy == wire.OperatePolicyMinCol || policy == wire.OperatePolicyMaxCol) && byColLen == 0 {
+		return 0, 0, fmt.Errorf("%w: column eviction policy with no column", ErrRecord)
+	}
+
+	nRows, m2, err := readCanonicalUvarint(inner, off)
+	if err != nil {
+		return 0, 0, err
+	}
+	off += m2
+	if nRows > wire.OperateMaxRows {
+		return 0, 0, fmt.Errorf("%w: table declares %d rows", ErrRecord, nRows)
+	}
+	if !wire.CountFitsIn(int(nRows), len(inner)-off, 3) {
+		return 0, 0, fmt.Errorf("%w: table declares %d rows but is too short", ErrRecord, nRows)
+	}
+	return nRows, off, nil
+}
+
+// skipDynamicValue returns the offset just past the value of a dynamic
+// field of the given stored type.
+func skipDynamicValue(rec []byte, off int, typ, n uint8) (int, error) {
+	if typ == wire.OperateTypeTable {
+		_, end, err := dynamicTableInner(rec, off)
+		return end, err
+	}
+	ln, err := cellDataLen(rec, off, typ, n)
+	if err != nil {
+		return 0, err
+	}
+	return off + ln, nil
+}
+
+// readName reads a [len u8][name] entry, returning the name's bytes (a
+// sub-slice of b, never copied) and the offset just past it.
+func readName(b []byte, off int) ([]byte, int, error) {
+	if off < 0 || off >= len(b) {
+		return nil, 0, fmt.Errorf("%w: truncated name", ErrRecord)
+	}
+	n := int(b[off])
+	off++
+	if n == 0 || n > wire.OperateMaxNameLen {
+		return nil, 0, fmt.Errorf("%w: name length %d", ErrRecord, n)
+	}
+	if len(b)-off < n {
+		return nil, 0, fmt.Errorf("%w: truncated name", ErrRecord)
+	}
+	return b[off : off+n], off + n, nil
+}
+
+// readTypeTag reads a [type u8][n u8 iff FIXED] tag, returning the type,
+// the FIXED width, and the offset of the value that follows.
+func readTypeTag(b []byte, off int) (typ, n uint8, valOff int, err error) {
+	if off < 0 || off >= len(b) {
+		return 0, 0, 0, fmt.Errorf("%w: truncated type tag", ErrRecord)
+	}
+	typ = b[off]
+	off++
+	if typ == wire.OperateTypeFixed {
+		if off >= len(b) {
+			return 0, 0, 0, fmt.Errorf("%w: truncated FIXED width", ErrRecord)
+		}
+		n = b[off]
+		off++
+		// FIXED's declared width is 1-255; a stored 0 is malformed, not a
+		// zero-width value.
+		if n == 0 {
+			return 0, 0, 0, fmt.Errorf("%w: FIXED(0) is not a width", ErrRecord)
+		}
+	}
+	return typ, n, off, nil
+}
+
+// --- shared byte readers --------------------------------------------------
+
+// readCellAt decodes one cell of type (typ, n) at off. It rejects the
+// non-canonical spellings wire.DecodeRecord rejects — an over-long varint,
+// and any NaN but the canonical quiet one — so the resolver accepts exactly
+// what the tree decoder accepts on the bytes it touches.
+func readCellAt(rec []byte, off int, typ, n uint8) (wire.Cell, error) {
+	if off < 0 || off > len(rec) {
+		return wire.Cell{}, fmt.Errorf("%w: cell offset out of range", ErrRecord)
+	}
+	b := rec[off:]
+	switch typ {
+	case wire.OperateTypeUVarint, wire.OperateTypeIVarint, wire.OperateTypeBytes:
+		if _, _, err := readCanonicalUvarint(b, 0); err != nil {
+			return wire.Cell{}, err
+		}
+	case wire.OperateTypeF32:
+		if len(b) < 4 {
+			return wire.Cell{}, fmt.Errorf("%w: truncated F32", ErrRecord)
+		}
+		bits := binary.LittleEndian.Uint32(b[:4])
+		if math.IsNaN(float64(math.Float32frombits(bits))) && bits != canonicalNaN32 {
+			return wire.Cell{}, fmt.Errorf("%w: non-canonical F32 NaN", ErrRecord)
+		}
+	case wire.OperateTypeF64:
+		if len(b) < 8 {
+			return wire.Cell{}, fmt.Errorf("%w: truncated F64", ErrRecord)
+		}
+		bits := binary.LittleEndian.Uint64(b[:8])
+		if math.IsNaN(math.Float64frombits(bits)) && bits != canonicalNaN64 {
+			return wire.Cell{}, fmt.Errorf("%w: non-canonical F64 NaN", ErrRecord)
+		}
+	}
+	cell, _, err := wire.DecodeCellData(typ, n, b)
+	if err != nil {
+		return wire.Cell{}, fmt.Errorf("%w: cell: %v", ErrRecord, err)
+	}
+	return cell, nil
+}
+
+// canonicalNaN32 and canonicalNaN64 are the only NaN bit patterns
+// wire.AppendCellData writes (design doc §2.5).
+const (
+	canonicalNaN32 uint32 = 0x7FC00000
+	canonicalNaN64 uint64 = 0x7FF8000000000000
+)
+
+// cellDataLen returns the stored byte length of a cell of type (typ, n) at
+// off, without decoding its value — what a skip needs.
+func cellDataLen(rec []byte, off int, typ, n uint8) (int, error) {
+	if off < 0 || off > len(rec) {
+		return 0, fmt.Errorf("%w: cell offset out of range", ErrRecord)
+	}
+	switch typ {
+	case wire.OperateTypeUnset:
+		return 0, nil
+	case wire.OperateTypeUVarint, wire.OperateTypeIVarint:
+		_, m, err := readCanonicalUvarint(rec, off)
+		return m, err
+	case wire.OperateTypeBytes:
+		ln, m, err := readCanonicalUvarint(rec, off)
+		if err != nil {
+			return 0, err
+		}
+		if ln > wire.OperateMaxBytesLen {
+			return 0, fmt.Errorf("%w: BYTES declares %d bytes", ErrRecord, ln)
+		}
+		if !wire.CountFitsIn(int(ln), len(rec)-(off+m), 1) {
+			return 0, fmt.Errorf("%w: BYTES runs past the record", ErrRecord)
+		}
+		return m + int(ln), nil
+	case wire.OperateTypeTable:
+		return 0, fmt.Errorf("%w: a table is not cell data", ErrRecord)
+	default:
+		w := wire.CellWidth(typ, n)
+		if w < 1 {
+			// -1 is an unknown type tag; 0 can only come from FIXED(0),
+			// which is not a legal width.
+			return 0, fmt.Errorf("%w: type %d has no stored width", ErrRecord, typ)
+		}
+		if len(rec)-off < w {
+			return 0, fmt.Errorf("%w: record ends inside a %d-byte cell", ErrRecord, w)
+		}
+		return w, nil
+	}
+}
+
+// readCanonicalUvarint reads one uvarint at off, rejecting a truncated
+// encoding and a non-minimal (zero-padded) one — the same rule
+// sdk/wire/operate_record.go applies, and the one that keeps a stored
+// record's bytes the only spelling of its value.
+func readCanonicalUvarint(b []byte, off int) (uint64, int, error) {
+	if off < 0 || off > len(b) {
+		return 0, 0, fmt.Errorf("%w: varint offset out of range", ErrRecord)
+	}
+	v, m := binary.Uvarint(b[off:])
+	if m <= 0 { // 0 = truncated, <0 = more than 64 bits
+		return 0, 0, fmt.Errorf("%w: truncated or oversized varint", ErrRecord)
+	}
+	if m != minUvarintLen(v) {
+		return 0, 0, fmt.Errorf("%w: non-canonical varint", ErrRecord)
+	}
+	return v, m, nil
+}
+
+// minUvarintLen returns the number of bytes binary.AppendUvarint uses for
+// v: the canonical LEB128 length.
+func minUvarintLen(v uint64) int {
+	n := 1
+	for v >= 0x80 {
+		v >>= 7
+		n++
+	}
+	return n
+}
+
+// fitsRemaining reports whether a decoded byte length fits in remaining
+// bytes, without narrowing it to int first: a length prefix is an arbitrary
+// attacker-controlled uvarint, and converting before comparing would wrap
+// on a 32-bit int.
+func fitsRemaining(n uint64, remaining int) bool {
+	if remaining < 0 {
+		return false
+	}
+	return n <= uint64(remaining)
+}
+
+// compareBytesString compares a byte slice against a string the way
+// bytes.Compare would, without the allocation a conversion would cost.
+func compareBytesString(b []byte, s string) int {
+	n := len(b)
+	if len(s) < n {
+		n = len(s)
+	}
+	for i := 0; i < n; i++ {
+		if b[i] != s[i] {
+			if b[i] < s[i] {
+				return -1
+			}
+			return 1
+		}
+	}
+	switch {
+	case len(b) < len(s):
+		return -1
+	case len(b) > len(s):
+		return 1
+	default:
+		return 0
+	}
+}

--- a/sdk/record/resolve.go
+++ b/sdk/record/resolve.go
@@ -105,6 +105,11 @@ type schemaEntry struct {
 // Absent (binary search cannot see the disorder, and it never returns a row
 // whose key does not match), and a field with no further segment resolves
 // to Table without reading the table's bytes at all.
+//
+// Both consequences are safe for a filter leaf, which reads Absent as "this
+// point does not match", and unsafe for an operator that reads Absent as a
+// positive answer. RowAbsentProven is that operator's entry point: it pays for
+// one walk of the table to turn Absent into a proof.
 type Resolver struct {
 	mu    sync.RWMutex
 	cache map[string]*schemaEntry
@@ -178,21 +183,12 @@ func (r *Resolver) resolveSchema(rec []byte, p Path) (Result, error) {
 	}
 
 	seg := p.Segs[0]
-	var pos int
-	if seg.ByPos {
-		if uint64(seg.Pos) >= uint64(len(s.Fields)) {
-			return Result{Kind: Absent}, nil
-		}
-		pos = int(seg.Pos)
-	} else {
-		if !s.StoreNames {
-			return Result{}, fmt.Errorf("%w: schema stores no names, use a position", ErrPath)
-		}
-		i, ok := s.FieldPos(seg.Name)
-		if !ok {
-			return Result{Kind: Absent}, nil
-		}
-		pos = i
+	pos, found, err := schemaFieldPos(s, seg)
+	if err != nil {
+		return Result{}, err
+	}
+	if !found {
+		return Result{Kind: Absent}, nil
 	}
 
 	fdef := &s.Fields[pos]
@@ -283,6 +279,28 @@ func (r *Resolver) resolveSchema(rec []byte, p Path) (Result, error) {
 		return Result{}, err
 	}
 	return Result{Kind: Scalar, Cell: cell}, nil
+}
+
+// schemaFieldPos resolves a path's first segment to a schema field position.
+// found is false when the segment names nothing in this schema (an unknown
+// name, or a position past the end) — the Absent outcome, which is never an
+// error. The one error is a NAME against a schema that stores none, which
+// cannot apply to this record's shape at all.
+func schemaFieldPos(s *wire.Schema, seg Segment) (pos int, found bool, err error) {
+	if seg.ByPos {
+		if uint64(seg.Pos) >= uint64(len(s.Fields)) {
+			return 0, false, nil
+		}
+		return int(seg.Pos), true, nil
+	}
+	if !s.StoreNames {
+		return 0, false, fmt.Errorf("%w: schema stores no names, use a position", ErrPath)
+	}
+	i, ok := s.FieldPos(seg.Name)
+	if !ok {
+		return 0, false, nil
+	}
+	return i, true, nil
 }
 
 // schemaFieldOffset returns the offset of field target's stored value. A
@@ -526,6 +544,285 @@ func compareLEBytes(a, b []byte) int {
 	default:
 		return 0
 	}
+}
+
+// --- proven absence -------------------------------------------------------
+
+// RowAbsentProven reports whether p — a field segment then a row segment —
+// names a row that is PROVABLY absent from a table this record really has.
+//
+// # Why Resolve is not enough
+//
+// Resolve reads only the bytes its path touches, which is what makes a
+// schema-mode row lookup one binary search over stored bytes. The price is
+// stated in the Resolver doc comment: a table whose rows are NOT in the
+// ascending key order DecodeRecord enforces can answer Absent for a row that
+// is actually stored, because a binary search cannot see the disorder, and a
+// field with no further segment answers Table without reading the table at
+// all. For a filter LEAF that is harmless — the row is reported missing, the
+// point does not match. For the row_absent OPERATOR it is not: a malformed
+// record would turn into a positive match, so a caller who can store bytes
+// under a payload key could make a point match a filter it does not satisfy.
+//
+// # What "proven" means
+//
+// Only on the Absent outcome does this walk the table once, verifying that the
+// keys are strictly ascending and that none of them is the one p names. It
+// returns true only when that walk completes: absence is then a fact about the
+// bytes, not an inference from an ordering the record merely claims. A record
+// that fails the walk is malformed and reports an error wrapping ErrRecord; a
+// row that IS present, a field that is not a table, and a field the record does
+// not have all report (false, nil), which is the same "cannot assert" answer
+// Resolve gives for them.
+//
+// The walk is bounded by the row count Resolve already bounded against the
+// record's remaining bytes, so it is O(rows) with no allocation, and it runs
+// only for points that resolved Absent. Row PRESENCE needs none of this and
+// must keep using Resolve: a matched row is proof of itself.
+func (r *Resolver) RowAbsentProven(rec []byte, p Path) (bool, error) {
+	if len(p.Segs) != 2 || p.Segs[0].Kind != SegField || p.Segs[1].Kind != SegRow {
+		return false, fmt.Errorf("%w: RowAbsentProven needs a field/row path", ErrPath)
+	}
+	res, err := r.Resolve(rec, p)
+	if err != nil {
+		return false, err
+	}
+	if res.Kind != Absent {
+		return false, nil
+	}
+	// The field must resolve to a TABLE for "the row is missing" to mean
+	// anything: resolveSchema answers Absent for a field name that is not in
+	// the schema BEFORE it looks for a row, and resolveDynamic does the same
+	// for a name no field carries.
+	fres, err := r.Resolve(rec, Path{Segs: p.Segs[:1:1]})
+	if err != nil {
+		return false, err
+	}
+	if fres.Kind != Table {
+		return false, nil
+	}
+	// rec[0] was validated by the Resolve calls above; the default arm is
+	// unreachable and fails closed rather than guessing a mode.
+	switch rec[0] {
+	case wire.OperateModeSchema:
+		if err := r.proveSchemaRowAbsent(rec, p); err != nil {
+			return false, err
+		}
+	case wire.OperateModeDynamic:
+		if err := proveDynamicRowAbsent(rec, p); err != nil {
+			return false, err
+		}
+	default:
+		return false, fmt.Errorf("%w: unknown mode byte %d", ErrRecord, rec[0])
+	}
+	return true, nil
+}
+
+// proveSchemaRowAbsent walks a schema-mode table's fixed-width rows once,
+// checking that their keys are strictly ascending and that none equals the key
+// p's row segment names. A nil error means the row is provably absent.
+func (r *Resolver) proveSchemaRowAbsent(rec []byte, p Path) error {
+	e, err := r.schemaFor(rec)
+	if err != nil {
+		return err
+	}
+	s, l := e.schema, e.layout
+	base := 1 + e.blobLen
+	if base > len(rec) {
+		return fmt.Errorf("%w: record ends inside its schema blob", ErrRecord)
+	}
+	pos, found, err := schemaFieldPos(s, p.Segs[0])
+	if err != nil {
+		return err
+	}
+	fdef := &s.Fields[pos]
+	// Unreachable: the caller resolved this field to Table already.
+	if !found || fdef.Type != wire.OperateTypeTable || fdef.Table == nil || l.Tables[pos] == nil {
+		return fmt.Errorf("%w: field is not a table", ErrRecord)
+	}
+	tl := l.Tables[pos]
+	off, err := schemaFieldOffset(rec, base, s, l, pos)
+	if err != nil {
+		return err
+	}
+	nRows, rowsOff, err := schemaTableHeader(rec, off, tl)
+	if err != nil {
+		return err
+	}
+
+	keyType := fdef.Table.KeyType
+	target, targetVal, matchable := schemaRowTarget(p.Segs[1], tl.KeyWidth)
+	if !matchable {
+		// No row of this table CAN carry that key — a quoted key of the wrong
+		// length, or a decimal too large for the key width. Absence follows from
+		// the key alone, so the ordering of rows that could never match it is
+		// not part of the proof.
+		return nil
+	}
+	kw := tl.KeyWidth
+	var prev []byte
+	for i := 0; i < int(nRows); i++ {
+		k := rec[rowsOff+i*tl.RowWidth:][:kw]
+		if prev != nil && compareStoredKeyBytes(prev, k, keyType) >= 0 {
+			return fmt.Errorf("%w: table rows are not in ascending key order", ErrRecord)
+		}
+		prev = k
+		var cmp int
+		if target != nil {
+			cmp = compareStoredKeyBytes(k, target, keyType)
+		} else {
+			cmp = compareStoredKeyValue(k, targetVal, keyType)
+		}
+		if cmp == 0 {
+			// Only reachable on a record whose rows are out of order in a way
+			// the ascending check above has not reached yet — a present row the
+			// binary search missed is the malformation, not an absence.
+			return fmt.Errorf("%w: the row is present but the ordered lookup missed it", ErrRecord)
+		}
+	}
+	return nil
+}
+
+// schemaRowTarget renders a row segment as the key it names at width kw, the
+// same way findSchemaRow does: quoted segments compare by their bytes, decimal
+// ones by value. matchable is false when no row of that width can carry the
+// key the segment names.
+func schemaRowTarget(seg Segment, kw int) (target []byte, targetVal uint64, matchable bool) {
+	if seg.KeyQuoted {
+		if len(seg.Key) != kw {
+			return nil, 0, false
+		}
+		return seg.Key, 0, true
+	}
+	v, err := strconv.ParseUint(seg.KeyText, 10, 64)
+	if err != nil {
+		return nil, 0, false
+	}
+	if kw < 8 && v >= uint64(1)<<(8*uint(kw)) {
+		return nil, 0, false
+	}
+	return nil, v, true
+}
+
+// proveDynamicRowAbsent is proveSchemaRowAbsent's dynamic-mode half. It walks
+// EVERY field, not just up to the named one: resolveDynamic stops early on the
+// first name greater than the one it wants, which is correct for a record whose
+// fields are ascending and is exactly what a malformed record subverts, so the
+// proof cannot reuse that shortcut. The same applies to the table's rows.
+func proveDynamicRowAbsent(rec []byte, p Path) error {
+	seg := p.Segs[0]
+	if seg.ByPos {
+		return fmt.Errorf("%w: dynamic records address fields by name, not position", ErrPath)
+	}
+	nFields, m, err := readCanonicalUvarint(rec, 1)
+	if err != nil {
+		return err
+	}
+	off := 1 + m
+	if nFields > wire.OperateMaxFields {
+		return fmt.Errorf("%w: record declares %d fields", ErrRecord, nFields)
+	}
+	if !wire.CountFitsIn(int(nFields), len(rec)-off, 3) {
+		return fmt.Errorf("%w: record declares %d fields but is too short", ErrRecord, nFields)
+	}
+
+	var prevName []byte
+	proved := false
+	for i := uint64(0); i < nFields; i++ {
+		name, next, err := readName(rec, off)
+		if err != nil {
+			return err
+		}
+		off = next
+		// Strict ascending order over the WHOLE field list also rules out a
+		// duplicate name, which is the other way a record could hide a second
+		// table under the name being asked about.
+		if prevName != nil && bytes.Compare(prevName, name) >= 0 {
+			return fmt.Errorf("%w: fields out of order", ErrRecord)
+		}
+		prevName = name
+		typ, n, valOff, err := readTypeTag(rec, off)
+		if err != nil {
+			return err
+		}
+		if compareBytesString(name, seg.Name) == 0 {
+			if typ != wire.OperateTypeTable {
+				return fmt.Errorf("%w: field is not a table", ErrRecord)
+			}
+			inner, _, err := dynamicTableInner(rec, valOff)
+			if err != nil {
+				return err
+			}
+			if err := proveDynamicTableRowAbsent(inner, p.Segs[1]); err != nil {
+				return err
+			}
+			proved = true
+		}
+		off, err = skipDynamicValue(rec, valOff, typ, n)
+		if err != nil {
+			return err
+		}
+	}
+	if !proved {
+		// Unreachable: the caller resolved this field to Table already.
+		return fmt.Errorf("%w: field is not in the record", ErrRecord)
+	}
+	return nil
+}
+
+// proveDynamicTableRowAbsent walks all of a dynamic table's rows, checking the
+// keys are strictly ascending and that none is the one seg names.
+func proveDynamicTableRowAbsent(inner []byte, seg Segment) error {
+	nRows, rowsOff, err := dynamicTableRows(inner)
+	if err != nil {
+		return err
+	}
+	var keyBuf [8]byte
+	target := seg.Key
+	if !seg.KeyQuoted {
+		v, perr := strconv.ParseUint(seg.KeyText, 10, 64)
+		if perr != nil {
+			// No row can carry a key this segment does not name (resolveDynamic
+			// answers Absent for it too), so absence follows from the key alone.
+			return nil
+		}
+		binary.LittleEndian.PutUint64(keyBuf[:], v)
+		target = keyBuf[:]
+	}
+
+	off := rowsOff
+	var prevKey []byte
+	for i := uint64(0); i < nRows; i++ {
+		rowLen, m, err := readCanonicalUvarint(inner, off)
+		if err != nil {
+			return err
+		}
+		off += m
+		if !fitsRemaining(rowLen, len(inner)-off) {
+			return fmt.Errorf("%w: row runs past its table", ErrRecord)
+		}
+		row := inner[off : off+int(rowLen)]
+		off += int(rowLen)
+		if len(row) < 1 {
+			return fmt.Errorf("%w: empty row", ErrRecord)
+		}
+		klen := int(row[0])
+		if klen == 0 || klen > wire.OperateMaxKeyLen {
+			return fmt.Errorf("%w: row key length %d", ErrRecord, klen)
+		}
+		if len(row)-1 < klen {
+			return fmt.Errorf("%w: row ends inside its key", ErrRecord)
+		}
+		key := row[1 : 1+klen]
+		if prevKey != nil && bytes.Compare(prevKey, key) >= 0 {
+			return fmt.Errorf("%w: rows out of order", ErrRecord)
+		}
+		prevKey = key
+		if bytes.Equal(key, target) {
+			return fmt.Errorf("%w: the row is present but the ordered lookup missed it", ErrRecord)
+		}
+	}
+	return nil
 }
 
 // --- schema cache ---------------------------------------------------------

--- a/sdk/record/resolve.go
+++ b/sdk/record/resolve.go
@@ -324,6 +324,63 @@ func schemaFieldOffset(rec []byte, base int, s *wire.Schema, l *wire.Layout, tar
 	return 0, fmt.Errorf("%w: field %d is in neither layout half", ErrRecord, target)
 }
 
+// walkSchemaFields visits every top-level field of a schema-mode record, in
+// schema position order, exactly once, reporting each field's byte offset
+// (and, for a table field, its row count — visit needs it anyway to know
+// where the table ends, so the walk hands it over rather than making the
+// caller re-read the header). It is schemaFieldOffset's iteration form:
+// IndexEntries needs an offset for every field, and calling
+// schemaFieldOffset once per field would re-walk the variable-length tail
+// from scratch each time, costing O(n²) instead of O(n).
+func walkSchemaFields(rec []byte, base int, s *wire.Schema, l *wire.Layout, visit func(pos, off int, isTable bool, nRows uint64) error) error {
+	off := base + l.FixedLen
+	if off > len(rec) {
+		return fmt.Errorf("%w: record ends inside its fixed fields", ErrRecord)
+	}
+	tailIdx := 0
+	for pos := range s.Fields {
+		if l.FixedOff[pos] >= 0 {
+			foff := base + l.FixedOff[pos]
+			if foff > len(rec) {
+				return fmt.Errorf("%w: record ends before field %d", ErrRecord, pos)
+			}
+			if err := visit(pos, foff, false, 0); err != nil {
+				return err
+			}
+			continue
+		}
+		if tailIdx >= len(l.VarTail) || l.VarTail[tailIdx] != pos {
+			// Unreachable for a Layout built from this schema (VarTail lists
+			// exactly the non-fixed positions, in order).
+			return fmt.Errorf("%w: field %d is in neither layout half", ErrRecord, pos)
+		}
+		tailIdx++
+		foff := off
+		f := &s.Fields[pos]
+		isTable := f.Type == wire.OperateTypeTable
+		var nRows uint64
+		if isTable {
+			var rowsOff int
+			var err error
+			nRows, rowsOff, err = schemaTableHeader(rec, off, l.Tables[pos])
+			if err != nil {
+				return err
+			}
+			off = rowsOff + int(nRows)*l.Tables[pos].RowWidth
+		} else {
+			n, err := cellDataLen(rec, off, f.Type, f.N)
+			if err != nil {
+				return err
+			}
+			off += n
+		}
+		if err := visit(pos, foff, isTable, nRows); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 // schemaTableHeader reads a schema-mode table's row count from off and
 // returns it with the offset of the first row, having bounded the rows
 // against the bytes actually left (design doc §2.3).

--- a/sdk/record/resolve_test.go
+++ b/sdk/record/resolve_test.go
@@ -1,0 +1,719 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package record
+
+import (
+	"bytes"
+	"encoding/binary"
+	"errors"
+	"math"
+	"math/rand"
+	"sync"
+	"testing"
+
+	"github.com/rostamlabs/rostam/sdk/wire"
+)
+
+// su64 reinterprets a signed value as the uint64 bit pattern Cell.U stores
+// for a signed type. A constant expression like uint64(int64(-5)) does not
+// compile, so negative fixtures go through this helper.
+func su64(i int64) uint64 { return uint64(i) }
+
+// sinkResult keeps TestResolveNoAlloc's result live so the compiler cannot
+// delete the call it is measuring.
+var sinkResult Result
+
+// sessionRecord builds the design doc's session record (§2.2 example, plus
+// a signed field and a variable-length tail field so the tail walk is
+// exercised) and returns its stored bytes:
+//
+//	#0 rc   U8      = 7
+//	#1 bc   U8      = 3
+//	#2 hist U32     = 1234
+//	#3 bal  I32     = -5
+//	#4 tag  BYTES   = "de"
+//	#5 b    TABLE(key U64; c0 "hi" U32, c1 "lo" U32) = {42: (500, 1), 99: (7, 2)}
+func sessionRecord(t *testing.T, storeNames bool) ([]byte, *wire.Record) {
+	t.Helper()
+	s := &wire.Schema{
+		Version:    3,
+		StoreNames: storeNames,
+		Fields: []wire.FieldDef{
+			{Name: "rc", Type: wire.OperateTypeU8},
+			{Name: "bc", Type: wire.OperateTypeU8},
+			{Name: "hist", Type: wire.OperateTypeU32},
+			{Name: "bal", Type: wire.OperateTypeI32},
+			{Name: "tag", Type: wire.OperateTypeBytes},
+			{Name: "b", Type: wire.OperateTypeTable, Table: &wire.TableDef{
+				KeyType: wire.OperateTypeU64,
+				Cols: []wire.ColumnDef{
+					{Name: "hi", Type: wire.OperateTypeU32},
+					{Name: "lo", Type: wire.OperateTypeU32},
+				},
+			}},
+		},
+	}
+	if err := s.Validate(); err != nil {
+		t.Fatalf("session schema invalid: %v", err)
+	}
+	rec := &wire.Record{Mode: wire.OperateModeSchema, Schema: s, Fields: []wire.Field{
+		{Cell: wire.Cell{Type: wire.OperateTypeU8, U: 7}},
+		{Cell: wire.Cell{Type: wire.OperateTypeU8, U: 3}},
+		{Cell: wire.Cell{Type: wire.OperateTypeU32, U: 1234}},
+		{Cell: wire.Cell{Type: wire.OperateTypeI32, U: su64(-5)}},
+		{Cell: wire.Cell{Type: wire.OperateTypeBytes, B: []byte("de")}},
+		{Cell: wire.Cell{Type: wire.OperateTypeTable}, Table: &wire.Table{Rows: []wire.Row{
+			{Key: leKey(t, 42), Cols: []wire.Col{
+				{Cell: wire.Cell{Type: wire.OperateTypeU32, U: 500}},
+				{Cell: wire.Cell{Type: wire.OperateTypeU32, U: 1}},
+			}},
+			{Key: leKey(t, 99), Cols: []wire.Col{
+				{Cell: wire.Cell{Type: wire.OperateTypeU32, U: 7}},
+				{Cell: wire.Cell{Type: wire.OperateTypeU32, U: 2}},
+			}},
+		}}},
+	}}
+	enc := rec.Encode()
+	if enc == nil {
+		t.Fatal("session record failed to encode")
+	}
+	dec, err := wire.DecodeRecord(enc)
+	if err != nil {
+		t.Fatalf("session record failed to decode: %v", err)
+	}
+	return enc, dec
+}
+
+func leKey(t *testing.T, v uint64) []byte {
+	t.Helper()
+	b := make([]byte, 8)
+	binary.LittleEndian.PutUint64(b, v)
+	return b
+}
+
+// dynamicRecord builds the dynamic-mode example: a scalar, a BYTES field,
+// and a table with one 8-byte little-endian key (what client.KeyU64
+// produces, addressable in decimal) and one raw ASCII key (addressable
+// quoted).
+func dynamicRecord(t *testing.T) ([]byte, *wire.Record) {
+	t.Helper()
+	rec := &wire.Record{Mode: wire.OperateModeDynamic, Fields: []wire.Field{
+		{Name: "cnt", Cell: wire.Cell{Type: wire.OperateTypeU32, U: 9}},
+		{Name: "raw", Cell: wire.Cell{Type: wire.OperateTypeBytes, B: []byte("hi")}},
+		{Name: "t", Cell: wire.Cell{Type: wire.OperateTypeTable}, Table: &wire.Table{Rows: []wire.Row{
+			{Key: leKey(t, 42), Cols: []wire.Col{
+				{Name: "hi", Cell: wire.Cell{Type: wire.OperateTypeU32, U: 500}},
+				{Name: "lo", Cell: wire.Cell{Type: wire.OperateTypeU8, U: 1}},
+			}},
+			{Key: []byte("DE"), Cols: []wire.Col{
+				{Name: "hi", Cell: wire.Cell{Type: wire.OperateTypeU32, U: 7}},
+			}},
+		}}},
+	}}
+	enc := rec.Encode()
+	if enc == nil {
+		t.Fatal("dynamic record failed to encode")
+	}
+	dec, err := wire.DecodeRecord(enc)
+	if err != nil {
+		t.Fatalf("dynamic record failed to decode: %v", err)
+	}
+	return enc, dec
+}
+
+// resultsEqual compares two Results structurally, treating two NaN cells as
+// equal (reflect.DeepEqual does not).
+func resultsEqual(a, b Result) bool {
+	if a.Kind != b.Kind || a.Count != b.Count {
+		return false
+	}
+	if a.Cell.Type != b.Cell.Type || a.Cell.N != b.Cell.N || a.Cell.U != b.Cell.U {
+		return false
+	}
+	if !bytes.Equal(a.Cell.B, b.Cell.B) {
+		return false
+	}
+	if math.IsNaN(a.Cell.F) || math.IsNaN(b.Cell.F) {
+		return math.IsNaN(a.Cell.F) && math.IsNaN(b.Cell.F)
+	}
+	return a.Cell.F == b.Cell.F
+}
+
+// errClass reduces an error to the class the oracle comparison cares about.
+func errClass(err error) string {
+	switch {
+	case err == nil:
+		return "nil"
+	case errors.Is(err, ErrPath):
+		return "path"
+	case errors.Is(err, ErrRecord):
+		return "record"
+	default:
+		return "other"
+	}
+}
+
+func mustPath(t *testing.T, s string) Path {
+	t.Helper()
+	p, err := ParsePath(s)
+	if err != nil {
+		t.Fatalf("ParsePath(%q): %v", s, err)
+	}
+	return p
+}
+
+func TestResolveSessionExample(t *testing.T) {
+	cases := []struct {
+		path    string
+		want    Result
+		wantErr error
+	}{
+		{path: "rc", want: Result{Kind: Scalar, Cell: wire.Cell{Type: wire.OperateTypeU8, U: 7}}},
+		{path: "bc", want: Result{Kind: Scalar, Cell: wire.Cell{Type: wire.OperateTypeU8, U: 3}}},
+		{path: "hist", want: Result{Kind: Scalar, Cell: wire.Cell{Type: wire.OperateTypeU32, U: 1234}}},
+		{path: "bal", want: Result{Kind: Scalar, Cell: wire.Cell{Type: wire.OperateTypeI32, U: su64(-5)}}},
+		{path: "tag", want: Result{Kind: Scalar, Cell: wire.Cell{Type: wire.OperateTypeBytes, B: []byte("de")}}},
+		{path: "b", want: Result{Kind: Table}},
+		{path: "b#count", want: Result{Kind: Count, Count: 2}},
+		{path: "b/42", want: Result{Kind: RowPresent}},
+		{path: "b/99", want: Result{Kind: RowPresent}},
+		{path: "b/7", want: Result{Kind: Absent}},
+		{path: "b/42/hi", want: Result{Kind: Scalar, Cell: wire.Cell{Type: wire.OperateTypeU32, U: 500}}},
+		{path: "b/42/lo", want: Result{Kind: Scalar, Cell: wire.Cell{Type: wire.OperateTypeU32, U: 1}}},
+		{path: "b/99/hi", want: Result{Kind: Scalar, Cell: wire.Cell{Type: wire.OperateTypeU32, U: 7}}},
+		{path: "b/99/lo", want: Result{Kind: Scalar, Cell: wire.Cell{Type: wire.OperateTypeU32, U: 2}}},
+		{path: "b/42/#0", want: Result{Kind: Scalar, Cell: wire.Cell{Type: wire.OperateTypeU32, U: 500}}},
+		{path: "b/42/zz", want: Result{Kind: Absent}},
+		{path: "b/42/#9", want: Result{Kind: Absent}},
+		{path: `b/"quoted"`, want: Result{Kind: Absent}}, // wrong key width for a U64 key
+		{path: "b/18446744073709551615", want: Result{Kind: Absent}},
+		{path: "zz", want: Result{Kind: Absent}},
+		{path: "#0", want: Result{Kind: Scalar, Cell: wire.Cell{Type: wire.OperateTypeU8, U: 7}}},
+		{path: "#5#count", want: Result{Kind: Count, Count: 2}},
+		{path: "#9", want: Result{Kind: Absent}},
+		{path: "#9/42", want: Result{Kind: Absent}},
+		{path: "rc#count", wantErr: ErrPath},
+		{path: "rc/42", wantErr: ErrPath},
+		{path: "rc/42/hi", wantErr: ErrPath},
+		{path: "tag/42", wantErr: ErrPath},
+	}
+
+	enc, dec := sessionRecord(t, true)
+	r := NewResolver(8)
+	for _, tc := range cases {
+		p := mustPath(t, tc.path)
+		got, err := r.Resolve(enc, p)
+		if tc.wantErr != nil {
+			if !errors.Is(err, tc.wantErr) {
+				t.Errorf("Resolve(%q) error = %v, want %v", tc.path, err, tc.wantErr)
+			}
+		} else {
+			if err != nil {
+				t.Errorf("Resolve(%q): unexpected error %v", tc.path, err)
+				continue
+			}
+			if !resultsEqual(got, tc.want) {
+				t.Errorf("Resolve(%q) = %+v, want %+v", tc.path, got, tc.want)
+			}
+		}
+		// The oracle must agree on every one of these, error class included.
+		oracle, oerr := resolveTree(dec, p)
+		if errClass(err) != errClass(oerr) {
+			t.Errorf("Resolve(%q) error class %s, oracle %s", tc.path, errClass(err), errClass(oerr))
+		}
+		if err == nil && oerr == nil && !resultsEqual(got, oracle) {
+			t.Errorf("Resolve(%q) = %+v, oracle = %+v", tc.path, got, oracle)
+		}
+	}
+}
+
+func TestResolveSessionExampleWithoutNames(t *testing.T) {
+	cases := []struct {
+		path    string
+		want    Result
+		wantErr error
+	}{
+		{path: "#0", want: Result{Kind: Scalar, Cell: wire.Cell{Type: wire.OperateTypeU8, U: 7}}},
+		{path: "#3", want: Result{Kind: Scalar, Cell: wire.Cell{Type: wire.OperateTypeI32, U: su64(-5)}}},
+		{path: "#4", want: Result{Kind: Scalar, Cell: wire.Cell{Type: wire.OperateTypeBytes, B: []byte("de")}}},
+		{path: "#5", want: Result{Kind: Table}},
+		{path: "#5#count", want: Result{Kind: Count, Count: 2}},
+		{path: "#5/42", want: Result{Kind: RowPresent}},
+		{path: "#5/42/#0", want: Result{Kind: Scalar, Cell: wire.Cell{Type: wire.OperateTypeU32, U: 500}}},
+		{path: "#5/42/#1", want: Result{Kind: Scalar, Cell: wire.Cell{Type: wire.OperateTypeU32, U: 1}}},
+		{path: "#5/7", want: Result{Kind: Absent}},
+		// Names cannot apply at all when the schema stores none.
+		{path: "rc", wantErr: ErrPath},
+		{path: "b#count", wantErr: ErrPath},
+		{path: "#5/42/hi", wantErr: ErrPath},
+	}
+
+	enc, dec := sessionRecord(t, false)
+	r := NewResolver(8)
+	for _, tc := range cases {
+		p := mustPath(t, tc.path)
+		got, err := r.Resolve(enc, p)
+		if tc.wantErr != nil {
+			if !errors.Is(err, tc.wantErr) {
+				t.Errorf("Resolve(%q) error = %v, want %v", tc.path, err, tc.wantErr)
+			}
+		} else {
+			if err != nil {
+				t.Errorf("Resolve(%q): unexpected error %v", tc.path, err)
+				continue
+			}
+			if !resultsEqual(got, tc.want) {
+				t.Errorf("Resolve(%q) = %+v, want %+v", tc.path, got, tc.want)
+			}
+		}
+		oracle, oerr := resolveTree(dec, p)
+		if errClass(err) != errClass(oerr) {
+			t.Errorf("Resolve(%q) error class %s, oracle %s", tc.path, errClass(err), errClass(oerr))
+		}
+		if err == nil && oerr == nil && !resultsEqual(got, oracle) {
+			t.Errorf("Resolve(%q) = %+v, oracle = %+v", tc.path, got, oracle)
+		}
+	}
+}
+
+func TestResolveDynamicExample(t *testing.T) {
+	cases := []struct {
+		path    string
+		want    Result
+		wantErr error
+	}{
+		{path: "cnt", want: Result{Kind: Scalar, Cell: wire.Cell{Type: wire.OperateTypeU32, U: 9}}},
+		{path: "raw", want: Result{Kind: Scalar, Cell: wire.Cell{Type: wire.OperateTypeBytes, B: []byte("hi")}}},
+		{path: "t", want: Result{Kind: Table}},
+		{path: "t#count", want: Result{Kind: Count, Count: 2}},
+		// A decimal row key addresses the 8-byte little-endian encoding of
+		// the number — what client.KeyU64 writes.
+		{path: "t/42", want: Result{Kind: RowPresent}},
+		{path: "t/42/hi", want: Result{Kind: Scalar, Cell: wire.Cell{Type: wire.OperateTypeU32, U: 500}}},
+		{path: "t/42/lo", want: Result{Kind: Scalar, Cell: wire.Cell{Type: wire.OperateTypeU8, U: 1}}},
+		{path: "t/7", want: Result{Kind: Absent}},
+		// A quoted row key addresses raw bytes.
+		{path: `t/"DE"`, want: Result{Kind: RowPresent}},
+		{path: `t/"DE"/hi`, want: Result{Kind: Scalar, Cell: wire.Cell{Type: wire.OperateTypeU32, U: 7}}},
+		{path: `t/"DE"/lo`, want: Result{Kind: Absent}},
+		{path: `t/"XX"`, want: Result{Kind: Absent}},
+		{path: "zz", want: Result{Kind: Absent}},
+		{path: "zz/1/c", want: Result{Kind: Absent}},
+		// Positions never apply in dynamic mode.
+		{path: "#0", wantErr: ErrPath},
+		{path: "#0#count", wantErr: ErrPath},
+		{path: "t/42/#0", wantErr: ErrPath},
+		// Shape errors.
+		{path: "cnt#count", wantErr: ErrPath},
+		{path: "cnt/42", wantErr: ErrPath},
+	}
+
+	enc, dec := dynamicRecord(t)
+	r := NewResolver(8)
+	for _, tc := range cases {
+		p := mustPath(t, tc.path)
+		got, err := r.Resolve(enc, p)
+		if tc.wantErr != nil {
+			if !errors.Is(err, tc.wantErr) {
+				t.Errorf("Resolve(%q) error = %v, want %v", tc.path, err, tc.wantErr)
+			}
+		} else {
+			if err != nil {
+				t.Errorf("Resolve(%q): unexpected error %v", tc.path, err)
+				continue
+			}
+			if !resultsEqual(got, tc.want) {
+				t.Errorf("Resolve(%q) = %+v, want %+v", tc.path, got, tc.want)
+			}
+		}
+		oracle, oerr := resolveTree(dec, p)
+		if errClass(err) != errClass(oerr) {
+			t.Errorf("Resolve(%q) error class %s, oracle %s", tc.path, errClass(err), errClass(oerr))
+		}
+		if err == nil && oerr == nil && !resultsEqual(got, oracle) {
+			t.Errorf("Resolve(%q) = %+v, oracle = %+v", tc.path, got, oracle)
+		}
+	}
+}
+
+// TestResolveMatchesOracle is the property this whole task exists to hold:
+// over random records in both modes and random paths, the byte-level
+// resolver returns exactly what the tree oracle returns — same Result, or
+// the same error class.
+func TestResolveMatchesOracle(t *testing.T) {
+	records, paths := 2000, 20
+	if testing.Short() {
+		records, paths = 200, 8
+	}
+	rng := rand.New(rand.NewSource(20260908))
+	r := NewResolver(64)
+	checked := 0
+	seen := map[string]int{}
+	for i := 0; i < records; i++ {
+		var enc []byte
+		var dec *wire.Record
+		var err error
+		if i%2 == 0 {
+			enc, dec, err = randomSchemaRecord(rng)
+		} else {
+			enc, dec, err = randomDynamicRecord(rng)
+		}
+		if err != nil {
+			t.Fatalf("generator: %v", err)
+		}
+		for j := 0; j < paths; j++ {
+			s := randomPath(rng, dec)
+			p, perr := ParsePath(s)
+			if perr != nil {
+				continue
+			}
+			checked++
+			got, gerr := r.Resolve(enc, p)
+			want, werr := resolveTree(dec, p)
+			if errClass(gerr) == "record" {
+				t.Fatalf("record %d path %q: resolver called a well-formed record malformed: %v", i, s, gerr)
+			}
+			if errClass(gerr) != errClass(werr) {
+				t.Fatalf("record %d path %q: error class %s (%v), oracle %s (%v)", i, s, errClass(gerr), gerr, errClass(werr), werr)
+			}
+			if gerr == nil && !resultsEqual(got, want) {
+				t.Fatalf("record %d path %q: got %+v, oracle %+v", i, s, got, want)
+			}
+			seen[outcomeName(got, gerr, dec.Mode)]++
+		}
+	}
+	if checked < records {
+		t.Fatalf("only %d path resolutions checked over %d records", checked, records)
+	}
+	t.Logf("%d resolutions checked: %v", checked, seen)
+	// A property test that only ever produced "absent" would pass while
+	// proving nothing, so require every outcome, in both modes, to show up.
+	floor := checked / 200
+	if floor < 1 {
+		floor = 1
+	}
+	for _, mode := range []string{"schema", "dynamic"} {
+		for _, kind := range []string{"scalar", "count", "row_present", "table", "absent", "path_error"} {
+			if n := seen[mode+"/"+kind]; n < floor {
+				t.Fatalf("only %d %s %s outcomes over %d resolutions (want >= %d): %v",
+					n, mode, kind, checked, floor, seen)
+			}
+		}
+	}
+}
+
+// outcomeName labels one resolution for the distribution check above.
+func outcomeName(res Result, err error, mode uint8) string {
+	m := "dynamic"
+	if mode == wire.OperateModeSchema {
+		m = "schema"
+	}
+	if err != nil {
+		return m + "/" + errClass(err) + "_error"
+	}
+	switch res.Kind {
+	case Scalar:
+		return m + "/scalar"
+	case Count:
+		return m + "/count"
+	case RowPresent:
+		return m + "/row_present"
+	case Table:
+		return m + "/table"
+	default:
+		return m + "/absent"
+	}
+}
+
+// TestResolveHostileNeverPanics drives the resolver with every prefix and
+// every single-byte mutation of both example records, plus random bytes: a
+// stored record is attacker-influenced (set_payload stores whatever a
+// client sends), so no input may panic, produce an error outside the
+// package's two classes, or mutate the caller's slice.
+func TestResolveHostileNeverPanics(t *testing.T) {
+	sess, _ := sessionRecord(t, true)
+	dyn, _ := dynamicRecord(t)
+
+	paths := []Path{
+		mustPath(t, "rc"),
+		mustPath(t, "tag"),
+		mustPath(t, "b#count"),
+		mustPath(t, "b/42"),
+		mustPath(t, "b/42/hi"),
+		mustPath(t, "#5/42/#1"),
+		mustPath(t, "cnt"),
+		mustPath(t, "t#count"),
+		mustPath(t, `t/"DE"/hi`),
+		mustPath(t, "t/42/lo"),
+	}
+	r := NewResolver(16)
+
+	run := func(name string, in []byte) {
+		before := append([]byte(nil), in...)
+		for _, p := range paths {
+			res, err := r.Resolve(in, p)
+			if err != nil && errClass(err) == "other" {
+				t.Fatalf("%s: error outside ErrPath/ErrRecord: %v", name, err)
+			}
+			if err != nil && res.Kind != Absent {
+				t.Fatalf("%s: error %v returned a non-zero result %+v", name, err, res)
+			}
+		}
+		if !bytes.Equal(before, in) {
+			t.Fatalf("%s: Resolve mutated its input", name)
+		}
+	}
+
+	for _, base := range [][]byte{sess, dyn} {
+		for n := 0; n <= len(base); n++ {
+			run("prefix", base[:n:n])
+		}
+		mut := append([]byte(nil), base...)
+		for i := range base {
+			orig := mut[i]
+			for v := 0; v < 256; v++ {
+				mut[i] = byte(v)
+				run("mutation", mut)
+			}
+			mut[i] = orig
+		}
+	}
+
+	rng := rand.New(rand.NewSource(11))
+	n := 4000
+	if testing.Short() {
+		n = 500
+	}
+	for i := 0; i < n; i++ {
+		buf := make([]byte, rng.Intn(40))
+		for j := range buf {
+			buf[j] = byte(rng.Intn(256))
+		}
+		run("random", buf)
+	}
+}
+
+// TestResolveCellDoesNotAliasInput guards the hazard a byte-level resolver
+// invites: a BYTES or FIXED cell must be copied out of the record, never
+// handed back as a slice into the caller's (possibly reused) buffer.
+func TestResolveCellDoesNotAliasInput(t *testing.T) {
+	enc, _ := sessionRecord(t, true)
+	buf := append([]byte(nil), enc...)
+	r := NewResolver(4)
+	res, err := r.Resolve(buf, mustPath(t, "tag"))
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	if string(res.Cell.B) != "de" {
+		t.Fatalf("tag = %q, want %q", res.Cell.B, "de")
+	}
+	for i := range buf {
+		buf[i] ^= 0xFF
+	}
+	if string(res.Cell.B) != "de" {
+		t.Fatalf("cell aliased the record bytes: tag became %q", res.Cell.B)
+	}
+}
+
+// TestResolveNoAlloc is the point of resolving over bytes instead of
+// decoding the tree: once the schema is cached, reading a column of an
+// existing row allocates nothing.
+func TestResolveNoAlloc(t *testing.T) {
+	enc, _ := sessionRecord(t, true)
+	r := NewResolver(8)
+	p := mustPath(t, "b/42/hi")
+	if _, err := r.Resolve(enc, p); err != nil {
+		t.Fatalf("warm-up Resolve: %v", err)
+	}
+	if got := testing.AllocsPerRun(200, func() {
+		res, err := r.Resolve(enc, p)
+		if err != nil {
+			t.Fatalf("Resolve: %v", err)
+		}
+		sinkResult = res
+	}); got > 0 {
+		t.Fatalf("Resolve allocated %v times per run, want 0", got)
+	}
+	if sinkResult.Kind != Scalar || sinkResult.Cell.U != 500 {
+		t.Fatalf("measured the wrong thing: %+v", sinkResult)
+	}
+}
+
+// TestSchemaCacheBounded checks the cache honours its bound (clear when
+// full) and that a hit and a miss are indistinguishable in the answer.
+func TestSchemaCacheBounded(t *testing.T) {
+	r := NewResolver(2)
+	var encs [][]byte
+	for v := 0; v < 5; v++ {
+		s := &wire.Schema{Version: uint16(v), StoreNames: true, Fields: []wire.FieldDef{
+			{Name: "rc", Type: wire.OperateTypeU32},
+		}}
+		rec := &wire.Record{Mode: wire.OperateModeSchema, Schema: s, Fields: []wire.Field{
+			{Cell: wire.Cell{Type: wire.OperateTypeU32, U: uint64(100 + v)}},
+		}}
+		enc := rec.Encode()
+		if enc == nil {
+			t.Fatalf("schema version %d failed to encode", v)
+		}
+		encs = append(encs, enc)
+	}
+
+	p := mustPath(t, "rc")
+	for round := 0; round < 3; round++ {
+		for v, enc := range encs {
+			got, err := r.Resolve(enc, p)
+			if err != nil {
+				t.Fatalf("Resolve(version %d): %v", v, err)
+			}
+			if got.Kind != Scalar || got.Cell.U != uint64(100+v) {
+				t.Fatalf("Resolve(version %d) = %+v", v, got)
+			}
+			r.mu.RLock()
+			size := len(r.cache)
+			r.mu.RUnlock()
+			if size > 2 {
+				t.Fatalf("cache grew to %d entries, bound is 2", size)
+			}
+		}
+	}
+}
+
+// TestResolverConcurrent backs the claim Task 5 relies on: one Resolver is
+// shared by every query goroutine, so its schema cache must tolerate
+// concurrent hits, misses, and the clear-when-full it does under the write
+// lock. Run under -race this is the test that would catch a missing lock.
+func TestResolverConcurrent(t *testing.T) {
+	r := NewResolver(2) // small enough that the workers keep evicting
+	sess, _ := sessionRecord(t, true)
+	dyn, _ := dynamicRecord(t)
+	var extra [][]byte
+	for v := 0; v < 4; v++ {
+		s := &wire.Schema{Version: uint16(v), StoreNames: true, Fields: []wire.FieldDef{
+			{Name: "rc", Type: wire.OperateTypeU32},
+		}}
+		rec := &wire.Record{Mode: wire.OperateModeSchema, Schema: s, Fields: []wire.Field{
+			{Cell: wire.Cell{Type: wire.OperateTypeU32, U: uint64(100 + v)}},
+		}}
+		extra = append(extra, rec.Encode())
+	}
+
+	type job struct {
+		rec  []byte
+		path string
+		want Result
+	}
+	jobs := []job{
+		{sess, "b/42/hi", Result{Kind: Scalar, Cell: wire.Cell{Type: wire.OperateTypeU32, U: 500}}},
+		{sess, "b#count", Result{Kind: Count, Count: 2}},
+		{dyn, `t/"DE"/hi`, Result{Kind: Scalar, Cell: wire.Cell{Type: wire.OperateTypeU32, U: 7}}},
+	}
+	for v, enc := range extra {
+		jobs = append(jobs, job{enc, "rc", Result{Kind: Scalar, Cell: wire.Cell{Type: wire.OperateTypeU32, U: uint64(100 + v)}}})
+	}
+	paths := make([]Path, len(jobs))
+	for i, j := range jobs {
+		paths[i] = mustPath(t, j.path)
+	}
+
+	var wg sync.WaitGroup
+	for w := 0; w < 8; w++ {
+		wg.Add(1)
+		go func(w int) {
+			defer wg.Done()
+			for i := 0; i < 300; i++ {
+				k := (i + w) % len(jobs)
+				got, err := r.Resolve(jobs[k].rec, paths[k])
+				if err != nil {
+					t.Errorf("worker %d: Resolve(%q): %v", w, jobs[k].path, err)
+					return
+				}
+				if !resultsEqual(got, jobs[k].want) {
+					t.Errorf("worker %d: Resolve(%q) = %+v, want %+v", w, jobs[k].path, got, jobs[k].want)
+					return
+				}
+			}
+		}(w)
+	}
+	wg.Wait()
+}
+
+// TestResolveWithoutCache checks a resolver built with no cache budget
+// still answers, and answers identically to a cached one — the cache may
+// never influence the result.
+func TestResolveWithoutCache(t *testing.T) {
+	enc, _ := sessionRecord(t, true)
+	uncached := NewResolver(0)
+	cached := NewResolver(8)
+	for _, s := range []string{"rc", "tag", "b#count", "b/42/hi", "b/7"} {
+		p := mustPath(t, s)
+		a, aerr := uncached.Resolve(enc, p)
+		b, berr := cached.Resolve(enc, p)
+		if errClass(aerr) != errClass(berr) {
+			t.Fatalf("%q: uncached err %v, cached err %v", s, aerr, berr)
+		}
+		if !resultsEqual(a, b) {
+			t.Fatalf("%q: uncached %+v, cached %+v", s, a, b)
+		}
+	}
+}
+
+// TestResolveRejectsMalformedPaths covers the shapes ParsePath never
+// builds but a caller assembling a Path by hand could: Resolve is exported
+// and Path is a plain struct, so the segment kinds have to be checked
+// rather than assumed.
+func TestResolveRejectsMalformedPaths(t *testing.T) {
+	enc, _ := sessionRecord(t, true)
+	r := NewResolver(4)
+	cases := []struct {
+		name string
+		p    Path
+	}{
+		{"no segments", Path{}},
+		{"four segments", Path{Segs: []Segment{
+			{Kind: SegField, Name: "b"}, {Kind: SegRow, KeyText: "42"},
+			{Kind: SegCol, Name: "hi"}, {Kind: SegCol, Name: "lo"},
+		}}},
+		{"row first", Path{Segs: []Segment{{Kind: SegRow, KeyText: "42"}}}},
+		{"count with a row after it", Path{Segs: []Segment{
+			{Kind: SegCount, Name: "b"}, {Kind: SegRow, KeyText: "42"},
+		}}},
+		{"field where a row belongs", Path{Segs: []Segment{
+			{Kind: SegField, Name: "b"}, {Kind: SegField, Name: "hi"},
+		}}},
+		{"row where a column belongs", Path{Segs: []Segment{
+			{Kind: SegField, Name: "b"}, {Kind: SegRow, KeyText: "42"}, {Kind: SegRow, KeyText: "1"},
+		}}},
+	}
+	for _, tc := range cases {
+		if _, err := r.Resolve(enc, tc.p); !errors.Is(err, ErrPath) {
+			t.Errorf("%s: error = %v, want ErrPath", tc.name, err)
+		}
+	}
+}
+
+// TestSchemaBlobLenAgreesWithDecodeSchema pins the cache's fast path to the
+// authoritative decoder: the scanner that finds where a schema blob ends
+// must agree with DecodeSchema on every blob DecodeSchema accepts. A
+// disagreement only costs a cache miss (the cached key is compared byte for
+// byte), but a silent drift would quietly disable the cache.
+func TestSchemaBlobLenAgreesWithDecodeSchema(t *testing.T) {
+	rng := rand.New(rand.NewSource(3))
+	for i := 0; i < 500; i++ {
+		enc, _, err := randomSchemaRecord(rng)
+		if err != nil {
+			t.Fatalf("generator: %v", err)
+		}
+		blob := enc[1:]
+		_, want, derr := wire.DecodeSchema(blob)
+		if derr != nil {
+			t.Fatalf("generated schema failed to decode: %v", derr)
+		}
+		got, ok := schemaBlobLen(blob)
+		if !ok {
+			t.Fatalf("record %d: schemaBlobLen refused a valid blob", i)
+		}
+		if got != want {
+			t.Fatalf("record %d: schemaBlobLen = %d, DecodeSchema consumed %d", i, got, want)
+		}
+	}
+}

--- a/sdk/record/resolve_test.go
+++ b/sdk/record/resolve_test.go
@@ -139,6 +139,15 @@ func resultsEqual(a, b Result) bool {
 	return a.Cell.F == b.Cell.F
 }
 
+// isZeroResult reports whether res is the zero Result — the only thing an
+// error return may carry. Checking Kind alone would not catch it: Absent is
+// itself the zero Kind, so a stray Count or Cell would slip through.
+func isZeroResult(res Result) bool {
+	return res.Kind == Absent && res.Count == 0 &&
+		res.Cell.Type == 0 && res.Cell.N == 0 && res.Cell.U == 0 &&
+		res.Cell.F == 0 && res.Cell.B == nil
+}
+
 // errClass reduces an error to the class the oracle comparison cares about.
 func errClass(err error) string {
 	switch {
@@ -347,7 +356,7 @@ func TestResolveMatchesOracle(t *testing.T) {
 	}
 	rng := rand.New(rand.NewSource(20260908))
 	r := NewResolver(64)
-	checked := 0
+	checked, specials := 0, 0
 	seen := map[string]int{}
 	for i := 0; i < records; i++ {
 		var enc []byte
@@ -380,12 +389,22 @@ func TestResolveMatchesOracle(t *testing.T) {
 				t.Fatalf("record %d path %q: got %+v, oracle %+v", i, s, got, want)
 			}
 			seen[outcomeName(got, gerr, dec.Mode)]++
+			if gerr == nil && got.Kind == Scalar &&
+				(math.IsNaN(got.Cell.F) || math.IsInf(got.Cell.F, 0)) {
+				specials++
+			}
 		}
 	}
 	if checked < records {
 		t.Fatalf("only %d path resolutions checked over %d records", checked, records)
 	}
-	t.Logf("%d resolutions checked: %v", checked, seen)
+	t.Logf("%d resolutions checked (%d NaN/Inf scalars): %v", checked, specials, seen)
+	// NaN and the infinities are the float values the resolver treats
+	// specially (readCellAt rejects every NaN spelling but the canonical
+	// one), so at least some must actually reach the oracle comparison.
+	if specials == 0 {
+		t.Fatalf("no NaN or Inf float cell was ever resolved; the generator stopped drawing them")
+	}
 	// A property test that only ever produced "absent" would pass while
 	// proving nothing, so require every outcome, in both modes, to show up.
 	floor := checked / 200
@@ -455,7 +474,7 @@ func TestResolveHostileNeverPanics(t *testing.T) {
 			if err != nil && errClass(err) == "other" {
 				t.Fatalf("%s: error outside ErrPath/ErrRecord: %v", name, err)
 			}
-			if err != nil && res.Kind != Absent {
+			if err != nil && !isZeroResult(res) {
 				t.Fatalf("%s: error %v returned a non-zero result %+v", name, err, res)
 			}
 		}
@@ -653,6 +672,78 @@ func TestResolveWithoutCache(t *testing.T) {
 		}
 		if !resultsEqual(a, b) {
 			t.Fatalf("%q: uncached %+v, cached %+v", s, a, b)
+		}
+	}
+}
+
+// TestResolveWideFixedKey pins the case a uint64 cannot hold: a FIXED row
+// key wider than 8 bytes, where a decimal segment denotes the number's
+// little-endian bytes zero-filled out to the key width. The randomised
+// oracle test draws these too; this one names the arithmetic so a
+// regression in it reads as itself.
+func TestResolveWideFixedKey(t *testing.T) {
+	const kw = 12
+	wide := func(v uint64) []byte {
+		b := make([]byte, kw)
+		binary.LittleEndian.PutUint64(b[:8], v)
+		return b
+	}
+	s := &wire.Schema{Version: 1, StoreNames: true, Fields: []wire.FieldDef{
+		{Name: "b", Type: wire.OperateTypeTable, Table: &wire.TableDef{
+			KeyType: wire.OperateTypeFixed,
+			KeyN:    kw,
+			Cols:    []wire.ColumnDef{{Name: "hi", Type: wire.OperateTypeU32}},
+		}},
+	}}
+	if err := s.Validate(); err != nil {
+		t.Fatalf("schema invalid: %v", err)
+	}
+	// "zzzz…" sorts after every little-endian small number, so the rows are
+	// already in the bytewise order a FIXED key is stored in.
+	textKey := bytes.Repeat([]byte("z"), kw)
+	rec := &wire.Record{Mode: wire.OperateModeSchema, Schema: s, Fields: []wire.Field{
+		{Cell: wire.Cell{Type: wire.OperateTypeTable}, Table: &wire.Table{Rows: []wire.Row{
+			{Key: wide(42), Cols: []wire.Col{{Cell: wire.Cell{Type: wire.OperateTypeU32, U: 500}}}},
+			{Key: wide(300), Cols: []wire.Col{{Cell: wire.Cell{Type: wire.OperateTypeU32, U: 7}}}},
+			{Key: textKey, Cols: []wire.Col{{Cell: wire.Cell{Type: wire.OperateTypeU32, U: 9}}}},
+		}}},
+	}}
+	enc := rec.Encode()
+	if enc == nil {
+		t.Fatal("record failed to encode")
+	}
+	dec, err := wire.DecodeRecord(enc)
+	if err != nil {
+		t.Fatalf("record failed to decode: %v", err)
+	}
+
+	cases := []struct {
+		path string
+		want Result
+	}{
+		{"b/42", Result{Kind: RowPresent}},
+		{"b/42/hi", Result{Kind: Scalar, Cell: wire.Cell{Type: wire.OperateTypeU32, U: 500}}},
+		{"b/300/hi", Result{Kind: Scalar, Cell: wire.Cell{Type: wire.OperateTypeU32, U: 7}}},
+		{`b/"zzzzzzzzzzzz"/hi`, Result{Kind: Scalar, Cell: wire.Cell{Type: wire.OperateTypeU32, U: 9}}},
+		{"b/7", Result{Kind: Absent}},
+		{"b/18446744073709551615", Result{Kind: Absent}},
+		{`b/"zzz"`, Result{Kind: Absent}}, // wrong width for this key
+		{"b#count", Result{Kind: Count, Count: 3}},
+	}
+	r := NewResolver(4)
+	for _, tc := range cases {
+		p := mustPath(t, tc.path)
+		got, err := r.Resolve(enc, p)
+		if err != nil {
+			t.Errorf("Resolve(%q): %v", tc.path, err)
+			continue
+		}
+		if !resultsEqual(got, tc.want) {
+			t.Errorf("Resolve(%q) = %+v, want %+v", tc.path, got, tc.want)
+		}
+		oracle, oerr := resolveTree(dec, p)
+		if oerr != nil || !resultsEqual(got, oracle) {
+			t.Errorf("Resolve(%q) = %+v, oracle = %+v (err %v)", tc.path, got, oracle, oerr)
 		}
 	}
 }

--- a/sdk/record/value.go
+++ b/sdk/record/value.go
@@ -1,0 +1,226 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package record
+
+import (
+	"bytes"
+	"fmt"
+	"math"
+	"strconv"
+
+	"github.com/rostamlabs/rostam/sdk/vtypes"
+	"github.com/rostamlabs/rostam/sdk/wire"
+)
+
+// CellValue maps a decoded wire.Cell to the payload-shaped vtypes.Value the
+// filter compilers compare against, per the value mapping ruling:
+//
+//   - the eight fixed-width int types and IVARINT already carry the value's
+//     int64 bit pattern in Cell.U (design doc §2.1: sign-extended for a
+//     signed type), so they map straight to ValueInt.
+//   - U64 and UVARINT can legitimately hold a magnitude above what an int64
+//     can represent; when Cell.U exceeds math.MaxInt64 the value maps to
+//     ValueFloat(float64(u)) instead — a lossy but total conversion, since
+//     there is no wider signed payload kind.
+//   - F32/F64 map to ValueFloat (F32 is already widened to float64 in Cell.F
+//     by DecodeCellData).
+//   - BYTES/FIXED map to ValueString, the raw bytes reinterpreted as a Go
+//     string (a copy, since a string conversion of a []byte always copies).
+//   - UNSET, TABLE, and any tag this package does not know map to
+//     (Value{}, false): neither carries a value a filter can compare.
+func CellValue(c wire.Cell) (vtypes.Value, bool) {
+	switch c.Type {
+	case wire.OperateTypeU64, wire.OperateTypeUVarint:
+		if c.U > math.MaxInt64 {
+			return vtypes.NewFloat(float64(c.U)), true
+		}
+		return vtypes.NewInt(int64(c.U)), true //nolint:gosec // bounded above
+	case wire.OperateTypeU8, wire.OperateTypeU16, wire.OperateTypeU32,
+		wire.OperateTypeI8, wire.OperateTypeI16, wire.OperateTypeI32, wire.OperateTypeI64,
+		wire.OperateTypeIVarint:
+		// U8/U16/U32 never exceed math.MaxInt64; the signed types and
+		// IVARINT already hold their int64 bit pattern (see doc comment
+		// above), so a plain reinterpret is exact in every case.
+		return vtypes.NewInt(int64(c.U)), true //nolint:gosec // reinterpret stored bits
+	case wire.OperateTypeF32, wire.OperateTypeF64:
+		return vtypes.NewFloat(c.F), true
+	case wire.OperateTypeBytes, wire.OperateTypeFixed:
+		return vtypes.NewString(string(c.B)), true
+	default: // OperateTypeUnset, OperateTypeTable, and any unknown tag
+		return vtypes.Value{}, false
+	}
+}
+
+// ResultValue maps a Resolve result to the payload-shaped vtypes.Value a
+// filter compares against: Scalar goes through CellValue; Count (a table's
+// row count) maps to ValueInt; Absent, RowPresent, and Table carry no value
+// a filter can compare, so they report ok == false.
+func ResultValue(res Result) (vtypes.Value, bool) {
+	switch res.Kind {
+	case Scalar:
+		return CellValue(res.Cell)
+	case Count:
+		// res.Count is a table row count, bounded by wire.OperateMaxRows
+		// (1<<20) — the callers that produce a Count (schemaTableHeader,
+		// dynamicTableRows) both check this before returning it — so the
+		// cast to int64 never loses precision.
+		return vtypes.NewInt(int64(res.Count)), true //nolint:gosec // bounded by OperateMaxRows
+	default: // Absent, RowPresent, Table
+		return vtypes.Value{}, false
+	}
+}
+
+// Entry is one synthetic index field IndexEntries extracts from a record:
+// Field is the path part after the payload key ("rc", "#2", "b#count" — the
+// same spelling a filter's "payloadKey/path" field string would use to name
+// it), and Value is what that field maps to.
+type Entry struct {
+	Field string
+	Value vtypes.Value
+}
+
+// IndexEntries extracts every synthetic index field a collection
+// auto-indexes for rec, per the indexing ruling: one Entry per top-level
+// scalar field (skipping one whose CellValue declines, and skipping a NaN
+// float), plus one "<field>#count" Entry per top-level table field holding
+// its row count. Table columns are never indexed. Entries are emitted in
+// schema field order (schema mode) or ascending stored name order (dynamic
+// mode) — both a pure function of rec's bytes, so the result is
+// deterministic.
+//
+// IndexEntries never panics on hostile bytes: any error wraps ErrRecord.
+func (r *Resolver) IndexEntries(rec []byte) ([]Entry, error) {
+	if len(rec) < 1 {
+		return nil, fmt.Errorf("%w: empty record", ErrRecord)
+	}
+	switch rec[0] {
+	case wire.OperateModeSchema:
+		return r.indexEntriesSchema(rec)
+	case wire.OperateModeDynamic:
+		return indexEntriesDynamic(rec)
+	default:
+		return nil, fmt.Errorf("%w: unknown mode byte %d", ErrRecord, rec[0])
+	}
+}
+
+// indexEntriesSchema implements IndexEntries for a schema-mode record.
+func (r *Resolver) indexEntriesSchema(rec []byte) ([]Entry, error) {
+	e, err := r.schemaFor(rec)
+	if err != nil {
+		return nil, err
+	}
+	s, l := e.schema, e.layout
+	base := 1 + e.blobLen
+	if base > len(rec) {
+		return nil, fmt.Errorf("%w: record ends inside its schema blob", ErrRecord)
+	}
+
+	// Every field contributes at most one Entry, so len(s.Fields) — already
+	// bounded by wire.OperateMaxFields when this schema was decoded — is a
+	// safe, tight capacity.
+	entries := make([]Entry, 0, len(s.Fields))
+	err = walkSchemaFields(rec, base, s, l, func(pos, off int, isTable bool, nRows uint64) error {
+		name := schemaFieldLabel(s.StoreNames, s.Fields[pos].Name, pos)
+		if isTable {
+			entries = append(entries, Entry{Field: name + countSuffix, Value: vtypes.NewInt(int64(nRows))}) //nolint:gosec // bounded by OperateMaxRows
+			return nil
+		}
+		fdef := &s.Fields[pos]
+		cell, cerr := readCellAt(rec, off, fdef.Type, fdef.N)
+		if cerr != nil {
+			return cerr
+		}
+		if v, ok := CellValue(cell); ok && !isNaNValue(v) {
+			entries = append(entries, Entry{Field: name, Value: v})
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return entries, nil
+}
+
+// indexEntriesDynamic implements IndexEntries for a dynamic-mode record,
+// walking its fields the same way resolveDynamic does but visiting every
+// one instead of stopping at a named match.
+func indexEntriesDynamic(rec []byte) ([]Entry, error) {
+	nFields, m, err := readCanonicalUvarint(rec, 1)
+	if err != nil {
+		return nil, err
+	}
+	off := 1 + m
+	if nFields > wire.OperateMaxFields {
+		return nil, fmt.Errorf("%w: record declares %d fields", ErrRecord, nFields)
+	}
+	if !wire.CountFitsIn(int(nFields), len(rec)-off, 3) {
+		return nil, fmt.Errorf("%w: record declares %d fields but is too short", ErrRecord, nFields)
+	}
+
+	// nFields is already bounded by wire.OperateMaxFields above, and each
+	// field contributes at most one Entry.
+	entries := make([]Entry, 0, nFields)
+	var prevName []byte
+	for i := uint64(0); i < nFields; i++ {
+		name, next, nerr := readName(rec, off)
+		if nerr != nil {
+			return nil, nerr
+		}
+		off = next
+		if prevName != nil && bytes.Compare(prevName, name) >= 0 {
+			return nil, fmt.Errorf("%w: fields out of order", ErrRecord)
+		}
+		prevName = name
+
+		typ, n, valOff, terr := readTypeTag(rec, off)
+		if terr != nil {
+			return nil, terr
+		}
+
+		if typ == wire.OperateTypeTable {
+			inner, end, ierr := dynamicTableInner(rec, valOff)
+			if ierr != nil {
+				return nil, ierr
+			}
+			nRows, _, rerr := dynamicTableRows(inner)
+			if rerr != nil {
+				return nil, rerr
+			}
+			entries = append(entries, Entry{Field: string(name) + countSuffix, Value: vtypes.NewInt(int64(nRows))}) //nolint:gosec // bounded by OperateMaxRows
+			off = end
+			continue
+		}
+
+		cell, cerr := readCellAt(rec, valOff, typ, n)
+		if cerr != nil {
+			return nil, cerr
+		}
+		nextOff, serr := skipDynamicValue(rec, valOff, typ, n)
+		if serr != nil {
+			return nil, serr
+		}
+		off = nextOff
+
+		if v, ok := CellValue(cell); ok && !isNaNValue(v) {
+			entries = append(entries, Entry{Field: string(name), Value: v})
+		}
+	}
+	return entries, nil
+}
+
+// schemaFieldLabel renders a schema-mode field's index-entry name: the
+// field name when the schema stores names, else its position as "#N" — the
+// same spelling ParsePath accepts back as a field segment.
+func schemaFieldLabel(storeNames bool, name string, pos int) string {
+	if storeNames {
+		return name
+	}
+	return "#" + strconv.Itoa(pos)
+}
+
+// isNaNValue reports whether v is a NaN float — the one value CellValue can
+// produce that IndexEntries declines to index (the indexing ruling: "the
+// index declines them anyway; emit nothing").
+func isNaNValue(v vtypes.Value) bool {
+	return v.Kind == vtypes.ValueFloat && math.IsNaN(v.Flt)
+}

--- a/sdk/record/value_test.go
+++ b/sdk/record/value_test.go
@@ -1,0 +1,524 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package record
+
+import (
+	"bytes"
+	"math"
+	"math/rand"
+	"testing"
+
+	"github.com/rostamlabs/rostam/sdk/vtypes"
+	"github.com/rostamlabs/rostam/sdk/wire"
+)
+
+// valuesEqual compares two vtypes.Value the way resultsEqual compares two
+// Results: NaN floats are equal to each other (reflect/== would not agree).
+func valuesEqual(a, b vtypes.Value) bool {
+	if a.Kind != b.Kind {
+		return false
+	}
+	switch a.Kind {
+	case vtypes.ValueFloat:
+		if math.IsNaN(a.Flt) || math.IsNaN(b.Flt) {
+			return math.IsNaN(a.Flt) && math.IsNaN(b.Flt)
+		}
+		return a.Flt == b.Flt
+	default:
+		return a.Equal(b)
+	}
+}
+
+// TestCellValueMapping is the table for the value-mapping ruling: every
+// OperateType* tag, exercised at values that pin the interesting boundaries
+// (the U64/UVarint MaxInt64 edge, a negative signed value, empty and
+// multi-byte BYTES/FIXED, and UNSET/TABLE both declining).
+func TestCellValueMapping(t *testing.T) {
+	cases := []struct {
+		name string
+		cell wire.Cell
+		want vtypes.Value
+		ok   bool
+	}{
+		{"U8", wire.Cell{Type: wire.OperateTypeU8, U: 7}, vtypes.NewInt(7), true},
+		{"U8 max", wire.Cell{Type: wire.OperateTypeU8, U: 255}, vtypes.NewInt(255), true},
+		{"U16", wire.Cell{Type: wire.OperateTypeU16, U: 65535}, vtypes.NewInt(65535), true},
+		{"U32", wire.Cell{Type: wire.OperateTypeU32, U: 4294967295}, vtypes.NewInt(4294967295), true},
+		{"U64 within int64", wire.Cell{Type: wire.OperateTypeU64, U: math.MaxInt64}, vtypes.NewInt(math.MaxInt64), true},
+		{"U64 above int64", wire.Cell{Type: wire.OperateTypeU64, U: math.MaxInt64 + 1}, vtypes.NewFloat(float64(uint64(math.MaxInt64) + 1)), true},
+		{"U64 max", wire.Cell{Type: wire.OperateTypeU64, U: math.MaxUint64}, vtypes.NewFloat(float64(uint64(math.MaxUint64))), true},
+		{"UVarint within int64", wire.Cell{Type: wire.OperateTypeUVarint, U: math.MaxInt64}, vtypes.NewInt(math.MaxInt64), true},
+		{"UVarint above int64", wire.Cell{Type: wire.OperateTypeUVarint, U: math.MaxInt64 + 1}, vtypes.NewFloat(float64(uint64(math.MaxInt64) + 1)), true},
+		{"I8 negative", wire.Cell{Type: wire.OperateTypeI8, U: su64(-5)}, vtypes.NewInt(-5), true},
+		{"I8 positive", wire.Cell{Type: wire.OperateTypeI8, U: su64(5)}, vtypes.NewInt(5), true},
+		{"I16 negative", wire.Cell{Type: wire.OperateTypeI16, U: su64(-1234)}, vtypes.NewInt(-1234), true},
+		{"I32 negative", wire.Cell{Type: wire.OperateTypeI32, U: su64(-5)}, vtypes.NewInt(-5), true},
+		{"I64 negative", wire.Cell{Type: wire.OperateTypeI64, U: su64(math.MinInt64)}, vtypes.NewInt(math.MinInt64), true},
+		{"I64 positive", wire.Cell{Type: wire.OperateTypeI64, U: su64(math.MaxInt64)}, vtypes.NewInt(math.MaxInt64), true},
+		{"IVarint negative", wire.Cell{Type: wire.OperateTypeIVarint, U: su64(-99)}, vtypes.NewInt(-99), true},
+		{"F32", wire.Cell{Type: wire.OperateTypeF32, F: 1.5}, vtypes.NewFloat(1.5), true},
+		{"F32 NaN", wire.Cell{Type: wire.OperateTypeF32, F: math.NaN()}, vtypes.NewFloat(math.NaN()), true},
+		{"F32 Inf", wire.Cell{Type: wire.OperateTypeF32, F: math.Inf(1)}, vtypes.NewFloat(math.Inf(1)), true},
+		{"F64", wire.Cell{Type: wire.OperateTypeF64, F: -2.25}, vtypes.NewFloat(-2.25), true},
+		{"F64 NaN", wire.Cell{Type: wire.OperateTypeF64, F: math.NaN()}, vtypes.NewFloat(math.NaN()), true},
+		{"F64 -Inf", wire.Cell{Type: wire.OperateTypeF64, F: math.Inf(-1)}, vtypes.NewFloat(math.Inf(-1)), true},
+		{"BYTES", wire.Cell{Type: wire.OperateTypeBytes, B: []byte("hi")}, vtypes.NewString("hi"), true},
+		{"BYTES empty", wire.Cell{Type: wire.OperateTypeBytes, B: []byte{}}, vtypes.NewString(""), true},
+		{"BYTES nil", wire.Cell{Type: wire.OperateTypeBytes, B: nil}, vtypes.NewString(""), true},
+		{"FIXED", wire.Cell{Type: wire.OperateTypeFixed, N: 3, B: []byte("abc")}, vtypes.NewString("abc"), true},
+		{"FIXED binary", wire.Cell{Type: wire.OperateTypeFixed, N: 2, B: []byte{0x00, 0xFF}}, vtypes.NewString(string([]byte{0x00, 0xFF})), true},
+		{"Unset", wire.Cell{Type: wire.OperateTypeUnset}, vtypes.Value{}, false},
+		{"Table", wire.Cell{Type: wire.OperateTypeTable}, vtypes.Value{}, false},
+		{"unknown type", wire.Cell{Type: wire.OperateTypeCount}, vtypes.Value{}, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, ok := CellValue(tc.cell)
+			if ok != tc.ok {
+				t.Fatalf("CellValue(%+v) ok = %v, want %v", tc.cell, ok, tc.ok)
+			}
+			if ok && !valuesEqual(got, tc.want) {
+				t.Fatalf("CellValue(%+v) = %+v, want %+v", tc.cell, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestCellValueEveryOperateType checks every declared OperateType* tag
+// (0..OperateTypeCount-1) is handled by CellValue without panicking, and
+// that the type-dispatch table has no silent gap for a tag this package
+// does not yet know by name.
+func TestCellValueEveryOperateType(t *testing.T) {
+	scalarWidth := map[uint8]int{
+		wire.OperateTypeU8: 1, wire.OperateTypeU16: 2, wire.OperateTypeU32: 4, wire.OperateTypeU64: 8,
+		wire.OperateTypeI8: 1, wire.OperateTypeI16: 2, wire.OperateTypeI32: 4, wire.OperateTypeI64: 8,
+	}
+	for typ := uint8(0); typ < wire.OperateTypeCount; typ++ {
+		c := wire.Cell{Type: typ, N: 1, B: []byte{1}}
+		if _, ok := scalarWidth[typ]; ok {
+			c.U = 1
+		}
+		got, ok := CellValue(c)
+		switch typ {
+		case wire.OperateTypeUnset, wire.OperateTypeTable:
+			if ok {
+				t.Errorf("type %d: CellValue ok = true, want false", typ)
+			}
+		default:
+			if !ok {
+				t.Errorf("type %d: CellValue ok = false, want true", typ)
+			}
+			_ = got
+		}
+	}
+}
+
+// TestResultValue covers ResultValue for every Kind.
+func TestResultValue(t *testing.T) {
+	cases := []struct {
+		name string
+		res  Result
+		want vtypes.Value
+		ok   bool
+	}{
+		{"Absent", Result{Kind: Absent}, vtypes.Value{}, false},
+		{"Scalar int", Result{Kind: Scalar, Cell: wire.Cell{Type: wire.OperateTypeU32, U: 42}}, vtypes.NewInt(42), true},
+		{"Scalar unset", Result{Kind: Scalar, Cell: wire.Cell{Type: wire.OperateTypeUnset}}, vtypes.Value{}, false},
+		{"Count", Result{Kind: Count, Count: 5}, vtypes.NewInt(5), true},
+		{"Count zero", Result{Kind: Count, Count: 0}, vtypes.NewInt(0), true},
+		{"RowPresent", Result{Kind: RowPresent}, vtypes.Value{}, false},
+		{"Table", Result{Kind: Table}, vtypes.Value{}, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, ok := ResultValue(tc.res)
+			if ok != tc.ok {
+				t.Fatalf("ResultValue(%+v) ok = %v, want %v", tc.res, ok, tc.ok)
+			}
+			if ok && !valuesEqual(got, tc.want) {
+				t.Fatalf("ResultValue(%+v) = %+v, want %+v", tc.res, got, tc.want)
+			}
+		})
+	}
+}
+
+// entryFields extracts just the Field names, in order, for a compact
+// comparison against the expected slice.
+func entryFields(es []Entry) []string {
+	out := make([]string, len(es))
+	for i, e := range es {
+		out[i] = e.Field
+	}
+	return out
+}
+
+func fieldsEqual(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+// TestIndexEntriesSessionRecord pins IndexEntries on the shared session
+// record fixture (sessionRecord from resolve_test.go): rc, bc, hist, bal,
+// tag are top-level scalars and b is a table, so schema field order puts
+// b's "#count" entry at position 5, last.
+func TestIndexEntriesSessionRecord(t *testing.T) {
+	enc, _ := sessionRecord(t, true)
+	r := NewResolver(8)
+	entries, err := r.IndexEntries(enc)
+	if err != nil {
+		t.Fatalf("IndexEntries: %v", err)
+	}
+	wantFields := []string{"rc", "bc", "hist", "bal", "tag", "b#count"}
+	if !fieldsEqual(entryFields(entries), wantFields) {
+		t.Fatalf("IndexEntries fields = %v, want %v", entryFields(entries), wantFields)
+	}
+	want := map[string]vtypes.Value{
+		"rc":      vtypes.NewInt(7),
+		"bc":      vtypes.NewInt(3),
+		"hist":    vtypes.NewInt(1234),
+		"bal":     vtypes.NewInt(-5),
+		"tag":     vtypes.NewString("de"),
+		"b#count": vtypes.NewInt(2),
+	}
+	for _, e := range entries {
+		w, ok := want[e.Field]
+		if !ok {
+			t.Fatalf("unexpected entry field %q", e.Field)
+		}
+		if !valuesEqual(e.Value, w) {
+			t.Errorf("entry %q = %+v, want %+v", e.Field, e.Value, w)
+		}
+	}
+}
+
+// TestIndexEntriesSessionRecordWithoutNames is the same record with
+// StoreNames false: field labels fall back to "#pos".
+func TestIndexEntriesSessionRecordWithoutNames(t *testing.T) {
+	enc, _ := sessionRecord(t, false)
+	r := NewResolver(8)
+	entries, err := r.IndexEntries(enc)
+	if err != nil {
+		t.Fatalf("IndexEntries: %v", err)
+	}
+	wantFields := []string{"#0", "#1", "#2", "#3", "#4", "#5#count"}
+	if !fieldsEqual(entryFields(entries), wantFields) {
+		t.Fatalf("IndexEntries fields = %v, want %v", entryFields(entries), wantFields)
+	}
+	want := map[string]vtypes.Value{
+		"#0":       vtypes.NewInt(7),
+		"#1":       vtypes.NewInt(3),
+		"#2":       vtypes.NewInt(1234),
+		"#3":       vtypes.NewInt(-5),
+		"#4":       vtypes.NewString("de"),
+		"#5#count": vtypes.NewInt(2),
+	}
+	for _, e := range entries {
+		w, ok := want[e.Field]
+		if !ok {
+			t.Fatalf("unexpected entry field %q", e.Field)
+		}
+		if !valuesEqual(e.Value, w) {
+			t.Errorf("entry %q = %+v, want %+v", e.Field, e.Value, w)
+		}
+	}
+}
+
+// TestIndexEntriesDynamicRecord covers the dynamic example (dynamicRecord
+// from resolve_test.go): cnt, raw, t (a table), stored in ascending name
+// order ("cnt" < "raw" < "t").
+func TestIndexEntriesDynamicRecord(t *testing.T) {
+	enc, _ := dynamicRecord(t)
+	entries, err := (&Resolver{}).IndexEntries(enc)
+	if err != nil {
+		t.Fatalf("IndexEntries: %v", err)
+	}
+	wantFields := []string{"cnt", "raw", "t#count"}
+	if !fieldsEqual(entryFields(entries), wantFields) {
+		t.Fatalf("IndexEntries fields = %v, want %v", entryFields(entries), wantFields)
+	}
+	want := map[string]vtypes.Value{
+		"cnt":     vtypes.NewInt(9),
+		"raw":     vtypes.NewString("hi"),
+		"t#count": vtypes.NewInt(2),
+	}
+	for _, e := range entries {
+		w, ok := want[e.Field]
+		if !ok {
+			t.Fatalf("unexpected entry field %q", e.Field)
+		}
+		if !valuesEqual(e.Value, w) {
+			t.Errorf("entry %q = %+v, want %+v", e.Field, e.Value, w)
+		}
+	}
+}
+
+// TestIndexEntriesSkipsNaN checks a NaN float field contributes no entry,
+// in both modes, while its non-NaN siblings still do.
+func TestIndexEntriesSkipsNaN(t *testing.T) {
+	t.Run("schema", func(t *testing.T) {
+		s := &wire.Schema{Version: 1, StoreNames: true, Fields: []wire.FieldDef{
+			{Name: "a", Type: wire.OperateTypeU32},
+			{Name: "f", Type: wire.OperateTypeF64},
+		}}
+		if err := s.Validate(); err != nil {
+			t.Fatalf("schema invalid: %v", err)
+		}
+		rec := &wire.Record{Mode: wire.OperateModeSchema, Schema: s, Fields: []wire.Field{
+			{Cell: wire.Cell{Type: wire.OperateTypeU32, U: 1}},
+			{Cell: wire.Cell{Type: wire.OperateTypeF64, F: math.NaN()}},
+		}}
+		enc := rec.Encode()
+		if enc == nil {
+			t.Fatal("record failed to encode")
+		}
+		entries, err := NewResolver(4).IndexEntries(enc)
+		if err != nil {
+			t.Fatalf("IndexEntries: %v", err)
+		}
+		if !fieldsEqual(entryFields(entries), []string{"a"}) {
+			t.Fatalf("IndexEntries fields = %v, want [a]", entryFields(entries))
+		}
+	})
+	t.Run("dynamic", func(t *testing.T) {
+		rec := &wire.Record{Mode: wire.OperateModeDynamic, Fields: []wire.Field{
+			{Name: "a", Cell: wire.Cell{Type: wire.OperateTypeU32, U: 1}},
+			{Name: "f", Cell: wire.Cell{Type: wire.OperateTypeF32, F: math.NaN()}},
+		}}
+		enc := rec.Encode()
+		if enc == nil {
+			t.Fatal("record failed to encode")
+		}
+		entries, err := NewResolver(4).IndexEntries(enc)
+		if err != nil {
+			t.Fatalf("IndexEntries: %v", err)
+		}
+		if !fieldsEqual(entryFields(entries), []string{"a"}) {
+			t.Fatalf("IndexEntries fields = %v, want [a]", entryFields(entries))
+		}
+	})
+}
+
+// TestIndexEntriesSkipsUnset checks a dynamic-mode UNSET field (legal in
+// dynamic mode, per doc.go) contributes no entry.
+func TestIndexEntriesSkipsUnset(t *testing.T) {
+	rec := &wire.Record{Mode: wire.OperateModeDynamic, Fields: []wire.Field{
+		{Name: "a", Cell: wire.Cell{Type: wire.OperateTypeU32, U: 1}},
+		{Name: "u", Cell: wire.Cell{Type: wire.OperateTypeUnset}},
+	}}
+	enc := rec.Encode()
+	if enc == nil {
+		t.Fatal("record failed to encode")
+	}
+	entries, err := NewResolver(4).IndexEntries(enc)
+	if err != nil {
+		t.Fatalf("IndexEntries: %v", err)
+	}
+	if !fieldsEqual(entryFields(entries), []string{"a"}) {
+		t.Fatalf("IndexEntries fields = %v, want [a]", entryFields(entries))
+	}
+}
+
+// TestIndexEntriesMatchesOracle checks IndexEntries against a from-scratch
+// oracle built directly off the decoded tree, over the same random-record
+// generators resolve.go's oracle test uses: same field set, same order, same
+// values (NaN skip included), on every random record in both modes.
+func TestIndexEntriesMatchesOracle(t *testing.T) {
+	records := 500
+	if testing.Short() {
+		records = 100
+	}
+	rng := rand.New(rand.NewSource(20260908))
+	r := NewResolver(32)
+	for i := 0; i < records; i++ {
+		var enc []byte
+		var dec *wire.Record
+		var err error
+		if i%2 == 0 {
+			enc, dec, err = randomSchemaRecord(rng)
+		} else {
+			enc, dec, err = randomDynamicRecord(rng)
+		}
+		if err != nil {
+			t.Fatalf("generator: %v", err)
+		}
+		got, gerr := r.IndexEntries(enc)
+		if gerr != nil {
+			t.Fatalf("record %d: IndexEntries: %v", i, gerr)
+		}
+		want := oracleIndexEntries(t, dec)
+		if len(got) != len(want) {
+			t.Fatalf("record %d: got %d entries %v, want %d %v", i, len(got), entryFields(got), len(want), entryFields(want))
+		}
+		for j := range got {
+			if got[j].Field != want[j].Field {
+				t.Fatalf("record %d entry %d: field %q, want %q (got %v, want %v)", i, j, got[j].Field, want[j].Field, entryFields(got), entryFields(want))
+			}
+			if !valuesEqual(got[j].Value, want[j].Value) {
+				t.Fatalf("record %d entry %q: value %+v, want %+v", i, got[j].Field, got[j].Value, want[j].Value)
+			}
+		}
+	}
+}
+
+// oracleIndexEntries computes IndexEntries' expected output directly off
+// the decoded tree, independent of resolve.go's byte-walking code.
+func oracleIndexEntries(t *testing.T, rec *wire.Record) []Entry {
+	t.Helper()
+	var entries []Entry
+	label := func(storeNames bool, name string, pos int) string {
+		if storeNames {
+			return name
+		}
+		return "#" + itoa(pos)
+	}
+	switch rec.Mode {
+	case wire.OperateModeSchema:
+		s := rec.Schema
+		for i := range s.Fields {
+			fd := &s.Fields[i]
+			name := label(s.StoreNames, fd.Name, i)
+			if fd.Type == wire.OperateTypeTable {
+				entries = append(entries, Entry{Field: name + "#count", Value: vtypes.NewInt(int64(len(rec.Fields[i].Table.Rows)))})
+				continue
+			}
+			v, ok := CellValue(rec.Fields[i].Cell)
+			if !ok || (v.Kind == vtypes.ValueFloat && math.IsNaN(v.Flt)) {
+				continue
+			}
+			entries = append(entries, Entry{Field: name, Value: v})
+		}
+	case wire.OperateModeDynamic:
+		for i := range rec.Fields {
+			f := &rec.Fields[i]
+			if f.Cell.Type == wire.OperateTypeTable {
+				entries = append(entries, Entry{Field: f.Name + "#count", Value: vtypes.NewInt(int64(len(f.Table.Rows)))})
+				continue
+			}
+			v, ok := CellValue(f.Cell)
+			if !ok || (v.Kind == vtypes.ValueFloat && math.IsNaN(v.Flt)) {
+				continue
+			}
+			entries = append(entries, Entry{Field: f.Name, Value: v})
+		}
+	}
+	return entries
+}
+
+// itoa avoids importing strconv twice in the test file's oracle helper.
+func itoa(i int) string {
+	if i == 0 {
+		return "0"
+	}
+	neg := i < 0
+	if neg {
+		i = -i
+	}
+	var buf [20]byte
+	pos := len(buf)
+	for i > 0 {
+		pos--
+		buf[pos] = byte('0' + i%10)
+		i /= 10
+	}
+	if neg {
+		pos--
+		buf[pos] = '-'
+	}
+	return string(buf[pos:])
+}
+
+// TestIndexEntriesHostileNeverPanics drives IndexEntries with every prefix
+// and every single-byte mutation of both example records, plus random
+// bytes: never panic, never mutate the input, and any error must wrap
+// ErrRecord (a malformed record) or ErrPath (never — IndexEntries takes no
+// path — so in practice only ErrRecord).
+func TestIndexEntriesHostileNeverPanics(t *testing.T) {
+	sess, _ := sessionRecord(t, true)
+	dyn, _ := dynamicRecord(t)
+	r := NewResolver(16)
+
+	run := func(name string, in []byte) {
+		before := append([]byte(nil), in...)
+		entries, err := r.IndexEntries(in)
+		if err != nil {
+			if errClass(err) == "other" {
+				t.Fatalf("%s: error outside ErrPath/ErrRecord: %v", name, err)
+			}
+			if entries != nil {
+				t.Fatalf("%s: error %v returned non-nil entries %v", name, err, entries)
+			}
+		}
+		if !bytes.Equal(before, in) {
+			t.Fatalf("%s: IndexEntries mutated its input", name)
+		}
+	}
+
+	for _, base := range [][]byte{sess, dyn} {
+		for n := 0; n <= len(base); n++ {
+			run("prefix", base[:n:n])
+		}
+		mut := append([]byte(nil), base...)
+		for i := range base {
+			orig := mut[i]
+			for v := 0; v < 256; v++ {
+				mut[i] = byte(v)
+				run("mutation", mut)
+			}
+			mut[i] = orig
+		}
+	}
+
+	rng := rand.New(rand.NewSource(11))
+	n := 4000
+	if testing.Short() {
+		n = 500
+	}
+	for i := 0; i < n; i++ {
+		buf := make([]byte, rng.Intn(40))
+		for j := range buf {
+			buf[j] = byte(rng.Intn(256))
+		}
+		run("random", buf)
+	}
+}
+
+// TestIndexEntriesEmptyRecord checks the one-byte-short and empty cases
+// IndexEntries must reject cleanly.
+func TestIndexEntriesEmptyRecord(t *testing.T) {
+	r := NewResolver(4)
+	if _, err := r.IndexEntries(nil); !bytesIsRecordErr(err) {
+		t.Fatalf("IndexEntries(nil) error = %v, want ErrRecord", err)
+	}
+	if _, err := r.IndexEntries([]byte{}); !bytesIsRecordErr(err) {
+		t.Fatalf("IndexEntries([]) error = %v, want ErrRecord", err)
+	}
+	if _, err := r.IndexEntries([]byte{0xFF}); !bytesIsRecordErr(err) {
+		t.Fatalf("IndexEntries(unknown mode) error = %v, want ErrRecord", err)
+	}
+}
+
+func bytesIsRecordErr(err error) bool {
+	return err != nil && errClass(err) == "record"
+}
+
+// TestIndexEntriesNoNamesTableColumnsNotIndexed pins the indexing ruling
+// directly: table columns are never indexed, only the top-level "#count".
+func TestIndexEntriesNoNamesTableColumnsNotIndexed(t *testing.T) {
+	enc, _ := sessionRecord(t, true)
+	entries, err := NewResolver(4).IndexEntries(enc)
+	if err != nil {
+		t.Fatalf("IndexEntries: %v", err)
+	}
+	for _, e := range entries {
+		if e.Field == "hi" || e.Field == "lo" || e.Field == "b/42/hi" {
+			t.Fatalf("table column leaked into index entries: %q", e.Field)
+		}
+	}
+}

--- a/sdk/vtypes/filter.go
+++ b/sdk/vtypes/filter.go
@@ -42,6 +42,15 @@ const (
 	FilterGeoRadius  // geo field within RadiusM meters (haversine) of center
 	FilterGeoBox     // geo field inside an SW->NE bounding box (inclusive)
 	FilterGeoPolygon // geo field inside a polygon exterior ring (ray-casting)
+
+	// Record row-presence operators. Appended after FilterGeoPolygon so
+	// existing wire-encoded op numbers are never renumbered. Both address a
+	// path ending in a table row segment (see sdk/record); they take no
+	// Value. FilterRowExists is true iff the row is present; FilterRowAbsent
+	// is its asymmetric negation (see vector/filter.go's compileRowPresence
+	// doc comment for the asymmetry: it is NOT simply "not exists").
+	FilterRowExists
+	FilterRowAbsent
 )
 
 var filterOpNames = map[FilterOp]string{
@@ -67,6 +76,8 @@ var filterOpNames = map[FilterOp]string{
 	FilterGeoRadius:  "geo_radius",
 	FilterGeoBox:     "geo_bounding_box",
 	FilterGeoPolygon: "geo_polygon",
+	FilterRowExists:  "row_exists",
+	FilterRowAbsent:  "row_absent",
 }
 
 var filterOpByName = func() map[string]FilterOp {

--- a/sdk/vtypes/filter_test.go
+++ b/sdk/vtypes/filter_test.go
@@ -1,0 +1,57 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package vtypes
+
+import "testing"
+
+// TestFilterOpRowPresenceTextRoundtrip pins FilterRowExists/FilterRowAbsent
+// to their wire values and their JSON names ("row_exists"/"row_absent"), and
+// checks MarshalText/UnmarshalText agree in both directions.
+//
+// NOTE on the values: the plan docs (contract.md/constraints.md) state 21/22
+// "following FilterGeoPolygon", but FilterGeoPolygon is ALREADY 21 in the
+// existing enum (FilterAnd..FilterGeoPolygon is 22 values, 0-21 — verified by
+// enumerating every FilterOp's MarshalText). Using literal 21 for
+// FilterRowExists would silently collide with FilterGeoPolygon=21. The
+// append-only/never-renumber rule (constraints.md) takes priority over the
+// docs' arithmetic slip, so these are appended after the last existing op:
+// FilterRowExists=22, FilterRowAbsent=23. Flagged to the team lead to correct
+// the docs; no other code was found depending on the literal 21/22.
+func TestFilterOpRowPresenceTextRoundtrip(t *testing.T) {
+	cases := []struct {
+		op   FilterOp
+		val  FilterOp
+		name string
+	}{
+		{FilterRowExists, 22, "row_exists"},
+		{FilterRowAbsent, 23, "row_absent"},
+	}
+	for _, c := range cases {
+		if c.op != c.val {
+			t.Errorf("%s: FilterOp value = %d, want %d", c.name, c.op, c.val)
+		}
+		text, err := c.op.MarshalText()
+		if err != nil {
+			t.Fatalf("%s: MarshalText: %v", c.name, err)
+		}
+		if string(text) != c.name {
+			t.Errorf("MarshalText(%d) = %q, want %q", c.op, text, c.name)
+		}
+		var got FilterOp
+		if err := got.UnmarshalText([]byte(c.name)); err != nil {
+			t.Fatalf("UnmarshalText(%q): %v", c.name, err)
+		}
+		if got != c.op {
+			t.Errorf("UnmarshalText(%q) = %d, want %d", c.name, got, c.op)
+		}
+	}
+}
+
+// TestFilterOpRowPresenceRejectsUnknownName is a control: a near-miss name
+// must not silently parse as one of the two new ops.
+func TestFilterOpRowPresenceRejectsUnknownName(t *testing.T) {
+	var got FilterOp
+	if err := got.UnmarshalText([]byte("row_present")); err == nil {
+		t.Errorf("UnmarshalText(row_present) succeeded as %d, want a hard error", got)
+	}
+}

--- a/sdk/vtypes/value.go
+++ b/sdk/vtypes/value.go
@@ -57,6 +57,11 @@ type Value struct {
 	// Raw bytes marshal to base64 automatically via encoding/json's []byte
 	// handling. omitempty is safe here (unlike Lat/Lon): an empty/nil record is
 	// not a distinct meaningful value the way (0,0) is a real geo point.
+	//
+	// OWNERSHIP: like Strs/Ints/Flts, Rec is a REFERENCE, and the engine's
+	// metadata copies are map-level — see the Metadata doc comment. A record
+	// handed to the engine, or handed back by an in-process read, shares its
+	// bytes with the stored value. Read it; never write through it.
 	Rec []byte `json:"rec,omitempty"`
 }
 
@@ -99,6 +104,28 @@ func (v Value) Equal(o Value) bool {
 
 // Metadata is the per-vector attribute map. nil signals "no metadata" —
 // that's the common case so it's the cheap one.
+//
+// # Slice ownership
+//
+// Four kinds carry a slice rather than a scalar: ValueStrings, ValueInts,
+// ValueFloats and ValueRecord. For all four the slice is held BY REFERENCE, in
+// both directions, and that is the whole contract:
+//
+//   - INTO the engine: the constructors (NewStrings, NewInts, NewFloats,
+//     NewRecord) store the caller's slice as given, so a caller must not mutate
+//     it after handing it off.
+//   - OUT of the engine: the copies the engine makes of a metadata map are
+//     MAP-level — a fresh map with the same Values — so a Value's slice in a
+//     returned payload still points at the engine's own bytes. Reading it is
+//     safe under the API that returned it; writing through it mutates live
+//     stored data (and, for a record, leaves the payload index's synthetic
+//     postings describing bytes that no longer exist), so it is a caller
+//     contract violation for every one of the four kinds.
+//
+// ValueRecord is not special here: it follows the policy the list kinds have
+// always had. Callers that need to own a payload should copy the slice they
+// intend to keep, or read through a transport — every network client is handed
+// bytes the codec wrote, never the engine's own.
 type Metadata = map[string]Value
 
 // NewString returns a Value carrying a string.
@@ -127,7 +154,9 @@ func NewFloats(f []float64) Value { return Value{Kind: ValueFloats, Flts: f} }
 func NewGeo(lat, lon float64) Value { return Value{Kind: ValueGeo, Lat: lat, Lon: lon} }
 
 // NewRecord returns a Value carrying an opaque record-encoded byte blob. rec
-// is stored by reference; callers must not mutate it after handing it off.
+// is stored by reference; callers must not mutate it after handing it off, and
+// must not write through a record they got back from a read either — see the
+// Metadata doc comment.
 func NewRecord(rec []byte) Value { return Value{Kind: ValueRecord, Rec: rec} }
 
 func stringSliceEqual(a, b []string) bool {

--- a/sdk/vtypes/value.go
+++ b/sdk/vtypes/value.go
@@ -3,6 +3,7 @@
 package vtypes
 
 import (
+	"bytes"
 	"fmt"
 )
 
@@ -24,6 +25,11 @@ const (
 	// APPEND-ONLY: it must stay 8 so existing snapshots/WAL records (which encode
 	// the kind as a raw u8) keep decoding correctly. Never renumber the kinds.
 	ValueGeo
+	// ValueRecord carries an opaque record-encoded byte blob (see sdk/record) in
+	// the Rec field. APPEND-ONLY: it must stay 9 (ValueGeo+1) for the same reason
+	// ValueGeo must stay 8 — the kind is a raw u8 on disk and on the wire. Never
+	// renumber the kinds.
+	ValueRecord
 )
 
 // Value is a tagged union holding one metadata attribute. Only the field
@@ -47,6 +53,11 @@ type Value struct {
 	// — i.e. omitempty here means "field absent", never "coordinate absent".
 	Lat float64 `json:"lat,omitempty"`
 	Lon float64 `json:"lon,omitempty"`
+	// Rec holds an opaque record-encoded byte blob when Kind == ValueRecord.
+	// Raw bytes marshal to base64 automatically via encoding/json's []byte
+	// handling. omitempty is safe here (unlike Lat/Lon): an empty/nil record is
+	// not a distinct meaningful value the way (0,0) is a real geo point.
+	Rec []byte `json:"rec,omitempty"`
 }
 
 // IsZero reports whether the Value is the zero value (Kind == ValueNone).
@@ -78,6 +89,10 @@ func (v Value) Equal(o Value) bool {
 		// below, so any two geo points would compare equal — silently making
 		// FilterEq always match and FilterNe never match on a geo field.
 		return v.Lat == o.Lat && v.Lon == o.Lon
+	case ValueRecord:
+		// CRITICAL: same bug class as ValueGeo above — without this case every
+		// pair of records would compare equal via the default `return true`.
+		return bytes.Equal(v.Rec, o.Rec)
 	}
 	return true
 }
@@ -110,6 +125,10 @@ func NewFloats(f []float64) Value { return Value{Kind: ValueFloats, Flts: f} }
 
 // NewGeo returns a Value carrying a WGS84 geographic point (lat/lon in degrees).
 func NewGeo(lat, lon float64) Value { return Value{Kind: ValueGeo, Lat: lat, Lon: lon} }
+
+// NewRecord returns a Value carrying an opaque record-encoded byte blob. rec
+// is stored by reference; callers must not mutate it after handing it off.
+func NewRecord(rec []byte) Value { return Value{Kind: ValueRecord, Rec: rec} }
 
 func stringSliceEqual(a, b []string) bool {
 	if len(a) != len(b) {
@@ -157,6 +176,7 @@ var valueKindNames = map[ValueKind]string{
 	ValueInts:    "ints",
 	ValueFloats:  "floats",
 	ValueGeo:     "geo",
+	ValueRecord:  "record",
 }
 
 var valueKindByName = func() map[string]ValueKind {

--- a/sdk/vtypes/value_test.go
+++ b/sdk/vtypes/value_test.go
@@ -1,0 +1,92 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package vtypes
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+// TestValueRecordJSONRoundtrip pins the exact JSON shape a ValueRecord
+// produces: {"kind":"record","rec":"AQID"} — Rec's raw bytes marshal to
+// base64 automatically via encoding/json's []byte handling, and the kind
+// name comes from ValueKind.MarshalText.
+func TestValueRecordJSONRoundtrip(t *testing.T) {
+	v := Value{Kind: ValueRecord, Rec: []byte{1, 2, 3}}
+
+	b, err := json.Marshal(v)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	const want = `{"kind":"record","rec":"AQID"}`
+	if string(b) != want {
+		t.Fatalf("Marshal = %s, want %s", b, want)
+	}
+
+	var got Value
+	if err := json.Unmarshal(b, &got); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	if got.Kind != ValueRecord {
+		t.Fatalf("Kind = %v, want ValueRecord", got.Kind)
+	}
+	if string(got.Rec) != string(v.Rec) {
+		t.Fatalf("Rec = %v, want %v", got.Rec, v.Rec)
+	}
+}
+
+// TestValueRecordEqual exercises the three cases the bug class in Equal's doc
+// comment warns about: without an explicit case, ANY two ValueRecords would
+// compare equal via the default `return true`.
+func TestValueRecordEqual(t *testing.T) {
+	tests := []struct {
+		name string
+		a, b Value
+		want bool
+	}{
+		{"equal bytes", NewRecord([]byte{1, 2, 3}), NewRecord([]byte{1, 2, 3}), true},
+		{"different bytes", NewRecord([]byte{1, 2, 3}), NewRecord([]byte{1, 2, 4}), false},
+		{"different length", NewRecord([]byte{1, 2, 3}), NewRecord([]byte{1, 2}), false},
+		{"nil vs empty", NewRecord(nil), NewRecord([]byte{}), true},
+		{"nil vs nil", NewRecord(nil), NewRecord(nil), true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.a.Equal(tt.b); got != tt.want {
+				t.Errorf("Equal = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestValueKindNamesAppendOnly pins ValueRecord's numeric value at 9
+// (ValueGeo+1). The kind is encoded as a raw u8 on disk (snapshot/WAL) and
+// over the wire, so renumbering it would silently corrupt every existing
+// snapshot and break replay — this test exists to catch an accidental
+// reorder of the const block, not to validate any behavior.
+func TestValueKindNamesAppendOnly(t *testing.T) {
+	if ValueRecord != 9 {
+		t.Fatalf("ValueRecord = %d, want 9 (ValueGeo+1)", ValueRecord)
+	}
+	if ValueGeo != 8 {
+		t.Fatalf("ValueGeo = %d, want 8", ValueGeo)
+	}
+}
+
+func TestValueRecordKindName(t *testing.T) {
+	name, err := ValueRecord.MarshalText()
+	if err != nil {
+		t.Fatalf("MarshalText: %v", err)
+	}
+	if string(name) != "record" {
+		t.Fatalf("MarshalText = %q, want %q", name, "record")
+	}
+
+	var k ValueKind
+	if err := k.UnmarshalText([]byte("record")); err != nil {
+		t.Fatalf("UnmarshalText: %v", err)
+	}
+	if k != ValueRecord {
+		t.Fatalf("UnmarshalText = %v, want ValueRecord", k)
+	}
+}

--- a/sdk/wire/operate_record.go
+++ b/sdk/wire/operate_record.go
@@ -323,6 +323,10 @@ func decodeCellDataCanonical(t uint8, n uint8, b []byte) (Cell, int, error) {
 	return c, m, nil
 }
 
+// TWIN: sdk/record/resolve.go carries an unexported copy of this helper (and of
+// minUvarintLen); keep both in lockstep, including the byte-length vs
+// element-count split described below.
+//
 // fitsRemaining reports whether a decoded byte-length n (as opposed to an
 // element count — CountFitsIn is for those) fits within remaining bytes,
 // without ever narrowing n to int: n can be an arbitrary attacker-controlled

--- a/sdk/wire/operate_schema.go
+++ b/sdk/wire/operate_schema.go
@@ -77,6 +77,10 @@ const schemaFlagStoreNames uint8 = 1 << 0
 
 // minUvarintLen returns the number of bytes binary.AppendUvarint would use to
 // encode v: the canonical (minimal) LEB128 length.
+//
+// TWIN: sdk/record/resolve.go carries an unexported copy so the record leaf can
+// enforce the same canonical-uvarint rule without importing it. Keep both in
+// lockstep.
 func minUvarintLen(v uint64) int {
 	n := 1
 	for v >= 0x80 {

--- a/server/handlers.go
+++ b/server/handlers.go
@@ -190,7 +190,14 @@ func clientFacingErr(err error) bool {
 		// storage cap. A caller mistake with a clear remedy (send a smaller
 		// record), and the message names the key and both sizes — all of which
 		// the caller sent — so it is safe to return verbatim, like a bad dim.
+		//
+		// Matched by sentinel AND by string: shard.decodePBResult rebuilds an op
+		// error with errors.New across replication, so a clustered apply loses
+		// errors.Is identity and the error would fall through to the redacted
+		// internal-fault bucket. Comparing against the sentinel's own .Error()
+		// text cannot drift from it.
 		errors.Is(err, vector.ErrRecordTooLarge),
+		strings.Contains(err.Error(), vector.ErrRecordTooLarge.Error()),
 		errors.Is(err, vector.ErrEmptyFilter),
 		errors.Is(err, vector.ErrEmptyGroupBy),
 		errors.Is(err, vector.ErrSparseMismatch),

--- a/server/handlers.go
+++ b/server/handlers.go
@@ -191,13 +191,16 @@ func clientFacingErr(err error) bool {
 		// record), and the message names the key and both sizes — all of which
 		// the caller sent — so it is safe to return verbatim, like a bad dim.
 		//
-		// Matched by sentinel AND by string: shard.decodePBResult rebuilds an op
-		// error with errors.New across replication, so a clustered apply loses
-		// errors.Is identity and the error would fall through to the redacted
-		// internal-fault bucket. Comparing against the sentinel's own .Error()
-		// text cannot drift from it.
+		// Matched by sentinel AND by exact message shape: shard.decodePBResult
+		// rebuilds an op error with errors.New across replication, so a
+		// clustered apply loses errors.Is identity and the error would fall
+		// through to the redacted internal-fault bucket. The message-shape arm
+		// uses vector.IsRecordTooLargeMessage, NOT strings.Contains — a bare
+		// substring check would also match an unrelated internal error that
+		// merely wraps the sentinel (e.g. a WAL/path error), leaking it to the
+		// caller unredacted.
 		errors.Is(err, vector.ErrRecordTooLarge),
-		strings.Contains(err.Error(), vector.ErrRecordTooLarge.Error()),
+		vector.IsRecordTooLargeMessage(err.Error()),
 		errors.Is(err, vector.ErrEmptyFilter),
 		errors.Is(err, vector.ErrEmptyGroupBy),
 		errors.Is(err, vector.ErrSparseMismatch),

--- a/server/handlers.go
+++ b/server/handlers.go
@@ -186,6 +186,11 @@ func mapResult(disp Dispatcher, result []byte, err error, reqID string) (uint8, 
 func clientFacingErr(err error) bool {
 	switch {
 	case errors.Is(err, vector.ErrDimMismatch),
+		// vector.ErrRecordTooLarge: a payload carrying a record value above the
+		// storage cap. A caller mistake with a clear remedy (send a smaller
+		// record), and the message names the key and both sizes — all of which
+		// the caller sent — so it is safe to return verbatim, like a bad dim.
+		errors.Is(err, vector.ErrRecordTooLarge),
 		errors.Is(err, vector.ErrEmptyFilter),
 		errors.Is(err, vector.ErrEmptyGroupBy),
 		errors.Is(err, vector.ErrSparseMismatch),

--- a/server/redaction_test.go
+++ b/server/redaction_test.go
@@ -4,6 +4,7 @@ package server
 
 import (
 	"errors"
+	"fmt"
 	"strings"
 	"testing"
 
@@ -144,5 +145,45 @@ func TestMapResultKeepsWASMUpdateRefusalVisible(t *testing.T) {
 	}
 	if !strings.Contains(msg, "NEW op name") {
 		t.Errorf("payload = %q, want the remedy to survive", msg)
+	}
+}
+
+// TestMapResultKeepsRecordTooLargeVisible pins vector.ErrRecordTooLarge as a
+// client-facing signal on the binary transport, in all three shapes it can
+// arrive in. The sentinel arm was already classified; the STRINGIFIED arm is
+// the one that was not, and it is the shape a clustered write produces —
+// shard.decodePBResult rebuilds an op error with errors.New(string(payload))
+// across replication, so errors.Is stops matching and the caller got the
+// redacted "internal error" for a mistake they could have fixed.
+//
+// The message is safe to disclose: it names the payload key the caller chose
+// and the two sizes, and nothing about the server.
+func TestMapResultKeepsRecordTooLargeVisible(t *testing.T) {
+	disp := &fakeDispatcher{}
+	const detail = ": payload key \"session\" holds a 20000000-byte record, the cap is 16777216 bytes"
+	for _, tc := range []struct {
+		name string
+		err  error
+	}{
+		{"sentinel", vector.ErrRecordTooLarge},
+		{"wrapped", fmt.Errorf("vector_insert: %w"+detail, vector.ErrRecordTooLarge)},
+		{"stringified", errors.New(vector.ErrRecordTooLarge.Error() + detail)},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			_, payload := mapResult(disp, nil, tc.err, "")
+			msg, err := DecodeErrorPayload(payload)
+			if err != nil {
+				t.Fatalf("DecodeErrorPayload: %v", err)
+			}
+			if msg == "internal error" || !strings.Contains(msg, "exceeds the storage cap") {
+				t.Errorf("record-too-large redacted: got %q", msg)
+			}
+		})
+	}
+	// Negative control: an unrelated fault is still redacted, so the new string
+	// arm did not widen the bucket.
+	_, payload := mapResult(disp, nil, errors.New("open /var/lib/rostam/shard-7: no such file"), "")
+	if msg, _ := DecodeErrorPayload(payload); msg != "internal error" {
+		t.Errorf("unrelated fault = %q, want the redacted message", msg)
 	}
 }

--- a/server/redaction_test.go
+++ b/server/redaction_test.go
@@ -149,25 +149,31 @@ func TestMapResultKeepsWASMUpdateRefusalVisible(t *testing.T) {
 }
 
 // TestMapResultKeepsRecordTooLargeVisible pins vector.ErrRecordTooLarge as a
-// client-facing signal on the binary transport, in all three shapes it can
-// arrive in. The sentinel arm was already classified; the STRINGIFIED arm is
-// the one that was not, and it is the shape a clustered write produces —
-// shard.decodePBResult rebuilds an op error with errors.New(string(payload))
-// across replication, so errors.Is stops matching and the caller got the
-// redacted "internal error" for a mistake they could have fixed.
+// client-facing signal on the binary transport, in every shape it can arrive
+// in. The sentinel arm was already classified; the message-shape arm is the
+// one that recognizes the STRINGIFIED forms — shard.decodePBResult rebuilds
+// an op error with errors.New(string(payload)) across replication, so
+// errors.Is stops matching and the caller got the redacted "internal error"
+// for a mistake they could have fixed.
 //
-// The message is safe to disclose: it names the payload key the caller chose
-// and the two sizes, and nothing about the server.
+// The message-shape arm is vector.IsRecordTooLargeMessage, an exact-shape
+// matcher, NOT a bare strings.Contains — the negative controls below assert
+// that distinction: an unrelated internal error whose message merely contains
+// the sentinel text must still be redacted.
 func TestMapResultKeepsRecordTooLargeVisible(t *testing.T) {
 	disp := &fakeDispatcher{}
-	const detail = ": payload key \"session\" holds a 20000000-byte record, the cap is 16777216 bytes"
+	single := fmt.Errorf("%w: payload key %q holds a 20000000-byte record, the cap is 16777216 bytes",
+		vector.ErrRecordTooLarge, "session")
+	bulk := fmt.Errorf("payload %d: %w", 3, single)
 	for _, tc := range []struct {
 		name string
 		err  error
 	}{
 		{"sentinel", vector.ErrRecordTooLarge},
-		{"wrapped", fmt.Errorf("vector_insert: %w"+detail, vector.ErrRecordTooLarge)},
-		{"stringified", errors.New(vector.ErrRecordTooLarge.Error() + detail)},
+		{"single-payload form (%w wrapped)", single},
+		{"bulk form (%w wrapped, real shape checkRecordValuesAll produces)", bulk},
+		{"single-payload form, stringified across replication", errors.New(single.Error())},
+		{"bulk form, stringified across replication", errors.New(bulk.Error())},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			_, payload := mapResult(disp, nil, tc.err, "")
@@ -180,10 +186,24 @@ func TestMapResultKeepsRecordTooLargeVisible(t *testing.T) {
 			}
 		})
 	}
-	// Negative control: an unrelated fault is still redacted, so the new string
-	// arm did not widen the bucket.
-	_, payload := mapResult(disp, nil, errors.New("open /var/lib/rostam/shard-7: no such file"), "")
-	if msg, _ := DecodeErrorPayload(payload); msg != "internal error" {
-		t.Errorf("unrelated fault = %q, want the redacted message", msg)
+	// Negative controls: an unrelated fault is still redacted, including one
+	// that merely CONTAINS the sentinel text inside an unrelated wrapper — the
+	// exact bug a bare strings.Contains classifier would reintroduce.
+	for _, tc := range []struct {
+		name string
+		err  error
+	}{
+		{"unrelated fault, no sentinel text", errors.New("open /var/lib/rostam/shard-7: no such file")},
+		{"unrelated fault wrapping the sentinel (%v)",
+			fmt.Errorf("wal append failed at /var/lib/rostam/x: %v", vector.ErrRecordTooLarge)},
+		{"unrelated fault stringified across replication",
+			errors.New(fmt.Errorf("wal append failed at /var/lib/rostam/x: %v", vector.ErrRecordTooLarge).Error())},
+	} {
+		t.Run("negative/"+tc.name, func(t *testing.T) {
+			_, payload := mapResult(disp, nil, tc.err, "")
+			if msg, _ := DecodeErrorPayload(payload); msg != "internal error" {
+				t.Errorf("unrelated fault = %q, want the redacted message", msg)
+			}
+		})
 	}
 }

--- a/vector/build_concurrent.go
+++ b/vector/build_concurrent.go
@@ -49,6 +49,9 @@ func (h *hnsw) BuildConcurrent(ids []uint64, vecs [][]float32, workers int) erro
 // search landing between build and apply returns a WRONG (empty-ish) answer
 // rather than an error.
 func (h *hnsw) BuildConcurrentMeta(ids []uint64, vecs [][]float32, metas []Metadata, workers int) error {
+	if err := checkRecordValuesAll(metas); err != nil {
+		return err
+	}
 	if len(metas) != 0 && len(metas) != len(ids) {
 		return ErrBuildMetaLenMismatch
 	}

--- a/vector/collection.go
+++ b/vector/collection.go
@@ -313,6 +313,13 @@ func (c *Collection) InsertCASKeyTTLAt(id uint64, vec []float32, ttl time.Durati
 // insert with that version + keyExpires so a later replay restores them too. Starts
 // the sweeper like Insert.
 func (c *Collection) RestoreInsert(id uint64, vec []float32, ttl time.Duration, meta Metadata, sparse *SparseVector, keyExpires map[string]uint64, version uint64) error {
+	// Checked HERE as well as in the engine body, because THIS layer owns the
+	// {apply, then append} ordering below: idx.RestoreInsert mutates the index
+	// before the WAL append runs, so a payload the codec cannot encode has to be
+	// refused before either step, not between them.
+	if err := checkRecordValues(meta); err != nil {
+		return err
+	}
 	c.startSweeper()
 	if c.wal == nil {
 		return c.idx.RestoreInsert(id, vec, ttl, meta, sparse, keyExpires, version)
@@ -342,6 +349,10 @@ func (c *Collection) RestoreInsert(id uint64, vec []float32, ttl time.Duration, 
 // version-preserving insert path (reshard/resplit backfill) under an apply stamp
 // (#4 vector TTL determinism).
 func (c *Collection) RestoreInsertAt(id uint64, vec []float32, ttl time.Duration, meta Metadata, sparse *SparseVector, keyExpires map[string]uint64, version uint64, nowMs int64) error {
+	// See RestoreInsert: this layer applies before it appends.
+	if err := checkRecordValues(meta); err != nil {
+		return err
+	}
 	c.startSweeper()
 	if c.wal == nil {
 		return c.idx.RestoreInsertAt(id, vec, ttl, meta, sparse, keyExpires, version, nowMs)

--- a/vector/collection.go
+++ b/vector/collection.go
@@ -735,6 +735,9 @@ func (c *Collection) StageBulk(ids []uint64, vecs [][]float32) error {
 // point. Everything StageBulk documents about dimension checking applies here
 // unchanged.
 func (c *Collection) StageBulkPayloads(ids []uint64, vecs [][]float32, metas []Metadata) error {
+	if err := checkRecordValuesAll(metas); err != nil {
+		return err
+	}
 	// NILNESS here, LENGTH in BuildConcurrentMeta, and the difference is deliberate.
 	// This function has to decide whether to MATERIALIZE the payload column, and
 	// only nil can mean "this caller has no payload column at all" — an empty
@@ -824,6 +827,9 @@ func (c *Collection) UpsertCAS(id uint64, vec []float32, content string, ttl tim
 // deadlines; the WAL logs them so replay restores them verbatim. Empty/nil
 // keyTTLMs is the zero-overhead path.
 func (c *Collection) UpsertCASKeyTTL(id uint64, vec []float32, content string, ttl time.Duration, meta Metadata, sparse *SparseVector, keyTTLMs map[string]int64, cas CASCond) (uint64, error) {
+	if err := checkRecordValues(meta); err != nil {
+		return 0, err
+	}
 	c.startSweeper()
 	// opMu is held across {apply + WAL WRITE} only, scoped to a closure (see
 	// InsertCASKeyTTL) so a panic inside idx.Get/Delete/Insert or a WAL append
@@ -1295,6 +1301,9 @@ func (c *Collection) DeleteByFilterAt(filter Filter, nowMs int64) (int, error) {
 // precheck + unconditional delete), then re-inserts via InsertAt so the point/per-key
 // deadlines are stamped identically on every replica (#4 vector TTL determinism).
 func (c *Collection) UpsertCASKeyTTLAt(id uint64, vec []float32, content string, ttl time.Duration, meta Metadata, sparse *SparseVector, keyTTLMs map[string]int64, cas CASCond, nowMs int64) (uint64, error) {
+	if err := checkRecordValues(meta); err != nil {
+		return 0, err
+	}
 	c.startSweeper()
 	// opMu is held across {apply + WAL WRITE} only, scoped to a closure (see
 	// UpsertCASKeyTTL) so a panic inside idx.DeleteAt/InsertAt or a WAL append

--- a/vector/filter.go
+++ b/vector/filter.go
@@ -605,6 +605,12 @@ func compileIsEmpty(field string) (Predicate, error) {
 			// absence). Made explicit instead of relying on the default below so a
 			// future kind can't silently inherit the wrong answer here.
 			return false
+		case ValueRecord:
+			// A record's own emptiness is its byte length, mirroring the
+			// ValueString case above — an explicit case rather than falling to
+			// the default (which would wrongly answer "never empty" the way a
+			// geo point never is).
+			return len(got.Rec) == 0
 		default:
 			return false
 		}
@@ -615,6 +621,10 @@ func compileIsEmpty(field string) (Predicate, error) {
 // its kind is ValueNone (an explicit null). An absent field is NOT null —
 // that's the is_empty/is_null distinction. It returns an error for signature
 // uniformity with the other leaf compilers; it never fails.
+//
+// ValueRecord considered: this checks presence + ValueNone only (no per-kind
+// switch), so a present record already answers correctly — not null — with no
+// change needed here.
 func compileIsNull(field string) (Predicate, error) {
 	return func(m Metadata) bool {
 		got, ok := lookupPath(m, field)

--- a/vector/filter.go
+++ b/vector/filter.go
@@ -822,6 +822,13 @@ func validateLatLon(lat, lon float64) error {
 // scalar where this filter expects a table) — already falls out of the
 // Kind != RowPresent check, so row_exists needs no separate branch for it.
 //
+// The per-point closure tries the EXACT payload key m[f.Field] first, like
+// every other leaf op (lookupPath, fieldLookup.get): a literal payload key
+// that itself contains '/' wins over splitting the field. Both ops answer
+// false for such a point — the field named a value, not a table. Only the
+// SHAPE check above is compile-time; whether a literal key exists varies per
+// point and cannot be hoisted.
+//
 // row_absent is DELIBERATELY NOT simply "not row_exists": it reports true
 // only when Resolve AFFIRMATIVELY finds the row missing from a REAL table on
 // this point (Kind == Absent) — never for a point that cannot even be asked
@@ -846,8 +853,28 @@ func compileRowPresence(f Filter) (Predicate, error) {
 		return nil, fmt.Errorf("vector: filter op %q requires a path naming exactly a table row (field/row), got %q", mustOpName(f.Op), pathStr)
 	}
 	exists := f.Op == FilterRowExists
+	field := f.Field
 	return func(m Metadata) bool {
 		if m == nil {
+			return false
+		}
+		// EXACT PAYLOAD KEY FIRST, exactly as lookupPath and fieldLookup.get
+		// resolve a field string: a literal payload key wins over splitting at
+		// the first '/'. Whether the literal key exists is a per-POINT fact, so
+		// this cannot be hoisted to the compile-time validation above; only the
+		// path SHAPE can be.
+		//
+		// Both ops answer false here, and for the same reason: the field named a
+		// literal payload value, not a table, so there was never a table to
+		// search. row_exists is false because no row was found; row_absent is
+		// false by the same asymmetry documented above — a point that cannot be
+		// asked the question is not in a position to assert anything about a row.
+		// Without this, a point holding both {"session": <record>} and a literal
+		// "session/b/42" key answered row_exists true while lookupPath on the
+		// same field returned the literal value, so two seams disagreed about one
+		// field string — the divergence the exact-key-first rule exists to
+		// prevent.
+		if _, exact := m[field]; exact {
 			return false
 		}
 		rv, ok := m[payloadKey]

--- a/vector/filter.go
+++ b/vector/filter.go
@@ -96,17 +96,21 @@ func compileLeaf(f Filter) (Predicate, error) {
 	}
 	field := f.Field
 	want := f.Value
+	// The record path in field (when it has one) is a compile-time constant:
+	// newFieldLookup parses it ONCE here so the per-point work in the closures
+	// below is a map lookup plus at most one Resolve. See fieldLookup.
+	look := newFieldLookup(field)
 
 	switch f.Op {
 	case FilterEq:
 		return func(m Metadata) bool {
-			got, ok := lookupPath(m, field)
+			got, ok := look.get(m)
 			return ok && got.Equal(want)
 		}, nil
 	case FilterNe:
 		// Strict-exists: a missing field does NOT satisfy 'ne'.
 		return func(m Metadata) bool {
-			got, ok := lookupPath(m, field)
+			got, ok := look.get(m)
 			return ok && !got.Equal(want)
 		}, nil
 	case FilterGt, FilterGte, FilterLt, FilterLte:
@@ -138,8 +142,9 @@ func compileLeaf(f Filter) (Predicate, error) {
 // float64 (int and float interoperate); string fields compare lexicographically.
 // A kind mismatch or missing field evaluates to false.
 func compileOrdering(field string, op FilterOp, want Value) (Predicate, error) {
+	look := newFieldLookup(field)
 	return func(m Metadata) bool {
-		got, ok := lookupPath(m, field)
+		got, ok := look.get(m)
 		if !ok {
 			return false
 		}
@@ -243,11 +248,12 @@ func compareString(a, b string) int {
 // compileIn builds an 'in' predicate: the field's scalar value must be a
 // member of the want array (strings/ints/floats). Type checked at compile.
 func compileIn(field string, want Value) (Predicate, error) {
+	look := newFieldLookup(field)
 	switch want.Kind {
 	case ValueStrings:
 		set := want.Strs
 		return func(m Metadata) bool {
-			got, ok := lookupPath(m, field)
+			got, ok := look.get(m)
 			if !ok || got.Kind != ValueString {
 				return false
 			}
@@ -261,7 +267,7 @@ func compileIn(field string, want Value) (Predicate, error) {
 	case ValueInts:
 		set := want.Ints
 		return func(m Metadata) bool {
-			got, ok := lookupPath(m, field)
+			got, ok := look.get(m)
 			if !ok || got.Kind != ValueInt {
 				return false
 			}
@@ -275,7 +281,7 @@ func compileIn(field string, want Value) (Predicate, error) {
 	case ValueFloats:
 		set := want.Flts
 		return func(m Metadata) bool {
-			got, ok := lookupPath(m, field)
+			got, ok := look.get(m)
 			if !ok || got.Kind != ValueFloat {
 				return false
 			}
@@ -294,11 +300,12 @@ func compileIn(field string, want Value) (Predicate, error) {
 // compileContains builds a 'contains' predicate: the field must be an array
 // (strings/ints/floats) containing the want scalar. Type checked at compile.
 func compileContains(field string, want Value) (Predicate, error) {
+	look := newFieldLookup(field)
 	switch want.Kind {
 	case ValueString:
 		needle := want.Str
 		return func(m Metadata) bool {
-			got, ok := lookupPath(m, field)
+			got, ok := look.get(m)
 			if !ok || got.Kind != ValueStrings {
 				return false
 			}
@@ -312,7 +319,7 @@ func compileContains(field string, want Value) (Predicate, error) {
 	case ValueInt:
 		needle := want.Int
 		return func(m Metadata) bool {
-			got, ok := lookupPath(m, field)
+			got, ok := look.get(m)
 			if !ok || got.Kind != ValueInts {
 				return false
 			}
@@ -326,7 +333,7 @@ func compileContains(field string, want Value) (Predicate, error) {
 	case ValueFloat:
 		needle := want.Flt
 		return func(m Metadata) bool {
-			got, ok := lookupPath(m, field)
+			got, ok := look.get(m)
 			if !ok || got.Kind != ValueFloats {
 				return false
 			}
@@ -412,12 +419,13 @@ func elementKeysOf(v Value) []scalarKey {
 // tokenizes the field value (which is unavoidable without an index). An empty
 // query matches any present string/strings field. Missing/wrong-kind → false.
 func compileMatch(field string, want Value) (Predicate, error) {
+	look := newFieldLookup(field)
 	if want.Kind != ValueString {
 		return nil, fmt.Errorf("vector: filter op 'match' requires a string value, got kind %d", want.Kind)
 	}
 	queryTokens := tokenize(want.Str)
 	return func(m Metadata) bool {
-		got, ok := lookupPath(m, field)
+		got, ok := look.get(m)
 		if !ok {
 			return false
 		}
@@ -556,6 +564,7 @@ func tokenize(s string) []string {
 // closure. Matches a string field; for a strings field, ANY element matching
 // satisfies. Missing/wrong-kind → false.
 func compileRegex(field string, want Value) (Predicate, error) {
+	look := newFieldLookup(field)
 	if want.Kind != ValueString {
 		return nil, fmt.Errorf("vector: filter op 'regex' requires a string value, got kind %d", want.Kind)
 	}
@@ -564,7 +573,7 @@ func compileRegex(field string, want Value) (Predicate, error) {
 		return nil, fmt.Errorf("vector: filter op 'regex' has invalid pattern %q: %w", want.Str, err)
 	}
 	return func(m Metadata) bool {
-		got, ok := lookupPath(m, field)
+		got, ok := look.get(m)
 		if !ok {
 			return false
 		}
@@ -588,8 +597,9 @@ func compileRegex(field string, want Value) (Predicate, error) {
 // present with ValueNone, an empty string, or an empty array. It returns an
 // error for signature uniformity with the other leaf compilers; it never fails.
 func compileIsEmpty(field string) (Predicate, error) {
+	look := newFieldLookup(field)
 	return func(m Metadata) bool {
-		got, ok := lookupPath(m, field)
+		got, ok := look.get(m)
 		if !ok {
 			return true
 		}
@@ -631,8 +641,9 @@ func compileIsEmpty(field string) (Predicate, error) {
 // switch), so a present record already answers correctly — not null — with no
 // change needed here.
 func compileIsNull(field string) (Predicate, error) {
+	look := newFieldLookup(field)
 	return func(m Metadata) bool {
-		got, ok := lookupPath(m, field)
+		got, ok := look.get(m)
 		return ok && got.Kind == ValueNone
 	}, nil
 }
@@ -643,6 +654,7 @@ func compileIsNull(field string) (Predicate, error) {
 // closure. The field is read via numericValue (datetime stored as int64
 // unix-ms by convention). Missing/non-numeric field → false.
 func compileDatetime(field string, op FilterOp, want Value) (Predicate, error) {
+	look := newFieldLookup(field)
 	ms, ok := datetimeBound(want)
 	if !ok {
 		if want.Kind != ValueString {
@@ -652,7 +664,7 @@ func compileDatetime(field string, op FilterOp, want Value) (Predicate, error) {
 	}
 	bound := float64(ms)
 	return func(m Metadata) bool {
-		got, ok := lookupPath(m, field)
+		got, ok := look.get(m)
 		if !ok {
 			return false
 		}
@@ -711,6 +723,7 @@ func dtToOrdering(op FilterOp) FilterOp {
 // slice itself) and only reads the field via lookupPath, requiring a ValueGeo
 // (missing field or non-geo kind -> false).
 func compileGeo(field string, op FilterOp, g *GeoCondition) (Predicate, error) {
+	look := newFieldLookup(field)
 	if g == nil {
 		return nil, fmt.Errorf("vector: filter op %q requires a 'geo' condition", mustOpName(op))
 	}
@@ -727,7 +740,7 @@ func compileGeo(field string, op FilterOp, g *GeoCondition) (Predicate, error) {
 		}
 		centerLat, centerLon, radius := g.CenterLat, g.CenterLon, g.RadiusM
 		return func(m Metadata) bool {
-			got, ok := lookupPath(m, field)
+			got, ok := look.get(m)
 			if !ok || got.Kind != ValueGeo {
 				return false
 			}
@@ -750,7 +763,7 @@ func compileGeo(field string, op FilterOp, g *GeoCondition) (Predicate, error) {
 		}
 		minLat, minLon, maxLat, maxLon := g.MinLat, g.MinLon, g.MaxLat, g.MaxLon
 		return func(m Metadata) bool {
-			got, ok := lookupPath(m, field)
+			got, ok := look.get(m)
 			if !ok || got.Kind != ValueGeo {
 				return false
 			}
@@ -770,7 +783,7 @@ func compileGeo(field string, op FilterOp, g *GeoCondition) (Predicate, error) {
 			}
 		}
 		return func(m Metadata) bool {
-			got, ok := lookupPath(m, field)
+			got, ok := look.get(m)
 			if !ok || got.Kind != ValueGeo {
 				return false
 			}

--- a/vector/filter.go
+++ b/vector/filter.go
@@ -419,11 +419,11 @@ func elementKeysOf(v Value) []scalarKey {
 // tokenizes the field value (which is unavoidable without an index). An empty
 // query matches any present string/strings field. Missing/wrong-kind → false.
 func compileMatch(field string, want Value) (Predicate, error) {
-	look := newFieldLookup(field)
 	if want.Kind != ValueString {
 		return nil, fmt.Errorf("vector: filter op 'match' requires a string value, got kind %d", want.Kind)
 	}
 	queryTokens := tokenize(want.Str)
+	look := newFieldLookup(field)
 	return func(m Metadata) bool {
 		got, ok := look.get(m)
 		if !ok {
@@ -564,7 +564,6 @@ func tokenize(s string) []string {
 // closure. Matches a string field; for a strings field, ANY element matching
 // satisfies. Missing/wrong-kind → false.
 func compileRegex(field string, want Value) (Predicate, error) {
-	look := newFieldLookup(field)
 	if want.Kind != ValueString {
 		return nil, fmt.Errorf("vector: filter op 'regex' requires a string value, got kind %d", want.Kind)
 	}
@@ -572,6 +571,7 @@ func compileRegex(field string, want Value) (Predicate, error) {
 	if err != nil {
 		return nil, fmt.Errorf("vector: filter op 'regex' has invalid pattern %q: %w", want.Str, err)
 	}
+	look := newFieldLookup(field)
 	return func(m Metadata) bool {
 		got, ok := look.get(m)
 		if !ok {

--- a/vector/filter.go
+++ b/vector/filter.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"math"
 	"regexp"
+	"strconv"
 	"strings"
 	"time"
 	"unicode"
@@ -844,14 +845,14 @@ func validateLatLon(lat, lon float64) error {
 func compileRowPresence(f Filter) (Predicate, error) {
 	payloadKey, pathStr, ok := record.SplitField(f.Field)
 	if !ok {
-		return nil, fmt.Errorf("vector: filter op %q requires a payloadKey/path field, got %q", mustOpName(f.Op), f.Field)
+		return nil, fmt.Errorf("vector: filter op %q requires a payloadKey/path field, got %s", mustOpName(f.Op), clipField(f.Field))
 	}
 	p, err := record.ParsePath(pathStr)
 	if err != nil {
-		return nil, fmt.Errorf("vector: filter op %q has an invalid record path %q: %w", mustOpName(f.Op), pathStr, err)
+		return nil, fmt.Errorf("vector: filter op %q has an invalid record path %s: %w", mustOpName(f.Op), clipField(pathStr), err)
 	}
 	if len(p.Segs) != 2 || p.Segs[1].Kind != record.SegRow {
-		return nil, fmt.Errorf("vector: filter op %q requires a path naming exactly a table row (field/row), got %q", mustOpName(f.Op), pathStr)
+		return nil, fmt.Errorf("vector: filter op %q requires a path naming exactly a table row (field/row), got %s", mustOpName(f.Op), clipField(pathStr))
 	}
 	exists := f.Op == FilterRowExists
 	field := f.Field
@@ -920,6 +921,29 @@ func compileRowPresence(f Filter) (Predicate, error) {
 		}
 		return fres.Kind == record.Table
 	}, nil
+}
+
+// clipField renders a caller-supplied field or record path for an error
+// message: the whole thing when it is short, otherwise a 64-byte prefix and
+// the full length.
+//
+// The field string is attacker-controlled and bounded only by the route body
+// cap (httpapi's maxJSONBody, 32 MiB), so quoting it whole made REJECTING a
+// hostile filter allocate another copy of it — with %q, up to four bytes of
+// escapes per input byte — which is the cost the bound in record.ParsePath was
+// added to avoid. The length is what a caller actually needs to see when the
+// path is too long; the prefix is what they need when it is merely wrong, and
+// 64 bytes shows a real path in full (the grammar's own cap is 1024).
+//
+// This is compile-time only, once per filter leaf per request, so the cost of
+// the branch is irrelevant — but so is the cost of quoting the whole input,
+// which is exactly why there is no reason to pay it.
+func clipField(s string) string {
+	const maxShown = 64
+	if len(s) <= maxShown {
+		return strconv.Quote(s)
+	}
+	return fmt.Sprintf("%s… (%d bytes)", strconv.Quote(s[:maxShown]), len(s))
 }
 
 func mustOpName(op FilterOp) string {

--- a/vector/filter.go
+++ b/vector/filter.go
@@ -10,6 +10,8 @@ import (
 	"time"
 	"unicode"
 	"unicode/utf8"
+
+	"github.com/rostamlabs/rostam/sdk/record"
 )
 
 // Predicate is a compiled filter: given a vector's metadata (nil if the
@@ -68,7 +70,8 @@ func compileNode(f Filter) (Predicate, error) {
 	case FilterEq, FilterNe, FilterGt, FilterGte, FilterLt, FilterLte, FilterIn, FilterContains,
 		FilterMatch, FilterRegex, FilterIsEmpty, FilterIsNull,
 		FilterDtGt, FilterDtGte, FilterDtLt, FilterDtLte,
-		FilterGeoRadius, FilterGeoBox, FilterGeoPolygon:
+		FilterGeoRadius, FilterGeoBox, FilterGeoPolygon,
+		FilterRowExists, FilterRowAbsent:
 		return compileLeaf(f)
 	default:
 		return nil, fmt.Errorf("vector: unknown filter op %d", f.Op)
@@ -124,6 +127,8 @@ func compileLeaf(f Filter) (Predicate, error) {
 		return compileDatetime(field, f.Op, want)
 	case FilterGeoRadius, FilterGeoBox, FilterGeoPolygon:
 		return compileGeo(field, f.Op, f.Geo)
+	case FilterRowExists, FilterRowAbsent:
+		return compileRowPresence(f)
 	default:
 		return nil, fmt.Errorf("vector: compileLeaf called with non-leaf op %d", f.Op)
 	}
@@ -786,6 +791,65 @@ func validateLatLon(lat, lon float64) error {
 		return fmt.Errorf("longitude %v out of range [-180,180]", lon)
 	}
 	return nil
+}
+
+// compileRowPresence builds the FilterRowExists / FilterRowAbsent predicate.
+// f.Field must have the "payloadKey/path" shape (record.SplitField) with a
+// path naming exactly a table row (a field segment then a row segment, e.g.
+// "b/42") — that shape is validated ONCE here, at compile time, because it
+// depends only on the filter's field STRING, never on any point's data; the
+// parsed record.Path is cached in the closure so per-point work is Resolve
+// only, per the Task 5 parsing-cost ruling (contrast with lookupPath, which
+// re-parses per call because it is shared by every scalar leaf op and has no
+// dedicated per-op compile step).
+//
+// At each point, row_exists is true iff Resolve reports Kind == RowPresent.
+// Every "cannot apply" outcome — a missing payload key, a payload key that
+// is not a ValueRecord, or a Resolve error (e.g. the record's schema puts a
+// scalar where this filter expects a table) — already falls out of the
+// Kind != RowPresent check, so row_exists needs no separate branch for it.
+//
+// row_absent is DELIBERATELY NOT simply "not row_exists": it reports true
+// only when Resolve AFFIRMATIVELY finds the row missing from a REAL table on
+// this point (Kind == Absent) — never for a point that cannot even be asked
+// the question. Concretely, row_absent answers false (not true) when the
+// payload key is missing, holds something other than a ValueRecord, or
+// Resolve errors (e.g. this point's schema has a scalar, not a table, at
+// that field). The rationale: "the row is absent" presupposes there was a
+// table to search; a point with no such record, or no such table, is not in
+// a position to assert anything about a row inside one. This is the one
+// asymmetry in an otherwise-mirrored pair of ops, and it is why row_absent
+// cannot be compiled as `!rowExists(m)`.
+func compileRowPresence(f Filter) (Predicate, error) {
+	payloadKey, pathStr, ok := record.SplitField(f.Field)
+	if !ok {
+		return nil, fmt.Errorf("vector: filter op %q requires a payloadKey/path field, got %q", mustOpName(f.Op), f.Field)
+	}
+	p, err := record.ParsePath(pathStr)
+	if err != nil {
+		return nil, fmt.Errorf("vector: filter op %q has an invalid record path %q: %w", mustOpName(f.Op), pathStr, err)
+	}
+	if len(p.Segs) != 2 || p.Segs[1].Kind != record.SegRow {
+		return nil, fmt.Errorf("vector: filter op %q requires a path naming exactly a table row (field/row), got %q", mustOpName(f.Op), pathStr)
+	}
+	exists := f.Op == FilterRowExists
+	return func(m Metadata) bool {
+		if m == nil {
+			return false
+		}
+		rv, ok := m[payloadKey]
+		if !ok || rv.Kind != ValueRecord {
+			return false
+		}
+		res, rerr := recordResolver.Resolve(rv.Rec, p)
+		if rerr != nil {
+			return false
+		}
+		if exists {
+			return res.Kind == record.RowPresent
+		}
+		return res.Kind == record.Absent
+	}, nil
 }
 
 func mustOpName(op FilterOp) string {

--- a/vector/filter.go
+++ b/vector/filter.go
@@ -831,17 +831,21 @@ func validateLatLon(lat, lon float64) error {
 // point and cannot be hoisted.
 //
 // row_absent is DELIBERATELY NOT simply "not row_exists": it reports true
-// only when Resolve AFFIRMATIVELY finds the row missing from a REAL table on
-// this point (Kind == Absent) — never for a point that cannot even be asked
-// the question. Concretely, row_absent answers false (not true) when the
-// payload key is missing, holds something other than a ValueRecord, holds a
-// record whose shape has NO SUCH FIELD at all (an unknown field name, or an
-// out-of-range position), or when Resolve errors (e.g. this point's record
-// has a scalar, not a table, at that field). The rationale: "the row is
-// absent" presupposes there was a table to search; a point with no such
-// record, or no such table, is not in a position to assert anything about a
-// row inside one. This is the one asymmetry in an otherwise-mirrored pair of
-// ops, and it is why row_absent cannot be compiled as `!rowExists(m)`.
+// only when the row is PROVED missing from a REAL table on this point
+// (record.Resolver.RowAbsentProven) — never for a point that cannot even be
+// asked the question, and never on a record whose bytes could be hiding the
+// row. Concretely, row_absent answers false (not true) when the payload key
+// is missing, holds something other than a ValueRecord, holds a record whose
+// shape has NO SUCH FIELD at all (an unknown field name, or an out-of-range
+// position), when Resolve errors (e.g. this point's record has a scalar, not
+// a table, at that field), or when the table it names is malformed — rows out
+// of the ascending key order the format requires, which is the case a binary
+// search cannot distinguish from a genuinely missing row. The rationale: "the
+// row is absent" presupposes there was a table to search; a point with no such
+// record, no such table, or an unreadable one, is not in a position to assert
+// anything about a row inside it. This is the one asymmetry in an
+// otherwise-mirrored pair of ops, and it is why row_absent cannot be compiled
+// as `!rowExists(m)`.
 func compileRowPresence(f Filter) (Predicate, error) {
 	payloadKey, pathStr, ok := record.SplitField(f.Field)
 	if !ok {
@@ -856,11 +860,6 @@ func compileRowPresence(f Filter) (Predicate, error) {
 	}
 	exists := f.Op == FilterRowExists
 	field := f.Field
-	// The FIELD-ONLY prefix of the same path, cached beside it for row_absent's
-	// "is there a table here at all?" question — see the closure below. Sliced
-	// with a full slice expression so an append through either Path can never
-	// reach the other's backing array.
-	fieldPath := record.Path{Segs: p.Segs[:1:1]}
 	return func(m Metadata) bool {
 		if m == nil {
 			return false
@@ -888,38 +887,39 @@ func compileRowPresence(f Filter) (Predicate, error) {
 		if !ok || rv.Kind != ValueRecord {
 			return false
 		}
-		res, rerr := recordResolver.Resolve(rv.Rec, p)
-		if rerr != nil {
-			return false
-		}
 		if exists {
+			// Row PRESENCE is proof of itself: Resolve returns RowPresent only
+			// for a row whose stored key equals the one asked for, so the hot
+			// path stays one Resolve and no allocation.
+			res, rerr := recordResolver.Resolve(rv.Rec, p)
+			if rerr != nil {
+				return false
+			}
 			return res.Kind == record.RowPresent
 		}
-		if res.Kind != record.Absent {
-			return false
-		}
-		// Absent is ambiguous, and only for row_absent. resolveSchema answers
-		// Absent for a field NAME that is not in this record's schema (and for
-		// an out-of-range positional segment) BEFORE it ever looks for a row, so
-		// "session/zzz/42" on a record with no zzz field reached here as Absent
-		// and read as "the row is missing from the table". That contradicts the
-		// contract above, and it disagreed with the neighbouring case: a SCALAR
-		// at the field errors with ErrPath and correctly answers false, though
-		// both are "no table at that field".
+		// row_absent asserts something POSITIVE about a point, so it cannot rest
+		// on either of Resolve's two documented leniencies. RowAbsentProven
+		// carries both checks:
 		//
-		// Resolve the FIELD-ONLY prefix to disambiguate: Kind == Table means the
-		// field really is a table, so the earlier Absent was a genuinely missing
-		// row. This is a second Resolve, and there is no cheaper "is this field a
-		// table" question in the resolver — but it runs ONLY on the row_absent
-		// branch and ONLY for points that already resolved Absent, and it is the
-		// cheapest kind of Resolve there is: in schema mode a field with no
-		// further segment answers Table off the cached schema without reading the
-		// table's bytes at all.
-		fres, ferr := recordResolver.Resolve(rv.Rec, fieldPath)
-		if ferr != nil {
-			return false
-		}
-		return fres.Kind == record.Table
+		//   - the field must really resolve to a TABLE. resolveSchema answers
+		//     Absent for a field NAME that is not in this record's schema (and
+		//     for an out-of-range position) BEFORE it looks for a row, so
+		//     "session/zzz/42" on a record with no zzz field used to read as "the
+		//     row is missing from the table" — contradicting the contract above,
+		//     and disagreeing with the neighbouring case where a SCALAR at the
+		//     field errors with ErrPath and correctly answers false;
+		//   - the table's rows must actually be in the ascending key order the
+		//     format requires. Resolve's schema-mode row lookup is a binary
+		//     search, which cannot see disorder, so an out-of-order table answers
+		//     Absent for a row that IS stored — and record bytes are not
+		//     validated at ingest in this phase, so that record is storable.
+		//
+		// Both checks run ONLY here, only for points that already resolved
+		// Absent, and the walk is bounded by the row count Resolve bounded
+		// against the record's own length. An error (a malformed record) answers
+		// false, exactly like every other "cannot apply" outcome.
+		proven, perr := recordResolver.RowAbsentProven(rv.Rec, p)
+		return perr == nil && proven
 	}, nil
 }
 

--- a/vector/filter.go
+++ b/vector/filter.go
@@ -833,13 +833,14 @@ func validateLatLon(lat, lon float64) error {
 // only when Resolve AFFIRMATIVELY finds the row missing from a REAL table on
 // this point (Kind == Absent) — never for a point that cannot even be asked
 // the question. Concretely, row_absent answers false (not true) when the
-// payload key is missing, holds something other than a ValueRecord, or
-// Resolve errors (e.g. this point's schema has a scalar, not a table, at
-// that field). The rationale: "the row is absent" presupposes there was a
-// table to search; a point with no such record, or no such table, is not in
-// a position to assert anything about a row inside one. This is the one
-// asymmetry in an otherwise-mirrored pair of ops, and it is why row_absent
-// cannot be compiled as `!rowExists(m)`.
+// payload key is missing, holds something other than a ValueRecord, holds a
+// record whose shape has NO SUCH FIELD at all (an unknown field name, or an
+// out-of-range position), or when Resolve errors (e.g. this point's record
+// has a scalar, not a table, at that field). The rationale: "the row is
+// absent" presupposes there was a table to search; a point with no such
+// record, or no such table, is not in a position to assert anything about a
+// row inside one. This is the one asymmetry in an otherwise-mirrored pair of
+// ops, and it is why row_absent cannot be compiled as `!rowExists(m)`.
 func compileRowPresence(f Filter) (Predicate, error) {
 	payloadKey, pathStr, ok := record.SplitField(f.Field)
 	if !ok {
@@ -854,6 +855,11 @@ func compileRowPresence(f Filter) (Predicate, error) {
 	}
 	exists := f.Op == FilterRowExists
 	field := f.Field
+	// The FIELD-ONLY prefix of the same path, cached beside it for row_absent's
+	// "is there a table here at all?" question — see the closure below. Sliced
+	// with a full slice expression so an append through either Path can never
+	// reach the other's backing array.
+	fieldPath := record.Path{Segs: p.Segs[:1:1]}
 	return func(m Metadata) bool {
 		if m == nil {
 			return false
@@ -888,7 +894,31 @@ func compileRowPresence(f Filter) (Predicate, error) {
 		if exists {
 			return res.Kind == record.RowPresent
 		}
-		return res.Kind == record.Absent
+		if res.Kind != record.Absent {
+			return false
+		}
+		// Absent is ambiguous, and only for row_absent. resolveSchema answers
+		// Absent for a field NAME that is not in this record's schema (and for
+		// an out-of-range positional segment) BEFORE it ever looks for a row, so
+		// "session/zzz/42" on a record with no zzz field reached here as Absent
+		// and read as "the row is missing from the table". That contradicts the
+		// contract above, and it disagreed with the neighbouring case: a SCALAR
+		// at the field errors with ErrPath and correctly answers false, though
+		// both are "no table at that field".
+		//
+		// Resolve the FIELD-ONLY prefix to disambiguate: Kind == Table means the
+		// field really is a table, so the earlier Absent was a genuinely missing
+		// row. This is a second Resolve, and there is no cheaper "is this field a
+		// table" question in the resolver — but it runs ONLY on the row_absent
+		// branch and ONLY for points that already resolved Absent, and it is the
+		// cheapest kind of Resolve there is: in schema mode a field with no
+		// further segment answers Table off the cached schema without reading the
+		// table's bytes at all.
+		fres, ferr := recordResolver.Resolve(rv.Rec, fieldPath)
+		if ferr != nil {
+			return false
+		}
+		return fres.Kind == record.Table
 	}, nil
 }
 

--- a/vector/filter_bitset.go
+++ b/vector/filter_bitset.go
@@ -469,13 +469,13 @@ func (h *hnsw) gateProfitable(minSize, nsets, k int) bool {
 func filterIndexExact(f Filter) bool {
 	switch f.Op {
 	case FilterEq, FilterContains:
-		if f.Field == contentField || isRecordPath(f.Field) {
+		if !indexNarrowable(f.Field, f.Op) {
 			return false
 		}
 		_, ok := scalarKeyOf(f.Value)
 		return ok
 	case FilterIn:
-		if f.Field == contentField || isRecordPath(f.Field) {
+		if !indexNarrowable(f.Field, f.Op) {
 			return false
 		}
 		switch f.Value.Kind {
@@ -487,7 +487,7 @@ func filterIndexExact(f Filter) bool {
 			return false
 		}
 	case FilterGt, FilterGte, FilterLt, FilterLte:
-		if f.Field == contentField || isRecordPath(f.Field) {
+		if !indexNarrowable(f.Field, f.Op) {
 			return false
 		}
 		// Mirror orderingSet's own kind test: a want that can drive neither the
@@ -501,7 +501,7 @@ func filterIndexExact(f Filter) bool {
 		}
 		return f.Value.Kind == ValueString
 	case FilterDtGt, FilterDtGte, FilterDtLt, FilterDtLte:
-		if f.Field == contentField || isRecordPath(f.Field) {
+		if !indexNarrowable(f.Field, f.Op) {
 			return false
 		}
 		// datetimeBound is the SHARED lowering (compileDatetime calls it too), so

--- a/vector/filter_bitset.go
+++ b/vector/filter_bitset.go
@@ -443,10 +443,14 @@ func (h *hnsw) gateProfitable(minSize, nsets, k int) bool {
 //     cannot appear in an exact plan; an And containing one is a superset plan
 //     (the un-narrowed conjunct is re-checked by the predicate).
 //
-// contentField is declined here too, but it is no longer THIS function's
-// problem and the checks below are now defence in depth: indexNarrowable
-// declines $content at every posting-set lookup, so no $content set reaches a
-// plan at all.
+// contentField and every record path (isRecordPath) are declined here too,
+// but neither is really THIS function's problem any more: indexNarrowable
+// declines both at every posting-set lookup upstream (collectEqTerms and
+// friends), so neither ever reaches a plan for these checks to grade. They
+// stay as defence in depth — this function derives its own answer per op
+// straight from f.Field, not from what collectNarrowSets happened to plan,
+// so it must independently agree with indexNarrowable rather than trust that
+// whatever reached it was already filtered.
 //
 // The original note here read "only the EXACT classification could turn that
 // into wrong results — a superset plan re-checks, and an empty gate just rejects
@@ -465,13 +469,13 @@ func (h *hnsw) gateProfitable(minSize, nsets, k int) bool {
 func filterIndexExact(f Filter) bool {
 	switch f.Op {
 	case FilterEq, FilterContains:
-		if f.Field == contentField {
+		if f.Field == contentField || isRecordPath(f.Field) {
 			return false
 		}
 		_, ok := scalarKeyOf(f.Value)
 		return ok
 	case FilterIn:
-		if f.Field == contentField {
+		if f.Field == contentField || isRecordPath(f.Field) {
 			return false
 		}
 		switch f.Value.Kind {
@@ -483,7 +487,7 @@ func filterIndexExact(f Filter) bool {
 			return false
 		}
 	case FilterGt, FilterGte, FilterLt, FilterLte:
-		if f.Field == contentField {
+		if f.Field == contentField || isRecordPath(f.Field) {
 			return false
 		}
 		// Mirror orderingSet's own kind test: a want that can drive neither the
@@ -497,7 +501,7 @@ func filterIndexExact(f Filter) bool {
 		}
 		return f.Value.Kind == ValueString
 	case FilterDtGt, FilterDtGte, FilterDtLt, FilterDtLte:
-		if f.Field == contentField {
+		if f.Field == contentField || isRecordPath(f.Field) {
 			return false
 		}
 		// datetimeBound is the SHARED lowering (compileDatetime calls it too), so

--- a/vector/filter_bitset.go
+++ b/vector/filter_bitset.go
@@ -478,6 +478,8 @@ func filterIndexExact(f Filter) bool {
 		case ValueStrings, ValueInts, ValueFloats:
 			return true
 		default:
+			// ValueRecord considered: falls here, correctly declining — a record
+			// is not an array, so FilterIn's index-exactness claim doesn't apply.
 			return false
 		}
 	case FilterGt, FilterGte, FilterLt, FilterLte:

--- a/vector/filter_bitset.go
+++ b/vector/filter_bitset.go
@@ -443,13 +443,15 @@ func (h *hnsw) gateProfitable(minSize, nsets, k int) bool {
 //     cannot appear in an exact plan; an And containing one is a superset plan
 //     (the un-narrowed conjunct is re-checked by the predicate).
 //
-// contentField and every record path (isRecordPath) are declined here too,
-// but neither is really THIS function's problem any more: indexNarrowable
-// declines both at every posting-set lookup upstream (collectEqTerms and
-// friends), so neither ever reaches a plan for these checks to grade. They
-// stay as defence in depth — this function derives its own answer per op
-// straight from f.Field, not from what collectNarrowSets happened to plan,
-// so it must independently agree with indexNarrowable rather than trust that
+// contentField and the record paths the index cannot prove anything about are
+// declined here too, through the SAME indexNarrowable the posting-set lookups
+// use (which is why this function needs the index's malformed-record state:
+// a path under a poisoned payload key must never be graded exact, because the
+// damaged record still resolves fields that were never posted). Upstream
+// already declines them at every collect* helper, so none of them normally
+// reaches a plan for these checks to grade — but this function derives its own
+// answer per op straight from f.Field rather than from what collectNarrowSets
+// happened to plan, so it must independently agree rather than trust that
 // whatever reached it was already filtered.
 //
 // The original note here read "only the EXACT classification could turn that
@@ -466,16 +468,16 @@ func (h *hnsw) gateProfitable(minSize, nsets, k int) bool {
 // slot, which would let an exact gate admit a slot the predicate rejects. The
 // caller gates exactness on the arena's per-key-deadline count being zero
 // (buildAdmitGate); this function is about op semantics only.
-func filterIndexExact(f Filter) bool {
+func filterIndexExact(f Filter, poison recordPoison) bool {
 	switch f.Op {
 	case FilterEq, FilterContains:
-		if !indexNarrowable(f.Field, f.Op) {
+		if !indexNarrowable(f.Field, f.Op, poison) {
 			return false
 		}
 		_, ok := scalarKeyOf(f.Value)
 		return ok
 	case FilterIn:
-		if !indexNarrowable(f.Field, f.Op) {
+		if !indexNarrowable(f.Field, f.Op, poison) {
 			return false
 		}
 		switch f.Value.Kind {
@@ -487,7 +489,7 @@ func filterIndexExact(f Filter) bool {
 			return false
 		}
 	case FilterGt, FilterGte, FilterLt, FilterLte:
-		if !indexNarrowable(f.Field, f.Op) {
+		if !indexNarrowable(f.Field, f.Op, poison) {
 			return false
 		}
 		// Mirror orderingSet's own kind test: a want that can drive neither the
@@ -501,7 +503,7 @@ func filterIndexExact(f Filter) bool {
 		}
 		return f.Value.Kind == ValueString
 	case FilterDtGt, FilterDtGte, FilterDtLt, FilterDtLte:
-		if !indexNarrowable(f.Field, f.Op) {
+		if !indexNarrowable(f.Field, f.Op, poison) {
 			return false
 		}
 		// datetimeBound is the SHARED lowering (compileDatetime calls it too), so
@@ -514,7 +516,7 @@ func filterIndexExact(f Filter) bool {
 			return false // an empty And matches everything; the index narrows nothing
 		}
 		for i := range f.And {
-			if !filterIndexExact(f.And[i]) {
+			if !filterIndexExact(f.And[i], poison) {
 				return false
 			}
 		}
@@ -657,7 +659,7 @@ func (h *hnsw) buildAdmitGate(s *layerScratch, f Filter, plan []narrowSet, k int
 	// re-checks the predicate.
 	exact := exactPlan &&
 		len(kept) == filterLeafCount(f) &&
-		filterIndexExact(f) &&
+		filterIndexExact(f, h.payloadIdx.badRecords) &&
 		h.arena.KeyDeadlineSlots() == 0
 	s.gate.build(kept, h.arena.Capacity(), exact || admitGateForceExact)
 	h.filterGates.Add(1)

--- a/vector/filter_bitset_test.go
+++ b/vector/filter_bitset_test.go
@@ -876,7 +876,7 @@ func TestAdmitGateExactClassification(t *testing.T) {
 		{"not", Filter{Op: FilterNot, Not: &Filter{Op: FilterEq, Field: "a", Value: NewString("x")}}, false},
 	}
 	for _, tc := range cases {
-		if got := filterIndexExact(tc.f); got != tc.want {
+		if got := filterIndexExact(tc.f, nil); got != tc.want {
 			t.Errorf("filterIndexExact(%s) = %v, want %v", tc.name, got, tc.want)
 		}
 	}
@@ -897,7 +897,7 @@ func TestAdmitGateSkippedConjunctIsNotExact(t *testing.T) {
 		{Op: FilterEq, Field: "color", Value: NewString("red")},
 		{Op: FilterIn, Field: "size", Value: NewInts([]int64{1, 2, 3})},
 	}}
-	if !filterIndexExact(f) {
+	if !filterIndexExact(f, nil) {
 		t.Fatal("precondition: both conjunct ops should be classified EXACT by op")
 	}
 	armed, exact := gateExactFor(t, h, f)

--- a/vector/group.go
+++ b/vector/group.go
@@ -276,6 +276,8 @@ func groupKeyString(v Value) (string, bool) {
 	}
 	// ValueGeo (and list/none kinds) cannot serve as a group-by key: a lat/lon
 	// point is a 2-D value with no meaningful single-string bucket identity, so
-	// it declines here (ok=false) and the row is simply not grouped.
+	// it declines here (ok=false) and the row is simply not grouped. ValueRecord
+	// declines for the same reason: a record is a byte blob, not a single scalar
+	// bucket identity.
 	return "", false
 }

--- a/vector/hnsw.go
+++ b/vector/hnsw.go
@@ -2014,6 +2014,9 @@ func (h *hnsw) RestoreInsertAt(id uint64, vec []float32, ttl time.Duration, meta
 }
 
 func (h *hnsw) restoreInsertBody(id uint64, vec []float32, ttl time.Duration, meta Metadata, sparse *SparseVector, keyExpires map[string]uint64, version uint64, stamped bool, nowMs uint64) error {
+	if err := checkRecordValues(meta); err != nil {
+		return err
+	}
 	if len(vec) != h.cfg.Dim {
 		return ErrDimMismatch
 	}
@@ -3076,6 +3079,9 @@ func (h *hnsw) clearPayloadBody(id uint64, cas CASCond, stamped bool, nowMs uint
 // section. Returns ErrIDNotFound for a dead/absent point. Both maps are stored by
 // reference (caller hands off ownership); nil clears the respective state.
 func (h *hnsw) RestorePayload(id uint64, meta Metadata, keyExpires map[string]uint64, version uint64) error {
+	if err := checkRecordValues(meta); err != nil {
+		return err
+	}
 	h.mu.Lock()
 	defer h.mu.Unlock()
 	slot, ok := h.arena.Slot(id)

--- a/vector/hnsw.go
+++ b/vector/hnsw.go
@@ -1902,6 +1902,9 @@ func (h *hnsw) InsertAt(id uint64, vec []float32, ttl time.Duration, meta Metada
 // one-snapshot rule and byte-identical to the historical multi-read path under a
 // stable clock.
 func (h *hnsw) insertBody(id uint64, vec []float32, ttl time.Duration, meta Metadata, sparse *SparseVector, keyTTLMs map[string]int64, cas CASCond, stamped bool, nowMs uint64) (uint64, map[string]uint64, error) {
+	if err := checkRecordValues(meta); err != nil {
+		return 0, nil, err
+	}
 	// A failed mmap slab growth freed the backing region; reject rather than
 	// write into it (see arena.poisoned / ErrIndexPoisoned).
 	if h.arena.poisoned.Load() {
@@ -2869,6 +2872,9 @@ func (h *hnsw) SetPayloadAt(id uint64, patch Metadata, keyTTLMs map[string]int64
 }
 
 func (h *hnsw) setPayloadBody(id uint64, patch Metadata, keyTTLMs map[string]int64, cas CASCond, stamped bool, nowMs uint64) (Metadata, map[string]uint64, uint64, error) {
+	if err := checkRecordValues(patch); err != nil {
+		return nil, nil, 0, err
+	}
 	h.mu.Lock()
 	defer h.mu.Unlock()
 	now := nowMs
@@ -2936,6 +2942,9 @@ func (h *hnsw) OverwritePayloadAt(id uint64, meta Metadata, keyTTLMs map[string]
 }
 
 func (h *hnsw) overwritePayloadBody(id uint64, meta Metadata, keyTTLMs map[string]int64, cas CASCond, stamped bool, nowMs uint64) (Metadata, map[string]uint64, uint64, error) {
+	if err := checkRecordValues(meta); err != nil {
+		return nil, nil, 0, err
+	}
 	h.mu.Lock()
 	defer h.mu.Unlock()
 	now := nowMs
@@ -3159,6 +3168,9 @@ func (h *hnsw) InsertIfAbsentVersionAt(id uint64, vec []float32, ttl time.Durati
 }
 
 func (h *hnsw) insertIfAbsentBody(id uint64, vec []float32, ttl time.Duration, meta Metadata, sparse *SparseVector, keyExpires map[string]uint64, version uint64, stamped bool, nowMs uint64) (inserted bool, err error) {
+	if err := checkRecordValues(meta); err != nil {
+		return false, err
+	}
 	start := time.Now()
 	defer func() { h.insertLat.observe(time.Since(start)) }()
 

--- a/vector/hnsw.go
+++ b/vector/hnsw.go
@@ -2522,11 +2522,16 @@ func (h *hnsw) linkRead(t *linkTask) {
 	h.linkNode(s, t.nd, t.stored, t.level, t.now)
 }
 
-// Get retrieves the live record for id: a DEEP COPY of its vector, metadata, and
+// Get retrieves the live record for id: a copy of its vector, metadata map, and
 // sparse vector, plus the remaining TTL. ok is false when id is absent,
 // tombstoned (deleted), or TTL-expired — the exact liveness gate the search path
-// uses (mirror admits). The returned vec/meta/sparse are owned by the caller
-// (mutating them never corrupts the arena). For a cosine-metric index the stored
+// uses (mirror admits). The returned vec/sparse are owned by the caller, and so
+// is the meta MAP — inserting or deleting keys in it never reaches the arena.
+// The Values inside it are copied as structs, so a slice-backed one
+// (strings/ints/floats/record) still points at the arena's own bytes: read it,
+// never write through it. That is vtypes.Metadata's documented slice-ownership
+// contract, identical for all four kinds; a caller that needs to own the bytes
+// copies them, and every network client already gets a codec-written copy. For a cosine-metric index the stored
 // (and therefore returned) vector is the NORMALIZED vector, not the original
 // caller-supplied one — Insert normalizes on the way in. ttl is the remaining
 // duration to the deadline (0 = no expiry).
@@ -2682,10 +2687,17 @@ func keyExpired(deadline, now uint64) bool {
 	return deadline != 0 && deadline <= now
 }
 
-// cloneMeta returns a deep copy of m, or nil when m is empty. Callers that read
-// m from arena.Metadata(slot) MUST hold h.mu (read or write) while doing so; the
-// copy then lets the four payload mutators build newMeta without aliasing arena
-// storage.
+// cloneMeta returns a MAP-level copy of m, or nil when m is empty: a fresh map
+// holding the same Values, so adding, replacing or deleting a key in the copy
+// never touches the arena's map. The Values themselves are copied as structs,
+// which means a slice-backed Value (strings/ints/floats/record) still points at
+// the same backing bytes — the payload mutators only ever replace whole Values,
+// never write through one, and vtypes.Metadata documents that contract for
+// callers too.
+//
+// Callers that read m from arena.Metadata(slot) MUST hold h.mu (read or write)
+// while doing so; the copy then lets the four payload mutators build newMeta
+// without aliasing the arena's MAP.
 func cloneMeta(m Metadata) Metadata {
 	if len(m) == 0 {
 		return nil

--- a/vector/ivf.go
+++ b/vector/ivf.go
@@ -496,6 +496,9 @@ func (ix *ivf) InsertAt(id uint64, vec []float32, ttl time.Duration, meta Metada
 }
 
 func (ix *ivf) insertBody(id uint64, vec []float32, ttl time.Duration, meta Metadata, sparse *SparseVector, keyTTLMs map[string]int64, cas CASCond, stamped bool, nowMs uint64) (uint64, map[string]uint64, error) {
+	if err := checkRecordValues(meta); err != nil {
+		return 0, nil, err
+	}
 	start := time.Now()
 	defer func() { ix.insertLat.observe(time.Since(start)) }()
 
@@ -1192,6 +1195,9 @@ func (ix *ivf) InsertIfAbsentVersionAt(id uint64, vec []float32, ttl time.Durati
 }
 
 func (ix *ivf) insertIfAbsentBody(id uint64, vec []float32, ttl time.Duration, meta Metadata, sparse *SparseVector, keyExpires map[string]uint64, version uint64, stamped bool, nowMs uint64) (bool, error) {
+	if err := checkRecordValues(meta); err != nil {
+		return false, err
+	}
 	start := time.Now()
 	defer func() { ix.insertLat.observe(time.Since(start)) }()
 
@@ -1287,6 +1293,9 @@ func (ix *ivf) BuildConcurrent(ids []uint64, vecs [][]float32, workers int) erro
 // so a payload's postings are the arena's stored metadata and the payload index,
 // and nothing else.
 func (ix *ivf) BuildConcurrentMeta(ids []uint64, vecs [][]float32, metas []Metadata, workers int) error {
+	if err := checkRecordValuesAll(metas); err != nil {
+		return err
+	}
 	if len(metas) != 0 && len(metas) != len(ids) {
 		return ErrBuildMetaLenMismatch
 	}
@@ -3549,6 +3558,9 @@ func (ix *ivf) SetPayloadAt(id uint64, patch Metadata, keyTTLMs map[string]int64
 }
 
 func (ix *ivf) setPayloadBody(id uint64, patch Metadata, keyTTLMs map[string]int64, cas CASCond, stamped bool, nowMs uint64) (Metadata, map[string]uint64, uint64, error) {
+	if err := checkRecordValues(patch); err != nil {
+		return nil, nil, 0, err
+	}
 	ix.mu.Lock()
 	defer ix.mu.Unlock()
 	now := nowMs
@@ -3607,6 +3619,9 @@ func (ix *ivf) OverwritePayloadAt(id uint64, meta Metadata, keyTTLMs map[string]
 }
 
 func (ix *ivf) overwritePayloadBody(id uint64, meta Metadata, keyTTLMs map[string]int64, cas CASCond, stamped bool, nowMs uint64) (Metadata, map[string]uint64, uint64, error) {
+	if err := checkRecordValues(meta); err != nil {
+		return nil, nil, 0, err
+	}
 	ix.mu.Lock()
 	defer ix.mu.Unlock()
 	now := nowMs

--- a/vector/ivf.go
+++ b/vector/ivf.go
@@ -547,6 +547,9 @@ func (ix *ivf) RestoreInsertAt(id uint64, vec []float32, ttl time.Duration, meta
 }
 
 func (ix *ivf) restoreInsertBody(id uint64, vec []float32, ttl time.Duration, meta Metadata, sparse *SparseVector, keyExpires map[string]uint64, version uint64, stamped bool, nowMs uint64) error {
+	if err := checkRecordValues(meta); err != nil {
+		return err
+	}
 	if len(vec) != ix.cfg.Dim {
 		return ErrDimMismatch
 	}
@@ -3730,6 +3733,9 @@ func (ix *ivf) clearPayloadBody(id uint64, cas CASCond, stamped bool, nowMs uint
 }
 
 func (ix *ivf) RestorePayload(id uint64, meta Metadata, keyExpires map[string]uint64, version uint64) error {
+	if err := checkRecordValues(meta); err != nil {
+		return err
+	}
 	ix.mu.Lock()
 	defer ix.mu.Unlock()
 	slot, ok := ix.arena.Slot(id)

--- a/vector/metadata.go
+++ b/vector/metadata.go
@@ -39,6 +39,8 @@ func numericValue(v Value) (float64, bool) {
 	case ValueFloat:
 		return v.Flt, true
 	default:
+		// ValueRecord considered: falls here, correctly declining — a record is
+		// not a scalar number.
 		return 0, false
 	}
 }

--- a/vector/metadata.go
+++ b/vector/metadata.go
@@ -2,31 +2,71 @@
 
 package vector
 
+import "github.com/rostamlabs/rostam/sdk/record"
+
 // The Value tagged union, its ValueKind enumeration, the Metadata map, the
 // Value constructors, and the ValueKind text (un)marshaling now live in the
 // engine-free vtypes leaf package and are re-exported via vtypes_aliases.go.
 // The two helpers below stay here because they are used only by the filter
 // compiler in this package, not by the wire codec or client.
 
-// lookupPath resolves a (possibly dotted) field name against metadata. It
-// always tries the EXACT key first, so a flattened dotted key (e.g. the flat
-// entry {"address.city": ...}) matches and non-dotted keys behave exactly as a
-// raw map lookup — fully backward-compatible. The dotted-path traversal of
-// nested ValueObject maps is a documented follow-up: today Metadata is flat
-// (no ValueObject kind), so the practical effect is exact-key lookup. Keeping
-// the indirection here lets the future nested traversal slot in without
-// touching every leaf op.
+// recordResolver is the package-level record.Resolver shared by every filter
+// evaluation and (from Task 6) indexing pass. 1024 rather than a smaller
+// number: on clear-when-full the cache falls back to a full schema decode,
+// and a single collection can carry many schema versions over its lifetime
+// (every operate schema change adds one), so a small bound would thrash.
+// Resolver is safe for concurrent use (its own doc comment), so one instance
+// is shared across every query goroutine.
+var recordResolver = record.NewResolver(1024)
+
+// lookupPath resolves a (possibly dotted, possibly record-path) field name
+// against metadata. It always tries the EXACT key first, so a flattened
+// dotted key (e.g. the flat entry {"address.city": ...}) matches and
+// non-dotted keys behave exactly as a raw map lookup — fully
+// backward-compatible. A payload key literally named "a/b" therefore always
+// wins over treating "a/b" as "payload key a, record path b".
+//
+// Only when there is no exact match does it try record.SplitField: if field
+// splits into payloadKey/path and m[payloadKey] holds a ValueRecord, the path
+// is parsed and resolved against that record's bytes via the shared
+// recordResolver, and a Scalar/Count result is converted to a Value.
+//
+// Every other outcome — no '/' in field, no exact match and payloadKey holds
+// something other than a ValueRecord, a path that fails to parse, or a
+// Resolve that returns ErrPath/ErrRecord or a Table/RowPresent/Absent result
+// (none of which is a scalar a filter can compare) — reports (Value{},
+// false). This is deliberate even for a malformed path: the filter is
+// compiled ONCE for the whole predicate tree, but the record named by
+// payloadKey varies per point, so a path that is well-formed syntax but
+// cannot apply to THIS point's record must degrade to "field absent" rather
+// than fail the whole search. compileRowPresence is the one place a record
+// path is inspected for something other than a scalar value (row presence).
 func lookupPath(m Metadata, field string) (Value, bool) {
 	if m == nil {
 		return Value{}, false
 	}
-	// Exact key wins (covers flattened dotted keys and all plain keys).
+	// Exact key wins (covers flattened dotted keys, record-path-shaped keys,
+	// and all plain keys).
 	if v, ok := m[field]; ok {
 		return v, true
 	}
-	// Future: when ValueObject exists, split on '.' and traverse nested maps
-	// here. No such kind today, so a non-exact dotted key simply misses.
-	return Value{}, false
+	payloadKey, path, ok := record.SplitField(field)
+	if !ok {
+		return Value{}, false
+	}
+	rv, ok := m[payloadKey]
+	if !ok || rv.Kind != ValueRecord {
+		return Value{}, false
+	}
+	p, err := record.ParsePath(path)
+	if err != nil {
+		return Value{}, false
+	}
+	res, err := recordResolver.Resolve(rv.Rec, p)
+	if err != nil {
+		return Value{}, false
+	}
+	return record.ResultValue(res)
 }
 
 // numericValue extracts a float64 from a scalar numeric Value (int or float).

--- a/vector/metadata.go
+++ b/vector/metadata.go
@@ -46,6 +46,16 @@ var recordResolver = record.NewResolver(1024)
 // cannot apply to THIS point's record must degrade to "field absent" rather
 // than fail the whole search. compileRowPresence is the one place a record
 // path is inspected for something other than a scalar value (row presence).
+//
+// IT PARSES PER CALL, AND THAT IS ONLY CORRECT FOR ITS REMAINING CALLERS. This
+// is the BARE-STRING entry: it is handed a field string with no compile step
+// behind it (order_by key extraction, the payload index's reindex resolve), so
+// it has nowhere to cache the parse. The filter leaves do NOT come through here
+// any more — compileLeaf and its sub-compilers build a fieldLookup once, at
+// compile time, and compileRowPresence caches its own record.Path the same way —
+// because on the scan hot path this parse would otherwise repeat per point for
+// an answer that is constant across the whole scan. Any NEW per-point caller
+// should compile a fieldLookup instead of calling this.
 func lookupPath(m Metadata, field string) (Value, bool) {
 	if m == nil {
 		return Value{}, false
@@ -68,6 +78,76 @@ func lookupPath(m Metadata, field string) (Value, bool) {
 		return Value{}, false
 	}
 	res, err := recordResolver.Resolve(rv.Rec, p)
+	if err != nil {
+		return Value{}, false
+	}
+	return record.ResultValue(res)
+}
+
+// fieldLookup is lookupPath with the record path parsed ONCE — at filter-COMPILE
+// time — instead of once per point. It exists because the two costs are not the
+// same cost: SplitField+ParsePath depends only on the filter's field STRING,
+// which is fixed for the whole scan, while only the Resolve depends on the
+// point. Calling lookupPath per point therefore re-derived a constant on every
+// row (strings.Split + a Segment slice per call), which is what made an ordinary
+// numeric record-path leaf allocate per point on the scan hot path.
+//
+// It is deliberately NOT a replacement for lookupPath: lookupPath stays the
+// bare-string entry for callers that have no compile step of their own (order_by
+// key extraction, the reindex resolve), and the two MUST agree exactly. They do,
+// by construction: every rejection lookupPath expresses by returning false — no
+// '/' in the field, a path that does not parse, a payload key that holds
+// something other than a ValueRecord, a Resolve error, a non-scalar result — is
+// reproduced here, with the first two hoisted to newFieldLookup (a field that
+// fails them can only ever be an exact-key match, for every point).
+type fieldLookup struct {
+	// field is the whole field string, always tried as an EXACT payload key
+	// first — so a payload key literally named "a/b" keeps winning over
+	// treating "a/b" as a record path, exactly as in lookupPath.
+	field string
+	// payloadKey and path are set only when field is path-shaped AND its path
+	// parses; isPath records that. When it is false the lookup is an exact-key
+	// lookup and nothing else.
+	payloadKey string
+	path       record.Path
+	isPath     bool
+}
+
+// newFieldLookup compiles field once. It never fails: a field that is not
+// path-shaped, or whose path is malformed, degrades to the exact-key lookup —
+// the same outcome lookupPath produces for it on every point.
+func newFieldLookup(field string) fieldLookup {
+	fl := fieldLookup{field: field}
+	payloadKey, pathStr, ok := record.SplitField(field)
+	if !ok {
+		return fl
+	}
+	p, err := record.ParsePath(pathStr)
+	if err != nil {
+		return fl
+	}
+	fl.payloadKey, fl.path, fl.isPath = payloadKey, p, true
+	return fl
+}
+
+// get is the per-point half: an exact-key lookup, then (only for a compiled
+// record path) one Resolve against this point's record bytes. Allocation-free
+// for a scalar result once the resolver's schema cache is warm.
+func (fl fieldLookup) get(m Metadata) (Value, bool) {
+	if m == nil {
+		return Value{}, false
+	}
+	if v, ok := m[fl.field]; ok {
+		return v, true
+	}
+	if !fl.isPath {
+		return Value{}, false
+	}
+	rv, ok := m[fl.payloadKey]
+	if !ok || rv.Kind != ValueRecord {
+		return Value{}, false
+	}
+	res, err := recordResolver.Resolve(rv.Rec, fl.path)
 	if err != nil {
 		return Value{}, false
 	}

--- a/vector/metadata.go
+++ b/vector/metadata.go
@@ -78,13 +78,14 @@ func lookupPath(m Metadata, field string) (Value, bool) {
 // This is intentionally syntactic only: it does not (and cannot) know
 // whether some point's metadata happens to carry field as an EXACT literal
 // key (lookupPath's exact-key precedence would still honor that at
-// evaluation time). Callers of isRecordPath — indexNarrowable and
-// filterIndexExact — use it to decide whether the payload INDEX can prove
-// anything about the field across every point, not to decide what one
-// point's predicate evaluates to; declining a field the index cannot prove
-// is always sound (the predicate re-checks it), so treating a
-// path-shaped-but-possibly-literal field as "not narrowable" costs nothing
-// but a slower fallback, never a wrong answer.
+// evaluation time). Its sole caller, indexNarrowable, uses it to route: a
+// field that is not a record path is a plain literal key the index handles
+// as it always has, and a field that IS one goes on to recordPathIndexed,
+// which decides per shape and per op whether postings exist to prove
+// anything from. Declining is always sound (the predicate re-checks), so
+// both a path-shaped-but-possibly-literal field and a genuinely literal
+// path-shaped key are safe either way: the literal case indexes and resolves
+// through the SAME field name on both sides.
 func isRecordPath(field string) bool {
 	_, path, ok := record.SplitField(field)
 	if !ok {
@@ -92,6 +93,86 @@ func isRecordPath(field string) bool {
 	}
 	_, err := record.ParsePath(path)
 	return err == nil
+}
+
+// recordPathIndexedShape reports whether field names a record location the
+// payload index POSTS a synthetic entry for. It is the single definition of
+// "indexed shape", used on BOTH sides — reindex asks it what to write, and
+// recordPathIndexed asks it what the planner may read — so the two can never
+// drift into the one disagreement that matters: a shape the planner trusts
+// but nothing ever posted, whose empty posting map would read as "nothing
+// matches" instead of "never indexed".
+//
+// The indexed shapes are exactly the ones record.Resolver.IndexEntries
+// enumerates: a single top-level field segment named BY NAME ("session/rc"),
+// optionally with the "#count" suffix naming a table's row count
+// ("session/b#count").
+//
+// A POSITION ("session/#0") is deliberately NOT an indexed shape, and it is
+// the one place this set is narrower than the Task 6 addendum's list. Resolve
+// answers a positional segment for EVERY schema-mode record, but IndexEntries
+// names a names-carrying schema's fields by NAME and only a names-LESS
+// schema's by position (schemaFieldLabel). So for the common record —
+// StoreNames = true — "session/#0" resolves to a value while no posting for it
+// exists, which is exactly the under-report that turns into dropped rows. The
+// index cannot tell from the field string which spelling a given point's
+// record will produce, so the positional spelling stays on the predicate.
+//
+// Everything longer (a row "session/b/42", a cell "session/b/42/hi") is not
+// indexed either: this phase never expands table contents.
+func recordPathIndexedShape(field string) bool {
+	_, path, ok := record.SplitField(field)
+	if !ok {
+		return false
+	}
+	p, err := record.ParsePath(path)
+	if err != nil || len(p.Segs) != 1 {
+		return false
+	}
+	seg := p.Segs[0]
+	if seg.ByPos {
+		return false
+	}
+	return seg.Kind == record.SegField || seg.Kind == record.SegCount
+}
+
+// recordPathIndexed reports whether the payload index can prove anything about
+// a RECORD PATH field under op — i.e. whether the postings for field are
+// EXACTLY the slots whose lookupPath(field) value satisfies op.
+//
+// It has two halves, and both are necessary:
+//
+// SHAPE: recordPathIndexedShape above — only the shapes reindex actually
+// posts. For any other shape the posting map is empty because nothing ever
+// wrote to it, not because nothing matches, which is the same asymmetry that
+// makes contentField un-narrowable.
+//
+// OP: only the ops whose posting set is exact for an indexed shape — equality,
+// In, the ordering family, and the FilterDt* spellings that lower to it. A
+// record's scalars are posted as whole-value eq keys ONLY: no tokens, no
+// contains-element entries, no geo cells. So contains / match / regex, and the
+// shape-only predicates is_empty / is_null / row_exists / row_absent, have no
+// postings of their own and must stay on the predicate. (ne is narrowed by
+// nothing, for any field anywhere, so it needs no case of its own — it simply
+// falls into the default with the rest.)
+//
+// Callers pass a field that may or may not be a record path at all; a field
+// that is not one is not this function's business, which is why
+// indexNarrowable asks isRecordPath first.
+func recordPathIndexed(field string, op FilterOp) bool {
+	if !recordPathIndexedShape(field) {
+		return false
+	}
+	switch op {
+	case FilterEq, FilterIn,
+		FilterGt, FilterGte, FilterLt, FilterLte,
+		FilterDtGt, FilterDtGte, FilterDtLt, FilterDtLte:
+		return true
+	default:
+		// FilterNe, FilterContains, FilterMatch, FilterRegex, FilterIsEmpty,
+		// FilterIsNull, FilterRowExists, FilterRowAbsent, the geo family.
+		return false
+	}
 }
 
 // numericValue extracts a float64 from a scalar numeric Value (int or float).

--- a/vector/metadata.go
+++ b/vector/metadata.go
@@ -178,8 +178,13 @@ var ErrRecordTooLarge = errors.New("vector: record payload value exceeds the sto
 func checkRecordValues(m Metadata) error {
 	for k, v := range m {
 		if v.Kind == ValueRecord && len(v.Rec) > maxRecordValueBytes {
-			return fmt.Errorf("%w: payload key %q holds a %d-byte record, the cap is %d bytes",
-				ErrRecordTooLarge, k, len(v.Rec), maxRecordValueBytes)
+			// The key goes through clipField, not %q: it is caller-supplied and
+			// bounded only by the route body cap, and this message is now
+			// returned VERBATIM to the caller on every transport (it is a
+			// client error, classified 400 / InvalidArgument) and carried across
+			// replication as a string. A short key renders exactly as %q did.
+			return fmt.Errorf("%w: payload key %s holds a %d-byte record, the cap is %d bytes",
+				ErrRecordTooLarge, clipField(k), len(v.Rec), maxRecordValueBytes)
 		}
 	}
 	return nil

--- a/vector/metadata.go
+++ b/vector/metadata.go
@@ -5,6 +5,7 @@ package vector
 import (
 	"errors"
 	"fmt"
+	"strings"
 
 	"github.com/rostamlabs/rostam/sdk/record"
 )
@@ -199,6 +200,119 @@ func checkRecordValuesAll(metas []Metadata) error {
 		}
 	}
 	return nil
+}
+
+// IsRecordTooLargeMessage reports whether s is the EXACT serialised form of an
+// ErrRecordTooLarge error produced by checkRecordValues (single-payload) or
+// checkRecordValuesAll (bulk) — byte for byte apart from the caller-controlled
+// key and the two decimal sizes.
+//
+// WHY THIS EXISTS INSTEAD OF errors.Is. shard.decodePBResult rebuilds a
+// replicated op error with errors.New(string(...)), so a clustered apply loses
+// the sentinel's identity and errors.Is(err, ErrRecordTooLarge) no longer
+// matches. A classifier that needs to recognize the replicated form must match
+// the message text instead — but a bare strings.Contains(err.Error(),
+// ErrRecordTooLarge.Error()) is unsafe: it makes ANY error whose message
+// merely mentions the sentinel text client-facing, including an unrelated
+// internal error that wraps it, e.g.
+// fmt.Errorf("wal append failed at %s: %w", path, ErrRecordTooLarge) — that
+// would bypass internal-error redaction and leak the WAL path to the caller.
+//
+// This matcher anchors on the exact prefix and suffix checkRecordValues /
+// checkRecordValuesAll produce, so only their own output — not an arbitrary
+// superstring of the sentinel — is recognized. The three recognized shapes (N
+// and M are decimal byte counts; <key> is clipField's bounded rendering of the
+// caller's payload key, arbitrary content within that bound):
+//
+//	vector: record payload value exceeds the storage cap
+//	vector: record payload value exceeds the storage cap: payload key <key> holds a N-byte record, the cap is M bytes
+//	payload I: vector: record payload value exceeds the storage cap: payload key <key> holds a N-byte record, the cap is M bytes
+//
+// The first (bare sentinel text, no detail) is not produced by any current
+// call site — every real one goes through checkRecordValues, which always
+// appends the detail — but is matched anyway by exact equality so a future
+// path that stringifies the bare sentinel (e.g. errors.New(ErrRecordTooLarge.
+// Error())) is not silently redacted; the equality check cannot mis-fire on
+// anything else, so it costs nothing to include.
+//
+// Phase 2 adds the same treatment for ErrRecordMalformed, ErrPayloadKeyNotRecord,
+// and ErrVectorRecordAbsent; this helper does not attempt those.
+func IsRecordTooLargeMessage(s string) bool {
+	if len(s) == 0 || len(s) > maxRecordTooLargeMessageLen {
+		return false
+	}
+	if s == ErrRecordTooLarge.Error() {
+		return true
+	}
+	rest, ok := cutRecordTooLargePrefix(s)
+	if !ok {
+		return false
+	}
+	return hasRecordTooLargeSuffix(rest)
+}
+
+// maxRecordTooLargeMessageLen bounds the input IsRecordTooLargeMessage scans,
+// so classification cost cannot scale with an attacker-chosen string's length.
+// The largest real message (bulk form, clipField at its longest) sits well
+// under 400 bytes; this leaves generous headroom without opening a scan-cost
+// vector on unbounded input.
+const maxRecordTooLargeMessageLen = 2048
+
+// recordTooLargeSinglePrefix is the fixed text that opens the single-payload
+// form, ending right before the caller-controlled clipField(k) rendering.
+var recordTooLargeSinglePrefix = ErrRecordTooLarge.Error() + ": payload key "
+
+// recordTooLargeSuffixMid and recordTooLargeSuffixTail bracket the two decimal
+// byte counts in the fixed tail that follows clipField(k): "... holds a
+// <N>-byte record, the cap is <maxRecordValueBytes> bytes". The cap is a
+// compile-time constant, so its rendered text is fixed too.
+const recordTooLargeSuffixMid = " holds a "
+
+var recordTooLargeSuffixTail = fmt.Sprintf("-byte record, the cap is %d bytes", maxRecordValueBytes)
+
+// cutRecordTooLargePrefix strips either the single-payload prefix or the bulk
+// "payload <digits>: " wrapper followed by the single-payload prefix, and
+// returns what follows (the clipField rendering plus the fixed numeric tail).
+func cutRecordTooLargePrefix(s string) (string, bool) {
+	if rest, ok := strings.CutPrefix(s, recordTooLargeSinglePrefix); ok {
+		return rest, true
+	}
+	rest, ok := strings.CutPrefix(s, "payload ")
+	if !ok {
+		return "", false
+	}
+	i := 0
+	for i < len(rest) && rest[i] >= '0' && rest[i] <= '9' {
+		i++
+	}
+	if i == 0 {
+		return "", false
+	}
+	rest, ok = strings.CutPrefix(rest[i:], ": ")
+	if !ok {
+		return "", false
+	}
+	return strings.CutPrefix(rest, recordTooLargeSinglePrefix)
+}
+
+// hasRecordTooLargeSuffix reports whether s ends with the fixed tail that
+// follows clipField(k): a decimal byte count, then the fixed suffix text.
+// Whatever precedes " holds a " is the clipField rendering — arbitrary within
+// its own bound — so this only anchors the fixed structure around it, the same
+// way cutRecordTooLargePrefix anchors the fixed structure that precedes it.
+func hasRecordTooLargeSuffix(s string) bool {
+	rest, ok := strings.CutSuffix(s, recordTooLargeSuffixTail)
+	if !ok {
+		return false
+	}
+	i := len(rest)
+	for i > 0 && rest[i-1] >= '0' && rest[i-1] <= '9' {
+		i--
+	}
+	if i == len(rest) {
+		return false
+	}
+	return strings.HasSuffix(rest[:i], recordTooLargeSuffixMid)
 }
 
 // recordPoison is the READ side of the payload index's per-payload-key

--- a/vector/metadata.go
+++ b/vector/metadata.go
@@ -69,39 +69,46 @@ func lookupPath(m Metadata, field string) (Value, bool) {
 	return record.ResultValue(res)
 }
 
-// isRecordPath reports whether field has the "payloadKey/path" shape a
-// record path filter uses: record.SplitField finds a '/' AND the tail
-// parses as a record.Path. A field that does not have that shape (no '/',
-// or a malformed tail) is a literal key and isRecordPath reports false for
-// it — unchanged from today's behaviour.
+// recordPoison is the READ side of the payload index's per-payload-key
+// malformed-record counters (payloadIndex.badRecords / payloadIndexID.
+// badRecords): it answers "does some live slot hold a record under this
+// payload key that the index could not enumerate?".
 //
-// This is intentionally syntactic only: it does not (and cannot) know
-// whether some point's metadata happens to carry field as an EXACT literal
-// key (lookupPath's exact-key precedence would still honor that at
-// evaluation time). Its sole caller, indexNarrowable, uses it to route: a
-// field that is not a record path is a plain literal key the index handles
-// as it always has, and a field that IS one goes on to recordPathIndexed,
-// which decides per shape and per op whether postings exist to prove
-// anything from. Declining is always sound (the predicate re-checks), so
-// both a path-shaped-but-possibly-literal field and a genuinely literal
-// path-shaped key are safe either way: the literal case indexes and resolves
-// through the SAME field name on both sides.
-func isRecordPath(field string) bool {
-	_, path, ok := record.SplitField(field)
-	if !ok {
-		return false
-	}
-	_, err := record.ParsePath(path)
-	return err == nil
-}
+// WHY THE GUARD NEEDS IT, AND WHY NOTHING CHEAPER WORKS. IndexEntries is
+// ALL-OR-NOTHING: it walks every field of a record and returns an error if ANY
+// of them is damaged. Resolve is not — it reads only the bytes on its own path
+// (sdk/record/resolve.go says so), so a record with a torn tail still answers
+// for a leading field: in schema mode schemaFieldOffset reaches a FIXED field
+// without walking the variable-length tail at all, and in dynamic mode the
+// walk stops at the named match before it reaches the damage. A partially
+// damaged record therefore indexes NOTHING while lookupPath keeps resolving
+// it, and every empty-set inference over a path under that payload key becomes
+// a lie: "no posting" would mean "never indexed", not "no match", so an
+// accelerated query drops the row — silently, and with an exact gate, without
+// even a predicate re-check to catch it.
+//
+// Posting the entries IndexEntries produced before it failed is not an
+// alternative (it produces none on error), and posting a partial list would
+// leave the identical hole for every field past the damage. So the index fails
+// CLOSED for the whole payload key while any live slot under it is
+// unindexable. It is a STATE, not a latch: repairing or dropping the last bad
+// record restores acceleration, because reindex maintains the count from both
+// sides.
+//
+// A nil recordPoison poisons nothing — the right answer for an index that
+// holds no records at all, and for a caller that has no index in hand.
+type recordPoison map[string]int
 
-// recordPathIndexedShape reports whether field names a record location the
-// payload index POSTS a synthetic entry for. It is the single definition of
-// "indexed shape", used on BOTH sides — reindex asks it what to write, and
-// recordPathIndexed asks it what the planner may read — so the two can never
-// drift into the one disagreement that matters: a shape the planner trusts
-// but nothing ever posted, whose empty posting map would read as "nothing
-// matches" instead of "never indexed".
+func (rp recordPoison) poisoned(payloadKey string) bool { return rp[payloadKey] > 0 }
+
+// recordShapeIndexed reports whether a PARSED record path names a location the
+// payload index posts a synthetic entry for. It is the single definition of
+// "indexed shape", consulted from BOTH sides — appendRecordIndexKeys asks it
+// what to write (through recordPathIndexedShape, which parses first) and
+// indexNarrowable asks it what the planner may read — so the two cannot drift
+// into the one disagreement that matters: a shape the planner trusts but
+// nothing ever posted, whose empty posting map reads as "nothing matches"
+// instead of "never indexed".
 //
 // The indexed shapes are exactly the ones record.Resolver.IndexEntries
 // enumerates: a single top-level field segment named BY NAME ("session/rc"),
@@ -111,22 +118,18 @@ func isRecordPath(field string) bool {
 // A POSITION ("session/#0") is deliberately NOT an indexed shape, and it is
 // the one place this set is narrower than the Task 6 addendum's list. Resolve
 // answers a positional segment for EVERY schema-mode record, but IndexEntries
-// names a names-carrying schema's fields by NAME and only a names-LESS
+// names a names-carrying schema's fields BY NAME and only a names-LESS
 // schema's by position (schemaFieldLabel). So for the common record —
 // StoreNames = true — "session/#0" resolves to a value while no posting for it
 // exists, which is exactly the under-report that turns into dropped rows. The
 // index cannot tell from the field string which spelling a given point's
-// record will produce, so the positional spelling stays on the predicate.
+// record will produce (one collection can hold both), so the positional
+// spelling stays on the predicate.
 //
 // Everything longer (a row "session/b/42", a cell "session/b/42/hi") is not
 // indexed either: this phase never expands table contents.
-func recordPathIndexedShape(field string) bool {
-	_, path, ok := record.SplitField(field)
-	if !ok {
-		return false
-	}
-	p, err := record.ParsePath(path)
-	if err != nil || len(p.Segs) != 1 {
+func recordShapeIndexed(p record.Path) bool {
+	if len(p.Segs) != 1 {
 		return false
 	}
 	seg := p.Segs[0]
@@ -136,43 +139,41 @@ func recordPathIndexedShape(field string) bool {
 	return seg.Kind == record.SegField || seg.Kind == record.SegCount
 }
 
-// recordPathIndexed reports whether the payload index can prove anything about
-// a RECORD PATH field under op — i.e. whether the postings for field are
-// EXACTLY the slots whose lookupPath(field) value satisfies op.
+// recordOpIndexed reports whether op's posting set over an indexed record
+// shape is EXACT — the second half of the narrowing decision, after the shape.
 //
-// It has two halves, and both are necessary:
-//
-// SHAPE: recordPathIndexedShape above — only the shapes reindex actually
-// posts. For any other shape the posting map is empty because nothing ever
-// wrote to it, not because nothing matches, which is the same asymmetry that
-// makes contentField un-narrowable.
-//
-// OP: only the ops whose posting set is exact for an indexed shape — equality,
-// In, the ordering family, and the FilterDt* spellings that lower to it. A
-// record's scalars are posted as whole-value eq keys ONLY: no tokens, no
-// contains-element entries, no geo cells. So contains / match / regex, and the
-// shape-only predicates is_empty / is_null / row_exists / row_absent, have no
-// postings of their own and must stay on the predicate. (ne is narrowed by
-// nothing, for any field anywhere, so it needs no case of its own — it simply
-// falls into the default with the rest.)
-//
-// Callers pass a field that may or may not be a record path at all; a field
-// that is not one is not this function's business, which is why
-// indexNarrowable asks isRecordPath first.
-func recordPathIndexed(field string, op FilterOp) bool {
-	if !recordPathIndexedShape(field) {
-		return false
-	}
+// A record's scalars are posted as whole-value equality keys and NOTHING else:
+// no tokens, no contains-element entries, no geo cells. So `contains`, `match`
+// and `regex`, and the shape-only predicates `is_empty`, `is_null`,
+// `row_exists` and `row_absent`, have no postings of their own and must stay on
+// the predicate. (`ne` is narrowed by nothing, for any field anywhere, so it
+// needs no case: it falls into the default with the rest.)
+func recordOpIndexed(op FilterOp) bool {
 	switch op {
 	case FilterEq, FilterIn,
 		FilterGt, FilterGte, FilterLt, FilterLte,
 		FilterDtGt, FilterDtGte, FilterDtLt, FilterDtLte:
 		return true
 	default:
-		// FilterNe, FilterContains, FilterMatch, FilterRegex, FilterIsEmpty,
-		// FilterIsNull, FilterRowExists, FilterRowAbsent, the geo family.
 		return false
 	}
+}
+
+// recordPathIndexedShape is recordShapeIndexed for an unparsed field name: it
+// splits the payload key off and parses the tail, reporting false for anything
+// that is not a record path at all. Used by the WRITE side
+// (appendRecordIndexKeys) to decide what to post; the read side parses once
+// inside indexNarrowable instead of calling this.
+func recordPathIndexedShape(field string) bool {
+	_, path, ok := record.SplitField(field)
+	if !ok {
+		return false
+	}
+	p, err := record.ParsePath(path)
+	if err != nil {
+		return false
+	}
+	return recordShapeIndexed(p)
 }
 
 // numericValue extracts a float64 from a scalar numeric Value (int or float).

--- a/vector/metadata.go
+++ b/vector/metadata.go
@@ -2,7 +2,12 @@
 
 package vector
 
-import "github.com/rostamlabs/rostam/sdk/record"
+import (
+	"errors"
+	"fmt"
+
+	"github.com/rostamlabs/rostam/sdk/record"
+)
 
 // The Value tagged union, its ValueKind enumeration, the Metadata map, the
 // Value constructors, and the ValueKind text (un)marshaling now live in the
@@ -67,6 +72,48 @@ func lookupPath(m Metadata, field string) (Value, bool) {
 		return Value{}, false
 	}
 	return record.ResultValue(res)
+}
+
+// ErrRecordTooLarge is returned by every metadata-accepting mutation entry —
+// insert, insert-if-absent, upsert, set-payload, overwrite, bulk stage/build,
+// dense/IVF/named/multi-vector alike — when the payload carries a ValueRecord
+// longer than maxRecordValueBytes.
+//
+// WHY THE CAP IS ENFORCED AT INGEST AND NOT WHERE IT IS DISCOVERED.
+// maxRecordValueBytes is the SNAPSHOT/WAL codec's cap (writeValue), so a point
+// whose record exceeds it can be held in memory but can never be written down:
+// the WAL append would have to fail mid-record and every snapshot of the
+// collection would fail for as long as the point stayed live. Accepting the
+// write and failing the durability is the one outcome that leaves the in-memory
+// state and the durable state permanently unable to agree, so the cap is
+// checked HERE, before any state change, where refusing costs the caller one
+// error and nothing else. It is a caller mistake, classified 400 on both
+// transports like ErrDimMismatch.
+var ErrRecordTooLarge = errors.New("vector: record payload value exceeds the storage cap")
+
+// checkRecordValues rejects a payload carrying an oversize ValueRecord. Every
+// mutation entry calls it BEFORE it touches any state or stages a WAL write;
+// the inner helpers those entries share deliberately do NOT repeat it, so each
+// op pays exactly one pass over its own payload.
+func checkRecordValues(m Metadata) error {
+	for k, v := range m {
+		if v.Kind == ValueRecord && len(v.Rec) > maxRecordValueBytes {
+			return fmt.Errorf("%w: payload key %q holds a %d-byte record, the cap is %d bytes",
+				ErrRecordTooLarge, k, len(v.Rec), maxRecordValueBytes)
+		}
+	}
+	return nil
+}
+
+// checkRecordValuesAll is checkRecordValues over a bulk batch, naming the
+// offending row so a rejected bulk stage/build says which point to fix.
+func checkRecordValuesAll(metas []Metadata) error {
+	for i, m := range metas {
+		if err := checkRecordValues(m); err != nil {
+			return fmt.Errorf("payload %d: %w", i, err)
+		}
+	}
+	return nil
 }
 
 // recordPoison is the READ side of the payload index's per-payload-key

--- a/vector/metadata.go
+++ b/vector/metadata.go
@@ -69,6 +69,31 @@ func lookupPath(m Metadata, field string) (Value, bool) {
 	return record.ResultValue(res)
 }
 
+// isRecordPath reports whether field has the "payloadKey/path" shape a
+// record path filter uses: record.SplitField finds a '/' AND the tail
+// parses as a record.Path. A field that does not have that shape (no '/',
+// or a malformed tail) is a literal key and isRecordPath reports false for
+// it — unchanged from today's behaviour.
+//
+// This is intentionally syntactic only: it does not (and cannot) know
+// whether some point's metadata happens to carry field as an EXACT literal
+// key (lookupPath's exact-key precedence would still honor that at
+// evaluation time). Callers of isRecordPath — indexNarrowable and
+// filterIndexExact — use it to decide whether the payload INDEX can prove
+// anything about the field across every point, not to decide what one
+// point's predicate evaluates to; declining a field the index cannot prove
+// is always sound (the predicate re-checks it), so treating a
+// path-shaped-but-possibly-literal field as "not narrowable" costs nothing
+// but a slower fallback, never a wrong answer.
+func isRecordPath(field string) bool {
+	_, path, ok := record.SplitField(field)
+	if !ok {
+		return false
+	}
+	_, err := record.ParsePath(path)
+	return err == nil
+}
+
 // numericValue extracts a float64 from a scalar numeric Value (int or float).
 // Returns (0, false) for non-numeric kinds. Used by the filter compiler's
 // ordering predicates to compare across int/float.

--- a/vector/multivector.go
+++ b/vector/multivector.go
@@ -676,6 +676,9 @@ func (m *MultiVectorIndex) addLockedAt(docID uint64, tokens [][]float32, meta Me
 // does NOT WAL-log. A version of 0 falls back to the normal bump (an old record
 // predating the version block defaults a fresh add to 1).
 func (m *MultiVectorIndex) restoreAdd(docID uint64, tokens [][]float32, meta Metadata, keyExpires map[string]uint64, version uint64, sparse *SparseVector) error {
+	if err := checkRecordValues(meta); err != nil {
+		return err
+	}
 	if len(tokens) == 0 {
 		return ErrEmptyDocument
 	}

--- a/vector/multivector.go
+++ b/vector/multivector.go
@@ -3,6 +3,7 @@
 package vector
 
 import (
+	"fmt"
 	"sort"
 	"strings"
 	"sync"
@@ -1007,7 +1008,7 @@ func (m *MultiVectorIndex) MultiRestoreAddSparse(docID uint64, tokens [][]float3
 // WAL-log: durability rides the Raft-replicated batch op that re-executes this on
 // replay (mirrors the dense bulk path), so callers must drive it through an op.
 func (m *MultiVectorIndex) MultiBulkBuild(recs []MultiScanRecord, workers int) (bool, error) {
-	for _, r := range recs {
+	for i, r := range recs {
 		if len(r.Tokens) == 0 {
 			return false, ErrEmptyDocument
 		}
@@ -1020,6 +1021,22 @@ func (m *MultiVectorIndex) MultiBulkBuild(recs []MultiScanRecord, workers int) (
 			if err := r.Sparse.Validate(); err != nil {
 				return false, err
 			}
+		}
+		// THIS ENTRY IS WIRE-REACHABLE and it is NOT a replay body, so it runs the
+		// record ingest gate. ops/mv_batch.go decodes a batch straight off the wire
+		// and calls it as the FAST PATH whenever the target index is empty,
+		// falling through to the gated MultiRestoreAddSparse only once documents
+		// exist — so without this the same op is gated or ungated depending on the
+		// target's emptiness, and the ungated case (a fresh partition) is exactly
+		// the one an offline MV resplit drives. The loop below writes r.Metadata
+		// into docMeta and reindexes it directly, with nothing else in front.
+		//
+		// The WHOLE batch is validated before m.mu is taken, so one bad record
+		// refuses every record rather than leaving a half-built index that can
+		// never use the fast path again. The offending row is named, exactly as
+		// checkRecordValuesAll names it for the dense bulk path.
+		if err := checkRecordValues(r.Metadata); err != nil {
+			return false, fmt.Errorf("payload %d: %w", i, err)
 		}
 	}
 	m.startSweeper()

--- a/vector/multivector.go
+++ b/vector/multivector.go
@@ -1202,11 +1202,13 @@ func (m *MultiVectorIndex) applyDocSparseLocked(docID uint64, sparse *SparseVect
 }
 
 // Get retrieves a live document by id: its token matrix (each row a DEEP-COPIED
-// normalized token vector) and its metadata (deep-copied), plus ok. ok is false
+// normalized token vector) and its metadata (a map-level copy — see cloneMeta
+// and vtypes.Metadata for the slice-ownership contract), plus ok. ok is false
 // when docID is absent — the MV index has no tombstones or TTL, so a docID is live
 // iff it has a token-set entry (mirror Exists/ScanDocuments). The returned
-// tokens/payload are owned by the caller (mutating them never corrupts the inner
-// arena or docMeta). Lock order: m.mu (read) outer, then the inner index's own mu
+// tokens are owned by the caller, and so is the payload MAP (adding or removing
+// keys never corrupts docMeta); a slice-backed Value inside it still points at
+// stored bytes and must not be written through. Lock order: m.mu (read) outer, then the inner index's own mu
 // (taken internally by vecsForIDs) — the same outer→inner order Search/ScanDocuments use.
 func (m *MultiVectorIndex) Get(docID uint64) (tokens [][]float32, payload Metadata, version uint64, ok bool) {
 	m.mu.RLock()
@@ -1228,8 +1230,9 @@ func (m *MultiVectorIndex) Get(docID uint64) (tokens [][]float32, payload Metada
 			tokens = append(tokens, v) // already a fresh copy owned by us
 		}
 	}
-	// Drop per-key-TTL-expired keys, then deep-copy so the caller owns the payload
-	// (liveMetaMap may alias m.docMeta on the no-expiry fast path).
+	// Drop per-key-TTL-expired keys, then copy the map so the caller owns it
+	// (liveMetaMap may alias m.docMeta on the no-expiry fast path). Slice-backed
+	// Values inside still point at stored bytes — vtypes.Metadata's contract.
 	payload = cloneMeta(liveMetaMap(m.docMeta[docID], m.keyTTL[docID], m.nowMs()))
 	return tokens, payload, version, true
 }

--- a/vector/multivector.go
+++ b/vector/multivector.go
@@ -557,6 +557,9 @@ func (m *MultiVectorIndex) AddCASKeyTTLSparseAt(docID uint64, tokens [][]float32
 }
 
 func (m *MultiVectorIndex) addCASKeyTTLSparseBody(docID uint64, tokens [][]float32, meta Metadata, keyTTLMs map[string]int64, sparse *SparseVector, cas CASCond, stamped bool, nowMs int64) (uint64, error) {
+	if err := checkRecordValues(meta); err != nil {
+		return 0, err
+	}
 	if len(tokens) == 0 {
 		return 0, ErrEmptyDocument
 	}
@@ -739,6 +742,9 @@ func (m *MultiVectorIndex) restoreAdd(docID uint64, tokens [][]float32, meta Met
 // always wins (mirror of hnsw.InsertIfAbsent). Returns ErrDimMismatch / ErrEmptyDocument
 // on a malformed document, exactly as Add.
 func (m *MultiVectorIndex) AddIfAbsent(docID uint64, tokens [][]float32, meta Metadata) (inserted bool, err error) {
+	if err := checkRecordValues(meta); err != nil {
+		return false, err
+	}
 	if len(tokens) == 0 {
 		return false, ErrEmptyDocument
 	}
@@ -831,6 +837,9 @@ func (m *MultiVectorIndex) MultiAddIfAbsentVersion(docID uint64, tokens [][]floa
 func (m *MultiVectorIndex) MultiAddIfAbsentVersionSparse(docID uint64, tokens [][]float32, meta Metadata, keyExpires map[string]uint64, version uint64, sparse *SparseVector) (inserted bool, err error) {
 	if version == 0 && len(keyExpires) == 0 && (sparse == nil || sparse.IsZero()) {
 		return m.AddIfAbsent(docID, tokens, meta) // byte-for-byte the existing path (logs version 1)
+	}
+	if err := checkRecordValues(meta); err != nil {
+		return false, err
 	}
 	if len(tokens) == 0 {
 		return false, ErrEmptyDocument
@@ -1408,6 +1417,9 @@ func (m *MultiVectorIndex) setPayloadLocked(docID uint64, patch Metadata, keyTTL
 }
 
 func (m *MultiVectorIndex) setPayloadLockedAt(docID uint64, patch Metadata, keyTTLMs map[string]int64, cas CASCond, now int64) (Metadata, map[string]int64, uint64, error) {
+	if err := checkRecordValues(patch); err != nil {
+		return nil, nil, 0, err
+	}
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	if _, exists := m.docTokens[docID]; !exists {
@@ -1566,6 +1578,9 @@ func (m *MultiVectorIndex) overwritePayloadLocked(docID uint64, meta Metadata, k
 }
 
 func (m *MultiVectorIndex) overwritePayloadLockedAt(docID uint64, meta Metadata, keyTTLMs map[string]int64, cas CASCond, now int64) (Metadata, map[string]int64, uint64, error) {
+	if err := checkRecordValues(meta); err != nil {
+		return nil, nil, 0, err
+	}
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	if _, exists := m.docTokens[docID]; !exists {

--- a/vector/mv_sparse_test.go
+++ b/vector/mv_sparse_test.go
@@ -453,7 +453,7 @@ func mvAddRecordBytes(t *testing.T, docID uint64, tokens [][]float32, meta Metad
 			_ = writeF32(&buf, f)
 		}
 	}
-	writeOptMeta(&buf, meta)
+	_ = writeOptMeta(&buf, meta)
 	writeOptKeyExpires(&buf, keyExpires)
 	writeOptVersion(&buf, version)
 	writeOptMVSparse(&buf, sparse)

--- a/vector/mv_wal.go
+++ b/vector/mv_wal.go
@@ -58,7 +58,9 @@ func (w *wal) appendMVAddStaged(docID uint64, tokens [][]float32, meta Metadata,
 			_ = writeF32(&buf, f)
 		}
 	}
-	writeOptMeta(&buf, meta)
+	if err := writeOptMeta(&buf, meta); err != nil {
+		return 0, err
+	}
 	writeOptKeyExpires(&buf, keyExpires)
 	// Trailing per-doc CAS version block (byte-identical when 0; an old record
 	// without it replays as version 0 -> a fresh add defaults to 1). Reuses the
@@ -128,7 +130,9 @@ func (w *wal) appendMVSetPayloadStaged(docID uint64, meta Metadata, keyExpires m
 	var buf bytes.Buffer
 	buf.WriteByte(byte(mvSetPayloadRec))
 	_ = writeU64(&buf, docID)
-	writeOptMeta(&buf, meta)
+	if err := writeOptMeta(&buf, meta); err != nil {
+		return 0, err
+	}
 	writeOptKeyExpires(&buf, keyExpires)
 	// Trailing per-doc CAS version (the resulting version), restored VERBATIM by
 	// replay. Byte-identical when 0.

--- a/vector/named.go
+++ b/vector/named.go
@@ -1178,11 +1178,14 @@ func (nc *NamedCollection) liveLockedAt(id uint64, now int64) bool {
 
 // Get retrieves a live point by id: a map of its per-space DEEP-COPIED vectors
 // (only the spaces the point actually populated appear — an omitted space is
-// absent from the map), the shared per-point payload (deep-copied), plus the
+// absent from the map), the shared per-point payload (a map-level copy — see
+// cloneMeta and vtypes.Metadata for the slice-ownership contract), plus the
 // remaining TTL. ok is false for an absent or TTL-expired point (mirror the
 // ScrollDocs liveness gate; the named family has no tombstones — the shared ids
-// set is authoritative). The returned vectors/payload are owned by the caller
-// (mutating them never corrupts the sub-arenas or the shared meta map). For a
+// set is authoritative). The returned vectors are owned by the caller, and so is
+// the payload MAP (adding or removing keys never corrupts the shared meta map);
+// a slice-backed Value inside it still points at stored bytes and must not be
+// written through. For a
 // cosine-metric space the returned vector is the NORMALIZED vector (Insert
 // normalizes on the way in). ttl is the remaining duration to the shared
 // deadline (0 = no expiry). Lock order: nc.mu (read) outer, then each sub-index's
@@ -1207,8 +1210,9 @@ func (nc *NamedCollection) Get(id uint64) (vectors map[string][]float32, payload
 			}
 		}
 	}
-	// Drop per-key-TTL-expired keys, then deep-copy so the caller owns the payload
-	// (liveMetaMap may alias nc.meta on the no-expiry fast path).
+	// Drop per-key-TTL-expired keys, then copy the map so the caller owns it
+	// (liveMetaMap may alias nc.meta on the no-expiry fast path). Slice-backed
+	// Values inside still point at stored bytes — vtypes.Metadata's contract.
 	payload = cloneMeta(liveMetaMap(nc.meta[id], nc.keyTTL[id], nc.nowMs()))
 	if dl := nc.ttl[id]; dl != 0 {
 		if now := nc.nowMs(); dl > now {

--- a/vector/named.go
+++ b/vector/named.go
@@ -499,6 +499,9 @@ func (nc *NamedCollection) InsertCASKeyTTLAt(id uint64, vectors map[string][]flo
 }
 
 func (nc *NamedCollection) insertCASKeyTTLBody(id uint64, vectors map[string][]float32, sparseVectors map[string]*SparseVector, payload Metadata, ttl time.Duration, keyTTLMs map[string]int64, cas CASCond, stamped bool, nowMs int64) (uint64, error) {
+	if err := checkRecordValues(payload); err != nil {
+		return 0, err
+	}
 	// Validate every name/dim/modality up front so a malformed request mutates
 	// nothing.
 	if err := nc.validateInsertSpaces(vectors, sparseVectors); err != nil {
@@ -1246,6 +1249,9 @@ func (nc *NamedCollection) setPayloadLocked(id uint64, patch Metadata, keyTTLMs 
 }
 
 func (nc *NamedCollection) setPayloadLockedAt(id uint64, patch Metadata, keyTTLMs map[string]int64, cas CASCond, now int64) (Metadata, map[string]int64, uint64, error) {
+	if err := checkRecordValues(patch); err != nil {
+		return nil, nil, 0, err
+	}
 	nc.mu.Lock()
 	defer nc.mu.Unlock()
 	if !nc.liveLockedAt(id, now) {
@@ -1394,6 +1400,9 @@ func (nc *NamedCollection) overwritePayloadLocked(id uint64, meta Metadata, keyT
 }
 
 func (nc *NamedCollection) overwritePayloadLockedAt(id uint64, meta Metadata, keyTTLMs map[string]int64, cas CASCond, now int64) (Metadata, map[string]int64, uint64, error) {
+	if err := checkRecordValues(meta); err != nil {
+		return nil, nil, 0, err
+	}
 	nc.mu.Lock()
 	defer nc.mu.Unlock()
 	if !nc.liveLockedAt(id, now) {

--- a/vector/named.go
+++ b/vector/named.go
@@ -670,6 +670,9 @@ func (nc *NamedCollection) insertLockedAt(id uint64, vectors map[string][]float3
 // normal bump (an old record predating the version block defaults a fresh insert
 // to 1).
 func (nc *NamedCollection) RestoreInsert(id uint64, vectors map[string][]float32, sparseVectors map[string]*SparseVector, payload Metadata, ttl time.Duration, keyExpires map[string]uint64, version uint64) error {
+	if err := checkRecordValues(payload); err != nil {
+		return err
+	}
 	if err := nc.validateInsertSpaces(vectors, sparseVectors); err != nil {
 		return err
 	}

--- a/vector/named_sparse_test.go
+++ b/vector/named_sparse_test.go
@@ -417,7 +417,7 @@ func TestNamedDenseOnlyWALByteIdentical(t *testing.T) {
 			_ = writeF32(&oldBuf, f)
 		}
 	}
-	writeOptMeta(&oldBuf, payload)
+	_ = writeOptMeta(&oldBuf, payload)
 	writeOptKeyExpires(&oldBuf, nil)
 	writeOptVersion(&oldBuf, 1)
 
@@ -434,7 +434,7 @@ func TestNamedDenseOnlyWALByteIdentical(t *testing.T) {
 			_ = writeF32(&newBuf, f)
 		}
 	}
-	writeOptMeta(&newBuf, payload)
+	_ = writeOptMeta(&newBuf, payload)
 	writeOptKeyExpires(&newBuf, nil)
 	writeOptVersion(&newBuf, 1)
 	writeNamedSparseVectors(&newBuf, nil) // dense-only: must write nothing

--- a/vector/named_wal.go
+++ b/vector/named_wal.go
@@ -64,7 +64,9 @@ func (w *wal) appendNamedInsertStaged(id uint64, vectors map[string][]float32, s
 			_ = writeF32(&buf, f)
 		}
 	}
-	writeOptMeta(&buf, payload)
+	if err := writeOptMeta(&buf, payload); err != nil {
+		return 0, err
+	}
 	writeOptKeyExpires(&buf, keyExpires)
 	// Trailing per-point CAS version block (byte-identical when 0; an old record
 	// without it replays as version 0 -> a fresh insert defaults to 1). Reuses the
@@ -162,7 +164,9 @@ func (w *wal) appendNamedSetPayloadStaged(id uint64, meta Metadata, keyExpires m
 	var buf bytes.Buffer
 	buf.WriteByte(byte(namedSetPayloadRec))
 	_ = writeU64(&buf, id)
-	writeOptMeta(&buf, meta)
+	if err := writeOptMeta(&buf, meta); err != nil {
+		return 0, err
+	}
 	writeOptKeyExpires(&buf, keyExpires)
 	// Trailing per-point CAS version (the resulting version), restored VERBATIM by
 	// replay. Byte-identical when 0 (an old record replays as version 0 -> leaves

--- a/vector/order.go
+++ b/vector/order.go
@@ -146,6 +146,8 @@ func stringValue(v Value) (string, bool) {
 	if v.Kind == ValueString {
 		return v.Str, true
 	}
+	// ValueRecord considered: falls to the ("", false) below, correctly
+	// declining — a record is not a scalar string ordering key.
 	return "", false
 }
 

--- a/vector/payload_column.go
+++ b/vector/payload_column.go
@@ -370,7 +370,7 @@ func (p *payloadIndex) collectColumnTerms(f Filter, capacity int, budget int64, 
 	// build (and then maintain forever) a column for the range leaf before the eq
 	// leaf declined the whole filter — a permanent per-slot cost bought for a
 	// query that cannot use it.
-	if !columnExpressible(f) {
+	if !columnExpressible(f, p.badRecords) {
 		return acc, false
 	}
 	acc, _, ok := p.appendColumnTerms(f, capacity, budget, acc)
@@ -380,20 +380,20 @@ func (p *payloadIndex) collectColumnTerms(f Filter, capacity int, budget int64, 
 // columnExpressible reports whether f's SHAPE can be answered from columns,
 // touching nothing but the filter itself. It must stay in exact agreement with
 // appendColumnTerms' op coverage; the two are adjacent for that reason.
-func columnExpressible(f Filter) bool {
+func columnExpressible(f Filter, poison recordPoison) bool {
 	switch f.Op {
 	case FilterGt, FilterGte, FilterLt, FilterLte:
 		bound, ok := numericValue(f.Value)
-		return ok && bound == bound && indexNarrowable(f.Field, f.Op)
+		return ok && bound == bound && indexNarrowable(f.Field, f.Op, poison)
 	case FilterDtGt, FilterDtGte, FilterDtLt, FilterDtLte:
 		_, ok := datetimeBound(f.Value)
-		return ok && indexNarrowable(f.Field, f.Op)
+		return ok && indexNarrowable(f.Field, f.Op, poison)
 	case FilterAnd:
 		if len(f.And) == 0 {
 			return false
 		}
 		for i := range f.And {
-			if !columnExpressible(f.And[i]) {
+			if !columnExpressible(f.And[i], poison) {
 				return false
 			}
 		}
@@ -441,7 +441,7 @@ func (p *payloadIndex) appendColumnTerms(f Filter, capacity int, budget int64, a
 // appendColumnTerm resolves one leaf's column and appends its term, returning
 // the budget less whatever the resolution had to allocate.
 func (p *payloadIndex) appendColumnTerm(acc []columnTerm, field string, op FilterOp, bound float64, capacity int, budget int64) ([]columnTerm, int64, bool) {
-	if !indexNarrowable(field, op) {
+	if !indexNarrowable(field, op, p.badRecords) {
 		// $content is readable by the predicate but never indexed, so its posting
 		// map is empty for a reason that has nothing to do with what matches — the
 		// same asymmetry that makes it un-narrowable makes it un-columnisable.

--- a/vector/payload_column.go
+++ b/vector/payload_column.go
@@ -132,6 +132,9 @@ func numericKeyValue(k scalarKey) (float64, bool) {
 	case ValueFloat:
 		return k.f, true
 	default:
+		// ValueRecord considered: k.kind can never be ValueRecord — scalarKeyOf
+		// declines records before a scalarKey is ever minted, so this correctly
+		// declines by construction, not just by accident.
 		return 0, false
 	}
 }

--- a/vector/payload_column.go
+++ b/vector/payload_column.go
@@ -384,10 +384,10 @@ func columnExpressible(f Filter) bool {
 	switch f.Op {
 	case FilterGt, FilterGte, FilterLt, FilterLte:
 		bound, ok := numericValue(f.Value)
-		return ok && bound == bound && indexNarrowable(f.Field)
+		return ok && bound == bound && indexNarrowable(f.Field, f.Op)
 	case FilterDtGt, FilterDtGte, FilterDtLt, FilterDtLte:
 		_, ok := datetimeBound(f.Value)
-		return ok && indexNarrowable(f.Field)
+		return ok && indexNarrowable(f.Field, f.Op)
 	case FilterAnd:
 		if len(f.And) == 0 {
 			return false
@@ -441,7 +441,7 @@ func (p *payloadIndex) appendColumnTerms(f Filter, capacity int, budget int64, a
 // appendColumnTerm resolves one leaf's column and appends its term, returning
 // the budget less whatever the resolution had to allocate.
 func (p *payloadIndex) appendColumnTerm(acc []columnTerm, field string, op FilterOp, bound float64, capacity int, budget int64) ([]columnTerm, int64, bool) {
-	if !indexNarrowable(field) {
+	if !indexNarrowable(field, op) {
 		// $content is readable by the predicate but never indexed, so its posting
 		// map is empty for a reason that has nothing to do with what matches — the
 		// same asymmetry that makes it un-narrowable makes it un-columnisable.

--- a/vector/payload_content_field_test.go
+++ b/vector/payload_content_field_test.go
@@ -183,10 +183,10 @@ func TestContentFieldOpsAgreeWithThePredicate(t *testing.T) {
 // downstream with a count mismatch.
 func TestContentFieldIsNeverIndexNarrowable(t *testing.T) {
 	for _, op := range []FilterOp{FilterEq, FilterIn, FilterGt, FilterContains, FilterMatch} {
-		if indexNarrowable(contentField, op) {
+		if indexNarrowable(contentField, op, nil) {
 			t.Fatalf("contentField must never be index-narrowable (op %v) — reindex does not index it", op)
 		}
-		if !indexNarrowable("tag", op) {
+		if !indexNarrowable("tag", op, nil) {
 			t.Fatalf("ordinary fields must stay narrowable (op %v)", op)
 		}
 	}
@@ -222,13 +222,13 @@ func TestContentFieldIsNeverIndexNarrowable(t *testing.T) {
 	// collectEqTerms is the one that does NOT go through a *Set function — the
 	// eq branch indexes p.fields inline — so it needs its own guard and its own
 	// check.
-	if _, ok := collectEqTerms(Filter{Op: FilterEq, Field: contentField, Value: NewString("x")}); ok {
+	if _, ok := collectEqTerms(Filter{Op: FilterEq, Field: contentField, Value: NewString("x")}, nil); ok {
 		t.Error("collectEqTerms accepted a bare $content Eq")
 	}
 	terms, ok := collectEqTerms(Filter{Op: FilterAnd, And: []Filter{
 		{Op: FilterEq, Field: "tag", Value: NewString("a")},
 		{Op: FilterEq, Field: contentField, Value: NewString("x")},
-	}})
+	}}, nil)
 	if !ok || len(terms) != 1 || terms[0].field != "tag" {
 		t.Errorf("collectEqTerms should keep the tag term and drop the $content one, got ok=%v terms=%v", ok, terms)
 	}

--- a/vector/payload_content_field_test.go
+++ b/vector/payload_content_field_test.go
@@ -182,11 +182,13 @@ func TestContentFieldOpsAgreeWithThePredicate(t *testing.T) {
 // posting-set lookup fails here with a precise message instead of somewhere
 // downstream with a count mismatch.
 func TestContentFieldIsNeverIndexNarrowable(t *testing.T) {
-	if indexNarrowable(contentField) {
-		t.Fatal("contentField must never be index-narrowable — reindex does not index it")
-	}
-	if !indexNarrowable("tag") {
-		t.Fatal("ordinary fields must stay narrowable")
+	for _, op := range []FilterOp{FilterEq, FilterIn, FilterGt, FilterContains, FilterMatch} {
+		if indexNarrowable(contentField, op) {
+			t.Fatalf("contentField must never be index-narrowable (op %v) — reindex does not index it", op)
+		}
+		if !indexNarrowable("tag", op) {
+			t.Fatalf("ordinary fields must stay narrowable (op %v)", op)
+		}
 	}
 
 	h := contentCorpus(t, 30)

--- a/vector/payload_content_record_test.go
+++ b/vector/payload_content_record_test.go
@@ -1,0 +1,233 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package vector
+
+import (
+	"math/rand"
+	"testing"
+)
+
+// A RECORD STORED UNDER $content.
+//
+// contentField is the one metadata key reindex refuses to index, and it skips
+// the entry BEFORE the ValueRecord branch — so a payload value of kind record
+// stored under "$content" contributes no synthetic postings at all, not even
+// for its top-level scalar fields. The compiled predicate reads it perfectly
+// well: lookupPath splits "$content/rc" like any other field string and
+// resolves into the record.
+//
+// indexNarrowable used to special-case only the BARE "$content" string, so
+// "$content/rc" split, parsed, and satisfied both recordShapeIndexed and
+// recordOpIndexed. The planner then graded a permanently empty posting set as
+// EXACT, filter-first brute-forced zero candidates, and every matching row was
+// dropped — silently, and without a predicate re-check to catch it. Nothing
+// reserves "$content": handleVectorUpsert takes it as an ordinary metadata key
+// straight off the wire, so this is wire-reachable rather than theoretical.
+//
+// These tests pin the fix (indexNarrowable declines any field whose SPLIT
+// payload key is contentField) at both levels: the planner predicate itself,
+// and the answers the two consumers give against a brute-force oracle.
+
+// contentRecordCorpus builds an index whose points carry a session record under
+// $content — the shape that used to narrow to empty — plus an ordinary literal
+// field so the "declining must not disable the siblings" case is testable too.
+func contentRecordCorpus(t *testing.T, n int) (*hnsw, map[uint64][]float32, map[uint64]Metadata) {
+	t.Helper()
+	const dim = 8
+	h, err := newHNSW(Config{Dim: dim, Metric: L2, M: 16, EfConstruction: 200, EfSearch: 128, Seed: 1})
+	if err != nil {
+		t.Fatalf("newHNSW: %v", err)
+	}
+	rng := rand.New(rand.NewSource(20260909))
+	corpus := make(map[uint64][]float32, n)
+	metas := make(map[uint64]Metadata, n)
+	for i := 1; i <= n; i++ {
+		v := make([]float32, dim)
+		for j := range v {
+			v[j] = float32(rng.NormFloat64())
+		}
+		id := uint64(i)
+		m := Metadata{"tag": NewString("a")}
+		// rc cycles 0..12, so an eq on 7 has both true and false points, and
+		// the last few points carry no record at all.
+		if i <= n-5 {
+			m[contentField] = NewRecord(sessionRecordBytesRC(t, uint8(i%13))) //nolint:gosec // i%13 fits uint8
+		}
+		corpus[id] = v
+		metas[id] = m
+		if _, _, err := h.Insert(id, v, 0, m, nil, nil, CASCond{}); err != nil {
+			t.Fatalf("insert %d: %v", i, err)
+		}
+	}
+	return h, corpus, metas
+}
+
+// TestContentRecordPathIsNeverIndexNarrowable pins the fix at the planner's own
+// level, so a refactor that reintroduces the hole fails here with a precise
+// message rather than downstream as a count mismatch.
+func TestContentRecordPathIsNeverIndexNarrowable(t *testing.T) {
+	paths := []string{
+		contentField + "/rc",      // an indexed SHAPE, the dangerous case
+		contentField + "/b#count", // the other indexed shape
+		contentField + "/b/42",    // a row
+		contentField + "/b/42/hi", // a cell
+		contentField + "/#0",      // positional
+	}
+	ops := []FilterOp{FilterEq, FilterIn, FilterGt, FilterGte, FilterLt, FilterContains, FilterMatch}
+	for _, field := range paths {
+		for _, op := range ops {
+			if indexNarrowable(field, op, nil) {
+				t.Errorf("indexNarrowable(%q, %v) = true — reindex writes no posting for any path under $content", field, op)
+			}
+		}
+	}
+	// The guard must be about $content specifically, not about record paths in
+	// general: an ordinary record path with an indexed shape still narrows.
+	if !indexNarrowable("session/rc", FilterEq, nil) {
+		t.Error("an ordinary record path stopped narrowing — the fix over-reached")
+	}
+
+	// filterIndexExact and columnExpressible route through the same helper, so
+	// the exact-gate and the column planner must inherit the decline. A leaf
+	// the gate calls EXACT is one whose empty set is taken as proof.
+	f := Filter{Op: FilterEq, Field: contentField + "/rc", Value: NewInt(7)}
+	if filterIndexExact(f, nil) {
+		t.Error("filterIndexExact graded a $content record path EXACT — an empty posting set would read as proven-empty")
+	}
+	if columnExpressible(f, nil) {
+		t.Error("columnExpressible accepted a $content record path")
+	}
+}
+
+// TestContentRecordPathFilterFirstMatchesBruteForce drives the two consumers
+// that consult the planner — SearchFiltered (filter-first KNN) and matchingIDs
+// (the selection delete-by-filter and scroll perform) — against a brute-force
+// evaluation of the SAME compiled predicate. A regression here is a wrong
+// ANSWER, not a slow one.
+func TestContentRecordPathFilterFirstMatchesBruteForce(t *testing.T) {
+	const (
+		n   = 60
+		dim = 8
+		k   = 12
+	)
+	h, corpus, metas := contentRecordCorpus(t, n)
+	q := make([]float32, dim)
+	for j := range q {
+		q[j] = float32(j) / 10
+	}
+
+	filters := []Filter{
+		{Op: FilterEq, Field: contentField + "/rc", Value: NewInt(7)},
+		{Op: FilterGt, Field: contentField + "/rc", Value: NewInt(10)},
+		{Op: FilterIn, Field: contentField + "/rc", Value: NewInts([]int64{3, 7})},
+		{Op: FilterGte, Field: contentField + "/b#count", Value: NewInt(1)},
+		{Op: FilterRowExists, Field: contentField + "/b/42"},
+		{Op: FilterAnd, And: []Filter{
+			{Op: FilterEq, Field: "tag", Value: NewString("a")},
+			{Op: FilterEq, Field: contentField + "/rc", Value: NewInt(7)},
+		}},
+	}
+
+	nonEmpty := false
+	for _, f := range filters {
+		pred := compileOrFail(t, f)
+
+		got, err := h.SearchFiltered(q, k, f)
+		if err != nil {
+			t.Fatalf("filter %+v: SearchFiltered: %v", f, err)
+		}
+		want := bruteForceFiltered(corpus, metas, q, k, pred)
+		if !eqUint64(resultIDs(got), want) {
+			t.Errorf("filter %+v: SearchFiltered ids %v != brute-force %v", f, resultIDs(got), want)
+		}
+
+		gotIDs, err := h.matchingIDs(f, pred)
+		if err != nil {
+			t.Fatalf("filter %+v: matchingIDs: %v", f, err)
+		}
+		wantSet := bruteMatchIDs(metas, pred)
+		if len(wantSet) > 0 {
+			nonEmpty = true
+		}
+		gotSet := make(map[uint64]struct{}, len(gotIDs))
+		for _, id := range gotIDs {
+			gotSet[id] = struct{}{}
+		}
+		if len(gotSet) != len(wantSet) {
+			t.Errorf("filter %+v: matchingIDs set size %d != brute-force %d", f, len(gotSet), len(wantSet))
+			continue
+		}
+		for id := range wantSet {
+			if _, ok := gotSet[id]; !ok {
+				t.Errorf("filter %+v: matchingIDs missing true match id %d (delete-by-filter would under-delete)", f, id)
+			}
+		}
+	}
+	if !nonEmpty {
+		t.Fatal("every filter's brute-force match set was empty; test proves nothing — fixture is broken")
+	}
+}
+
+// TestContentRecordPathCandidatesDecline pins the posting-set level: every
+// narrowing entry point must DECLINE (ok=false) for a path under $content
+// rather than answer the empty set, which reads as "no matches" to the planner
+// and the exact gate alike.
+func TestContentRecordPathCandidatesDecline(t *testing.T) {
+	h, _, _ := contentRecordCorpus(t, 30)
+	h.mu.RLock()
+	defer h.mu.RUnlock()
+	limit := h.effectiveFilterFirstLimit(h.arena.Size())
+	field := contentField + "/rc"
+
+	if _, ok := h.payloadIdx.eqSet(field, NewInt(7)); ok {
+		t.Error("eqSet answered for a $content record path instead of declining")
+	}
+	if _, ok := h.payloadIdx.inSet(field, NewInts([]int64{7}), limit); ok {
+		t.Error("inSet answered for a $content record path instead of declining")
+	}
+	if _, ok := h.payloadIdx.orderingSet(field, FilterGt, NewInt(1), limit); ok {
+		t.Error("orderingSet answered for a $content record path instead of declining")
+	}
+	if _, ok := collectEqTerms(Filter{Op: FilterEq, Field: field, Value: NewInt(7)}, nil); ok {
+		t.Error("collectEqTerms accepted a $content record path")
+	}
+	if _, ok := h.payloadIdx.candidates(Filter{Op: FilterEq, Field: field, Value: NewInt(7)}, limit); ok {
+		t.Error("candidates narrowed a $content record path — its posting set is permanently empty")
+	}
+	// The sibling conjunct must still narrow: declining is per leaf.
+	if _, ok := h.payloadIdx.candidates(Filter{Op: FilterEq, Field: "tag", Value: NewString("a")}, limit); !ok {
+		t.Error("an ordinary field stopped narrowing — the fix over-reached")
+	}
+}
+
+// TestContentRecordPathIDIndexDeclines is the named/multivector mirror. The
+// id-keyed payload index skips contentField in the same place for the same
+// reason, so it had the same hole; no shipped named/MV write path routes a
+// record into $content today, but "$content" is just a map key a caller can
+// set and the failure mode is silent wrong results.
+func TestContentRecordPathIDIndexDeclines(t *testing.T) {
+	p := newPayloadIndexID()
+	for id := uint64(1); id <= 20; id++ {
+		p.reindex(id, Metadata{
+			"tag":        NewString("a"),
+			contentField: NewRecord(sessionRecordBytesRC(t, uint8(id%13))), //nolint:gosec // id%13 fits uint8
+		})
+	}
+	const limit = 1000
+	field := contentField + "/rc"
+	if _, ok := p.eqSet(field, NewInt(7)); ok {
+		t.Error("id eqSet answered for a $content record path")
+	}
+	if _, ok := p.inSet(field, NewInts([]int64{7}), limit); ok {
+		t.Error("id inSet answered for a $content record path")
+	}
+	if _, ok := p.orderingSet(field, FilterGt, NewInt(1), limit); ok {
+		t.Error("id orderingSet answered for a $content record path")
+	}
+	if _, ok := p.candidatesCapped(Filter{Op: FilterEq, Field: field, Value: NewInt(7)}, limit, limit); ok {
+		t.Error("the id index narrowed a $content record path")
+	}
+	if _, ok := p.candidatesCapped(Filter{Op: FilterEq, Field: "tag", Value: NewString("a")}, limit, limit); !ok {
+		t.Error("an ordinary field stopped narrowing on the id index")
+	}
+}

--- a/vector/payload_index.go
+++ b/vector/payload_index.go
@@ -363,6 +363,7 @@ func (p *payloadIndex) reindex(slot uint32, meta Metadata) {
 	var geoCells []geoSlotCell
 	var slotTokens []fieldToken
 	var slotContains []fieldKey
+	var recKeys []fieldKey // scratch, reused across this slot's record fields
 	for field, v := range meta {
 		if field == contentField {
 			continue // document content is not a filterable field; never index it
@@ -383,6 +384,22 @@ func (p *payloadIndex) reindex(slot uint32, meta Metadata) {
 			}
 			set[slot] = struct{}{}
 			geoCells = append(geoCells, geoSlotCell{field, cell})
+			continue
+		}
+		// Record values expand into SYNTHETIC eq entries — one per top-level
+		// scalar field and per table row count, named "<field>/<recordField>"
+		// — and into nothing else. They take no other branch below anyway
+		// (scalarKeyOf declines a record, it is not a string or an array, so
+		// neither the token nor the contains index would see it), so the
+		// `continue` here changes nothing for the other sub-indexes; it just
+		// says so once.
+		if v.Kind == ValueRecord {
+			recKeys = appendRecordIndexKeys(recKeys[:0], meta, field, v.Rec)
+			for _, rk := range recKeys {
+				if p.postScalar(rk.field, rk.key, slot) {
+					keys = append(keys, rk)
+				}
+			}
 			continue
 		}
 		// Token index: a string/strings field is tokenized (same tokenize() as
@@ -412,20 +429,9 @@ func (p *payloadIndex) reindex(slot uint32, meta Metadata) {
 		if !ok {
 			continue
 		}
-		vals := p.fields[field]
-		if vals == nil {
-			vals = make(map[scalarKey]map[uint32]struct{})
-			p.fields[field] = vals
+		if p.postScalar(field, key, slot) {
+			keys = append(keys, fieldKey{field, key})
 		}
-		set := vals[key]
-		if set == nil {
-			set = make(map[uint32]struct{})
-			vals[key] = set
-			p.markDirty(field) // new distinct key -> sorted cache stale
-		}
-		set[slot] = struct{}{}
-		p.addPost(field, key.kind, 1)
-		keys = append(keys, fieldKey{field, key})
 	}
 	if keys != nil {
 		p.slotKeys[slot] = keys
@@ -439,6 +445,103 @@ func (p *payloadIndex) reindex(slot uint32, meta Metadata) {
 	if slotContains != nil {
 		p.containsSlotKeys[slot] = slotContains
 	}
+}
+
+// postScalar posts slot under (field, key) in the eq index, maintaining the
+// distinct-key bookkeeping (sorted-cache invalidation and the per-kind slot
+// counter). It reports whether the entry was NEW for this slot, i.e. whether
+// the caller must record a reverse entry for it.
+//
+// THE DUPLICATE CHECK IS THE ONE-KEY-PER-(SLOT, FIELD) INVARIANT, which two
+// separate proofs in this file rest on: posts[field] counts SLOTS (see
+// fieldTotalNumeric), and two distinct keys of one field have DISJOINT posting
+// sets (see unionRange's key-count pre-check). A literal field cannot violate
+// it — reindex walks `meta` once per field — but a record CAN: two entries of
+// one record can carry the same synthetic name (a table "b" and a scalar
+// literally named "b#count" both spell "b#count"). Both resolve through
+// lookupPath to the SAME value, so the second post is a pure duplicate; it is
+// dropped here rather than double-counted. reindex has already dropped this
+// slot's previous keys by the time anything is posted, so a slot found in the
+// set can only have been put there by this same call.
+func (p *payloadIndex) postScalar(field string, key scalarKey, slot uint32) bool {
+	vals := p.fields[field]
+	if vals == nil {
+		vals = make(map[scalarKey]map[uint32]struct{})
+		p.fields[field] = vals
+	}
+	set := vals[key]
+	if set == nil {
+		set = make(map[uint32]struct{})
+		vals[key] = set
+		p.markDirty(field) // new distinct key -> sorted cache stale
+	}
+	if _, dup := set[slot]; dup {
+		return false
+	}
+	set[slot] = struct{}{}
+	p.addPost(field, key.kind, 1)
+	return true
+}
+
+// appendRecordIndexKeys appends the synthetic eq entries a ValueRecord payload
+// key contributes to the index: for each top-level field and table row count
+// record.Resolver.IndexEntries enumerates, the pair (payloadKey + "/" + entry
+// name, that field's scalar key). Shared by both reindex implementations (the
+// slot-keyed dense index and the id-keyed named/MV mirror) so the two can
+// never index different things.
+//
+// THE VALUE COMES FROM lookupPath, NOT FROM THE ENTRY. IndexEntries is used
+// only to ENUMERATE the names; what is posted under each name is whatever
+// lookupPath resolves for it — which is, verbatim, the function the compiled
+// predicate reads the field through. That makes the exactness invariant
+// ("the posting set is exactly the slots whose lookupPath value matches")
+// true by construction rather than by an argument about two independent
+// walks agreeing, and it settles every awkward corner for free:
+//
+//   - Exact-key precedence. A literal payload key spelled "session/rc"
+//     shadows the record's rc for lookupPath, so it must shadow it here too.
+//     The literal is indexed by reindex's own loop under the SAME field name,
+//     so the synthetic entry is skipped outright rather than posted twice.
+//   - Ambiguous spellings. A record field named "b#count" and a table named
+//     "b" produce the same synthetic name; a schema carrying two fields of the
+//     same name (possible from hostile bytes — DecodeSchema does not Validate)
+//     produces the same name twice. lookupPath answers ONE value for the name
+//     either way, and that one value is what gets posted.
+//   - Malformed records. IndexEntries errors, nothing is enumerated, nothing
+//     is indexed — and lookupPath resolves nothing through the same bytes, so
+//     both sides agree the field is absent.
+//   - NaN. IndexEntries skips a NaN float and scalarKeyOf declines one, so it
+//     is unindexed on both counts; the comparators reject NaN, so "unindexed"
+//     and "matches nothing" say the same thing (see scalarKeyOf).
+//
+// The cost is one record resolution per enumerated entry, on the write path.
+// For the records this is built for (a handful of fields over a cached
+// schema) that is a few map probes; it scales with (entries × record size)
+// for a pathologically wide record.
+func appendRecordIndexKeys(acc []fieldKey, meta Metadata, payloadKey string, rec []byte) []fieldKey {
+	entries, err := recordResolver.IndexEntries(rec)
+	if err != nil {
+		return acc // malformed record: indexes nothing, resolves nothing
+	}
+	for i := range entries {
+		name := payloadKey + "/" + entries[i].Field
+		if !recordPathIndexedShape(name) {
+			continue // a shape the planner will never trust; posting it would be dead weight
+		}
+		if _, literal := meta[name]; literal {
+			continue // an exact payload key of this name wins, and is indexed as itself
+		}
+		v, ok := lookupPath(meta, name)
+		if !ok {
+			continue
+		}
+		key, ok := scalarKeyOf(v)
+		if !ok {
+			continue
+		}
+		acc = append(acc, fieldKey{name, key})
+	}
+	return acc
 }
 
 // addContains posts slot under each (already DISTINCT) element key in keys within
@@ -647,23 +750,33 @@ var emptySlotSet = map[uint32]struct{}{}
 // set as a superset silently drops every matching row.
 //
 // A record path (isRecordPath — a "payloadKey/path" field naming a location
-// inside a ValueRecord payload key, per sdk/record) breaks the SAME inference
-// the SAME way, for the same underlying reason: reindex only posts LITERAL
-// scalar keys (scalarKeyOf declines ValueRecord outright, per the
-// ValueRecord-considered comments throughout this file), so
-// p.fields["session/rc"] is always nil — even though lookupPath resolves
-// "session/rc" through the record perfectly well at predicate-evaluation
-// time. "No postings" therefore means "never indexed" here too, not "no
-// matches". This is a Phase-1 scoping choice, not a permanent one: Task 6
-// adds indexing for the shapes IndexEntries extracts (top-level scalar fields
-// and #count), and can re-enable indexNarrowable for exactly those shapes
-// once postings exist for them to prove anything from.
+// inside a ValueRecord payload key, per sdk/record) can break the SAME
+// inference the SAME way, and used to break it for every shape: reindex posted
+// only LITERAL scalar keys, so p.fields["session/rc"] was always nil even
+// though lookupPath resolves "session/rc" through the record perfectly well at
+// predicate-evaluation time.
 //
-// Declining instead is always safe: an un-narrowed conjunct is simply re-checked
-// by the predicate, and a filter that narrows on nothing else falls back to
-// graph traversal, which evaluates $content and record paths correctly.
-func indexNarrowable(field string) bool {
-	return field != contentField && !isRecordPath(field)
+// reindex now expands a record's top-level fields and table row counts into
+// synthetic postings named "<payloadKey>/<field>" (appendRecordIndexKeys), so
+// SOME record paths have postings and some still do not — and the ops differ
+// too, because a record scalar gets an eq key and nothing else. That decision
+// is not made here: recordPathIndexed owns it, per shape AND per op, and
+// filterIndexExact and columnExpressible route through this same function so
+// no consumer can disagree with the writer about what was indexed. `op` is
+// the leaf's op (already lowered to the plain ordering spelling where a caller
+// lowers FilterDt*, which is harmless: both spellings are narrowable).
+//
+// Declining is always safe: an un-narrowed conjunct is simply re-checked by
+// the predicate, and a filter that narrows on nothing else falls back to graph
+// traversal, which evaluates $content and every record path correctly.
+func indexNarrowable(field string, op FilterOp) bool {
+	if field == contentField {
+		return false
+	}
+	if !isRecordPath(field) {
+		return true
+	}
+	return recordPathIndexed(field, op)
 }
 
 // candidates returns (slots, true) when filter can be narrowed by the payload
@@ -941,7 +1054,7 @@ func intersectSlotSets(sets []narrowSet, maxCand int) ([]uint32, bool) {
 func collectEqTerms(f Filter) ([]fieldKey, bool) {
 	switch f.Op {
 	case FilterEq:
-		if !indexNarrowable(f.Field) {
+		if !indexNarrowable(f.Field, FilterEq) {
 			return nil, false
 		}
 		if key, ok := scalarKeyOf(f.Value); ok {
@@ -953,7 +1066,7 @@ func collectEqTerms(f Filter) ([]fieldKey, bool) {
 		for _, c := range f.And {
 			switch c.Op {
 			case FilterEq:
-				if !indexNarrowable(c.Field) {
+				if !indexNarrowable(c.Field, FilterEq) {
 					continue // $content is never indexed; the predicate re-checks it
 				}
 				if key, ok := scalarKeyOf(c.Value); ok {
@@ -1089,7 +1202,7 @@ func (p *payloadIndex) collectMatchSets(f Filter, limit int) ([]map[uint32]struc
 // postings, or a missing element key, yields the empty sentinel set (ok=true): no
 // doc's array contains want, so the exact superset is empty.
 func (p *payloadIndex) containsSet(field string, want Value, limit int) (map[uint32]struct{}, bool) {
-	if !indexNarrowable(field) {
+	if !indexNarrowable(field, FilterContains) {
 		return nil, false
 	}
 	key, ok := scalarKeyOf(want)
@@ -1169,7 +1282,7 @@ func (p *payloadIndex) collectContainsSets(f Filter, limit int) ([]map[uint32]st
 // A missing query token yields an empty set (ok=true): no doc has all tokens, so
 // the exact superset is empty. The returned set is a fresh map the caller owns.
 func (p *payloadIndex) matchSet(field string, want Value, limit int) (map[uint32]struct{}, bool) {
-	if !indexNarrowable(field) {
+	if !indexNarrowable(field, FilterMatch) {
 		return nil, false
 	}
 	if want.Kind != ValueString {
@@ -1237,7 +1350,7 @@ func (p *payloadIndex) matchSet(field string, want Value, limit int) (map[uint32
 // SUPERSET INVARIANT): the bbox fully contains the region and the cover fully
 // contains the bbox.
 func (p *payloadIndex) geoSet(field string, op FilterOp, g *GeoCondition, limit int) (map[uint32]struct{}, bool) {
-	if !indexNarrowable(field) {
+	if !indexNarrowable(field, op) {
 		return nil, false
 	}
 	if g == nil {
@@ -1350,7 +1463,7 @@ func (p *payloadIndex) collectRangeSets(f Filter, limit int) ([]narrowSet, bool)
 // eqSet returns the posting set for field == v (the shared stored map, not a
 // copy). ok=false when v is not equality-indexable.
 func (p *payloadIndex) eqSet(field string, v Value) (map[uint32]struct{}, bool) {
-	if !indexNarrowable(field) {
+	if !indexNarrowable(field, FilterEq) {
 		return nil, false
 	}
 	key, ok := scalarKeyOf(v)
@@ -1392,7 +1505,7 @@ func (p *payloadIndex) orderingSet(field string, op FilterOp, want Value, limit 
 // and a single budget cannot tell those two apart. The gate declines the first
 // shape and arms on the second; see gateRangeKeyDNS.
 func (p *payloadIndex) orderingSetCapped(field string, op FilterOp, want Value, massLimit, keyLimit int) (map[uint32]struct{}, bool) {
-	if !indexNarrowable(field) {
+	if !indexNarrowable(field, op) {
 		return nil, false
 	}
 	vals := p.fields[field]
@@ -1605,7 +1718,7 @@ func (p *payloadIndex) appendComplementSets(f Filter, liveCount, massLimit, keyL
 // cannot be complemented exactly. See collectComplementSets for why every guard
 // here is a hard bail.
 func (p *payloadIndex) complementLeaf(field string, op FilterOp, want Value, liveCount, massLimit, keyLimit int, acc []map[uint32]struct{}, mass int) ([]map[uint32]struct{}, int, bool) {
-	if !indexNarrowable(field) {
+	if !indexNarrowable(field, op) {
 		return acc, mass, false
 	}
 	neg, ok := negateOrdering(op)
@@ -1724,7 +1837,7 @@ func strRange(s []scalarKey, op FilterOp, want string) (lo, hi int) {
 // array (strings/ints/floats). ok=false for a non-array value or when the union
 // exceeds `limit`.
 func (p *payloadIndex) inSet(field string, want Value, limit int) (map[uint32]struct{}, bool) {
-	if !indexNarrowable(field) {
+	if !indexNarrowable(field, FilterIn) {
 		return nil, false
 	}
 	vals := p.fields[field]

--- a/vector/payload_index.go
+++ b/vector/payload_index.go
@@ -880,6 +880,19 @@ func indexNarrowable(field string, op FilterOp, poison recordPoison) bool {
 	if !ok {
 		return true // no '/': an ordinary literal key, indexed as it always was
 	}
+	// A record hanging off $content is invisible to the index for the SAME
+	// reason $content itself is: reindex skips the contentField entry before it
+	// reaches the ValueRecord branch, so no synthetic posting is ever written
+	// for any path under it. Without this, "$content/rc" splits, parses, and
+	// satisfies both recordShapeIndexed and recordOpIndexed, so the planner
+	// grades a permanently EMPTY posting set as exact and filter-first drops
+	// every matching row — the bare-$content hole one level deeper. Declining
+	// here (rather than teaching reindex to expand records under $content)
+	// keeps "$content is never a filter key" whole and keeps ONE record
+	// expansion site.
+	if payloadKey == contentField {
+		return false
+	}
 	p, err := record.ParsePath(path)
 	if err != nil {
 		// A literal key that merely CONTAINS a '/' but is not a valid path

--- a/vector/payload_index.go
+++ b/vector/payload_index.go
@@ -7,6 +7,8 @@ import (
 	"sort"
 	"sync"
 	"sync/atomic"
+
+	"github.com/rostamlabs/rostam/sdk/record"
 )
 
 // scalarKey is a comparable map key for an equality-indexable scalar Value
@@ -163,6 +165,16 @@ type payloadIndex struct {
 	// are disjoint.
 	posts map[string]fieldPosts
 
+	// badRecords counts, per PAYLOAD KEY, the live slots holding a ValueRecord
+	// that IndexEntries could not enumerate, and badSlotKeys records which keys
+	// each slot contributes so reindex removes its contribution exactly once.
+	// A non-zero count makes every path under that key un-narrowable — see
+	// recordPoison for why that is the only sound answer. Maintained by reindex
+	// under the owner's write lock, and rebuilt by rebuild for free because
+	// rebuild reindexes every slot.
+	badRecords  recordPoison
+	badSlotKeys map[uint32][]string
+
 	// cols is the numeric column sidecar: field -> slot-indexed []float64 with
 	// NaN for "no numeric value". Built lazily by the query path (ensureColumn,
 	// under colsMu) and maintained by reindex (updateColumns, under the owner's
@@ -268,6 +280,8 @@ func newPayloadIndex() *payloadIndex {
 		contains:         make(map[string]map[scalarKey]map[uint32]struct{}),
 		containsSlotKeys: make(map[uint32][]fieldKey),
 		posts:            make(map[string]fieldPosts),
+		badRecords:       make(recordPoison),
+		badSlotKeys:      make(map[uint32][]string),
 	}
 }
 
@@ -356,6 +370,15 @@ func (p *payloadIndex) reindex(slot uint32, meta Metadata) {
 		}
 		delete(p.containsSlotKeys, slot)
 	}
+	// The malformed-record markers are reverse entries like any other: dropped
+	// FIRST, so a slot whose record was repaired (or whose payload was cleared,
+	// which is the early return below) stops poisoning its payload key.
+	if old, ok := p.badSlotKeys[slot]; ok {
+		for _, key := range old {
+			p.dropBadRecord(key)
+		}
+		delete(p.badSlotKeys, slot)
+	}
 	if len(meta) == 0 {
 		return
 	}
@@ -364,6 +387,7 @@ func (p *payloadIndex) reindex(slot uint32, meta Metadata) {
 	var slotTokens []fieldToken
 	var slotContains []fieldKey
 	var recKeys []fieldKey // scratch, reused across this slot's record fields
+	var badKeys []string   // payload keys whose record this slot could not index
 	for field, v := range meta {
 		if field == contentField {
 			continue // document content is not a filterable field; never index it
@@ -394,7 +418,17 @@ func (p *payloadIndex) reindex(slot uint32, meta Metadata) {
 		// `continue` here changes nothing for the other sub-indexes; it just
 		// says so once.
 		if v.Kind == ValueRecord {
-			recKeys = appendRecordIndexKeys(recKeys[:0], meta, field, v.Rec)
+			var whole bool
+			recKeys, whole = appendRecordIndexKeys(recKeys[:0], meta, field, v.Rec)
+			if !whole {
+				// Enumeration failed, so this record's fields are NOT in the
+				// index — while Resolve will still answer for whichever of them
+				// survived the damage. Poison the payload key rather than post
+				// what little we have: see recordPoison.
+				p.addBadRecord(field)
+				badKeys = append(badKeys, field)
+				continue
+			}
 			for _, rk := range recKeys {
 				if p.postScalar(rk.field, rk.key, slot) {
 					keys = append(keys, rk)
@@ -444,6 +478,26 @@ func (p *payloadIndex) reindex(slot uint32, meta Metadata) {
 	}
 	if slotContains != nil {
 		p.containsSlotKeys[slot] = slotContains
+	}
+	if badKeys != nil {
+		p.badSlotKeys[slot] = badKeys
+	}
+}
+
+// addBadRecord records that one more live slot holds an unindexable record
+// under payloadKey. Must hold the owner's write lock.
+func (p *payloadIndex) addBadRecord(payloadKey string) {
+	p.badRecords[payloadKey]++
+}
+
+// dropBadRecord removes one slot's contribution to payloadKey's unindexable
+// count, deleting the entry at zero so the key leaves nothing behind and
+// poisoned() is a plain map probe. Must hold the owner's write lock.
+func (p *payloadIndex) dropBadRecord(payloadKey string) {
+	if n := p.badRecords[payloadKey]; n > 1 {
+		p.badRecords[payloadKey] = n - 1
+	} else {
+		delete(p.badRecords, payloadKey)
 	}
 }
 
@@ -507,9 +561,11 @@ func (p *payloadIndex) postScalar(field string, key scalarKey, slot uint32) bool
 //     same name (possible from hostile bytes — DecodeSchema does not Validate)
 //     produces the same name twice. lookupPath answers ONE value for the name
 //     either way, and that one value is what gets posted.
-//   - Malformed records. IndexEntries errors, nothing is enumerated, nothing
-//     is indexed — and lookupPath resolves nothing through the same bytes, so
-//     both sides agree the field is absent.
+//   - Malformed records. IndexEntries errors and whole == false; the caller
+//     poisons the payload key, because a PARTIALLY damaged record still
+//     resolves its intact fields (see recordPoison — this is the fix-round-1
+//     CRITICAL, and the reason this function reports the failure rather than
+//     swallowing it).
 //   - NaN. IndexEntries skips a NaN float and scalarKeyOf declines one, so it
 //     is unindexed on both counts; the comparators reject NaN, so "unindexed"
 //     and "matches nothing" say the same thing (see scalarKeyOf).
@@ -518,10 +574,16 @@ func (p *payloadIndex) postScalar(field string, key scalarKey, slot uint32) bool
 // For the records this is built for (a handful of fields over a cached
 // schema) that is a few map probes; it scales with (entries × record size)
 // for a pathologically wide record.
-func appendRecordIndexKeys(acc []fieldKey, meta Metadata, payloadKey string, rec []byte) []fieldKey {
+func appendRecordIndexKeys(acc []fieldKey, meta Metadata, payloadKey string, rec []byte) (out []fieldKey, whole bool) {
 	entries, err := recordResolver.IndexEntries(rec)
 	if err != nil {
-		return acc // malformed record: indexes nothing, resolves nothing
+		// The record could not be enumerated IN FULL. That is not the same as
+		// "it holds nothing": IndexEntries fails if ANY field is damaged, while
+		// Resolve reads only the bytes on its own path and keeps answering for
+		// the intact ones. The caller must fail the whole payload key closed —
+		// see recordPoison — because there is no partial posting set that could
+		// be trusted.
+		return acc, false
 	}
 	for i := range entries {
 		name := payloadKey + "/" + entries[i].Field
@@ -541,7 +603,7 @@ func appendRecordIndexKeys(acc []fieldKey, meta Metadata, payloadKey string, rec
 		}
 		acc = append(acc, fieldKey{name, key})
 	}
-	return acc
+	return acc, true
 }
 
 // addContains posts slot under each (already DISTINCT) element key in keys within
@@ -689,7 +751,12 @@ func (p *payloadIndex) rebuild(a *arena) {
 	p.contains = make(map[string]map[scalarKey]map[uint32]struct{})
 	p.containsSlotKeys = make(map[uint32][]fieldKey)
 	p.posts = make(map[string]fieldPosts) // reindex below refills it
-	p.dropColumns()                       // drop the column sidecar; the query path rebuilds it lazily
+	// Reset the malformed-record counters too, or a key poisoned before the
+	// rebuild would stay poisoned by slots that no longer exist. reindex below
+	// refills them from the metadata that actually survived.
+	p.badRecords = make(recordPoison)
+	p.badSlotKeys = make(map[uint32][]string)
+	p.dropColumns() // drop the column sidecar; the query path rebuilds it lazily
 	// EVERY SLOT IN idMap, TOMBSTONED OR NOT. This used to skip tombstoned slots,
 	// which looked like a tidy saving and was actually a divergence: the
 	// INCREMENTAL path (Delete tombstones without touching the index) leaves them
@@ -723,7 +790,8 @@ func (p *payloadIndex) isEmpty() bool {
 		return true
 	}
 	return len(p.fields) == 0 && len(p.slotKeys) == 0 && len(p.geo) == 0 &&
-		len(p.tokens) == 0 && len(p.contains) == 0 && len(p.posts) == 0 && len(p.cols) == 0
+		len(p.tokens) == 0 && len(p.contains) == 0 && len(p.posts) == 0 && len(p.cols) == 0 &&
+		len(p.badRecords) == 0 && len(p.badSlotKeys) == 0
 }
 
 // emptySlotSet is a shared read-only sentinel returned when a field has no
@@ -749,34 +817,65 @@ var emptySlotSet = map[uint32]struct{}{}
 // postings" means "never indexed", not "no matches", and treating the empty
 // set as a superset silently drops every matching row.
 //
-// A record path (isRecordPath — a "payloadKey/path" field naming a location
-// inside a ValueRecord payload key, per sdk/record) can break the SAME
-// inference the SAME way, and used to break it for every shape: reindex posted
-// only LITERAL scalar keys, so p.fields["session/rc"] was always nil even
-// though lookupPath resolves "session/rc" through the record perfectly well at
+// A record path (a "payloadKey/path" field naming a location inside a
+// ValueRecord payload key, per sdk/record) can break the SAME inference the
+// SAME way, and used to break it for every shape: reindex posted only LITERAL
+// scalar keys, so p.fields["session/rc"] was always nil even though lookupPath
+// resolves "session/rc" through the record perfectly well at
 // predicate-evaluation time.
 //
 // reindex now expands a record's top-level fields and table row counts into
 // synthetic postings named "<payloadKey>/<field>" (appendRecordIndexKeys), so
-// SOME record paths have postings and some still do not — and the ops differ
-// too, because a record scalar gets an eq key and nothing else. That decision
-// is not made here: recordPathIndexed owns it, per shape AND per op, and
-// filterIndexExact and columnExpressible route through this same function so
-// no consumer can disagree with the writer about what was indexed. `op` is
-// the leaf's op (already lowered to the plain ordering spelling where a caller
+// SOME record paths have postings and some do not — and the ops differ too,
+// because a record scalar gets an eq key and nothing else. THREE things decide
+// it, in this order:
+//
+//  1. the payload key must not be POISONED (recordPoison): a live slot holding
+//     a record IndexEntries could not enumerate makes every path under that key
+//     unprovable, because the damaged record still resolves its intact fields;
+//  2. the SHAPE must be one reindex posts (recordShapeIndexed);
+//  3. the OP's posting set must be exact for that shape (recordOpIndexed).
+//
+// filterIndexExact and columnExpressible route through this same function, so
+// no consumer can disagree with the writer about what was indexed. `op` is the
+// leaf's op (already lowered to the plain ordering spelling where a caller
 // lowers FilterDt*, which is harmless: both spellings are narrowable).
+//
+// A KNOWN, ACCEPTED PHASE-1 COST. A LITERAL payload key that merely LOOKS like
+// a record path ("a/b", "loc/home") loses match / contains / geo acceleration
+// here, even though reindex builds its tokens, contains entries and geo cells
+// exactly as for any other literal key. The decision is per FIELD NAME, and a
+// field name cannot tell the two apart: whether "a/b" is a literal key or a
+// path into a record under "a" is a per-POINT fact, and one collection may hold
+// both. Declining costs a graph fallback (and some dead index weight); guessing
+// the other way would cost correctness on the synthetic side. Making this exact
+// would need a per-field record of how each name was posted, which is Phase 2.
 //
 // Declining is always safe: an un-narrowed conjunct is simply re-checked by
 // the predicate, and a filter that narrows on nothing else falls back to graph
 // traversal, which evaluates $content and every record path correctly.
-func indexNarrowable(field string, op FilterOp) bool {
+func indexNarrowable(field string, op FilterOp, poison recordPoison) bool {
 	if field == contentField {
 		return false
 	}
-	if !isRecordPath(field) {
+	// ONE parse decides everything below: whether field is a record path at
+	// all, which payload key it hangs off, and which shape it names.
+	payloadKey, path, ok := record.SplitField(field)
+	if !ok {
+		return true // no '/': an ordinary literal key, indexed as it always was
+	}
+	p, err := record.ParsePath(path)
+	if err != nil {
+		// A literal key that merely CONTAINS a '/' but is not a valid path
+		// ("a/b/rc" with a non-numeric row segment). lookupPath resolves it by
+		// exact match only, and reindex posts it by exact match only, so the
+		// two agree and it narrows like any other literal key.
 		return true
 	}
-	return recordPathIndexed(field, op)
+	if poison.poisoned(payloadKey) {
+		return false
+	}
+	return recordShapeIndexed(p) && recordOpIndexed(op)
 }
 
 // candidates returns (slots, true) when filter can be narrowed by the payload
@@ -904,7 +1003,7 @@ func (p *payloadIndex) collectNarrowSets(f Filter, limit int) ([]narrowSet, bool
 		// Intersect the geo sets with any equality sets in the same And so the most
 		// selective conjunct(s) drive the candidate set; the predicate re-checks
 		// everything else. A pure geo filter just returns the geo union.
-		if eqTerms, ok := collectEqTerms(f); ok {
+		if eqTerms, ok := collectEqTerms(f, p.badRecords); ok {
 			for _, t := range eqTerms {
 				vals := p.fields[t.field]
 				if vals == nil {
@@ -931,7 +1030,7 @@ func (p *payloadIndex) collectNarrowSets(f Filter, limit int) ([]narrowSet, bool
 	// Equality narrowing. Also covers And(eq, range): the eq terms narrow and
 	// the predicate re-checks the range conjuncts, so range terms need no index
 	// here. Unchanged fast path.
-	if terms, ok := collectEqTerms(f); ok {
+	if terms, ok := collectEqTerms(f, p.badRecords); ok {
 		sets := make([]narrowSet, 0, len(terms))
 		for _, t := range terms {
 			vals := p.fields[t.field]
@@ -1051,10 +1150,10 @@ func intersectSlotSets(sets []narrowSet, maxCand int) ([]uint32, bool) {
 // constraints the caller re-checks via the predicate, so the collected terms'
 // intersection remains a superset of the matching set. Returns ok=false when
 // the filter is not an And/Eq narrowing shape (Or, Not, range-only, ...).
-func collectEqTerms(f Filter) ([]fieldKey, bool) {
+func collectEqTerms(f Filter, poison recordPoison) ([]fieldKey, bool) {
 	switch f.Op {
 	case FilterEq:
-		if !indexNarrowable(f.Field, FilterEq) {
+		if !indexNarrowable(f.Field, FilterEq, poison) {
 			return nil, false
 		}
 		if key, ok := scalarKeyOf(f.Value); ok {
@@ -1066,14 +1165,14 @@ func collectEqTerms(f Filter) ([]fieldKey, bool) {
 		for _, c := range f.And {
 			switch c.Op {
 			case FilterEq:
-				if !indexNarrowable(c.Field, FilterEq) {
+				if !indexNarrowable(c.Field, FilterEq, poison) {
 					continue // $content is never indexed; the predicate re-checks it
 				}
 				if key, ok := scalarKeyOf(c.Value); ok {
 					acc = append(acc, fieldKey{c.Field, key})
 				}
 			case FilterAnd:
-				if t, ok := collectEqTerms(c); ok {
+				if t, ok := collectEqTerms(c, poison); ok {
 					acc = append(acc, t...)
 				}
 			}
@@ -1202,7 +1301,7 @@ func (p *payloadIndex) collectMatchSets(f Filter, limit int) ([]map[uint32]struc
 // postings, or a missing element key, yields the empty sentinel set (ok=true): no
 // doc's array contains want, so the exact superset is empty.
 func (p *payloadIndex) containsSet(field string, want Value, limit int) (map[uint32]struct{}, bool) {
-	if !indexNarrowable(field, FilterContains) {
+	if !indexNarrowable(field, FilterContains, p.badRecords) {
 		return nil, false
 	}
 	key, ok := scalarKeyOf(want)
@@ -1282,7 +1381,7 @@ func (p *payloadIndex) collectContainsSets(f Filter, limit int) ([]map[uint32]st
 // A missing query token yields an empty set (ok=true): no doc has all tokens, so
 // the exact superset is empty. The returned set is a fresh map the caller owns.
 func (p *payloadIndex) matchSet(field string, want Value, limit int) (map[uint32]struct{}, bool) {
-	if !indexNarrowable(field, FilterMatch) {
+	if !indexNarrowable(field, FilterMatch, p.badRecords) {
 		return nil, false
 	}
 	if want.Kind != ValueString {
@@ -1350,7 +1449,7 @@ func (p *payloadIndex) matchSet(field string, want Value, limit int) (map[uint32
 // SUPERSET INVARIANT): the bbox fully contains the region and the cover fully
 // contains the bbox.
 func (p *payloadIndex) geoSet(field string, op FilterOp, g *GeoCondition, limit int) (map[uint32]struct{}, bool) {
-	if !indexNarrowable(field, op) {
+	if !indexNarrowable(field, op, p.badRecords) {
 		return nil, false
 	}
 	if g == nil {
@@ -1463,7 +1562,7 @@ func (p *payloadIndex) collectRangeSets(f Filter, limit int) ([]narrowSet, bool)
 // eqSet returns the posting set for field == v (the shared stored map, not a
 // copy). ok=false when v is not equality-indexable.
 func (p *payloadIndex) eqSet(field string, v Value) (map[uint32]struct{}, bool) {
-	if !indexNarrowable(field, FilterEq) {
+	if !indexNarrowable(field, FilterEq, p.badRecords) {
 		return nil, false
 	}
 	key, ok := scalarKeyOf(v)
@@ -1505,7 +1604,7 @@ func (p *payloadIndex) orderingSet(field string, op FilterOp, want Value, limit 
 // and a single budget cannot tell those two apart. The gate declines the first
 // shape and arms on the second; see gateRangeKeyDNS.
 func (p *payloadIndex) orderingSetCapped(field string, op FilterOp, want Value, massLimit, keyLimit int) (map[uint32]struct{}, bool) {
-	if !indexNarrowable(field, op) {
+	if !indexNarrowable(field, op, p.badRecords) {
 		return nil, false
 	}
 	vals := p.fields[field]
@@ -1718,7 +1817,7 @@ func (p *payloadIndex) appendComplementSets(f Filter, liveCount, massLimit, keyL
 // cannot be complemented exactly. See collectComplementSets for why every guard
 // here is a hard bail.
 func (p *payloadIndex) complementLeaf(field string, op FilterOp, want Value, liveCount, massLimit, keyLimit int, acc []map[uint32]struct{}, mass int) ([]map[uint32]struct{}, int, bool) {
-	if !indexNarrowable(field, op) {
+	if !indexNarrowable(field, op, p.badRecords) {
 		return acc, mass, false
 	}
 	neg, ok := negateOrdering(op)
@@ -1837,7 +1936,7 @@ func strRange(s []scalarKey, op FilterOp, want string) (lo, hi int) {
 // array (strings/ints/floats). ok=false for a non-array value or when the union
 // exceeds `limit`.
 func (p *payloadIndex) inSet(field string, want Value, limit int) (map[uint32]struct{}, bool) {
-	if !indexNarrowable(field, FilterIn) {
+	if !indexNarrowable(field, FilterIn, p.badRecords) {
 		return nil, false
 	}
 	vals := p.fields[field]

--- a/vector/payload_index.go
+++ b/vector/payload_index.go
@@ -630,26 +630,41 @@ var emptySlotSet = map[uint32]struct{}{}
 // indexNarrowable reports whether `field` can be narrowed by the payload index
 // at all.
 //
-// THE EMPTY-SET INFERENCE, AND THE ONE FIELD THAT BREAKS IT. Every narrowing
+// THE EMPTY-SET INFERENCE, AND THE FIELDS THAT BREAK IT. Every narrowing
 // path answers a missing field with the empty sentinel, and that is normally
 // sound: a field no document carries as an indexable value is a field no
 // document can MATCH on, so "no postings" and "no matches" are the same
 // statement. The inference depends on the index having TRIED to index the
-// field.
+// field. Two field shapes never get that try:
 //
-// contentField is the one key it never tries. reindex skips $content by design
-// (a document body is not a filter key, and equality-indexing megabytes of text
-// would be absurd), so its posting maps are permanently empty — while the
-// compiled predicate reads $content perfectly well, because content is stored as
-// an ordinary entry in the slot's metadata map and lookupPath finds it like any
-// other key. Only the RETURN path strips it (fetchDocs / docForLocked). So for
-// $content alone, "no postings" means "never indexed", not "no matches", and
-// treating the empty set as a superset silently drops every matching row.
+// contentField. reindex skips $content by design (a document body is not a
+// filter key, and equality-indexing megabytes of text would be absurd), so its
+// posting maps are permanently empty — while the compiled predicate reads
+// $content perfectly well, because content is stored as an ordinary entry in
+// the slot's metadata map and lookupPath finds it like any other key. Only the
+// RETURN path strips it (fetchDocs / docForLocked). So for $content alone, "no
+// postings" means "never indexed", not "no matches", and treating the empty
+// set as a superset silently drops every matching row.
+//
+// A record path (isRecordPath — a "payloadKey/path" field naming a location
+// inside a ValueRecord payload key, per sdk/record) breaks the SAME inference
+// the SAME way, for the same underlying reason: reindex only posts LITERAL
+// scalar keys (scalarKeyOf declines ValueRecord outright, per the
+// ValueRecord-considered comments throughout this file), so
+// p.fields["session/rc"] is always nil — even though lookupPath resolves
+// "session/rc" through the record perfectly well at predicate-evaluation
+// time. "No postings" therefore means "never indexed" here too, not "no
+// matches". This is a Phase-1 scoping choice, not a permanent one: Task 6
+// adds indexing for the shapes IndexEntries extracts (top-level scalar fields
+// and #count), and can re-enable indexNarrowable for exactly those shapes
+// once postings exist for them to prove anything from.
 //
 // Declining instead is always safe: an un-narrowed conjunct is simply re-checked
 // by the predicate, and a filter that narrows on nothing else falls back to
-// graph traversal, which evaluates $content correctly.
-func indexNarrowable(field string) bool { return field != contentField }
+// graph traversal, which evaluates $content and record paths correctly.
+func indexNarrowable(field string) bool {
+	return field != contentField && !isRecordPath(field)
+}
 
 // candidates returns (slots, true) when filter can be narrowed by the payload
 // index — the slots are a SUPERSET of the filter's matching live slots, so the

--- a/vector/payload_index.go
+++ b/vector/payload_index.go
@@ -52,6 +52,12 @@ func scalarKeyOf(v Value) (scalarKey, bool) {
 		return scalarKey{kind: ValueFloat, f: v.Flt}, true
 	case ValueBool:
 		return scalarKey{kind: ValueBool, b: v.Bool}, true
+	case ValueRecord:
+		// A record is a byte blob, not a scalar: it has no equality/ordering key
+		// here (its top-level fields get their own synthetic scalar entries via
+		// the record resolver, not this index). Made explicit rather than left to
+		// the default below, matching this file's own NaN-decline discipline.
+		return scalarKey{}, false
 	default:
 		return scalarKey{}, false
 	}
@@ -190,7 +196,7 @@ func (p *payloadIndex) addPost(field string, kind ValueKind, delta int) {
 		c.num += delta
 	case ValueString:
 		c.str += delta
-	default:
+	default: // ValueRecord (and bool) considered: never reaches here — scalarKeyOf declines records, so no scalarKey carries kind == ValueRecord.
 		return // bool: counted by neither, see fieldPosts
 	}
 	if c.num == 0 && c.str == 0 {
@@ -290,6 +296,8 @@ func (p *payloadIndex) ensureSorted(field string) *sortedKeys {
 	sc.num = sc.num[:0]
 	sc.str = sc.str[:0]
 	for key := range p.fields[field] {
+		// ValueRecord considered: key.kind can never be ValueRecord — scalarKeyOf
+		// declines records before a scalarKey is ever minted, so no case is needed.
 		switch key.kind {
 		case ValueInt:
 			sc.num = append(sc.num, numEntry{float64(key.i), key})
@@ -381,7 +389,8 @@ func (p *payloadIndex) reindex(slot uint32, meta Metadata) {
 		// the FilterMatch predicate) and each DISTINCT token posts the slot once
 		// (per-document). The eq index below still indexes a ValueString as one
 		// whole-string key; the two are independent. ValueStrings only lives here
-		// (scalarKeyOf declines slices).
+		// (scalarKeyOf declines slices). ValueRecord considered: no case, so it
+		// correctly declines tokenization like every other non-string kind.
 		switch v.Kind {
 		case ValueString:
 			slotTokens = p.addTokens(field, tokenize(v.Str), slot, slotTokens)
@@ -1746,6 +1755,8 @@ func (p *payloadIndex) inSet(field string, want Value, limit int) (map[uint32]st
 		}
 		return out, true
 	default:
+		// ValueRecord considered: falls here, correctly declining — a record is
+		// not an array, so it can never be a FilterIn value.
 		return nil, false
 	}
 }

--- a/vector/payload_index.go
+++ b/vector/payload_index.go
@@ -841,15 +841,31 @@ var emptySlotSet = map[uint32]struct{}{}
 // leaf's op (already lowered to the plain ordering spelling where a caller
 // lowers FilterDt*, which is harmless: both spellings are narrowable).
 //
-// A KNOWN, ACCEPTED PHASE-1 COST. A LITERAL payload key that merely LOOKS like
-// a record path ("a/b", "loc/home") loses match / contains / geo acceleration
-// here, even though reindex builds its tokens, contains entries and geo cells
-// exactly as for any other literal key. The decision is per FIELD NAME, and a
-// field name cannot tell the two apart: whether "a/b" is a literal key or a
-// path into a record under "a" is a per-POINT fact, and one collection may hold
-// both. Declining costs a graph fallback (and some dead index weight); guessing
-// the other way would cost correctness on the synthetic side. Making this exact
-// would need a per-field record of how each name was posted, which is Phase 2.
+// A KNOWN, ACCEPTED PHASE-1 COST, AND IT IS NOT UNIFORM ACROSS SHAPES. A
+// LITERAL payload key that merely LOOKS like a record path loses acceleration
+// here even though reindex builds its tokens, contains entries and geo cells
+// exactly as for any other literal key. HOW MUCH it loses depends on what its
+// tail parses as, because the shape guard runs before the op guard:
+//
+//   - ONE INDEXED SEGMENT ("a/b", "a/b#count"): recordShapeIndexed passes, so
+//     the op guard decides — eq / in / range still accelerate, and only
+//     match / contains / geo are declined.
+//   - ANY OTHER PARSEABLE PATH — a longer path ("metrics/q1/42", naming a row
+//     or a cell) or a positional segment ("a/#0") — fails recordShapeIndexed,
+//     so EVERY op is declined, eq and range included. These shapes have no
+//     postings at all, synthetic or otherwise, so there is nothing to be exact
+//     about.
+//   - A TAIL THAT IS NOT A VALID PATH ("metrics/2024/q1": "2024" is a legal
+//     field but "q1" is not a legal row key) never reaches either guard — the
+//     ParsePath failure above returns true and the key narrows like any other
+//     literal key, at full acceleration.
+//
+// The decision is per FIELD NAME, and a field name cannot tell the two apart:
+// whether "a/b" is a literal key or a path into a record under "a" is a
+// per-POINT fact, and one collection may hold both. Declining costs a graph
+// fallback (and some dead index weight); guessing the other way would cost
+// correctness on the synthetic side. Making this exact would need a per-field
+// record of how each name was posted, which is Phase 2.
 //
 // Declining is always safe: an un-narrowed conjunct is simply re-checked by
 // the predicate, and a filter that narrows on nothing else falls back to graph

--- a/vector/payload_index_id.go
+++ b/vector/payload_index_id.go
@@ -119,6 +119,8 @@ func (p *payloadIndexID) ensureSorted(field string) *sortedKeys {
 	sc.num = sc.num[:0]
 	sc.str = sc.str[:0]
 	for key := range p.fields[field] {
+		// ValueRecord considered: key.kind can never be ValueRecord — scalarKeyOf
+		// declines records before a scalarKey is ever minted, so no case is needed.
 		switch key.kind {
 		case ValueInt:
 			sc.num = append(sc.num, numEntry{float64(key.i), key})
@@ -196,7 +198,8 @@ func (p *payloadIndexID) reindex(id uint64, meta Metadata) {
 		// FilterMatch predicate) and each DISTINCT token posts the id once (per-
 		// document). The eq index below still indexes a ValueString as one whole-
 		// string key; the two are independent. ValueStrings only lives here
-		// (scalarKeyOf declines slices).
+		// (scalarKeyOf declines slices). ValueRecord considered: no case, so it
+		// correctly declines tokenization like every other non-string kind.
 		switch v.Kind {
 		case ValueString:
 			idTokens = p.addTokens(field, tokenize(v.Str), id, idTokens)
@@ -996,6 +999,8 @@ func (p *payloadIndexID) inSet(field string, want Value, limit int) (map[uint64]
 		}
 		return out, true
 	default:
+		// ValueRecord considered: falls here, correctly declining — a record is
+		// not an array, so it can never be a FilterIn value.
 		return nil, false
 	}
 }

--- a/vector/payload_index_id.go
+++ b/vector/payload_index_id.go
@@ -172,6 +172,7 @@ func (p *payloadIndexID) reindex(id uint64, meta Metadata) {
 	var geoCells []geoSlotCell
 	var idTokens []fieldToken
 	var idContains []fieldKey
+	var recKeys []fieldKey // scratch, reused across this id's record fields
 	for field, v := range meta {
 		if field == contentField {
 			continue // document content is not a filterable field; never index it
@@ -192,6 +193,19 @@ func (p *payloadIndexID) reindex(id uint64, meta Metadata) {
 			}
 			set[id] = struct{}{}
 			geoCells = append(geoCells, geoSlotCell{field, cell})
+			continue
+		}
+		// Record values expand into SYNTHETIC eq entries — one per top-level
+		// scalar field and per table row count, named "<field>/<recordField>"
+		// — and into nothing else, exactly as the dense index does (they share
+		// appendRecordIndexKeys, so the two can never index different things).
+		if v.Kind == ValueRecord {
+			recKeys = appendRecordIndexKeys(recKeys[:0], meta, field, v.Rec)
+			for _, rk := range recKeys {
+				if p.postScalar(rk.field, rk.key, id) {
+					keys = append(keys, rk)
+				}
+			}
 			continue
 		}
 		// Token index: a string/strings field is tokenized (same tokenize() as the
@@ -220,19 +234,9 @@ func (p *payloadIndexID) reindex(id uint64, meta Metadata) {
 		if !ok {
 			continue
 		}
-		vals := p.fields[field]
-		if vals == nil {
-			vals = make(map[scalarKey]map[uint64]struct{})
-			p.fields[field] = vals
+		if p.postScalar(field, key, id) {
+			keys = append(keys, fieldKey{field, key})
 		}
-		set := vals[key]
-		if set == nil {
-			set = make(map[uint64]struct{})
-			vals[key] = set
-			p.markDirty(field) // new distinct key -> sorted cache stale
-		}
-		set[id] = struct{}{}
-		keys = append(keys, fieldKey{field, key})
 	}
 	if keys != nil {
 		p.idKeys[id] = keys
@@ -246,6 +250,32 @@ func (p *payloadIndexID) reindex(id uint64, meta Metadata) {
 	if idContains != nil {
 		p.containsIDKeys[id] = idContains
 	}
+}
+
+// postScalar posts id under (field, key) in the eq index, invalidating the
+// sorted-key cache when the key is new, and reports whether the entry was NEW
+// for this id (i.e. whether the caller must record a reverse entry). The
+// duplicate check keeps the one-key-per-(id, field) invariant that a record's
+// synthetic entries could otherwise break; see payloadIndex.postScalar for the
+// argument in full. The id-keyed mirror of payloadIndex.postScalar, minus the
+// posts counter (this index has none — it feeds no complement gate).
+func (p *payloadIndexID) postScalar(field string, key scalarKey, id uint64) bool {
+	vals := p.fields[field]
+	if vals == nil {
+		vals = make(map[scalarKey]map[uint64]struct{})
+		p.fields[field] = vals
+	}
+	set := vals[key]
+	if set == nil {
+		set = make(map[uint64]struct{})
+		vals[key] = set
+		p.markDirty(field) // new distinct key -> sorted cache stale
+	}
+	if _, dup := set[id]; dup {
+		return false
+	}
+	set[id] = struct{}{}
+	return true
 }
 
 // addContains posts id under each (already DISTINCT) element key in keys within
@@ -646,7 +676,7 @@ func (p *payloadIndexID) collectMatchSets(f Filter, limit int) ([]map[uint64]str
 // postings yields the empty sentinel (ok=true). The id-keyed mirror of
 // payloadIndex.containsSet.
 func (p *payloadIndexID) containsSet(field string, want Value, limit int) (map[uint64]struct{}, bool) {
-	if !indexNarrowable(field) {
+	if !indexNarrowable(field, FilterContains) {
 		return nil, false
 	}
 	key, ok := scalarKeyOf(want)
@@ -718,7 +748,7 @@ func (p *payloadIndexID) collectContainsSets(f Filter, limit int) ([]map[uint64]
 // corpus set — never a truncated set). A missing query token yields an empty set
 // (ok=true): no id has all tokens. The id-keyed mirror of payloadIndex.matchSet.
 func (p *payloadIndexID) matchSet(field string, want Value, limit int) (map[uint64]struct{}, bool) {
-	if !indexNarrowable(field) {
+	if !indexNarrowable(field, FilterMatch) {
 		return nil, false
 	}
 	if want.Kind != ValueString {
@@ -778,7 +808,7 @@ func (p *payloadIndexID) matchSet(field string, want Value, limit int) (map[uint
 // overflow bail). The returned set is ALWAYS a superset of the true predicate
 // match set. Mirrors dense geoSet (reuses radiusBBox/polygonBBox/coverCells).
 func (p *payloadIndexID) geoSet(field string, op FilterOp, g *GeoCondition, limit int) (map[uint64]struct{}, bool) {
-	if !indexNarrowable(field) {
+	if !indexNarrowable(field, op) {
 		return nil, false
 	}
 	if g == nil {
@@ -887,7 +917,7 @@ func (p *payloadIndexID) collectRangeSets(f Filter, limit int) ([]map[uint64]str
 // eqSet returns the posting set for field == v (the shared stored map, not a
 // copy). ok=false when v is not equality-indexable. Mirrors dense eqSet.
 func (p *payloadIndexID) eqSet(field string, v Value) (map[uint64]struct{}, bool) {
-	if !indexNarrowable(field) {
+	if !indexNarrowable(field, FilterEq) {
 		return nil, false
 	}
 	key, ok := scalarKeyOf(v)
@@ -910,7 +940,7 @@ func (p *payloadIndexID) eqSet(field string, v Value) (map[uint64]struct{}, bool
 // when the union exceeds `limit`. Mirrors dense orderingSet (reuses
 // numericValue/numRange/strRange).
 func (p *payloadIndexID) orderingSet(field string, op FilterOp, want Value, limit int) (map[uint64]struct{}, bool) {
-	if !indexNarrowable(field) {
+	if !indexNarrowable(field, op) {
 		return nil, false
 	}
 	vals := p.fields[field]
@@ -953,7 +983,7 @@ func (p *payloadIndexID) orderingSet(field string, op FilterOp, want Value, limi
 // (strings/ints/floats). ok=false for a non-array value or when the union
 // exceeds `limit`. Mirrors dense inSet.
 func (p *payloadIndexID) inSet(field string, want Value, limit int) (map[uint64]struct{}, bool) {
-	if !indexNarrowable(field) {
+	if !indexNarrowable(field, FilterIn) {
 		return nil, false
 	}
 	vals := p.fields[field]

--- a/vector/payload_index_id.go
+++ b/vector/payload_index_id.go
@@ -75,6 +75,14 @@ type payloadIndexID struct {
 	// lock, which excludes writers but not other readers).
 	sorted   map[string]*sortedKeys
 	sortedMu sync.Mutex
+
+	// badRecords counts, per PAYLOAD KEY, the live ids holding a ValueRecord
+	// that IndexEntries could not enumerate; badIDKeys records which keys each
+	// id contributes so reindex removes its contribution exactly once. A
+	// non-zero count makes every path under that key un-narrowable — see
+	// recordPoison. The id-keyed mirror of payloadIndex.badRecords/badSlotKeys.
+	badRecords recordPoison
+	badIDKeys  map[uint64][]string
 }
 
 func newPayloadIndexID() *payloadIndexID {
@@ -88,6 +96,8 @@ func newPayloadIndexID() *payloadIndexID {
 		tokenIDKeys:    make(map[uint64][]fieldToken),
 		contains:       make(map[string]map[scalarKey]map[uint64]struct{}),
 		containsIDKeys: make(map[uint64][]fieldKey),
+		badRecords:     make(recordPoison),
+		badIDKeys:      make(map[uint64][]string),
 	}
 }
 
@@ -165,6 +175,14 @@ func (p *payloadIndexID) reindex(id uint64, meta Metadata) {
 		}
 		delete(p.containsIDKeys, id)
 	}
+	// Malformed-record markers are reverse entries like any other: dropped
+	// FIRST, so a repaired (or cleared) payload stops poisoning its key.
+	if old, ok := p.badIDKeys[id]; ok {
+		for _, key := range old {
+			p.dropBadRecord(key)
+		}
+		delete(p.badIDKeys, id)
+	}
 	if len(meta) == 0 {
 		return
 	}
@@ -173,6 +191,7 @@ func (p *payloadIndexID) reindex(id uint64, meta Metadata) {
 	var idTokens []fieldToken
 	var idContains []fieldKey
 	var recKeys []fieldKey // scratch, reused across this id's record fields
+	var badKeys []string   // payload keys whose record this id could not index
 	for field, v := range meta {
 		if field == contentField {
 			continue // document content is not a filterable field; never index it
@@ -200,7 +219,15 @@ func (p *payloadIndexID) reindex(id uint64, meta Metadata) {
 		// — and into nothing else, exactly as the dense index does (they share
 		// appendRecordIndexKeys, so the two can never index different things).
 		if v.Kind == ValueRecord {
-			recKeys = appendRecordIndexKeys(recKeys[:0], meta, field, v.Rec)
+			var whole bool
+			recKeys, whole = appendRecordIndexKeys(recKeys[:0], meta, field, v.Rec)
+			if !whole {
+				// Not enumerable in full: poison the payload key rather than
+				// index a partial view Resolve will contradict (recordPoison).
+				p.addBadRecord(field)
+				badKeys = append(badKeys, field)
+				continue
+			}
 			for _, rk := range recKeys {
 				if p.postScalar(rk.field, rk.key, id) {
 					keys = append(keys, rk)
@@ -249,6 +276,22 @@ func (p *payloadIndexID) reindex(id uint64, meta Metadata) {
 	}
 	if idContains != nil {
 		p.containsIDKeys[id] = idContains
+	}
+	if badKeys != nil {
+		p.badIDKeys[id] = badKeys
+	}
+}
+
+// addBadRecord records that one more live id holds an unindexable record under
+// payloadKey. dropBadRecord removes one such contribution, deleting the entry
+// at zero. Mirrors payloadIndex's pair; must hold the owner's write lock.
+func (p *payloadIndexID) addBadRecord(payloadKey string) { p.badRecords[payloadKey]++ }
+
+func (p *payloadIndexID) dropBadRecord(payloadKey string) {
+	if n := p.badRecords[payloadKey]; n > 1 {
+		p.badRecords[payloadKey] = n - 1
+	} else {
+		delete(p.badRecords, payloadKey)
 	}
 }
 
@@ -417,6 +460,11 @@ func (p *payloadIndexID) rebuild(meta map[uint64]Metadata) {
 	p.tokenIDKeys = make(map[uint64][]fieldToken)
 	p.contains = make(map[string]map[scalarKey]map[uint64]struct{})
 	p.containsIDKeys = make(map[uint64][]fieldKey)
+	// Reset the malformed-record counters too: reindex below refills them from
+	// the metadata that survives, so a key poisoned by an id that is gone does
+	// not stay poisoned forever.
+	p.badRecords = make(recordPoison)
+	p.badIDKeys = make(map[uint64][]string)
 	for id, m := range meta {
 		p.reindex(id, m)
 	}
@@ -452,7 +500,7 @@ func (p *payloadIndexID) candidatesCapped(f Filter, limit, maxCand int) ([]uint6
 		// Intersect the geo sets with any equality sets in the same And so the most
 		// selective conjunct(s) drive the candidate set; the predicate re-checks
 		// everything else. A pure geo filter just returns the geo union.
-		if eqTerms, ok := collectEqTerms(f); ok {
+		if eqTerms, ok := collectEqTerms(f, p.badRecords); ok {
 			for _, t := range eqTerms {
 				vals := p.fields[t.field]
 				if vals == nil {
@@ -478,7 +526,7 @@ func (p *payloadIndexID) candidatesCapped(f Filter, limit, maxCand int) ([]uint6
 
 	// Equality narrowing. Also covers And(eq, range): the eq terms narrow and the
 	// predicate re-checks the range conjuncts.
-	if terms, ok := collectEqTerms(f); ok {
+	if terms, ok := collectEqTerms(f, p.badRecords); ok {
 		sets := make([]map[uint64]struct{}, 0, len(terms))
 		for _, t := range terms {
 			vals := p.fields[t.field]
@@ -676,7 +724,7 @@ func (p *payloadIndexID) collectMatchSets(f Filter, limit int) ([]map[uint64]str
 // postings yields the empty sentinel (ok=true). The id-keyed mirror of
 // payloadIndex.containsSet.
 func (p *payloadIndexID) containsSet(field string, want Value, limit int) (map[uint64]struct{}, bool) {
-	if !indexNarrowable(field, FilterContains) {
+	if !indexNarrowable(field, FilterContains, p.badRecords) {
 		return nil, false
 	}
 	key, ok := scalarKeyOf(want)
@@ -748,7 +796,7 @@ func (p *payloadIndexID) collectContainsSets(f Filter, limit int) ([]map[uint64]
 // corpus set — never a truncated set). A missing query token yields an empty set
 // (ok=true): no id has all tokens. The id-keyed mirror of payloadIndex.matchSet.
 func (p *payloadIndexID) matchSet(field string, want Value, limit int) (map[uint64]struct{}, bool) {
-	if !indexNarrowable(field, FilterMatch) {
+	if !indexNarrowable(field, FilterMatch, p.badRecords) {
 		return nil, false
 	}
 	if want.Kind != ValueString {
@@ -808,7 +856,7 @@ func (p *payloadIndexID) matchSet(field string, want Value, limit int) (map[uint
 // overflow bail). The returned set is ALWAYS a superset of the true predicate
 // match set. Mirrors dense geoSet (reuses radiusBBox/polygonBBox/coverCells).
 func (p *payloadIndexID) geoSet(field string, op FilterOp, g *GeoCondition, limit int) (map[uint64]struct{}, bool) {
-	if !indexNarrowable(field, op) {
+	if !indexNarrowable(field, op, p.badRecords) {
 		return nil, false
 	}
 	if g == nil {
@@ -917,7 +965,7 @@ func (p *payloadIndexID) collectRangeSets(f Filter, limit int) ([]map[uint64]str
 // eqSet returns the posting set for field == v (the shared stored map, not a
 // copy). ok=false when v is not equality-indexable. Mirrors dense eqSet.
 func (p *payloadIndexID) eqSet(field string, v Value) (map[uint64]struct{}, bool) {
-	if !indexNarrowable(field, FilterEq) {
+	if !indexNarrowable(field, FilterEq, p.badRecords) {
 		return nil, false
 	}
 	key, ok := scalarKeyOf(v)
@@ -940,7 +988,7 @@ func (p *payloadIndexID) eqSet(field string, v Value) (map[uint64]struct{}, bool
 // when the union exceeds `limit`. Mirrors dense orderingSet (reuses
 // numericValue/numRange/strRange).
 func (p *payloadIndexID) orderingSet(field string, op FilterOp, want Value, limit int) (map[uint64]struct{}, bool) {
-	if !indexNarrowable(field, op) {
+	if !indexNarrowable(field, op, p.badRecords) {
 		return nil, false
 	}
 	vals := p.fields[field]
@@ -983,7 +1031,7 @@ func (p *payloadIndexID) orderingSet(field string, op FilterOp, want Value, limi
 // (strings/ints/floats). ok=false for a non-array value or when the union
 // exceeds `limit`. Mirrors dense inSet.
 func (p *payloadIndexID) inSet(field string, want Value, limit int) (map[uint64]struct{}, bool) {
-	if !indexNarrowable(field, FilterIn) {
+	if !indexNarrowable(field, FilterIn, p.badRecords) {
 		return nil, false
 	}
 	vals := p.fields[field]

--- a/vector/payload_index_record_guard_test.go
+++ b/vector/payload_index_record_guard_test.go
@@ -1,0 +1,47 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package vector
+
+import "testing"
+
+// TestRecordPathIndexNarrowableGuard pins the shape+op guard itself: exactly
+// the shapes reindex posts (a named top-level field, and a named field's
+// "#count") are narrowable, and only for the ops whose posting set is exact.
+func TestRecordPathIndexNarrowableGuard(t *testing.T) {
+	narrowOps := []FilterOp{FilterEq, FilterIn, FilterGt, FilterGte, FilterLt, FilterLte,
+		FilterDtGt, FilterDtGte, FilterDtLt, FilterDtLte}
+	wideOps := []FilterOp{FilterContains, FilterMatch, FilterRegex, FilterIsEmpty, FilterIsNull,
+		FilterRowExists, FilterRowAbsent, FilterNe}
+
+	indexedShapes := []string{"session/rc", "session/b#count", "session/rc#count", "a/b"}
+	declinedShapes := []string{"session/#0", "session/#0#count", "session/b/42", "session/b/42/hi"}
+
+	for _, field := range indexedShapes {
+		for _, op := range narrowOps {
+			if !indexNarrowable(field, op) {
+				t.Errorf("indexNarrowable(%q, %v) = false, want true (an indexed shape under an exact op)", field, op)
+			}
+		}
+		for _, op := range wideOps {
+			if indexNarrowable(field, op) {
+				t.Errorf("indexNarrowable(%q, %v) = true, want false (no postings exist for this op)", field, op)
+			}
+		}
+	}
+	for _, field := range declinedShapes {
+		for _, op := range append(append([]FilterOp{}, narrowOps...), wideOps...) {
+			if indexNarrowable(field, op) {
+				t.Errorf("indexNarrowable(%q, %v) = true, want false (this shape is never indexed)", field, op)
+			}
+		}
+	}
+	// Unchanged for everything that is not a record path.
+	for _, op := range append(append([]FilterOp{}, narrowOps...), wideOps...) {
+		if !indexNarrowable("country", op) {
+			t.Errorf("indexNarrowable(country, %v) = false, want true", op)
+		}
+		if indexNarrowable(contentField, op) {
+			t.Errorf("indexNarrowable($content, %v) = true, want false", op)
+		}
+	}
+}

--- a/vector/payload_index_record_guard_test.go
+++ b/vector/payload_index_record_guard_test.go
@@ -18,29 +18,29 @@ func TestRecordPathIndexNarrowableGuard(t *testing.T) {
 
 	for _, field := range indexedShapes {
 		for _, op := range narrowOps {
-			if !indexNarrowable(field, op) {
+			if !indexNarrowable(field, op, nil) {
 				t.Errorf("indexNarrowable(%q, %v) = false, want true (an indexed shape under an exact op)", field, op)
 			}
 		}
 		for _, op := range wideOps {
-			if indexNarrowable(field, op) {
+			if indexNarrowable(field, op, nil) {
 				t.Errorf("indexNarrowable(%q, %v) = true, want false (no postings exist for this op)", field, op)
 			}
 		}
 	}
 	for _, field := range declinedShapes {
 		for _, op := range append(append([]FilterOp{}, narrowOps...), wideOps...) {
-			if indexNarrowable(field, op) {
+			if indexNarrowable(field, op, nil) {
 				t.Errorf("indexNarrowable(%q, %v) = true, want false (this shape is never indexed)", field, op)
 			}
 		}
 	}
 	// Unchanged for everything that is not a record path.
 	for _, op := range append(append([]FilterOp{}, narrowOps...), wideOps...) {
-		if !indexNarrowable("country", op) {
+		if !indexNarrowable("country", op, nil) {
 			t.Errorf("indexNarrowable(country, %v) = false, want true", op)
 		}
-		if indexNarrowable(contentField, op) {
+		if indexNarrowable(contentField, op, nil) {
 			t.Errorf("indexNarrowable($content, %v) = true, want false", op)
 		}
 	}

--- a/vector/payload_index_record_poison_test.go
+++ b/vector/payload_index_record_poison_test.go
@@ -1,0 +1,369 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package vector
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/rostamlabs/rostam/sdk/wire"
+)
+
+// tornDynamicRecord is a dynamic-mode record {a: I64 = 5, z: BYTES "hello"}
+// with its LAST BYTE removed. It is the exact asymmetry this file is about:
+// IndexEntries walks every field and fails on the damaged tail, while Resolve
+// reads only the bytes on its own path and answers "a" perfectly well. An
+// index that treats "IndexEntries failed" as "this record contributes nothing"
+// therefore has no posting for a field the predicate still matches.
+func tornDynamicRecord(t *testing.T) []byte {
+	t.Helper()
+	enc := (&wire.Record{Mode: wire.OperateModeDynamic, Fields: []wire.Field{
+		{Name: "a", Cell: wire.Cell{Type: wire.OperateTypeI64, U: 5}},
+		{Name: "z", Cell: wire.Cell{Type: wire.OperateTypeBytes, B: []byte("hello")}},
+	}}).Encode()
+	if enc == nil {
+		t.Fatal("dynamic record failed to encode")
+	}
+	return enc[:len(enc)-1]
+}
+
+// goodDynamicRecord is tornDynamicRecord's intact twin, with a caller-chosen
+// value for "a" so a corpus can vary it.
+func goodDynamicRecord(t *testing.T, a int64) []byte {
+	t.Helper()
+	enc := (&wire.Record{Mode: wire.OperateModeDynamic, Fields: []wire.Field{
+		{Name: "a", Cell: wire.Cell{Type: wire.OperateTypeI64, U: su64(a)}},
+		{Name: "z", Cell: wire.Cell{Type: wire.OperateTypeBytes, B: []byte("hello")}},
+	}}).Encode()
+	if enc == nil {
+		t.Fatal("dynamic record failed to encode")
+	}
+	return enc
+}
+
+// tornSchemaRecord is the schema-mode route to the same asymmetry, and it is a
+// DIFFERENT route: walkSchemaFields fails on the damaged variable-length tail
+// ("z"), but schemaFieldOffset hands back the FIXED field "a"'s offset without
+// walking the tail at all, so "a" still resolves.
+func tornSchemaRecord(t *testing.T) []byte {
+	t.Helper()
+	s := &wire.Schema{Version: 1, StoreNames: true, Fields: []wire.FieldDef{
+		{Name: "a", Type: wire.OperateTypeI64},
+		{Name: "z", Type: wire.OperateTypeBytes},
+	}}
+	if err := s.Validate(); err != nil {
+		t.Fatalf("torn schema invalid: %v", err)
+	}
+	enc := (&wire.Record{Mode: wire.OperateModeSchema, Schema: s, Fields: []wire.Field{
+		{Cell: wire.Cell{Type: wire.OperateTypeI64, U: 5}},
+		{Cell: wire.Cell{Type: wire.OperateTypeBytes, B: []byte("hello")}},
+	}}).Encode()
+	if enc == nil {
+		t.Fatal("torn schema record failed to encode")
+	}
+	return enc[:len(enc)-1]
+}
+
+// namelessSchemaRecord is a schema-mode record whose schema stores NO names, so
+// IndexEntries labels its fields positionally ("#0") and a by-name path cannot
+// resolve at all. It is the other half of the positional-decline argument: the
+// corpus must contain records of both spellings, or "positional paths are not
+// indexed" is only ever tested against records that name their fields.
+func namelessSchemaRecord(t *testing.T, a int64) []byte {
+	t.Helper()
+	s := &wire.Schema{Version: 1, StoreNames: false, Fields: []wire.FieldDef{
+		{Type: wire.OperateTypeI64},
+	}}
+	if err := s.Validate(); err != nil {
+		t.Fatalf("nameless schema invalid: %v", err)
+	}
+	enc := (&wire.Record{Mode: wire.OperateModeSchema, Schema: s, Fields: []wire.Field{
+		{Cell: wire.Cell{Type: wire.OperateTypeI64, U: su64(a)}},
+	}}).Encode()
+	if enc == nil {
+		t.Fatal("nameless schema record failed to encode")
+	}
+	return enc
+}
+
+// TestRecordTornFixturesReproduceTheAsymmetry pins the PRECONDITION of every
+// test below: these bytes really do fail IndexEntries while still resolving a
+// field. If a future change to sdk/record makes IndexEntries partial (or makes
+// Resolve fail alongside it), the fail-closed machinery is being tested against
+// a fixture that no longer reproduces anything, and this test says so directly
+// instead of letting the others pass vacuously.
+func TestRecordTornFixturesReproduceTheAsymmetry(t *testing.T) {
+	for _, c := range []struct {
+		name string
+		rec  []byte
+	}{
+		{"dynamic", tornDynamicRecord(t)},
+		{"schema fixed field after a damaged tail", tornSchemaRecord(t)},
+	} {
+		t.Run(c.name, func(t *testing.T) {
+			if _, err := recordResolver.IndexEntries(c.rec); err == nil {
+				t.Fatal("IndexEntries succeeded — the fixture is not damaged and proves nothing")
+			}
+			v, ok := lookupPath(Metadata{"torn": NewRecord(c.rec)}, "torn/a")
+			if !ok || !v.Equal(NewInt(5)) {
+				t.Fatalf("lookupPath(torn/a) = (%+v, %v), want (5, true) — the fixture does not reproduce the asymmetry", v, ok)
+			}
+		})
+	}
+}
+
+// poisonCorpus inserts n points carrying an intact record under "torn" (a = i%9)
+// and replaces ONE of them (id badID) with the damaged record supplied, so the
+// payload key holds exactly one unindexable record among many good ones.
+func poisonCorpus(t *testing.T, n int, badID uint64, bad []byte) (*hnsw, map[uint64][]float32, map[uint64]Metadata) {
+	t.Helper()
+	h, err := newHNSW(Config{Dim: 4, Metric: L2, M: 16, EfConstruction: 200, EfSearch: 128, Seed: 1})
+	if err != nil {
+		t.Fatal(err)
+	}
+	corpus := make(map[uint64][]float32, n)
+	metas := make(map[uint64]Metadata, n)
+	for i := 1; i <= n; i++ {
+		id := uint64(i)
+		v := []float32{float32(i), float32(i % 7), 0, 1}
+		m := Metadata{"torn": NewRecord(goodDynamicRecord(t, int64(i%9)))} //nolint:gosec // bounded
+		if id == badID {
+			m = Metadata{"torn": NewRecord(bad)}
+		}
+		corpus[id] = v
+		metas[id] = m
+		if _, _, err := h.Insert(id, v, 0, m, nil, nil, CASCond{}); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return h, corpus, metas
+}
+
+// TestRecordPoisonedKeyFailsClosed is the fix-round-1 regression test. A record
+// that IndexEntries cannot fully enumerate contributes NO postings, but its
+// intact fields still resolve — so an accelerated query over any path under
+// that payload key would drop the row. The index must therefore fail CLOSED:
+// while any live slot under a payload key holds an unindexable record, every
+// path under that key declines to narrow and falls back to the predicate.
+//
+// It drives both damage routes and both consumers (SearchFiltered and the
+// matchingIDs selection delete-by-filter and scroll use), and then checks the
+// key regains acceleration once the bad record is replaced — fail-closed must
+// be a state, not a one-way latch.
+func TestRecordPoisonedKeyFailsClosed(t *testing.T) {
+	const badID = 7
+	routes := []struct {
+		name string
+		rec  []byte
+	}{
+		{"dynamic", tornDynamicRecord(t)},
+		{"schema fixed field after a damaged tail", tornSchemaRecord(t)},
+	}
+	for _, route := range routes {
+		t.Run(route.name, func(t *testing.T) {
+			h, corpus, metas := poisonCorpus(t, 60, badID, route.rec)
+			f := Filter{Op: FilterEq, Field: "torn/a", Value: NewInt(5)}
+			pred := compileOrFail(t, f)
+
+			want := bruteMatchIDs(metas, pred)
+			if _, ok := want[badID]; !ok {
+				t.Fatalf("the damaged point %d does not satisfy the predicate — the fixture proves nothing", badID)
+			}
+
+			gotIDs, err := h.matchingIDs(f, pred)
+			if err != nil {
+				t.Fatalf("matchingIDs: %v", err)
+			}
+			got := make(map[uint64]struct{}, len(gotIDs))
+			for _, id := range gotIDs {
+				got[id] = struct{}{}
+			}
+			for id := range want {
+				if _, ok := got[id]; !ok {
+					t.Errorf("matchingIDs is missing id %d (the damaged record's row is dropped; delete-by-filter would under-delete)", id)
+				}
+			}
+			if len(got) != len(want) {
+				t.Errorf("matchingIDs returned %d ids, want %d", len(got), len(want))
+			}
+
+			res, err := h.SearchFiltered([]float32{float32(badID), float32(badID % 7), 0, 1}, len(want), f)
+			if err != nil {
+				t.Fatalf("SearchFiltered: %v", err)
+			}
+			if !eqUint64(resultIDs(res), bruteForceFiltered(corpus, metas, []float32{float32(badID), float32(badID % 7), 0, 1}, len(want), pred)) {
+				t.Errorf("SearchFiltered ids %v != brute force", resultIDs(res))
+			}
+
+			// The mechanism, asserted directly: while the key is poisoned the
+			// planner must DECLINE, and no gate may be graded exact.
+			func() {
+				h.mu.RLock()
+				defer h.mu.RUnlock()
+				limit := h.effectiveFilterFirstLimit(h.arena.Size())
+				if cands, ok := h.payloadIdx.candidates(f, limit); ok {
+					t.Errorf("the index narrowed to %d candidates while the payload key holds an unindexable record", len(cands))
+				}
+				if _, ok := h.payloadIdx.eqSet("torn/a", NewInt(5)); ok {
+					t.Error("eqSet answered for a path under a poisoned payload key")
+				}
+				// The column sidecar is built FROM the posting map, so it
+				// inherits the same hole and must decline the same way.
+				rangeF := Filter{Op: FilterGt, Field: "torn/a", Value: NewInt(3)}
+				if _, ok := h.payloadIdx.collectColumnTerms(rangeF, h.arena.Capacity(), -1, nil); ok {
+					t.Error("a range under a poisoned payload key is column-expressible — the column would be built from postings that are missing the damaged slot")
+				}
+			}()
+			if armed, exact := gateExactFor(t, h, f); armed && exact {
+				t.Error("an EXACT gate armed over a poisoned payload key — it would skip the predicate re-check and lose the row")
+			}
+
+			// Replacing the damaged record un-poisons the key: acceleration
+			// must come back, and still agree with the predicate.
+			good := Metadata{"torn": NewRecord(goodDynamicRecord(t, 5))}
+			if _, _, _, err := h.SetPayload(badID, good, nil, CASCond{}); err != nil {
+				t.Fatalf("SetPayload: %v", err)
+			}
+			metas[badID] = good
+			func() {
+				h.mu.RLock()
+				defer h.mu.RUnlock()
+				limit := h.effectiveFilterFirstLimit(h.arena.Size())
+				cands, ok := h.payloadIdx.candidates(f, limit)
+				if !ok {
+					t.Fatal("the index still declines after the damaged record was replaced — fail-closed latched instead of tracking state")
+				}
+				if len(cands) == 0 || len(cands) >= len(metas) {
+					t.Fatalf("candidate set of %d over %d points is not a proper narrowing", len(cands), len(metas))
+				}
+			}()
+			gotIDs, err = h.matchingIDs(f, compileOrFail(t, f))
+			if err != nil {
+				t.Fatalf("matchingIDs after repair: %v", err)
+			}
+			want = bruteMatchIDs(metas, compileOrFail(t, f))
+			if len(gotIDs) != len(want) {
+				t.Errorf("after repair matchingIDs returned %d ids, want %d", len(gotIDs), len(want))
+			}
+		})
+	}
+}
+
+// TestRecordIndexSelectsEverySlotLookupPathResolves is the consistency
+// invariant stated as a test rather than as an argument: for every indexed
+// shape the index claims it can narrow, every live slot whose lookupPath
+// resolves to a MATCHING value must appear in the candidate set. Under-
+// selection is the failure mode that loses rows, so it is checked directly,
+// slot by slot, over a corpus that deliberately mixes intact records, a
+// damaged one, records under a names-less schema, non-record payload values
+// and absent keys.
+func TestRecordIndexSelectsEverySlotLookupPathResolves(t *testing.T) {
+	h, _, _ := recordCorpus(t, 500, 8)
+	h.mu.RLock()
+	defer h.mu.RUnlock()
+	limit := h.effectiveFilterFirstLimit(h.arena.Size())
+	now := uint64(h.now())
+
+	filters := []Filter{
+		{Op: FilterEq, Field: "session/rc", Value: NewInt(5)},
+		{Op: FilterIn, Field: "session/rc", Value: NewInts([]int64{3, 7})},
+		{Op: FilterGt, Field: "session/rc", Value: NewInt(10)},
+		{Op: FilterEq, Field: "session/tag", Value: NewString("de")},
+		{Op: FilterEq, Field: "session/b#count", Value: NewInt(2)},
+		{Op: FilterEq, Field: "session/#0", Value: NewInt(5)},
+		{Op: FilterEq, Field: "torn/a", Value: NewInt(5)},
+		{Op: FilterEq, Field: "nameless/#0", Value: NewInt(3)},
+	}
+	for _, f := range filters {
+		pred := compileOrFail(t, f)
+		cands, ok := h.payloadIdx.candidates(f, limit)
+		if !ok {
+			continue // declined: the predicate answers, which the brute-force test covers
+		}
+		in := make(map[uint32]struct{}, len(cands))
+		for _, s := range cands {
+			in[s] = struct{}{}
+		}
+		matched := 0
+		for slot := 0; slot < h.arena.Capacity(); slot++ {
+			u := uint32(slot) //nolint:gosec // bounded by capacity
+			if h.tombstoned[u] || h.isExpiredAt(u, now) {
+				continue
+			}
+			if !pred(h.liveMeta(u, now)) {
+				continue
+			}
+			matched++
+			if _, ok := in[u]; !ok {
+				t.Errorf("%+v: slot %d resolves to a matching value through lookupPath but is not in the candidate set", f, slot)
+			}
+		}
+		if matched == 0 {
+			t.Errorf("%+v: narrowed but no slot matches — the check is vacuous", f)
+		}
+	}
+}
+
+// TestRecordPoisonSurvivesRestoreAndMirrorsToTheIDIndex covers the two places
+// the fail-closed state could quietly go missing: a restored collection (whose
+// index is REBUILT from metadata rather than maintained incrementally) and the
+// id-keyed index used by named vectors and multivectors, which has its own
+// reindex and its own counters.
+func TestRecordPoisonSurvivesRestoreAndMirrorsToTheIDIndex(t *testing.T) {
+	t.Run("restore", func(t *testing.T) {
+		src, _, _ := poisonCorpus(t, 40, 7, tornDynamicRecord(t))
+		var buf bytes.Buffer
+		if err := src.Snapshot(&buf); err != nil {
+			t.Fatal(err)
+		}
+		dst, err := newHNSW(Config{Dim: 4, Metric: L2, M: 16, EfConstruction: 200, EfSearch: 128, Seed: 1})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := dst.Restore(&buf); err != nil {
+			t.Fatal(err)
+		}
+		dst.mu.RLock()
+		defer dst.mu.RUnlock()
+		if !dst.payloadIdx.badRecords.poisoned("torn") {
+			t.Fatal("the restored index does not know the payload key holds an unindexable record — rebuild lost the fail-closed state")
+		}
+		f := Filter{Op: FilterEq, Field: "torn/a", Value: NewInt(5)}
+		if cands, ok := dst.payloadIdx.candidates(f, dst.effectiveFilterFirstLimit(dst.arena.Size())); ok {
+			t.Errorf("the restored index narrowed to %d candidates under a poisoned payload key", len(cands))
+		}
+	})
+
+	t.Run("id-keyed mirror", func(t *testing.T) {
+		p := newPayloadIndexID()
+		p.reindex(1, Metadata{"torn": NewRecord(goodDynamicRecord(t, 5))})
+		p.reindex(2, Metadata{"torn": NewRecord(tornDynamicRecord(t))})
+		if !p.badRecords.poisoned("torn") {
+			t.Fatal("the id index did not poison the payload key")
+		}
+		if _, ok := p.eqSet("torn/a", NewInt(5)); ok {
+			t.Error("the id index answered eqSet under a poisoned payload key")
+		}
+		// Repairing id 2 clears the key and acceleration returns.
+		p.reindex(2, Metadata{"torn": NewRecord(goodDynamicRecord(t, 5))})
+		if p.badRecords.poisoned("torn") {
+			t.Fatal("the id index stayed poisoned after the damaged record was replaced")
+		}
+		set, ok := p.eqSet("torn/a", NewInt(5))
+		if !ok {
+			t.Fatal("the id index still declines after repair")
+		}
+		if len(set) != 2 {
+			t.Fatalf("eqSet(torn/a == 5) holds %d ids, want 2", len(set))
+		}
+		// Clearing the payload of the only bad id is the other way out.
+		p.reindex(2, Metadata{"torn": NewRecord(tornDynamicRecord(t))})
+		p.reindex(2, nil)
+		if p.badRecords.poisoned("torn") {
+			t.Fatal("clearing the payload left the key poisoned")
+		}
+		if len(p.badIDKeys) != 0 {
+			t.Errorf("badIDKeys leaked: %v", p.badIDKeys)
+		}
+	})
+}

--- a/vector/payload_index_record_test.go
+++ b/vector/payload_index_record_test.go
@@ -139,12 +139,21 @@ func TestReindexRecordSyntheticFieldsID(t *testing.T) {
 	}
 }
 
-// recordCorpus builds the shared 500-point fixture the brute-force tests use:
+// recordCorpus builds the shared 500-point fixture the brute-force tests use.
+// Every shape that resolves differently from how it indexes is represented:
 // most points carry a "session" record whose rc varies, some carry a plain
 // STRING under "session" (so a record path must reject a non-record payload
-// key), some carry no session at all, some carry a LITERAL payload key spelled
-// "session/rc" (which shadows the record's rc on both sides), and some carry a
-// literal "a/b" that parses as a record path but names no record.
+// key), some carry no session at all, some carry a NAMES-LESS schema record
+// (whose fields IndexEntries labels positionally, and which no by-name path
+// can address), some carry a LITERAL payload key spelled "session/rc" (which
+// shadows the record's rc on both sides), and some carry a literal "a/b" that
+// parses as a record path but names no record.
+//
+// Separately, EVERY point carries a record under "torn", and a few of those
+// are DAMAGED — one byte short, so IndexEntries fails while the intact leading
+// field still resolves. That key is therefore permanently poisoned in this
+// corpus, which is the point: every filter over "torn/..." must come back
+// correct through the predicate, and nothing may accelerate it.
 func recordCorpus(t *testing.T, n, dim int) (*hnsw, map[uint64][]float32, map[uint64]Metadata) {
 	t.Helper()
 	rng := rand.New(rand.NewSource(20260908))
@@ -170,8 +179,23 @@ func recordCorpus(t *testing.T, n, dim int) (*hnsw, map[uint64][]float32, map[ui
 		case i%7 == 0:
 			m["session"] = NewString("not a record at all")
 		case i%11 == 0: // no session key at all
+		case i%17 == 0:
+			// A names-less schema: "session/rc" cannot resolve for these
+			// points at all, and "session/#0" can — the exact pair that makes
+			// positional paths unindexable.
+			m["session"] = NewRecord(namelessSchemaRecord(t, int64(i%13)))
 		default:
 			m["session"] = NewRecord(sessionRecordBytesRC(t, uint8(i%13))) //nolint:gosec // i%13 fits uint8
+		}
+		// A second payload key that is POISONED: a handful of its records are
+		// damaged, so no path under it may ever be accelerated.
+		switch {
+		case i%97 == 0:
+			m["torn"] = NewRecord(tornDynamicRecord(t))
+		case i%89 == 0:
+			m["torn"] = NewRecord(tornSchemaRecord(t))
+		default:
+			m["torn"] = NewRecord(goodDynamicRecord(t, int64(i%9))) //nolint:gosec // bounded
 		}
 		if i%23 == 0 {
 			m["session/rc"] = NewInt(99) // literal key; shadows the record's rc
@@ -225,6 +249,15 @@ func recordFilterCases() []recordFilterCase {
 		{name: "row_absent", f: Filter{Op: FilterRowAbsent, Field: "session/b/7"}},
 		{name: "eq literal shadowing key", f: Filter{Op: FilterEq, Field: "session/rc", Value: NewInt(99)}},
 		{name: "eq literal path-shaped key", f: Filter{Op: FilterEq, Field: "a/b", Value: NewString("lit")}},
+		// Under the poisoned key: the damaged records still resolve their
+		// leading field, so these must return the damaged points too.
+		{name: "eq poisoned key", f: Filter{Op: FilterEq, Field: "torn/a", Value: NewInt(5)}},
+		{name: "gt poisoned key", f: Filter{Op: FilterGt, Field: "torn/a", Value: NewInt(3)}},
+		{name: "in poisoned key", f: Filter{Op: FilterIn, Field: "torn/a", Value: NewInts([]int64{5, 8})}},
+		// A names-less schema record: addressable only by position, never by
+		// name, and the positional spelling is never indexed.
+		{name: "eq nameless positional", f: Filter{Op: FilterEq, Field: "session/#0", Value: NewInt(3)}},
+		{name: "eq nameless by name", f: Filter{Op: FilterEq, Field: "session/zz", Value: NewInt(3)}, wantEmpty: true},
 	}
 	out := make([]recordFilterCase, 0, 2*len(base))
 	for _, c := range base {
@@ -457,6 +490,8 @@ func TestRecordFilterFirstActuallyNarrows(t *testing.T) {
 		{"match on a record string", Filter{Op: FilterMatch, Field: "session/tag", Value: NewString("de")}},
 		{"contains on a record string", Filter{Op: FilterContains, Field: "session/tag", Value: NewString("de")}},
 		{"row_exists", Filter{Op: FilterRowExists, Field: "session/b/42"}},
+		{"poisoned payload key", Filter{Op: FilterEq, Field: "torn/a", Value: NewInt(5)}},
+		{"range under a poisoned payload key", Filter{Op: FilterGt, Field: "torn/a", Value: NewInt(3)}},
 	}
 	for _, c := range declining {
 		if cands, ok := h.payloadIdx.candidates(c.f, limit); ok {

--- a/vector/payload_index_record_test.go
+++ b/vector/payload_index_record_test.go
@@ -1,0 +1,628 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package vector
+
+import (
+	"bytes"
+	"math/rand"
+	"testing"
+)
+
+// recordSlotIn reports whether slot carries a posting for (field, key) in the
+// dense payload index — the assertion every synthetic-field test makes.
+func recordSlotIn(p *payloadIndex, field string, key scalarKey, slot uint32) bool {
+	vals := p.fields[field]
+	if vals == nil {
+		return false
+	}
+	set := vals[key]
+	if set == nil {
+		return false
+	}
+	_, ok := set[slot]
+	return ok
+}
+
+func intKey(i int64) scalarKey  { return scalarKey{kind: ValueInt, i: i} }
+func strKey(s string) scalarKey { return scalarKey{kind: ValueString, str: s} }
+
+// TestReindexRecordSyntheticFields pins the indexing half of the contract: a
+// ValueRecord payload key posts one synthetic eq entry per top-level scalar
+// field and per table "#count", under "<payloadKey>/<field>", and NOTHING for
+// the shapes the planner refuses to accelerate (a table cell, a positional
+// "#N", the table field itself). It also pins the reverse-map discipline —
+// rewriting the record drops the old postings, clearing the payload drops all
+// of them — and the exact-key precedence lookupPath applies: a LITERAL payload
+// key spelled "session/rc" wins over the record's rc, on both sides.
+func TestReindexRecordSyntheticFields(t *testing.T) {
+	p := newPayloadIndex()
+	rec := sessionRecordBytes(t) // rc=7 bc=3 hist=1234 bal=-5 tag="de" b={42,99}
+	p.reindex(3, Metadata{"session": NewRecord(rec)})
+
+	present := []struct {
+		field string
+		key   scalarKey
+	}{
+		{"session/rc", intKey(7)},
+		{"session/bc", intKey(3)},
+		{"session/hist", intKey(1234)},
+		{"session/bal", intKey(-5)},
+		{"session/tag", strKey("de")},
+		{"session/b#count", intKey(2)},
+	}
+	for _, c := range present {
+		if !recordSlotIn(p, c.field, c.key, 3) {
+			t.Errorf("fields[%q][%+v] is missing slot 3 — the synthetic field was not indexed", c.field, c.key)
+		}
+	}
+	// posts must count each (slot, field) ONCE, or fieldTotalNumeric's
+	// complement-gate proof (posts >= liveCount ⇒ every live slot covered)
+	// stops being an upper bound on totality.
+	if got := p.posts["session/rc"].num; got != 1 {
+		t.Errorf("posts[session/rc].num = %d, want 1 (one slot, one key)", got)
+	}
+	if got := p.posts["session/tag"].str; got != 1 {
+		t.Errorf("posts[session/tag].str = %d, want 1", got)
+	}
+
+	// Shapes this phase deliberately does not post: a table cell, a table row,
+	// the table field itself, a positional field (IndexEntries names a
+	// names-carrying schema's fields by NAME, so "#0" has no posting and the
+	// planner must not treat its absence as proof), and "#count" on a scalar.
+	for _, field := range []string{"session/b/42/hi", "session/b/42", "session/b", "session/#0", "session/rc#count", "session/zz"} {
+		if len(p.fields[field]) != 0 {
+			t.Errorf("fields[%q] has postings %v — this shape must not be indexed", field, p.fields[field])
+		}
+	}
+
+	// Rewriting the record (SetPayload) drops the old key and adds the new.
+	p.reindex(3, Metadata{"session": NewRecord(sessionRecordBytesRC(t, 8))})
+	if recordSlotIn(p, "session/rc", intKey(7), 3) {
+		t.Error("fields[session/rc][7] still holds slot 3 after the record was rewritten to rc=8 — stale posting")
+	}
+	if !recordSlotIn(p, "session/rc", intKey(8), 3) {
+		t.Error("fields[session/rc][8] is missing slot 3 after the rewrite")
+	}
+
+	// Clearing the payload drops every synthetic posting and its reverse entry.
+	p.reindex(3, nil)
+	for _, c := range present {
+		if len(p.fields[c.field]) != 0 {
+			t.Errorf("fields[%q] survived ClearPayload: %v", c.field, p.fields[c.field])
+		}
+	}
+	if _, ok := p.slotKeys[3]; ok {
+		t.Error("slotKeys[3] survived ClearPayload — the reverse map leaked")
+	}
+	if len(p.posts) != 0 {
+		t.Errorf("posts survived ClearPayload: %v", p.posts)
+	}
+
+	// Exact-key precedence: a literal payload key spelled like a record path
+	// shadows the record's field, and the index must post the LITERAL value
+	// only — one key per (slot, field), the same one lookupPath resolves.
+	q := newPayloadIndex()
+	shadow := Metadata{"session": NewRecord(rec), "session/rc": NewInt(99)}
+	q.reindex(5, shadow)
+	if !recordSlotIn(q, "session/rc", intKey(99), 5) {
+		t.Error("fields[session/rc][99] is missing slot 5 — the literal key was not indexed")
+	}
+	if recordSlotIn(q, "session/rc", intKey(7), 5) {
+		t.Error("fields[session/rc][7] holds slot 5 — the record's rc was indexed even though a literal key shadows it")
+	}
+	if got := q.posts["session/rc"].num; got != 1 {
+		t.Errorf("posts[session/rc].num = %d with a shadowing literal key, want 1", got)
+	}
+	if v, ok := lookupPath(shadow, "session/rc"); !ok || !v.Equal(NewInt(99)) {
+		t.Fatalf("lookupPath disagrees with the index: got (%+v, %v), want (99, true)", v, ok)
+	}
+}
+
+// TestReindexRecordSyntheticFieldsID mirrors the above for the id-keyed index
+// (named vectors / multivector), which has its own reindex and would otherwise
+// silently post nothing while indexNarrowable says record paths are provable.
+func TestReindexRecordSyntheticFieldsID(t *testing.T) {
+	p := newPayloadIndexID()
+	p.reindex(11, Metadata{"session": NewRecord(sessionRecordBytes(t))})
+	if _, ok := p.fields["session/rc"][intKey(7)][11]; !ok {
+		t.Fatalf("id index: fields[session/rc][7] is missing id 11 (have %v)", p.fields["session/rc"])
+	}
+	if _, ok := p.fields["session/b#count"][intKey(2)][11]; !ok {
+		t.Fatal("id index: fields[session/b#count][2] is missing id 11")
+	}
+	if len(p.fields["session/#0"]) != 0 {
+		t.Error("id index: a positional shape must not be indexed")
+	}
+	p.reindex(11, nil)
+	if len(p.fields["session/rc"]) != 0 {
+		t.Errorf("id index: fields[session/rc] survived a payload clear: %v", p.fields["session/rc"])
+	}
+}
+
+// recordCorpus builds the shared 500-point fixture the brute-force tests use:
+// most points carry a "session" record whose rc varies, some carry a plain
+// STRING under "session" (so a record path must reject a non-record payload
+// key), some carry no session at all, some carry a LITERAL payload key spelled
+// "session/rc" (which shadows the record's rc on both sides), and some carry a
+// literal "a/b" that parses as a record path but names no record.
+func recordCorpus(t *testing.T, n, dim int) (*hnsw, map[uint64][]float32, map[uint64]Metadata) {
+	t.Helper()
+	rng := rand.New(rand.NewSource(20260908))
+	h, err := newHNSW(Config{Dim: dim, Metric: L2, M: 16, EfConstruction: 200, EfSearch: 128, Seed: 1})
+	if err != nil {
+		t.Fatal(err)
+	}
+	corpus := make(map[uint64][]float32, n)
+	metas := make(map[uint64]Metadata, n)
+	for i := 1; i <= n; i++ {
+		v := make([]float32, dim)
+		for j := range v {
+			v[j] = float32(rng.NormFloat64())
+		}
+		id := uint64(i)
+		m := Metadata{}
+		if i%2 == 0 {
+			m["country"] = NewString("DE")
+		} else {
+			m["country"] = NewString("US")
+		}
+		switch {
+		case i%7 == 0:
+			m["session"] = NewString("not a record at all")
+		case i%11 == 0: // no session key at all
+		default:
+			m["session"] = NewRecord(sessionRecordBytesRC(t, uint8(i%13))) //nolint:gosec // i%13 fits uint8
+		}
+		if i%23 == 0 {
+			m["session/rc"] = NewInt(99) // literal key; shadows the record's rc
+		}
+		if i%29 == 0 {
+			m["a/b"] = NewString("lit") // literal key that parses as a record path
+		}
+		corpus[id] = v
+		metas[id] = m
+		if _, _, err := h.Insert(id, v, 0, m, nil, nil, CASCond{}); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return h, corpus, metas
+}
+
+// recordFilterCases is the filter matrix both the search and the delete/scroll
+// entry point are checked against. wantEmpty marks the one case whose
+// brute-force match set is legitimately empty (contains over a scalar string
+// can never hold), so every other case is asserted NON-empty and cannot pass
+// vacuously.
+type recordFilterCase struct {
+	name      string
+	f         Filter
+	wantEmpty bool
+}
+
+func recordFilterCases() []recordFilterCase {
+	and := func(name string, f Filter) recordFilterCase {
+		return recordFilterCase{name: "and(country,+" + name + ")", f: Filter{Op: FilterAnd, And: []Filter{
+			{Op: FilterEq, Field: "country", Value: NewString("DE")}, f,
+		}}}
+	}
+	base := []recordFilterCase{
+		{name: "eq scalar", f: Filter{Op: FilterEq, Field: "session/rc", Value: NewInt(5)}},
+		{name: "in scalar", f: Filter{Op: FilterIn, Field: "session/rc", Value: NewInts([]int64{3, 7})}},
+		{name: "gt scalar", f: Filter{Op: FilterGt, Field: "session/rc", Value: NewInt(10)}},
+		{name: "lte scalar", f: Filter{Op: FilterLte, Field: "session/rc", Value: NewInt(4)}},
+		{name: "eq string scalar", f: Filter{Op: FilterEq, Field: "session/tag", Value: NewString("de")}},
+		{name: "eq count", f: Filter{Op: FilterEq, Field: "session/b#count", Value: NewInt(2)}},
+		{name: "gte count", f: Filter{Op: FilterGte, Field: "session/b#count", Value: NewInt(2)}},
+		{name: "lt count", f: Filter{Op: FilterLt, Field: "session/b#count", Value: NewInt(3)}},
+		{name: "eq positional", f: Filter{Op: FilterEq, Field: "session/#0", Value: NewInt(5)}},
+		{name: "in positional", f: Filter{Op: FilterIn, Field: "session/#0", Value: NewInts([]int64{3, 7})}},
+		{name: "gt positional", f: Filter{Op: FilterGt, Field: "session/#0", Value: NewInt(10)}},
+		{name: "eq column path", f: Filter{Op: FilterEq, Field: "session/b/42/hi", Value: NewInt(500)}},
+		{name: "gt column path", f: Filter{Op: FilterGt, Field: "session/b/42/hi", Value: NewInt(100)}},
+		{name: "match record string", f: Filter{Op: FilterMatch, Field: "session/tag", Value: NewString("de")}},
+		{name: "contains record string", f: Filter{Op: FilterContains, Field: "session/tag", Value: NewString("de")}, wantEmpty: true},
+		{name: "row_exists", f: Filter{Op: FilterRowExists, Field: "session/b/42"}},
+		{name: "row_absent", f: Filter{Op: FilterRowAbsent, Field: "session/b/7"}},
+		{name: "eq literal shadowing key", f: Filter{Op: FilterEq, Field: "session/rc", Value: NewInt(99)}},
+		{name: "eq literal path-shaped key", f: Filter{Op: FilterEq, Field: "a/b", Value: NewString("lit")}},
+	}
+	out := make([]recordFilterCase, 0, 2*len(base))
+	for _, c := range base {
+		out = append(out, c)
+		conj := and(c.name, c.f)
+		conj.wantEmpty = c.wantEmpty
+		out = append(out, conj)
+	}
+	return out
+}
+
+// TestRecordFilterFirstEqualsBruteForce is the whole point of the task: for
+// EVERY record-path shape and op — the ones the index now accelerates and the
+// ones it still declines — the filter-first search path and the
+// delete-by-filter / scroll selection must return exactly what a brute-force
+// evaluation of the SAME compiled predicate returns. An over-narrowed posting
+// set loses rows; an under-narrowed one returns rows the predicate rejects;
+// both fail here.
+func TestRecordFilterFirstEqualsBruteForce(t *testing.T) {
+	const (
+		n   = 500
+		dim = 8
+		k   = 12
+	)
+	h, corpus, metas := recordCorpus(t, n, dim)
+	q := make([]float32, dim)
+	rng := rand.New(rand.NewSource(7))
+	for j := range q {
+		q[j] = float32(rng.NormFloat64())
+	}
+
+	for _, c := range recordFilterCases() {
+		t.Run(c.name, func(t *testing.T) {
+			pred := compileOrFail(t, c.f)
+
+			wantSet := bruteMatchIDs(metas, pred)
+			if len(wantSet) == 0 != c.wantEmpty {
+				t.Fatalf("brute-force match set size %d contradicts wantEmpty=%v — the fixture proves nothing", len(wantSet), c.wantEmpty)
+			}
+
+			// Consumer 1: filter-first KNN.
+			got, err := h.SearchFiltered(q, k, c.f)
+			if err != nil {
+				t.Fatalf("SearchFiltered: %v", err)
+			}
+			want := bruteForceFiltered(corpus, metas, q, k, pred)
+			if !eqUint64(resultIDs(got), want) {
+				t.Errorf("SearchFiltered ids %v != brute-force %v", resultIDs(got), want)
+			}
+
+			// Consumer 2: the id selection matchingIDsAt performs for
+			// delete-by-filter and non-vector scroll.
+			gotIDs, err := h.matchingIDs(c.f, pred)
+			if err != nil {
+				t.Fatalf("matchingIDs: %v", err)
+			}
+			gotSet := make(map[uint64]struct{}, len(gotIDs))
+			for _, id := range gotIDs {
+				gotSet[id] = struct{}{}
+			}
+			for id := range wantSet {
+				if _, ok := gotSet[id]; !ok {
+					t.Errorf("matchingIDs is missing true match id %d (delete-by-filter would under-delete)", id)
+				}
+			}
+			for id := range gotSet {
+				if _, ok := wantSet[id]; !ok {
+					t.Errorf("matchingIDs returned id %d the predicate rejects (delete-by-filter would over-delete)", id)
+				}
+			}
+		})
+	}
+}
+
+// TestRecordColumnFastPathEqualsPredicate drives the numeric column sidecar
+// over a record path: a range on "session/rc" must be column-expressible,
+// build through ensureColumn from the synthetic postings, and agree with the
+// predicate SLOT BY SLOT — the comparison the search-level test can only
+// sample.
+func TestRecordColumnFastPathEqualsPredicate(t *testing.T) {
+	h, _, _ := recordCorpus(t, 400, 8)
+	h.mu.RLock()
+	defer h.mu.RUnlock()
+	now := uint64(h.now())
+	capacity := h.arena.Capacity()
+
+	cases := []struct {
+		name string
+		f    Filter
+	}{
+		{"gt rc", Filter{Op: FilterGt, Field: "session/rc", Value: NewInt(5)}},
+		{"lte rc", Filter{Op: FilterLte, Field: "session/rc", Value: NewInt(4)}},
+		{"gte count", Filter{Op: FilterGte, Field: "session/b#count", Value: NewInt(2)}},
+		{"and rc + plain", Filter{Op: FilterAnd, And: []Filter{
+			{Op: FilterGt, Field: "session/rc", Value: NewInt(3)},
+			{Op: FilterLt, Field: "session/hist", Value: NewInt(2000)},
+		}}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			pred := compileOrFail(t, tc.f)
+			terms, ok := h.payloadIdx.collectColumnTerms(tc.f, capacity, -1, nil)
+			if !ok {
+				t.Fatalf("%s: not column-expressible — the record path never reached ensureColumn", tc.name)
+			}
+			var g admitGate
+			g.armColumns(terms)
+			checked, accepted := 0, 0
+			for slot := 0; slot < capacity; slot++ {
+				u := uint32(slot) //nolint:gosec // bounded by capacity
+				if h.tombstoned[u] || h.isExpiredAt(u, now) {
+					continue
+				}
+				want := pred(h.liveMeta(u, now))
+				got := g.testCols(u)
+				checked++
+				if want {
+					accepted++
+				}
+				if got != want {
+					t.Fatalf("slot %d: column=%v predicate=%v (meta %v)", slot, got, want, h.liveMeta(u, now))
+				}
+			}
+			if checked == 0 || accepted == 0 || accepted == checked {
+				t.Fatalf("%d/%d accepted — the comparison is degenerate", accepted, checked)
+			}
+		})
+	}
+}
+
+// TestRecordIndexRebuildAfterRestore proves the synthetic postings are rebuilt
+// from metadata on Restore (rebuild -> reindex per slot), not merely maintained
+// incrementally on the insert path — a restored collection that lost them would
+// answer every record-path filter with the empty set.
+func TestRecordIndexRebuildAfterRestore(t *testing.T) {
+	src, err := newHNSW(Config{Dim: 4, Metric: L2, M: 8, EfConstruction: 50, EfSearch: 64, Seed: 1})
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := map[uint64]bool{}
+	metas := make(map[uint64]Metadata, 40)
+	for i := 1; i <= 40; i++ {
+		rc := uint8(i % 4) //nolint:gosec // bounded by 4
+		m := Metadata{"session": NewRecord(sessionRecordBytesRC(t, rc))}
+		if rc == 2 {
+			want[uint64(i)] = true
+		}
+		metas[uint64(i)] = m
+		if _, _, err := src.Insert(uint64(i), []float32{float32(i), 0, 0, 0}, 0, m, nil, nil, CASCond{}); err != nil {
+			t.Fatal(err)
+		}
+	}
+	var buf bytes.Buffer
+	if err := src.Snapshot(&buf); err != nil {
+		t.Fatal(err)
+	}
+	dst, err := newHNSW(Config{Dim: 4, Metric: L2, M: 8, EfConstruction: 50, EfSearch: 64, Seed: 1})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := dst.Restore(&buf); err != nil {
+		t.Fatal(err)
+	}
+	if len(dst.payloadIdx.fields["session/rc"][intKey(2)]) != len(want) {
+		t.Fatalf("restored fields[session/rc][2] holds %d slots, want %d — rebuild did not reconstruct the synthetic postings",
+			len(dst.payloadIdx.fields["session/rc"][intKey(2)]), len(want))
+	}
+	if len(dst.payloadIdx.fields["session/b#count"][intKey(2)]) != 40 {
+		t.Fatalf("restored fields[session/b#count][2] holds %d slots, want 40",
+			len(dst.payloadIdx.fields["session/b#count"][intKey(2)]))
+	}
+	f := Filter{Op: FilterEq, Field: "session/rc", Value: NewInt(2)}
+	got, err := dst.SearchFiltered([]float32{20, 0, 0, 0}, 40, f)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != len(want) {
+		t.Fatalf("restored search returned %d ids, want %d", len(got), len(want))
+	}
+	for _, r := range got {
+		if !want[r.ID] {
+			t.Fatalf("restored search returned non-matching id %d", r.ID)
+		}
+	}
+}
+
+// TestRecordFilterFirstActuallyNarrows is what keeps
+// TestRecordFilterFirstEqualsBruteForce honest. Equality between filter-first
+// and brute force is trivially true when the planner declines EVERYTHING and
+// falls back to graph traversal — which is exactly what Task 5 did and exactly
+// what this task changes. So: the accelerated shapes must produce a real,
+// PROPER-SUBSET candidate set from the index, and the declined ones must still
+// decline outright rather than answer with an empty posting map.
+func TestRecordFilterFirstActuallyNarrows(t *testing.T) {
+	h, _, metas := recordCorpus(t, 500, 8)
+	h.mu.RLock()
+	defer h.mu.RUnlock()
+	limit := h.effectiveFilterFirstLimit(h.arena.Size())
+
+	narrowing := []struct {
+		name string
+		f    Filter
+	}{
+		{"eq scalar", Filter{Op: FilterEq, Field: "session/rc", Value: NewInt(5)}},
+		{"in scalar", Filter{Op: FilterIn, Field: "session/rc", Value: NewInts([]int64{3, 7})}},
+		{"gt scalar", Filter{Op: FilterGt, Field: "session/rc", Value: NewInt(10)}},
+		{"eq string scalar", Filter{Op: FilterEq, Field: "session/tag", Value: NewString("de")}},
+		{"eq count", Filter{Op: FilterEq, Field: "session/b#count", Value: NewInt(2)}},
+	}
+	for _, c := range narrowing {
+		cands, ok := h.payloadIdx.candidates(c.f, limit)
+		if !ok {
+			t.Errorf("%s: the index declined to narrow — the acceleration this task adds is not being exercised", c.name)
+			continue
+		}
+		if len(cands) == 0 || len(cands) >= len(metas) {
+			t.Errorf("%s: candidate set of %d over a %d-point corpus is not a proper narrowing", c.name, len(cands), len(metas))
+		}
+	}
+
+	// The shapes that stay on the predicate must DECLINE (ok=false). Answering
+	// with the empty sentinel is the Task 5 bug: it reads as "no matches" to
+	// the planner and silently returns nothing.
+	declining := []struct {
+		name string
+		f    Filter
+	}{
+		{"positional", Filter{Op: FilterEq, Field: "session/#0", Value: NewInt(5)}},
+		{"column path", Filter{Op: FilterEq, Field: "session/b/42/hi", Value: NewInt(500)}},
+		{"match on a record string", Filter{Op: FilterMatch, Field: "session/tag", Value: NewString("de")}},
+		{"contains on a record string", Filter{Op: FilterContains, Field: "session/tag", Value: NewString("de")}},
+		{"row_exists", Filter{Op: FilterRowExists, Field: "session/b/42"}},
+	}
+	for _, c := range declining {
+		if cands, ok := h.payloadIdx.candidates(c.f, limit); ok {
+			t.Errorf("%s: the index narrowed to %d candidates for a shape it never posts — a wrong answer waiting to happen", c.name, len(cands))
+		}
+	}
+
+	// The per-entry-point guards, at the level the planner consumes them.
+	if _, ok := h.payloadIdx.matchSet("session/tag", NewString("de"), limit); ok {
+		t.Error("matchSet answered for a record path: record strings get no token postings")
+	}
+	if _, ok := h.payloadIdx.containsSet("session/tag", NewString("de"), limit); ok {
+		t.Error("containsSet answered for a record path: record strings get no contains postings")
+	}
+	if _, ok := h.payloadIdx.eqSet("session/#0", NewInt(5)); ok {
+		t.Error("eqSet answered for a positional record path, which IndexEntries does not name for a names-carrying schema")
+	}
+	if _, ok := h.payloadIdx.eqSet("session/rc", NewInt(5)); !ok {
+		t.Error("eqSet declined an indexed record path")
+	}
+}
+
+// recordGateCorpus is recordCorpus's all-records sibling: EVERY point carries a
+// session record, so posts[field].num reaches arena.Size() and the complement
+// gate's totality precondition (fieldTotalNumeric) can actually hold for a
+// synthetic field. Without that, the complement path silently declines and a
+// test over it proves nothing.
+func recordGateCorpus(t *testing.T, n int) *hnsw {
+	t.Helper()
+	rng := rand.New(rand.NewSource(4242))
+	h, err := newHNSW(Config{Dim: 8, Metric: L2, M: 16, EfConstruction: 200, EfSearch: 128, Seed: 1})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for i := 1; i <= n; i++ {
+		v := make([]float32, 8)
+		for j := range v {
+			v[j] = float32(rng.NormFloat64())
+		}
+		m := Metadata{"session": NewRecord(sessionRecordBytesRC(t, uint8(i%13)))} //nolint:gosec // i%13 fits uint8
+		if i%2 == 0 {
+			m["country"] = NewString("DE")
+		} else {
+			m["country"] = NewString("US")
+		}
+		if _, _, err := h.Insert(uint64(i), v, 0, m, nil, nil, CASCond{}); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return h
+}
+
+// TestRecordAdmitGateMatchesPredicate drives the traversal-time admission gate
+// — the ONE consumer that is allowed to skip the predicate re-check — over
+// record paths. Two properties, and the second is the whole reason the
+// exactness invariant has to hold rather than merely be plausible:
+//
+//   - SAFETY (every gate): a slot the predicate accepts must never be rejected
+//     by the gate. A gate narrower than the predicate loses rows silently.
+//   - EXACTNESS (a gate graded exact): the gate must equal the predicate slot
+//     for slot, because nothing downstream will re-check it.
+func TestRecordAdmitGateMatchesPredicate(t *testing.T) {
+	h := recordGateCorpus(t, 400)
+	h.mu.RLock()
+	defer h.mu.RUnlock()
+	limit := h.effectiveFilterFirstLimit(h.arena.Size())
+	now := uint64(h.now())
+
+	cases := []struct {
+		name      string
+		f         Filter
+		wantExact bool
+	}{
+		{"eq scalar", Filter{Op: FilterEq, Field: "session/rc", Value: NewInt(5)}, true},
+		{"in scalar", Filter{Op: FilterIn, Field: "session/rc", Value: NewInts([]int64{3, 7})}, true},
+		{"gt scalar", Filter{Op: FilterGt, Field: "session/rc", Value: NewInt(6)}, true},
+		{"eq string scalar", Filter{Op: FilterEq, Field: "session/tag", Value: NewString("de")}, true},
+		{"eq count", Filter{Op: FilterEq, Field: "session/b#count", Value: NewInt(2)}, true},
+		{"and plain + record", Filter{Op: FilterAnd, And: []Filter{
+			{Op: FilterEq, Field: "country", Value: NewString("DE")},
+			{Op: FilterEq, Field: "session/rc", Value: NewInt(5)},
+		}}, true},
+	}
+
+	prev := admitGateMode
+	defer func() { admitGateMode = prev }()
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			pred := compileOrFail(t, tc.f)
+			admitGateMode = gateForce
+			s := getLayerScratch()
+			defer layerScratchPool.Put(s)
+			plan, ok := h.payloadIdx.collectNarrowSets(tc.f, limit)
+			if !ok {
+				t.Fatalf("%s: not narrowable — the gate is not being exercised", tc.name)
+			}
+			h.buildAdmitGate(s, tc.f, plan, 10)
+			defer s.gate.disable()
+			if !s.gate.active() {
+				t.Fatalf("%s: no gate armed", tc.name)
+			}
+			if s.gate.exact != tc.wantExact {
+				t.Fatalf("%s: gate exact = %v, want %v", tc.name, s.gate.exact, tc.wantExact)
+			}
+			accepted, admitted := 0, 0
+			for slot := 0; slot < h.arena.Capacity(); slot++ {
+				u := uint32(slot) //nolint:gosec // bounded by capacity
+				if h.tombstoned[u] || h.isExpiredAt(u, now) {
+					continue
+				}
+				want := pred(h.liveMeta(u, now))
+				got := s.gate.test(u)
+				if want {
+					accepted++
+					if !got {
+						t.Fatalf("%s slot %d: the predicate accepts it but the gate rejects it — rows would be lost", tc.name, slot)
+					}
+				}
+				if got {
+					admitted++
+					if s.gate.exact && !want {
+						t.Fatalf("%s slot %d: an EXACT gate admits a slot the predicate rejects, and nothing re-checks it", tc.name, slot)
+					}
+				}
+			}
+			if accepted == 0 || admitted == 0 {
+				t.Fatalf("%s: %d accepted / %d admitted — the comparison is degenerate", tc.name, accepted, admitted)
+			}
+		})
+	}
+
+	// The COMPLEMENT gate marks what a range REJECTS and admits everything else,
+	// which is only sound when the index knows about every live slot. Every
+	// point here carries the record, so a synthetic field's numeric postings
+	// cover the whole arena and the precondition genuinely holds.
+	t.Run("complement over a synthetic field", func(t *testing.T) {
+		if !h.payloadIdx.fieldTotalNumeric("session/rc", h.arena.Size()) {
+			t.Fatal("session/rc is not numerically total over an all-records corpus — the synthetic postings do not cover every slot")
+		}
+		f := Filter{Op: FilterGte, Field: "session/rc", Value: NewInt(6)}
+		pred := compileOrFail(t, f)
+		admitGateMode = gateForceComplement
+		s := getLayerScratch()
+		defer layerScratchPool.Put(s)
+		h.buildComplementGate(s, f, 10)
+		defer s.gate.disable()
+		if !s.gate.active() {
+			t.Fatal("no complement gate armed over a total synthetic field")
+		}
+		accepted := 0
+		for slot := 0; slot < h.arena.Capacity(); slot++ {
+			u := uint32(slot) //nolint:gosec // bounded by capacity
+			if h.tombstoned[u] || h.isExpiredAt(u, now) {
+				continue
+			}
+			want := pred(h.liveMeta(u, now))
+			if want {
+				accepted++
+			}
+			if got := s.gate.test(u); got != want {
+				t.Fatalf("slot %d: complement gate=%v predicate=%v", slot, got, want)
+			}
+		}
+		if accepted == 0 {
+			t.Fatal("no slot satisfies the range — the comparison is degenerate")
+		}
+	})
+}

--- a/vector/record_filter_alloc_test.go
+++ b/vector/record_filter_alloc_test.go
@@ -1,0 +1,114 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package vector
+
+import (
+	"strings"
+	"testing"
+)
+
+// A record-path filter leaf is compiled ONCE and evaluated once per point, so
+// anything it re-derives per point is multiplied by the scan width. It used to
+// call lookupPath with the raw field string, which re-ran SplitField+ParsePath
+// for every row — a constant answer, recomputed, allocating a split slice and a
+// Segment slice each time. compileLeaf now builds a fieldLookup at compile time
+// and the closures resolve through it.
+//
+// This test pins the outcome at zero: an ordinary numeric record-path predicate
+// must allocate NOTHING per point once the resolver's schema cache is warm. It
+// is deliberately an absolute bound, not a comparison — a budget of "fewer than
+// before" would drift back up one allocation at a time.
+func TestRecordPathPredicateAllocFree(t *testing.T) {
+	meta := Metadata{
+		"session": NewRecord(sessionRecordBytes(t)),
+		"plain":   NewInt(3),
+	}
+
+	for _, tc := range []struct {
+		name  string
+		f     Filter
+		want  bool
+		field string
+	}{
+		{"gt record path", Filter{Op: FilterGt, Field: "session/rc", Value: NewInt(5)}, true, "session/rc"},
+		{"eq record path", Filter{Op: FilterEq, Field: "session/bc", Value: NewInt(3)}, true, "session/bc"},
+		{"count record path", Filter{Op: FilterEq, Field: "session/b#count", Value: NewInt(2)}, true, "session/b#count"},
+		{"gt plain key", Filter{Op: FilterGt, Field: "plain", Value: NewInt(1)}, true, "plain"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			pred, err := CompileFilter(tc.f)
+			if err != nil {
+				t.Fatalf("CompileFilter(%s): %v", tc.field, err)
+			}
+			// Warm the schema cache and confirm the predicate is actually
+			// answering — an alloc count of 0 on a predicate that returns false
+			// for the wrong reason would prove nothing.
+			if got := pred(meta); got != tc.want {
+				t.Fatalf("predicate on %s = %v, want %v", tc.field, got, tc.want)
+			}
+			if n := testing.AllocsPerRun(200, func() { _ = pred(meta) }); n != 0 {
+				t.Fatalf("predicate on %s allocated %.1f times per point, want 0", tc.field, n)
+			}
+		})
+	}
+}
+
+// TestCompiledLookupMatchesLookupPath is the equivalence half of the same
+// change: the compiled fieldLookup and the bare-string lookupPath must answer
+// IDENTICALLY for every field shape, because both are live — lookupPath still
+// serves order_by extraction and the payload index's reindex resolve, and a
+// disagreement between them is exactly how an accelerated query would drop a
+// row the predicate accepts.
+func TestCompiledLookupMatchesLookupPath(t *testing.T) {
+	rec := sessionRecordBytes(t)
+	metas := []Metadata{
+		nil,
+		{},
+		{"session": NewRecord(rec)},
+		{"session": NewInt(1)},               // payload key is not a record
+		{"session/rc": NewString("literal")}, // a literal key that looks like a path
+		{"session": NewRecord(rec), "session/rc": NewString("shadow")}, // literal shadows the path
+		{"": NewRecord(rec)},                       // the empty payload key is legal
+		{"session": NewRecord([]byte{0xFF, 0xFF})}, // malformed record bytes
+	}
+	fields := []string{
+		"session/rc", "session/bc", "session/bal", "session/tag",
+		"session/b#count", "session/b/42/hi", "session/#0",
+		"session", "plain", "no-slash",
+		"/rc",             // empty payload key
+		"session/",        // trailing slash: not a valid path
+		"session/2024/q1", // parses no further than the row segment: not a path
+		"a/b/c/d",         // too many segments
+		`session/"x"/hi`,  // quoted row key
+	}
+	for _, m := range metas {
+		for _, f := range fields {
+			wantV, wantOK := lookupPath(m, f)
+			gotV, gotOK := newFieldLookup(f).get(m)
+			if gotOK != wantOK || (wantOK && !gotV.Equal(wantV)) {
+				t.Fatalf("field %q on %v: compiled = (%v,%v), lookupPath = (%v,%v)",
+					f, m, gotV, gotOK, wantV, wantOK)
+			}
+		}
+	}
+}
+
+// A quoted row key in a filter field must be bounded before it can allocate:
+// the parse now refuses it at compile time instead of copying megabytes per
+// point. The compiled leaf degrades to an exact-key lookup, which is what
+// lookupPath answers for an unparseable path too.
+func TestHugeQuotedRowKeyFieldIsCheap(t *testing.T) {
+	field := `session/"` + strings.Repeat("x", 1<<20) + `"/hi`
+	meta := Metadata{"session": NewRecord(sessionRecordBytes(t))}
+
+	pred, err := CompileFilter(Filter{Op: FilterEq, Field: field, Value: NewInt(1)})
+	if err != nil {
+		t.Fatalf("CompileFilter: %v", err)
+	}
+	if pred(meta) {
+		t.Fatal("predicate on an unparseable path matched; want false (field absent)")
+	}
+	if n := testing.AllocsPerRun(50, func() { _ = pred(meta) }); n != 0 {
+		t.Fatalf("predicate allocated %.1f times per point on a 1 MiB quoted key, want 0", n)
+	}
+}

--- a/vector/record_filter_alloc_test.go
+++ b/vector/record_filter_alloc_test.go
@@ -34,6 +34,12 @@ func TestRecordPathPredicateAllocFree(t *testing.T) {
 		{"eq record path", Filter{Op: FilterEq, Field: "session/bc", Value: NewInt(3)}, true, "session/bc"},
 		{"count record path", Filter{Op: FilterEq, Field: "session/b#count", Value: NewInt(2)}, true, "session/b#count"},
 		{"gt plain key", Filter{Op: FilterGt, Field: "plain", Value: NewInt(1)}, true, "plain"},
+		// Row presence is on the same hot path. row_absent is the expensive
+		// one — it proves absence by walking the table (RowAbsentProven)
+		// instead of trusting the ordered lookup — so it is pinned here to
+		// keep that walk allocation-free.
+		{"row_exists record path", Filter{Op: FilterRowExists, Field: "session/b/42"}, true, "session/b/42"},
+		{"row_absent record path", Filter{Op: FilterRowAbsent, Field: "session/b/7"}, true, "session/b/7"},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			pred, err := CompileFilter(tc.f)

--- a/vector/record_filter_test.go
+++ b/vector/record_filter_test.go
@@ -4,6 +4,7 @@ package vector
 
 import (
 	"encoding/binary"
+	"math/rand"
 	"testing"
 
 	"github.com/rostamlabs/rostam/sdk/wire"
@@ -27,6 +28,15 @@ func su64(i int64) uint64 { return uint64(i) }
 //	#4 tag  BYTES   = "de"
 //	#5 b    TABLE(key U64; c0 "hi" U32, c1 "lo" U32) = {42: (500, 1), 99: (7, 2)}
 func sessionRecordBytes(t *testing.T) []byte {
+	t.Helper()
+	return sessionRecordBytesRC(t, 7)
+}
+
+// sessionRecordBytesRC is sessionRecordBytes with a caller-chosen rc value
+// (bc/hist/bal/tag/table b stay fixed) — used by tests that need many
+// distinct records differing only in rc, e.g. to populate a corpus for a
+// filter-first-vs-brute-force equivalence check.
+func sessionRecordBytesRC(t *testing.T, rc uint8) []byte {
 	t.Helper()
 	leKey := func(v uint64) []byte {
 		b := make([]byte, 8)
@@ -55,7 +65,7 @@ func sessionRecordBytes(t *testing.T) []byte {
 		t.Fatalf("session schema invalid: %v", err)
 	}
 	rec := &wire.Record{Mode: wire.OperateModeSchema, Schema: s, Fields: []wire.Field{
-		{Cell: wire.Cell{Type: wire.OperateTypeU8, U: 7}},
+		{Cell: wire.Cell{Type: wire.OperateTypeU8, U: uint64(rc)}},
 		{Cell: wire.Cell{Type: wire.OperateTypeU8, U: 3}},
 		{Cell: wire.Cell{Type: wire.OperateTypeU32, U: 1234}},
 		{Cell: wire.Cell{Type: wire.OperateTypeI32, U: su64(-5)}},
@@ -205,5 +215,129 @@ func TestCompileFilterRowPresenceCompileErrors(t *testing.T) {
 				}
 			})
 		}
+	}
+}
+
+// TestRecordPathFilterFirstMatchesBruteForce is the fix-round-1 regression
+// test: the payload-index planner must NEVER claim a record path is
+// index-narrowable (it has no postings — reindex only posts literal scalar
+// keys, and scalarKeyOf declines ValueRecord outright), because "field has
+// no postings" is the planner's proof that "field never matches" — and for a
+// record path that inference is false, not just unproven. Before the
+// indexNarrowable/filterIndexExact fix, `p.fields["session/rc"]` was always
+// nil, so the planner graded an Eq/Gt/In/row-presence leaf over a record path
+// as an EXACT, proven-empty set — searchIntoWith intersected the empty set
+// and returned zero results (bypassing graph fallback), and matchingIDsAt
+// took the same fast path and silently under-deleted. This test drives BOTH
+// consumers (SearchFiltered and matchingIDs, the selection matchingIDsAt
+// performs for delete-by-filter/scroll) over a real corpus and checks they
+// agree with a brute-force evaluation of the SAME compiled predicate — so a
+// regression here is a wrong ANSWER, not just a slow one.
+func TestRecordPathFilterFirstMatchesBruteForce(t *testing.T) {
+	const (
+		n   = 60
+		dim = 8
+		k   = 12
+	)
+	rng := rand.New(rand.NewSource(20260908))
+	h, err := newHNSW(Config{Dim: dim, Metric: L2, M: 16, EfConstruction: 200, EfSearch: 128, Seed: 1})
+	if err != nil {
+		t.Fatal(err)
+	}
+	corpus := make(map[uint64][]float32, n)
+	metas := make(map[uint64]Metadata, n)
+	for i := 1; i <= n; i++ {
+		v := make([]float32, dim)
+		for j := range v {
+			v[j] = float32(rng.NormFloat64())
+		}
+		id := uint64(i)
+		m := Metadata{}
+		if i%2 == 0 {
+			m["country"] = NewString("DE")
+		} else {
+			m["country"] = NewString("US")
+		}
+		// Most points carry a "session" record (rc varies 0..12 so Eq/Gt/In
+		// each have some true and some false points); the rest carry none, so
+		// every record-path filter also has to correctly reject points with
+		// no such payload key at all.
+		if i <= 45 {
+			m["session"] = NewRecord(sessionRecordBytesRC(t, uint8(i%13))) //nolint:gosec // i%13 fits uint8
+		}
+		corpus[id] = v
+		metas[id] = m
+		if _, _, err := h.Insert(id, v, 0, m, nil, nil, CASCond{}); err != nil {
+			t.Fatal(err)
+		}
+	}
+	q := make([]float32, dim)
+	for j := range q {
+		q[j] = float32(rng.NormFloat64())
+	}
+
+	filters := []Filter{
+		{Op: FilterEq, Field: "session/rc", Value: NewInt(5)},
+		{Op: FilterGt, Field: "session/rc", Value: NewInt(10)},
+		{Op: FilterIn, Field: "session/rc", Value: NewInts([]int64{3, 7})},
+		{Op: FilterRowExists, Field: "session/b/42"},
+		{Op: FilterAnd, And: []Filter{
+			{Op: FilterEq, Field: "country", Value: NewString("DE")},
+			{Op: FilterEq, Field: "session/rc", Value: NewInt(5)},
+		}},
+	}
+
+	for _, f := range filters {
+		pred := compileOrFail(t, f)
+
+		// Consumer 1: SearchFiltered (filter-first KNN through
+		// hnsw.searchIntoWith), compared against a brute-force top-k over the
+		// SAME compiled predicate.
+		got, err := h.SearchFiltered(q, k, f)
+		if err != nil {
+			t.Fatalf("filter %+v: SearchFiltered: %v", f, err)
+		}
+		want := bruteForceFiltered(corpus, metas, q, k, pred)
+		if !eqUint64(resultIDs(got), want) {
+			t.Errorf("filter %+v: SearchFiltered ids %v != brute-force %v", f, resultIDs(got), want)
+		}
+
+		// Consumer 2: matchingIDs, the id-selection matchingIDsAt performs for
+		// delete-by-filter and non-vector scroll, compared against a
+		// brute-force full-corpus evaluation of the same predicate (not
+		// capped to k, unlike the search path above).
+		gotIDs, err := h.matchingIDs(f, pred)
+		if err != nil {
+			t.Fatalf("filter %+v: matchingIDs: %v", f, err)
+		}
+		wantSet := bruteMatchIDs(metas, pred)
+		gotSet := make(map[uint64]struct{}, len(gotIDs))
+		for _, id := range gotIDs {
+			gotSet[id] = struct{}{}
+		}
+		if len(gotSet) != len(wantSet) {
+			t.Errorf("filter %+v: matchingIDs set size %d != brute-force %d (got=%v want=%v)", f, len(gotSet), len(wantSet), gotSet, wantSet)
+			continue
+		}
+		for id := range wantSet {
+			if _, ok := gotSet[id]; !ok {
+				t.Errorf("filter %+v: matchingIDs missing true match id %d (under-selects, so delete-by-filter would under-delete)", f, id)
+			}
+		}
+	}
+
+	// A control assertion pinning the bug's shape directly: at least one of
+	// the filters above must have a NON-EMPTY brute-force match set, or this
+	// whole test would pass vacuously (both sides empty) without ever
+	// exercising the planner's wrong "proven empty" claim.
+	nonEmpty := false
+	for _, f := range filters {
+		if len(bruteMatchIDs(metas, compileOrFail(t, f))) > 0 {
+			nonEmpty = true
+			break
+		}
+	}
+	if !nonEmpty {
+		t.Fatal("every filter's brute-force match set was empty; test proves nothing — fixture is broken")
 	}
 }

--- a/vector/record_filter_test.go
+++ b/vector/record_filter_test.go
@@ -6,6 +6,7 @@ import (
 	"bytes"
 	"encoding/binary"
 	"math/rand"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -280,35 +281,53 @@ func TestRowPresenceRefusesUnorderedTable(t *testing.T) {
 	}
 }
 
-// TestRowPresenceCompileErrorIsBounded pins the SIZE of a row-presence compile
-// error. The field string is caller-supplied and bounded only by the 32 MiB
-// route body cap, and both rejection branches used to quote it whole — with %q
-// that is up to four bytes of escapes per input byte, so refusing a hostile
-// filter cost another large copy of it, the very cost record.ParsePath's
-// pre-split length bound was added to avoid.
+// TestRowPresenceCompileErrorIsBounded pins the cost of REJECTING a
+// row-presence filter. The field string is caller-supplied and bounded only by
+// the 32 MiB route body cap, and every rejection branch used to quote it whole
+// — with %q that is up to four bytes of escapes per input byte, so refusing a
+// hostile filter cost another large copy of it, the very cost
+// record.ParsePath's pre-split length bound was added to avoid.
 //
-// The message now carries a 64-byte prefix and the length, so it stays a couple
-// of hundred bytes whatever the input, and rejecting stays flat in the size of
-// the field.
+// The property is SIZE INDEPENDENCE, measured against a small field that takes
+// the SAME rejection branch, and measured in BYTES. An absolute allocation
+// COUNT measures the race detector rather than this code — 4 without -race, 24
+// with it — and the count difference between two sizes is too noisy under
+// -race to assert on (observed swinging by 3 either way run to run, in both
+// directions). Bytes are the cost the fix is actually about: quoting the field
+// whole allocates in proportion to it, clipping allocates a message, and the
+// two differ by three orders of magnitude, so the comparison is not close.
+// This mirrors record.TestParsePathLengthBoundBeforeSplit, which measures the
+// same property the same way for the same reason. The count survives only as a
+// loose ceiling, for a rewrite that starts allocating per segment again.
+//
+// The message-length assertion is the one that actually fails when the fix is
+// reverted, and it is the one the finding was about.
 func TestRowPresenceCompileErrorIsBounded(t *testing.T) {
 	const big = 1 << 20
 	huge := strings.Repeat("x", big)
+	// Comfortably past record.ParsePath's 1024-byte path cap, so the two
+	// over-long cases below take the same rejection branch as their 1 MiB
+	// twins at 1/512th the size. A small field that took a DIFFERENT branch,
+	// or a different formatting path inside clipField, would compare two
+	// unrelated allocation profiles.
+	overCap := strings.Repeat("x", 2048)
 
 	for _, c := range []struct {
-		name  string
-		field string
+		name       string
+		small, big string
 	}{
-		// No '/' at all: rejected by SplitField, quoting f.Field.
-		{"no slash", huge},
-		// A path that parses to the wrong shape: rejected after ParsePath,
-		// quoting the path.
-		{"path too long", "session/" + huge},
-		// A row-and-column path built from an over-long column name: parses far
-		// enough to reach the shape check.
-		{"wrong shape", "session/b/42/" + huge},
+		// No '/' at all: rejected by SplitField, which formats f.Field. The
+		// small one is 256 bytes so it is past clipField's 64-byte threshold
+		// too: below it the whole string is quoted instead of clipped, which
+		// is a different formatting path and not the one being compared.
+		{"no slash", strings.Repeat("x", 256), huge},
+		// Rejected by ParsePath's length bound, which formats the path.
+		{"path too long", "session/" + overCap, "session/" + huge},
+		// Same branch, reached through a row-and-column shape.
+		{"wrong shape", "session/b/42/" + overCap, "session/b/42/" + huge},
 	} {
 		t.Run(c.name, func(t *testing.T) {
-			_, err := CompileFilter(Filter{Op: FilterRowExists, Field: c.field})
+			_, err := CompileFilter(Filter{Op: FilterRowExists, Field: c.big})
 			if err == nil {
 				t.Fatal("CompileFilter succeeded, want a compile error")
 			}
@@ -318,13 +337,54 @@ func TestRowPresenceCompileErrorIsBounded(t *testing.T) {
 			if strings.Contains(err.Error(), strings.Repeat("x", 128)) {
 				t.Error("error message echoed a long run of the field")
 			}
-			f := Filter{Op: FilterRowExists, Field: c.field}
-			if n := testing.AllocsPerRun(20, func() { _, _ = CompileFilter(f) }); n > 20 {
-				t.Errorf("rejecting a %d-byte field allocated %.1f times, want a small constant", big, n)
+			if _, serr := CompileFilter(Filter{Op: FilterRowExists, Field: c.small}); serr == nil {
+				t.Fatal("the small field compiled; it must take the same rejection branch as the big one")
+			}
+
+			bigF := Filter{Op: FilterRowExists, Field: c.big}
+			smallF := Filter{Op: FilterRowExists, Field: c.small}
+			smallBytes := bytesPerCompile(smallF)
+			bigBytes := bytesPerCompile(bigF)
+			bigN := testing.AllocsPerRun(20, func() { _, _ = CompileFilter(bigF) })
+			t.Logf("per rejection: %d bytes for a %d-byte field, %d bytes for a %d-byte field (%.0f allocs)",
+				smallBytes, len(c.small), bigBytes, len(c.big), bigN)
+			// The property: a 512x larger field costs the same. The slack
+			// covers the message itself and fmt's buffer sizing, and is two
+			// orders of magnitude below what quoting the field whole costs.
+			const byteSlack = 4 << 10
+			if bigBytes > smallBytes+byteSlack {
+				t.Errorf("rejection allocates in proportion to the field: %d bytes for %d vs %d bytes for %d",
+					smallBytes, len(c.small), bigBytes, len(c.big))
+			}
+			// Backstop on the COUNT, loose enough to survive the race
+			// runtime's own allocations (which roughly double it) and still
+			// catch a rewrite that allocates per segment.
+			if bigN > 64 {
+				t.Errorf("rejecting a %d-byte field allocated %.0f times, want a small constant", big, bigN)
 			}
 		})
 	}
 }
+
+// bytesPerCompile reports the average heap bytes one REJECTED CompileFilter
+// call allocates. runtime.MemStats rather than AllocsPerRun because the cost
+// this test is about is bytes — quoting a 1 MiB field is one big allocation,
+// which barely moves the count — and because the count carries the race
+// runtime's own allocations, which the byte delta between two calls cancels.
+func bytesPerCompile(f Filter) uint64 {
+	const runs = 20
+	var before, after runtime.MemStats
+	runtime.GC()
+	runtime.ReadMemStats(&before)
+	for i := 0; i < runs; i++ {
+		_, compileSink = CompileFilter(f)
+	}
+	runtime.ReadMemStats(&after)
+	return (after.TotalAlloc - before.TotalAlloc) / runs
+}
+
+// compileSink keeps the compiler from optimising the rejected calls away.
+var compileSink error
 
 // TestRecordPathFilterFirstMatchesBruteForce is the fix-round-1 regression
 // test: the payload-index planner must NEVER claim a record path is

--- a/vector/record_filter_test.go
+++ b/vector/record_filter_test.go
@@ -404,3 +404,66 @@ func TestRowPresenceExactPayloadKeyWins(t *testing.T) {
 		})
 	}
 }
+
+// TestRowAbsentRequiresATableAtTheField pins row_absent's contract against the
+// case that used to slip through it: a field the record does not have AT ALL.
+//
+// resolveSchema answers Kind == Absent for a field name that is not in the
+// record's schema, and for an out-of-range positional segment, BEFORE it looks
+// for a row — so "session/zzz/42" reached the closure as Absent and read as "the
+// row is missing from that table". That contradicts the documented contract
+// ("the row is absent" presupposes a table to search) and it disagreed with the
+// neighbouring case: a scalar at the field errors with ErrPath and correctly
+// answers false, though both are "no table at that field".
+//
+// row_absent is now true only when the field itself resolves to a TABLE. The
+// row_exists column is asserted alongside it in every case, because "both false"
+// is precisely the outcome the contract calls for when the question cannot be
+// asked.
+func TestRowAbsentRequiresATableAtTheField(t *testing.T) {
+	m := Metadata{"session": NewRecord(sessionRecordBytes(t))}
+	// A dynamic-mode record has no schema at all; a field it does not carry
+	// must answer the same way a schema-mode unknown field does.
+	dyn := Metadata{"session": NewRecord(goodDynamicRecord(t, 5))}
+
+	cases := []struct {
+		name       string
+		m          Metadata
+		field      string
+		wantExists bool
+		wantAbsent bool
+	}{
+		// The regression: the schema has no "zzz" field whatsoever. There is no
+		// table to search, so neither op may assert anything.
+		{"field absent from the schema", m, "session/zzz/42", false, false},
+		// Same shape by position: #9 is past the end of a 6-field schema.
+		{"positional segment out of range", m, "session/#9/42", false, false},
+		// A dynamic record that simply has no such field.
+		{"field absent from a dynamic record", dyn, "session/zzz/42", false, false},
+		// The neighbouring case that was always right, kept here so the two are
+		// asserted side by side: a SCALAR at the field errors with ErrPath.
+		{"scalar at the field", m, "session/rc/1", false, false},
+		{"scalar at the field, dynamic", dyn, "session/a/1", false, false},
+		// The genuine cases must be unaffected: a real table with the row
+		// missing, and one with the row present.
+		{"table present, row missing", m, "session/b/7", false, true},
+		{"table present, row present", m, "session/b/42", true, false},
+		// Positional addressing of a REAL table still works — the fix is about
+		// what the field resolves to, not how it is spelled.
+		{"table addressed by position, row missing", m, "session/#5/7", false, true},
+		{"table addressed by position, row present", m, "session/#5/42", true, false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			for _, tc := range []struct {
+				op   FilterOp
+				want bool
+			}{{FilterRowExists, c.wantExists}, {FilterRowAbsent, c.wantAbsent}} {
+				p := compileOrFail(t, Filter{Op: tc.op, Field: c.field})
+				if got := p(c.m); got != tc.want {
+					t.Errorf("%s(%q) = %v, want %v", mustOpName(tc.op), c.field, got, tc.want)
+				}
+			}
+		})
+	}
+}

--- a/vector/record_filter_test.go
+++ b/vector/record_filter_test.go
@@ -5,6 +5,7 @@ package vector
 import (
 	"encoding/binary"
 	"math/rand"
+	"strings"
 	"testing"
 
 	"github.com/rostamlabs/rostam/sdk/wire"
@@ -215,6 +216,52 @@ func TestCompileFilterRowPresenceCompileErrors(t *testing.T) {
 				}
 			})
 		}
+	}
+}
+
+// TestRowPresenceCompileErrorIsBounded pins the SIZE of a row-presence compile
+// error. The field string is caller-supplied and bounded only by the 32 MiB
+// route body cap, and both rejection branches used to quote it whole — with %q
+// that is up to four bytes of escapes per input byte, so refusing a hostile
+// filter cost another large copy of it, the very cost record.ParsePath's
+// pre-split length bound was added to avoid.
+//
+// The message now carries a 64-byte prefix and the length, so it stays a couple
+// of hundred bytes whatever the input, and rejecting stays flat in the size of
+// the field.
+func TestRowPresenceCompileErrorIsBounded(t *testing.T) {
+	const big = 1 << 20
+	huge := strings.Repeat("x", big)
+
+	for _, c := range []struct {
+		name  string
+		field string
+	}{
+		// No '/' at all: rejected by SplitField, quoting f.Field.
+		{"no slash", huge},
+		// A path that parses to the wrong shape: rejected after ParsePath,
+		// quoting the path.
+		{"path too long", "session/" + huge},
+		// A row-and-column path built from an over-long column name: parses far
+		// enough to reach the shape check.
+		{"wrong shape", "session/b/42/" + huge},
+	} {
+		t.Run(c.name, func(t *testing.T) {
+			_, err := CompileFilter(Filter{Op: FilterRowExists, Field: c.field})
+			if err == nil {
+				t.Fatal("CompileFilter succeeded, want a compile error")
+			}
+			if n := len(err.Error()); n >= 256 {
+				t.Errorf("error message is %d bytes, want < 256", n)
+			}
+			if strings.Contains(err.Error(), strings.Repeat("x", 128)) {
+				t.Error("error message echoed a long run of the field")
+			}
+			f := Filter{Op: FilterRowExists, Field: c.field}
+			if n := testing.AllocsPerRun(20, func() { _, _ = CompileFilter(f) }); n > 20 {
+				t.Errorf("rejecting a %d-byte field allocated %.1f times, want a small constant", big, n)
+			}
+		})
 	}
 }
 

--- a/vector/record_filter_test.go
+++ b/vector/record_filter_test.go
@@ -3,6 +3,7 @@
 package vector
 
 import (
+	"bytes"
 	"encoding/binary"
 	"math/rand"
 	"strings"
@@ -216,6 +217,66 @@ func TestCompileFilterRowPresenceCompileErrors(t *testing.T) {
 				}
 			})
 		}
+	}
+}
+
+// TestRowPresenceRefusesUnorderedTable is the vector-side half of the proven-
+// absence fix. Record bytes are not validated at ingest in this phase, so a
+// caller can store a table whose rows are NOT in the ascending key order the
+// format requires. A schema-mode row lookup is a binary search, which cannot
+// see the disorder, so it answers Absent for a row that IS stored — and
+// row_absent used to read that as a positive match. A point could then satisfy
+// a filter it does not satisfy, chosen by the bytes the caller stored.
+//
+// Both ops must answer FALSE on such a table: row_exists because the search
+// finds nothing, row_absent because absence is now PROVED by walking the table
+// (record.Resolver.RowAbsentProven) and the walk sees the disorder.
+//
+// The record is patched at the byte level — the encoder sorts rows and
+// DecodeRecord refuses the result — which is the test-only stand-in for the
+// hostile writer this defends against.
+func TestRowPresenceRefusesUnorderedTable(t *testing.T) {
+	enc := sessionRecordBytes(t)
+	ordered := Metadata{"session": NewRecord(append([]byte(nil), enc...))}
+
+	// The two stored rows of table b, byte for byte: an 8-byte little-endian
+	// key then two little-endian u32 columns. They are the last 32 bytes of the
+	// record (b is the last field), and swapping them leaves every offset and
+	// length in the record unchanged — only the ORDER becomes illegal.
+	row42 := []byte{42, 0, 0, 0, 0, 0, 0, 0, 0xF4, 0x01, 0, 0, 1, 0, 0, 0}
+	row99 := []byte{99, 0, 0, 0, 0, 0, 0, 0, 0x07, 0, 0, 0, 2, 0, 0, 0}
+	at := bytes.Index(enc, row42)
+	if at < 0 || !bytes.Equal(enc[at+16:], row99) {
+		t.Fatalf("fixture changed: rows 42/99 are not the last 32 bytes of the record (%x)", enc)
+	}
+	copy(enc[at:], row99)
+	copy(enc[at+16:], row42)
+	unordered := Metadata{"session": NewRecord(enc)}
+
+	for _, c := range []struct {
+		field                  string
+		wantExists, wantAbsent bool // on the ORDERED record
+	}{
+		{"session/b/42", true, false}, // a present row
+		{"session/b/99", true, false}, // the other present row
+		{"session/b/7", false, true},  // a row that really is absent
+	} {
+		t.Run(c.field, func(t *testing.T) {
+			for _, tc := range []struct {
+				op      FilterOp
+				ordered bool
+			}{{FilterRowExists, c.wantExists}, {FilterRowAbsent, c.wantAbsent}} {
+				p := compileOrFail(t, Filter{Op: tc.op, Field: c.field})
+				// The control: on the well-formed record the op answers normally.
+				if got := p(ordered); got != tc.ordered {
+					t.Errorf("%s on the ordered record = %v, want %v", mustOpName(tc.op), got, tc.ordered)
+				}
+				// The fix: on the damaged one, neither op asserts anything.
+				if got := p(unordered); got {
+					t.Errorf("%s on an out-of-order table = true, want false", mustOpName(tc.op))
+				}
+			}
+		})
 	}
 }
 

--- a/vector/record_filter_test.go
+++ b/vector/record_filter_test.go
@@ -1,0 +1,209 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package vector
+
+import (
+	"encoding/binary"
+	"testing"
+
+	"github.com/rostamlabs/rostam/sdk/wire"
+)
+
+// su64 reinterprets a signed value as the uint64 bit pattern Cell.U stores
+// for a signed type. A constant expression like uint64(int64(-5)) does not
+// compile (constant overflow), so negative fixtures go through this helper —
+// mirrors sdk/record/resolve_test.go's su64.
+func su64(i int64) uint64 { return uint64(i) }
+
+// sessionRecordBytes builds a schema-mode record with the same shape as
+// sdk/record's own session example (§2.2), so both packages' tests exercise
+// the same fixture without vector importing record's internal test file
+// (record's tests live in package record and are not importable):
+//
+//	#0 rc   U8      = 7
+//	#1 bc   U8      = 3
+//	#2 hist U32     = 1234
+//	#3 bal  I32     = -5
+//	#4 tag  BYTES   = "de"
+//	#5 b    TABLE(key U64; c0 "hi" U32, c1 "lo" U32) = {42: (500, 1), 99: (7, 2)}
+func sessionRecordBytes(t *testing.T) []byte {
+	t.Helper()
+	leKey := func(v uint64) []byte {
+		b := make([]byte, 8)
+		binary.LittleEndian.PutUint64(b, v)
+		return b
+	}
+	s := &wire.Schema{
+		Version:    1,
+		StoreNames: true,
+		Fields: []wire.FieldDef{
+			{Name: "rc", Type: wire.OperateTypeU8},
+			{Name: "bc", Type: wire.OperateTypeU8},
+			{Name: "hist", Type: wire.OperateTypeU32},
+			{Name: "bal", Type: wire.OperateTypeI32},
+			{Name: "tag", Type: wire.OperateTypeBytes},
+			{Name: "b", Type: wire.OperateTypeTable, Table: &wire.TableDef{
+				KeyType: wire.OperateTypeU64,
+				Cols: []wire.ColumnDef{
+					{Name: "hi", Type: wire.OperateTypeU32},
+					{Name: "lo", Type: wire.OperateTypeU32},
+				},
+			}},
+		},
+	}
+	if err := s.Validate(); err != nil {
+		t.Fatalf("session schema invalid: %v", err)
+	}
+	rec := &wire.Record{Mode: wire.OperateModeSchema, Schema: s, Fields: []wire.Field{
+		{Cell: wire.Cell{Type: wire.OperateTypeU8, U: 7}},
+		{Cell: wire.Cell{Type: wire.OperateTypeU8, U: 3}},
+		{Cell: wire.Cell{Type: wire.OperateTypeU32, U: 1234}},
+		{Cell: wire.Cell{Type: wire.OperateTypeI32, U: su64(-5)}},
+		{Cell: wire.Cell{Type: wire.OperateTypeBytes, B: []byte("de")}},
+		{Cell: wire.Cell{Type: wire.OperateTypeTable}, Table: &wire.Table{Rows: []wire.Row{
+			{Key: leKey(42), Cols: []wire.Col{
+				{Cell: wire.Cell{Type: wire.OperateTypeU32, U: 500}},
+				{Cell: wire.Cell{Type: wire.OperateTypeU32, U: 1}},
+			}},
+			{Key: leKey(99), Cols: []wire.Col{
+				{Cell: wire.Cell{Type: wire.OperateTypeU32, U: 7}},
+				{Cell: wire.Cell{Type: wire.OperateTypeU32, U: 2}},
+			}},
+		}}},
+	}}
+	enc := rec.Encode()
+	if enc == nil {
+		t.Fatal("session record failed to encode")
+	}
+	return enc
+}
+
+// TestLookupPathRecord covers lookupPath's record-path seam directly: exact
+// payload key precedence, resolving into a session record's scalar, table
+// cell, and #count, absence, and declining a payload key that is not a
+// record.
+func TestLookupPathRecord(t *testing.T) {
+	enc := sessionRecordBytes(t)
+	m := Metadata{
+		"session": NewRecord(enc),
+		// A flat key that happens to LOOK like a payloadKey/path string. Its
+		// presence must win outright — lookupPath must never even attempt to
+		// split it as "payloadKey a, path b" (which would resolve against a
+		// record named "a" that does not exist in m at all).
+		"a/b": NewString("literal-wins"),
+		// A payload key present but not a record: any path under it must
+		// decline, not panic or misinterpret its bytes as record bytes.
+		"notrecord": NewString("plain string"),
+	}
+
+	cases := []struct {
+		name  string
+		field string
+		want  Value
+		ok    bool
+	}{
+		{"exact key precedence over path shape", "a/b", NewString("literal-wins"), true},
+		{"scalar field", "session/rc", NewInt(7), true},
+		{"table cell by row+col", "session/b/42/hi", NewInt(500), true},
+		{"table row count", "session/b#count", NewInt(2), true},
+		{"absent field", "session/zz", Value{}, false},
+		{"absent row", "session/b/7", Value{}, false},
+		{"table field itself has no scalar value", "session/b", Value{}, false},
+		{"a present row has no scalar value either", "session/b/42", Value{}, false},
+		{"payload key not a record", "notrecord/rc", Value{}, false},
+		{"payload key missing entirely", "missing/rc", Value{}, false},
+		{"malformed record path", "session/rc#count", Value{}, false}, // #count on a non-table field
+		{"no slash, no exact key", "nonexistent", Value{}, false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got, ok := lookupPath(m, c.field)
+			if ok != c.ok {
+				t.Fatalf("lookupPath(%q) ok = %v, want %v (got %+v)", c.field, ok, c.ok, got)
+			}
+			if ok && !got.Equal(c.want) {
+				t.Errorf("lookupPath(%q) = %+v, want %+v", c.field, got, c.want)
+			}
+		})
+	}
+}
+
+// TestCompileFilterRecordPaths exercises the full CompileFilter path over a
+// metadata map holding a record-typed payload key: scalar comparators
+// (gt/eq/gte/in) reading through a record path, row_exists/row_absent (both
+// directions, plus the row_absent asymmetry against a "cannot apply"
+// outcome), and is_empty/is_null on the record field itself.
+func TestCompileFilterRecordPaths(t *testing.T) {
+	enc := sessionRecordBytes(t)
+	m := Metadata{"session": NewRecord(enc)}
+	emptyM := Metadata{"session": NewRecord(nil)}
+
+	cases := []struct {
+		name string
+		f    Filter
+		m    Metadata
+		want bool
+	}{
+		{"gt over a scalar record field", Filter{Op: FilterGt, Field: "session/rc", Value: NewInt(5)}, m, true},
+		{"gt false case over the same field", Filter{Op: FilterGt, Field: "session/rc", Value: NewInt(100)}, m, false},
+		{"eq over a table cell", Filter{Op: FilterEq, Field: "session/b/42/hi", Value: NewInt(500)}, m, true},
+		{"eq mismatch over a table cell", Filter{Op: FilterEq, Field: "session/b/42/hi", Value: NewInt(1)}, m, false},
+		{"gte over a table row count", Filter{Op: FilterGte, Field: "session/b#count", Value: NewInt(1)}, m, true},
+		{"in over a field addressed by position", Filter{Op: FilterIn, Field: "session/#0", Value: NewInts([]int64{7, 8})}, m, true},
+		{"in miss over a field addressed by position", Filter{Op: FilterIn, Field: "session/#0", Value: NewInts([]int64{1, 2})}, m, false},
+
+		{"row_exists on a present row", Filter{Op: FilterRowExists, Field: "session/b/42"}, m, true},
+		{"row_exists on an absent row", Filter{Op: FilterRowExists, Field: "session/b/7"}, m, false},
+		{"row_absent on an absent row", Filter{Op: FilterRowAbsent, Field: "session/b/7"}, m, true},
+		{"row_absent on a present row", Filter{Op: FilterRowAbsent, Field: "session/b/42"}, m, false},
+		// Asymmetry: a row segment on a SCALAR field cannot apply (Resolve
+		// errors ErrPath). row_exists is false for the same reason it would
+		// be for any non-RowPresent outcome; row_absent must ALSO be false
+		// here, not true — there was never a table to search, so "the row is
+		// absent" cannot be asserted about it.
+		{"row_exists cannot-apply (row segment on a scalar field)", Filter{Op: FilterRowExists, Field: "session/rc/1"}, m, false},
+		{"row_absent cannot-apply (row segment on a scalar field)", Filter{Op: FilterRowAbsent, Field: "session/rc/1"}, m, false},
+		// Same asymmetry when the payload key itself cannot apply: missing,
+		// or present but not a record.
+		{"row_absent on a missing payload key", Filter{Op: FilterRowAbsent, Field: "missing/b/7"}, m, false},
+		{"row_absent on an empty/malformed record", Filter{Op: FilterRowAbsent, Field: "session/b/7"}, emptyM, false},
+
+		{"is_empty on a non-empty record field", Filter{Op: FilterIsEmpty, Field: "session"}, m, false},
+		{"is_empty on an empty record field", Filter{Op: FilterIsEmpty, Field: "session"}, emptyM, true},
+		{"is_null on a present record field", Filter{Op: FilterIsNull, Field: "session"}, m, false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			p := compileOrFail(t, c.f)
+			if got := p(c.m); got != c.want {
+				t.Errorf("CompileFilter(%+v)(m) = %v, want %v", c.f, got, c.want)
+			}
+		})
+	}
+}
+
+// TestCompileFilterRowPresenceCompileErrors pins compileRowPresence's
+// compile-time validation: the field must split into payloadKey/path, the
+// path must parse, and the parsed path must name exactly a table row
+// (field+row, two segments) — never a bare field, a #count, or a row+column.
+func TestCompileFilterRowPresenceCompileErrors(t *testing.T) {
+	cases := []struct {
+		name  string
+		field string
+	}{
+		{"no slash at all", "session"},
+		{"malformed path (empty segment)", "session/"},
+		{"path names only a field, no row", "session/rc"},
+		{"path names a field's count, not a row", "session/b#count"},
+		{"path names a row AND a column", "session/b/42/hi"},
+	}
+	for _, op := range []FilterOp{FilterRowExists, FilterRowAbsent} {
+		for _, c := range cases {
+			t.Run(mustOpName(op)+"/"+c.name, func(t *testing.T) {
+				if _, err := CompileFilter(Filter{Op: op, Field: c.field}); err == nil {
+					t.Errorf("CompileFilter(op=%s, field=%q) succeeded, want a compile error", mustOpName(op), c.field)
+				}
+			})
+		}
+	}
+}

--- a/vector/record_filter_test.go
+++ b/vector/record_filter_test.go
@@ -341,3 +341,66 @@ func TestRecordPathFilterFirstMatchesBruteForce(t *testing.T) {
 		t.Fatal("every filter's brute-force match set was empty; test proves nothing — fixture is broken")
 	}
 }
+
+// TestRowPresenceExactPayloadKeyWins pins the exact-payload-key-first rule for
+// row_exists / row_absent.
+//
+// A filter's field string is tried as an EXACT payload key first, and only then
+// split at the first '/'; lookupPath and fieldLookup.get both do this, and the
+// rule exists so two seams never disagree about one field string. The row
+// presence closure used to skip the exact lookup entirely, so a point holding
+// BOTH a record under "session" AND a literal "session/b/42" key answered
+// row_exists true while lookupPath on the same field returned the literal
+// string. Both ops must answer false: the field named a value, not a table, and
+// "the row is absent" presupposes a table to search.
+func TestRowPresenceExactPayloadKeyWins(t *testing.T) {
+	enc := sessionRecordBytes(t)
+	// "session/b/42" is a PRESENT row in the record and "session/b/7" is an
+	// absent one, so the two literal keys pin both directions: without the fix
+	// the first answers row_exists true and the second answers row_absent true.
+	m := Metadata{
+		"session":      NewRecord(enc),
+		"session/b/42": NewString("literal-wins"),
+		"session/b/7":  NewString("literal-wins-too"),
+	}
+
+	// The control: lookupPath resolves both fields to the LITERAL value, which
+	// is the answer row presence has to agree with.
+	for _, field := range []string{"session/b/42", "session/b/7"} {
+		got, ok := lookupPath(m, field)
+		if !ok || got.Kind != ValueString {
+			t.Fatalf("precondition: lookupPath(%q) = (%+v, %v), want the literal string", field, got, ok)
+		}
+	}
+
+	for _, c := range []struct {
+		name  string
+		f     Filter
+		want  bool
+		alone bool // the answer when the literal key is NOT present
+	}{
+		{"row_exists over a literal key shadowing a present row",
+			Filter{Op: FilterRowExists, Field: "session/b/42"}, false, true},
+		{"row_absent over a literal key shadowing a present row",
+			Filter{Op: FilterRowAbsent, Field: "session/b/42"}, false, false},
+		{"row_exists over a literal key shadowing an absent row",
+			Filter{Op: FilterRowExists, Field: "session/b/7"}, false, false},
+		{"row_absent over a literal key shadowing an absent row",
+			Filter{Op: FilterRowAbsent, Field: "session/b/7"}, false, true},
+	} {
+		t.Run(c.name, func(t *testing.T) {
+			p := compileOrFail(t, c.f)
+			if got := p(m); got != c.want {
+				t.Errorf("%s over a shadowed field = %v, want %v — the literal payload key must win",
+					mustOpName(c.f.Op), got, c.want)
+			}
+			// Drop the literal key and the SAME filter resolves through the
+			// record again, so the fix shadows only what it should.
+			bare := Metadata{"session": NewRecord(enc)}
+			if got := p(bare); got != c.alone {
+				t.Errorf("%s with no literal key = %v, want %v — record resolution must be unaffected",
+					mustOpName(c.f.Op), got, c.alone)
+			}
+		})
+	}
+}

--- a/vector/record_oversize_test.go
+++ b/vector/record_oversize_test.go
@@ -306,3 +306,121 @@ func TestOversizeRecordLeavesSnapshotWritable(t *testing.T) {
 		t.Fatal("Snapshot wrote no bytes")
 	}
 }
+
+// THE RESTORE FAMILY IS NOT REPLAY-ONLY. ops/builtin.go routes an ordinary WIRE
+// insert to Collection.RestoreInsert/RestoreInsertAt whenever the decoded args
+// carry a non-zero version (the version-preserving reinsert the reshard backfill
+// uses), with the caller's own metadata. So these entries take attacker-supplied
+// payloads and must apply the same bound as the ordinary insert.
+//
+// The ordering makes it worse than a missed check: Collection.RestoreInsert
+// applies to the index and only THEN appends to the WAL, so an oversize record
+// used to be stored in memory and the append then failed — leaving a live point
+// with no log record, and a collection that could no longer snapshot.
+//
+// Rejecting here cannot break replay: no WAL record can carry an oversize record
+// (writeOptMeta refuses to encode one) and no snapshot can either (readValue caps
+// at maxRecordValueBytes), so a rejection on this path can only ever come from a
+// live caller.
+func TestOversizeRecordRejectedRestorePaths(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		cfg  Config
+	}{{"hnsw", oversizeDenseConfig()}, {"ivf", oversizeIVFConfig()}} {
+		t.Run(tc.name, func(t *testing.T) {
+			c, err := NewCollection("default/restore", tc.cfg)
+			if err != nil {
+				t.Fatalf("NewCollection: %v", err)
+			}
+			vec := []float32{1, 0, 0, 0}
+			good := Metadata{"rc": NewInt(1)}
+			if err := c.Insert(1, vec, 0, good, nil); err != nil {
+				t.Fatalf("baseline Insert: %v", err)
+			}
+
+			// The wire-reachable pair: a version-preserving reinsert.
+			wantTooLarge(t, "RestoreInsert", c.RestoreInsert(2, vec, 0, oversizeRecord(), nil, nil, 5))
+			if _, _, _, _, _, ok := c.Get(2); ok {
+				t.Fatal("rejected RestoreInsert still created point 2")
+			}
+			wantTooLarge(t, "RestoreInsertAt", c.RestoreInsertAt(3, vec, 0, oversizeRecord(), nil, nil, 5, 1_000))
+			if _, _, _, _, _, ok := c.Get(3); ok {
+				t.Fatal("rejected RestoreInsertAt still created point 3")
+			}
+
+			// The engine bodies are the authority (other callers exist), so drive
+			// them directly too — including RestorePayload, which has no Collection
+			// wrapper of its own.
+			wantTooLarge(t, "idx.RestoreInsert", c.idx.RestoreInsert(4, vec, 0, oversizeRecord(), nil, nil, 5))
+			wantTooLarge(t, "idx.RestoreInsertAt", c.idx.RestoreInsertAt(5, vec, 0, oversizeRecord(), nil, nil, 5, 1_000))
+			wantTooLarge(t, "idx.RestorePayload", c.idx.RestorePayload(1, oversizeRecord(), nil, 5))
+
+			// Point 1's payload must be untouched by the rejected RestorePayload.
+			_, meta, _, _, _, ok := c.Get(1)
+			if !ok {
+				t.Fatal("point 1 disappeared")
+			}
+			if got, gok := meta["rc"]; !gok || !got.Equal(NewInt(1)) {
+				t.Fatalf("point 1 payload changed after a rejected RestorePayload: %v", meta)
+			}
+			if _, gok := meta["session"]; gok {
+				t.Fatal("rejected RestorePayload still stored the oversize record")
+			}
+
+			// The whole point of the bound: the collection can still be written down.
+			var snap bytes.Buffer
+			if err := c.Snapshot(&snap); err != nil {
+				t.Fatalf("Snapshot after rejected restores: %v, want nil", err)
+			}
+		})
+	}
+}
+
+// TestOversizeRecordRejectedRestoreNamedMV covers the named and multi-vector
+// restore siblings, which the reshard/resplit backfill reaches the same way.
+func TestOversizeRecordRejectedRestoreNamedMV(t *testing.T) {
+	t.Run("named", func(t *testing.T) {
+		nc, err := NewNamedCollection("default/named-restore", namedTestConfig())
+		if err != nil {
+			t.Fatalf("NewNamedCollection: %v", err)
+		}
+		vecs := map[string][]float32{"title": {1, 0, 0, 0}, "image": {1, 0, 0}}
+		wantTooLarge(t, "NamedRestoreInsert",
+			nc.RestoreInsert(1, vecs, nil, oversizeRecord(), 0, nil, 5))
+		if _, _, _, _, ok := nc.Get(1); ok {
+			t.Fatal("rejected named RestoreInsert still created point 1")
+		}
+	})
+
+	t.Run("multivector", func(t *testing.T) {
+		m, err := NewMultiVectorIndex(MultiVectorConfig{Dim: 4, M: 16, EfConstruction: 200, EfSearch: 64, Seed: 1})
+		if err != nil {
+			t.Fatalf("NewMultiVectorIndex: %v", err)
+		}
+		tokens := [][]float32{{1, 0, 0, 0}}
+		wantTooLarge(t, "MultiRestoreAdd", m.MultiRestoreAdd(1, tokens, oversizeRecord(), nil, 5))
+		if _, _, _, ok := m.Get(1); ok {
+			t.Fatal("rejected MultiRestoreAdd still created doc 1")
+		}
+		wantTooLarge(t, "MultiRestoreAddSparse", m.MultiRestoreAddSparse(2, tokens, oversizeRecord(), nil, 5, nil))
+		if _, _, _, ok := m.Get(2); ok {
+			t.Fatal("rejected MultiRestoreAddSparse still created doc 2")
+		}
+	})
+}
+
+// TestRestoreAtCapAccepted pins that the restore paths reject only what the
+// codec rejects — the bound must not be tighter here than on the insert path,
+// or a legitimate reshard backfill would start failing.
+func TestRestoreAtCapAccepted(t *testing.T) {
+	c, err := NewCollection("default/restore-cap", oversizeDenseConfig())
+	if err != nil {
+		t.Fatalf("NewCollection: %v", err)
+	}
+	if err := c.RestoreInsert(1, []float32{1, 0, 0, 0}, 0, atCapRecord(), nil, nil, 5); err != nil {
+		t.Fatalf("RestoreInsert at exactly the cap: %v, want nil", err)
+	}
+	if _, _, _, _, version, ok := c.Get(1); !ok || version != 5 {
+		t.Fatalf("restored point: ok=%v version=%d, want true/5", ok, version)
+	}
+}

--- a/vector/record_oversize_test.go
+++ b/vector/record_oversize_test.go
@@ -1,0 +1,308 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package vector
+
+import (
+	"bytes"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// A ValueRecord above maxRecordValueBytes is the one payload value the
+// snapshot/WAL codec cannot write (writeValue rejects it), and it used to be
+// ACCEPTED at ingest. The consequences were not local: writeOptMeta discarded
+// writeValue's error after the kind byte had already been emitted, so the WAL
+// held a self-inconsistent meta block; on the next replay readOptMeta answered
+// false, replay returned errStopReplay, and every ACKNOWLEDGED write logged
+// after that record was discarded. Meanwhile every snapshot of the collection
+// failed for as long as the point stayed live. A base64 body of 17 MiB fits the
+// server's 32 MiB request cap, so the whole shape was remotely reachable.
+//
+// These tests pin the fix from both ends: rejected at every ingest entry
+// (checkRecordValues), and — as defence in depth for any path that reaches the
+// codec anyway — the WAL append fails BEFORE a byte of the half-built record
+// reaches the log.
+
+// oversizeRecord builds a payload whose record value is one byte past the cap.
+// It is not a valid record — it never needs to be, because the size check runs
+// before anything looks inside it.
+func oversizeRecord() Metadata {
+	return Metadata{"session": NewRecord(make([]byte, maxRecordValueBytes+1))}
+}
+
+// atCapRecord is the largest record the codec accepts: the boundary must be
+// inclusive, or the check would move the limit rather than enforce it.
+func atCapRecord() Metadata {
+	return Metadata{"session": NewRecord(make([]byte, maxRecordValueBytes))}
+}
+
+func wantTooLarge(t *testing.T, what string, err error) {
+	t.Helper()
+	if err == nil {
+		t.Fatalf("%s: got nil error, want ErrRecordTooLarge", what)
+	}
+	if !errors.Is(err, ErrRecordTooLarge) {
+		t.Fatalf("%s: err = %v, want ErrRecordTooLarge", what, err)
+	}
+}
+
+func oversizeDenseConfig() Config {
+	return Config{Dim: 4, M: 8, EfConstruction: 50, EfSearch: 50, Seed: 1}
+}
+
+func oversizeIVFConfig() Config {
+	return Config{Dim: 4, M: 8, EfConstruction: 50, EfSearch: 50, Seed: 1,
+		IndexType: IndexIVF, IVFNlist: 4, IVFNprobe: 2}
+}
+
+// TestOversizeRecordRejectedDense covers the dense (HNSW) entry-point family:
+// insert, insert-if-absent, upsert, set-payload, overwrite and the bulk
+// stage/build path. Each must reject with ErrRecordTooLarge and leave the
+// point exactly as it was.
+func TestOversizeRecordRejectedDense(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		cfg  Config
+	}{{"hnsw", oversizeDenseConfig()}, {"ivf", oversizeIVFConfig()}} {
+		t.Run(tc.name, func(t *testing.T) {
+			c, err := NewCollection("default/c", tc.cfg)
+			if err != nil {
+				t.Fatalf("NewCollection: %v", err)
+			}
+			vec := []float32{1, 0, 0, 0}
+			good := Metadata{"rc": NewInt(1)}
+			if err := c.Insert(1, vec, 0, good, nil); err != nil {
+				t.Fatalf("baseline Insert: %v", err)
+			}
+
+			wantTooLarge(t, "Insert", c.Insert(2, vec, 0, oversizeRecord(), nil))
+			if _, _, _, _, _, ok := c.Get(2); ok {
+				t.Fatal("rejected Insert still created point 2")
+			}
+
+			_, err = c.InsertIfAbsent(3, vec, 0, oversizeRecord(), nil)
+			wantTooLarge(t, "InsertIfAbsent", err)
+			if _, _, _, _, _, ok := c.Get(3); ok {
+				t.Fatal("rejected InsertIfAbsent still created point 3")
+			}
+
+			wantTooLarge(t, "Upsert", c.Upsert(1, vec, "doc", 0, oversizeRecord(), nil))
+			// Upsert is delete-then-insert: the point must survive a rejection.
+			_, meta, _, _, _, ok := c.Get(1)
+			if !ok {
+				t.Fatal("rejected Upsert deleted the existing point 1")
+			}
+			if got, gok := meta["rc"]; !gok || !got.Equal(NewInt(1)) {
+				t.Fatalf("point 1 payload changed after a rejected Upsert: %v", meta)
+			}
+
+			wantTooLarge(t, "SetPayload", c.SetPayload(1, oversizeRecord(), nil))
+			wantTooLarge(t, "OverwritePayload", c.OverwritePayload(1, oversizeRecord(), nil))
+			_, meta, _, _, _, _ = c.Get(1)
+			if got, gok := meta["rc"]; !gok || !got.Equal(NewInt(1)) {
+				t.Fatalf("point 1 payload changed after a rejected payload op: %v", meta)
+			}
+			if _, gok := meta["session"]; gok {
+				t.Fatal("rejected payload op still stored the oversize record")
+			}
+
+			// Bulk: the stage refuses the batch outright, so nothing is queued.
+			bulk, berr := NewCollection("default/bulk", tc.cfg)
+			if berr != nil {
+				t.Fatalf("NewCollection bulk: %v", berr)
+			}
+			wantTooLarge(t, "StageBulkPayloads", bulk.StageBulkPayloads(
+				[]uint64{9}, [][]float32{vec}, []Metadata{oversizeRecord()}))
+			wantTooLarge(t, "BuildConcurrentMeta", bulk.BuildConcurrentMeta(
+				[]uint64{9}, [][]float32{vec}, []Metadata{oversizeRecord()}, 1))
+			if n := bulk.Stats().Size; n != 0 {
+				t.Fatalf("rejected bulk build left %d points", n)
+			}
+		})
+	}
+}
+
+// TestOversizeRecordRejectedNamed covers the named-vector family.
+func TestOversizeRecordRejectedNamed(t *testing.T) {
+	nc, err := NewNamedCollection("default/named", namedTestConfig())
+	if err != nil {
+		t.Fatalf("NewNamedCollection: %v", err)
+	}
+	vecs := map[string][]float32{"title": {1, 0, 0, 0}, "image": {1, 0, 0}}
+	good := Metadata{"rc": NewInt(1)}
+	if err := nc.Insert(1, vecs, good, 0); err != nil {
+		t.Fatalf("baseline Insert: %v", err)
+	}
+
+	wantTooLarge(t, "NamedInsert", nc.Insert(2, vecs, oversizeRecord(), 0))
+	if _, _, _, _, ok := nc.Get(2); ok {
+		t.Fatal("rejected named Insert still created point 2")
+	}
+	wantTooLarge(t, "NamedSetPayload", nc.SetPayload(1, oversizeRecord(), nil))
+	wantTooLarge(t, "NamedOverwritePayload", nc.OverwritePayload(1, oversizeRecord(), nil))
+	_, payload, _, _, ok := nc.Get(1)
+	if !ok {
+		t.Fatal("point 1 disappeared")
+	}
+	if got, gok := payload["rc"]; !gok || !got.Equal(NewInt(1)) {
+		t.Fatalf("named payload changed after a rejected op: %v", payload)
+	}
+	if _, gok := payload["session"]; gok {
+		t.Fatal("rejected named payload op still stored the oversize record")
+	}
+}
+
+// TestOversizeRecordRejectedMultiVector covers the multi-vector family,
+// including the if-absent path that delegates to AddIfAbsent.
+func TestOversizeRecordRejectedMultiVector(t *testing.T) {
+	m, err := NewMultiVectorIndex(MultiVectorConfig{Dim: 4, M: 16, EfConstruction: 200, EfSearch: 64, Seed: 1})
+	if err != nil {
+		t.Fatalf("NewMultiVectorIndex: %v", err)
+	}
+	tokens := [][]float32{{1, 0, 0, 0}}
+	good := Metadata{"rc": NewInt(1)}
+	if err := m.Add(1, tokens, good); err != nil {
+		t.Fatalf("baseline Add: %v", err)
+	}
+
+	wantTooLarge(t, "MVAdd", m.Add(2, tokens, oversizeRecord()))
+	if _, _, _, ok := m.Get(2); ok {
+		t.Fatal("rejected MV Add still created doc 2")
+	}
+	_, err = m.AddIfAbsent(3, tokens, oversizeRecord())
+	wantTooLarge(t, "MVAddIfAbsent", err)
+	if _, _, _, ok := m.Get(3); ok {
+		t.Fatal("rejected MV AddIfAbsent still created doc 3")
+	}
+	// The versioned if-absent path does NOT delegate to AddIfAbsent (version != 0).
+	_, err = m.MultiAddIfAbsentVersion(4, tokens, oversizeRecord(), nil, 5)
+	wantTooLarge(t, "MVMultiAddIfAbsentVersion", err)
+	if _, _, _, ok := m.Get(4); ok {
+		t.Fatal("rejected MV MultiAddIfAbsentVersion still created doc 4")
+	}
+
+	wantTooLarge(t, "MVSetPayload", m.SetPayload(1, oversizeRecord(), nil))
+	wantTooLarge(t, "MVOverwritePayload", m.OverwritePayload(1, oversizeRecord(), nil))
+	_, payload, _, ok := m.Get(1)
+	if !ok {
+		t.Fatal("doc 1 disappeared")
+	}
+	if got, gok := payload["rc"]; !gok || !got.Equal(NewInt(1)) {
+		t.Fatalf("MV payload changed after a rejected op: %v", payload)
+	}
+	if _, gok := payload["session"]; gok {
+		t.Fatal("rejected MV payload op still stored the oversize record")
+	}
+}
+
+// TestRecordAtCapAccepted pins the boundary: exactly maxRecordValueBytes is
+// still a legal value, so the check rejects only what the codec rejects.
+func TestRecordAtCapAccepted(t *testing.T) {
+	c, err := NewCollection("default/cap", oversizeDenseConfig())
+	if err != nil {
+		t.Fatalf("NewCollection: %v", err)
+	}
+	if err := c.Insert(1, []float32{1, 0, 0, 0}, 0, atCapRecord(), nil); err != nil {
+		t.Fatalf("Insert at exactly the cap: %v, want nil", err)
+	}
+}
+
+// TestWriteOptMetaOversizeFailsAppend is the durability half. writeOptMeta must
+// report the encode failure, and every staged append must fail on it BEFORE the
+// record reaches the log — a partially written meta block is what replay reads
+// as a torn record, and it answers by discarding every acked write behind it.
+func TestWriteOptMetaOversizeFailsAppend(t *testing.T) {
+	t.Run("codec returns the error", func(t *testing.T) {
+		var buf bytes.Buffer
+		if err := writeOptMeta(&buf, oversizeRecord()); err == nil {
+			t.Fatal("writeOptMeta on an oversize record: got nil error, want one")
+		}
+	})
+
+	path := filepath.Join(t.TempDir(), "w.wal")
+	w, err := openWAL(path, true)
+	if err != nil {
+		t.Fatalf("openWAL: %v", err)
+	}
+	defer func() { _ = w.close() }()
+
+	vec := []float32{1, 0, 0, 0}
+	// A good record first, so the test proves the FAILED append adds nothing
+	// rather than that the file happens to be empty.
+	if _, err := w.appendInsertStaged(1, vec, 0, Metadata{"rc": NewInt(1)}, nil, nil, 1); err != nil {
+		t.Fatalf("baseline appendInsertStaged: %v", err)
+	}
+	size := func() int64 {
+		fi, serr := os.Stat(path)
+		if serr != nil {
+			t.Fatalf("stat: %v", serr)
+		}
+		return fi.Size()
+	}
+	before := size()
+	if before == 0 {
+		t.Fatal("baseline append wrote nothing")
+	}
+
+	for _, tc := range []struct {
+		name string
+		run  func() (uint64, error)
+	}{
+		{"insert", func() (uint64, error) {
+			return w.appendInsertStaged(2, vec, 0, oversizeRecord(), nil, nil, 1)
+		}},
+		{"setPayload", func() (uint64, error) {
+			return w.appendSetPayloadStaged(1, oversizeRecord(), nil, 2)
+		}},
+		{"namedInsert", func() (uint64, error) {
+			return w.appendNamedInsertStaged(3, map[string][]float32{"t": vec}, nil, 0, oversizeRecord(), nil, 1)
+		}},
+		{"namedSetPayload", func() (uint64, error) {
+			return w.appendNamedSetPayloadStaged(1, oversizeRecord(), nil, 2)
+		}},
+		{"mvAdd", func() (uint64, error) {
+			return w.appendMVAddStaged(4, [][]float32{vec}, oversizeRecord(), nil, 1, nil)
+		}},
+		{"mvSetPayload", func() (uint64, error) {
+			return w.appendMVSetPayloadStaged(1, oversizeRecord(), nil, 2)
+		}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			seq, aerr := tc.run()
+			if aerr == nil {
+				t.Fatal("staged append with an oversize record: got nil error, want one")
+			}
+			if seq != 0 {
+				t.Fatalf("failed append staged seq %d, want 0 (nothing may be staged)", seq)
+			}
+			if got := size(); got != before {
+				t.Fatalf("WAL grew from %d to %d bytes on a failed append", before, got)
+			}
+		})
+	}
+}
+
+// TestOversizeRecordLeavesSnapshotWritable is the reviewer's scenario end to
+// end: the oversize insert is refused, and because it never landed, an ordinary
+// insert alongside it still snapshots. Before the fix the refused point was
+// live and every snapshot of the collection failed while it stayed live.
+func TestOversizeRecordLeavesSnapshotWritable(t *testing.T) {
+	c, err := NewCollection("default/snap", oversizeDenseConfig())
+	if err != nil {
+		t.Fatalf("NewCollection: %v", err)
+	}
+	vec := []float32{1, 0, 0, 0}
+	wantTooLarge(t, "Insert", c.Insert(1, vec, 0, oversizeRecord(), nil))
+	if err := c.Insert(2, vec, 0, Metadata{"session": NewRecord(sessionRecordBytes(t))}, nil); err != nil {
+		t.Fatalf("normal Insert after a rejected one: %v", err)
+	}
+	var snap bytes.Buffer
+	if err := c.Snapshot(&snap); err != nil {
+		t.Fatalf("Snapshot: %v, want nil", err)
+	}
+	if snap.Len() == 0 {
+		t.Fatal("Snapshot wrote no bytes")
+	}
+}

--- a/vector/record_oversize_test.go
+++ b/vector/record_oversize_test.go
@@ -424,3 +424,34 @@ func TestRestoreAtCapAccepted(t *testing.T) {
 		t.Fatalf("restored point: ok=%v version=%d, want true/5", ok, version)
 	}
 }
+
+// TestOversizeRecordErrorBoundsThePayloadKey pins the SIZE of the rejection
+// message. The payload key is caller-supplied and bounded only by the route
+// body cap, and this error is a classified CLIENT error on every transport, so
+// its text is returned to the caller verbatim and carried across replication as
+// a string — quoting an unbounded key whole would hand a hostile caller a
+// megabyte-scale message to allocate, format, log and ship, on the path whose
+// whole point is to refuse cheaply.
+//
+// clipField (the same helper the row-presence compile errors use) keeps a short
+// key rendering exactly as %q did, which is what the transport tests' fixtures
+// assume.
+func TestOversizeRecordErrorBoundsThePayloadKey(t *testing.T) {
+	const big = 1 << 20
+	huge := string(bytes.Repeat([]byte("k"), big))
+	err := checkRecordValues(Metadata{huge: NewRecord(make([]byte, maxRecordValueBytes+1))})
+	wantTooLarge(t, "oversize record under a 1 MiB payload key", err)
+	if n := len(err.Error()); n >= 256 {
+		t.Errorf("error message is %d bytes, want < 256", n)
+	}
+	if bytes.Contains([]byte(err.Error()), bytes.Repeat([]byte("k"), 128)) {
+		t.Error("error message echoed a long run of the payload key")
+	}
+	// A short key is unchanged, so nothing that reads this message has to
+	// change with it.
+	short := checkRecordValues(oversizeRecord())
+	wantTooLarge(t, "oversize record under a short payload key", short)
+	if !bytes.Contains([]byte(short.Error()), []byte(`payload key "session" holds a`)) {
+		t.Errorf("short-key message changed shape: %q", short.Error())
+	}
+}

--- a/vector/record_payload_ownership_test.go
+++ b/vector/record_payload_ownership_test.go
@@ -1,0 +1,128 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package vector
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/rostamlabs/rostam/sdk/wire"
+)
+
+// A record payload follows the SAME ownership policy as the three list kinds:
+// the slice is held by reference in both directions, and the engine's metadata
+// copies are map-level (cloneMeta, and the inline map copy in Get). So an
+// IN-PROCESS reader is handed Values whose slices still point at stored bytes,
+// for records and for strings/ints/floats alike, and writing through one is a
+// caller contract violation — vtypes.Metadata documents it for all four kinds.
+//
+// This test pins the two halves of that policy that actually matter:
+//
+//  1. The WIRE path hands out nothing of the engine's. Every network client
+//     reads a payload the codec wrote into its own buffer, so mutating it
+//     cannot reach stored bytes. That is what makes the in-process aliasing a
+//     local, documented contract rather than a remotely reachable hazard.
+//  2. Records are not a NEW hazard: a string list behaves identically, which is
+//     why the fix for one would have to be the fix for all four.
+func TestGetPayloadWirePathIsCallerOwned(t *testing.T) {
+	const dim = 4
+	h, err := newHNSW(Config{Dim: dim, Metric: L2, M: 16, EfConstruction: 100, EfSearch: 32, Seed: 1})
+	if err != nil {
+		t.Fatal(err)
+	}
+	rec := sessionRecordBytes(t)
+	stored := append([]byte(nil), rec...) // the reference copy, never handed to the engine
+	meta := Metadata{
+		"session": NewRecord(append([]byte(nil), rec...)),
+		"tags":    NewStrings([]string{"alpha", "beta"}),
+	}
+	vec := []float32{1, 2, 3, 4}
+	if _, _, err := h.Insert(1, vec, 0, meta, nil, nil, CASCond{}); err != nil {
+		t.Fatal(err)
+	}
+
+	// Read the point the way a network client does: through the result codec.
+	gv, gm, ttl, sparse, version, ok := h.Get(1)
+	if !ok {
+		t.Fatal("Get(1) = !ok")
+	}
+	body := wire.EncodeVectorGetResultV(true, gv, gm, ttl, sparse, true, true, version)
+	_, _, wm, _, _, _, err := wire.DecodeVectorGetResultV(body)
+	if err != nil {
+		t.Fatalf("DecodeVectorGetResultV: %v", err)
+	}
+
+	// Mutate everything the decoded payload holds, as hostilely as a caller can.
+	wrec := wm["session"]
+	if wrec.Kind != ValueRecord || !bytes.Equal(wrec.Rec, stored) {
+		t.Fatalf("decoded record = %v, want the stored bytes", wrec)
+	}
+	for i := range wrec.Rec {
+		wrec.Rec[i] ^= 0xFF
+	}
+	wtags := wm["tags"]
+	if wtags.Kind != ValueStrings || len(wtags.Strs) != 2 {
+		t.Fatalf("decoded tags = %v, want two strings", wtags)
+	}
+	wtags.Strs[0] = "MUTATED"
+
+	// The engine is untouched: the stored record still resolves, the synthetic
+	// postings still describe it, and the list value is unchanged.
+	_, after, _, _, _, ok := h.Get(1)
+	if !ok {
+		t.Fatal("Get(1) after the mutation = !ok")
+	}
+	if got := after["session"]; !bytes.Equal(got.Rec, stored) {
+		t.Errorf("stored record changed through the wire payload:\n got %x\nwant %x", got.Rec, stored)
+	}
+	if got := after["tags"]; got.Strs[0] != "alpha" {
+		t.Errorf("stored string list changed through the wire payload: %q", got.Strs)
+	}
+	// The predicate is the real consumer of those bytes: a corrupted record
+	// would stop resolving, so this is the assertion that the STORED record is
+	// still a record and still says what it said.
+	pred := compileOrFail(t, Filter{Op: FilterEq, Field: "session/rc", Value: NewInt(7)})
+	if !pred(after) {
+		t.Error("session/rc == 7 no longer matches the stored record")
+	}
+	rowPred := compileOrFail(t, Filter{Op: FilterRowExists, Field: "session/b/42"})
+	if !rowPred(after) {
+		t.Error("row_exists(session/b/42) no longer matches the stored record")
+	}
+}
+
+// TestGetPayloadInProcessAliasingIsUniform is the companion fact, asserted so
+// the policy is visible rather than inferred: an in-process Get hands back
+// Values that ALIAS stored bytes, and it does so identically for a record and
+// for a string list. If a future change deep-copies one of them on the read
+// path it must deep-copy all four kinds, and this test will say so.
+func TestGetPayloadInProcessAliasingIsUniform(t *testing.T) {
+	const dim = 4
+	h, err := newHNSW(Config{Dim: dim, Metric: L2, M: 16, EfConstruction: 100, EfSearch: 32, Seed: 1})
+	if err != nil {
+		t.Fatal(err)
+	}
+	meta := Metadata{
+		"session": NewRecord(sessionRecordBytes(t)),
+		"tags":    NewStrings([]string{"alpha"}),
+	}
+	if _, _, err := h.Insert(1, []float32{1, 2, 3, 4}, 0, meta, nil, nil, CASCond{}); err != nil {
+		t.Fatal(err)
+	}
+	_, a, _, _, _, ok := h.Get(1)
+	if !ok {
+		t.Fatal("Get(1) = !ok")
+	}
+	_, b, _, _, _, ok := h.Get(1)
+	if !ok {
+		t.Fatal("second Get(1) = !ok")
+	}
+	// Two independent reads share the same backing arrays: the copies are
+	// map-level, so the slice headers still point at one set of bytes.
+	if &a["session"].Rec[0] != &b["session"].Rec[0] {
+		t.Error("record payload was copied on the read path; the list kinds are not — make the policy uniform")
+	}
+	if &a["tags"].Strs[0] != &b["tags"].Strs[0] {
+		t.Error("string-list payload was copied on the read path; the record kind is not — make the policy uniform")
+	}
+}

--- a/vector/record_too_large_message_test.go
+++ b/vector/record_too_large_message_test.go
@@ -1,0 +1,89 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package vector
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+)
+
+// TestIsRecordTooLargeMessage pins IsRecordTooLargeMessage against the exact
+// shapes checkRecordValues / checkRecordValuesAll produce, and against the
+// class of input it exists to REJECT: an unrelated error whose message merely
+// contains the sentinel text. A bare strings.Contains would pass every case in
+// the reject table below, which is exactly the bug (a WAL/path/IO error that
+// wraps ErrRecordTooLarge becoming client-facing verbatim, unredacted).
+func TestIsRecordTooLargeMessage(t *testing.T) {
+	single := checkRecordValues(Metadata{"session": NewRecord(make([]byte, maxRecordValueBytes+1))}).Error()
+	if !strings.HasPrefix(single, ErrRecordTooLarge.Error()+": payload key \"session\" holds a ") {
+		t.Fatalf("single-form fixture drifted from checkRecordValues: %q", single)
+	}
+
+	longKey := string(make([]byte, 200))
+	for i := range longKey {
+		// A printable filler so clipField's quoting/prefix branch is exercised
+		// without embedding NUL bytes in the fixture.
+		longKey = longKey[:i] + "k" + longKey[i+1:]
+	}
+	singleLongKey := checkRecordValues(Metadata{longKey: NewRecord(make([]byte, maxRecordValueBytes+1))}).Error()
+
+	bulkRow0 := checkRecordValuesAll([]Metadata{
+		{"session": NewRecord(make([]byte, maxRecordValueBytes+1))},
+	}).Error()
+	bulkRow12 := checkRecordValuesAll([]Metadata{
+		{}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {},
+		{"session": NewRecord(make([]byte, maxRecordValueBytes+1))},
+	}).Error()
+
+	accept := []struct {
+		name string
+		msg  string
+	}{
+		{"bare sentinel text", ErrRecordTooLarge.Error()},
+		{"single-payload form, short key", single},
+		{"single-payload form, long/clipped key", singleLongKey},
+		{"bulk form, row 0", bulkRow0},
+		{"bulk form, row 12 (multi-digit index)", bulkRow12},
+		{"single form re-stringified (simulates decodePBResult)", errors.New(single).Error()},
+		{"bulk form re-stringified (simulates decodePBResult)", errors.New(bulkRow12).Error()},
+	}
+	for _, tc := range accept {
+		t.Run("accept/"+tc.name, func(t *testing.T) {
+			if !IsRecordTooLargeMessage(tc.msg) {
+				t.Errorf("IsRecordTooLargeMessage(%q) = false, want true", tc.msg)
+			}
+		})
+	}
+
+	reject := []struct {
+		name string
+		msg  string
+	}{
+		{"empty string", ""},
+		{"unrelated error containing the sentinel text (%v wrap)",
+			fmt.Errorf("wal append failed at /var/lib/rostam/x: %v", ErrRecordTooLarge).Error()},
+		{"unrelated error containing the sentinel text (%w wrap, op-name prefixed)",
+			fmt.Errorf("vector_insert: %w", ErrRecordTooLarge).Error()},
+		{"sentinel text embedded mid-message with unrelated trailing content",
+			"apply failed: " + ErrRecordTooLarge.Error() + " (retrying on shard 3)"},
+		{"single-payload form with a byte cut off the front",
+			strings.TrimPrefix(single, "v")},
+		{"single-payload form with trailing garbage appended",
+			single + " extra"},
+		{"bulk form with the row index missing",
+			"payload : " + single},
+		{"looks like the bulk prefix but the sentinel text is misquoted",
+			"payload 0: vector: record payload value exceeds the storage cap (no detail)"},
+		{"oversize input beyond the length bound",
+			strings.Repeat("vector: record payload value exceeds the storage cap: payload key \"k\" holds a 1-byte record, the cap is 16777216 bytes ", 64)},
+	}
+	for _, tc := range reject {
+		t.Run("reject/"+tc.name, func(t *testing.T) {
+			if IsRecordTooLargeMessage(tc.msg) {
+				t.Errorf("IsRecordTooLargeMessage(%q) = true, want false", tc.msg)
+			}
+		})
+	}
+}

--- a/vector/snapshot.go
+++ b/vector/snapshot.go
@@ -1058,6 +1058,13 @@ func writeValue(w io.Writer, v Value) error {
 		// [len:u32][bytes], mirroring ValueString above. This one function pair
 		// serves WAL, snapshot, and persist, so this case makes a record-bearing
 		// collection durable on every path.
+		if len(v.Rec) > maxRecordValueBytes {
+			// Keeps the invariant symmetric with readValue's reject-on-read below:
+			// nothing this process ever writes can trip the read-side bound, so a
+			// bound failure on read always means a hostile or corrupt frame, never
+			// one of our own snapshots/WAL entries.
+			return fmt.Errorf("%w: record value %d bytes exceeds %d byte cap", ErrSnapshotFormat, len(v.Rec), maxRecordValueBytes)
+		}
 		if err := writeU32(w, uint32(len(v.Rec))); err != nil {
 			return err
 		}
@@ -1070,17 +1077,30 @@ func writeValue(w io.Writer, v Value) error {
 	}
 }
 
+// maxRecordValueBytes hard-bounds a single ValueRecord's byte length on
+// read, independent of the reader type. It equals maxOperateRecordBytes
+// (ops/operate_engine.go, design doc §2.7) — the cap the operate engine
+// already enforces on a STORED record before it can ever reach writeValue —
+// so a length prefix claiming more than this cannot possibly be a valid
+// record: it is either a corrupt frame or hostile input, and is rejected
+// before any allocation. vector cannot import ops (ops depends on vector),
+// so the value is duplicated rather than shared; keep the two in sync.
+const maxRecordValueBytes = 16 << 20
+
 // sizedReader is implemented by readers that can report how many bytes remain
-// unread (e.g. *bytes.Reader). readValue's ValueRecord case uses it to reject
-// an oversized length prefix BEFORE allocating — a hostile or corrupt frame
-// otherwise drives an attacker/corruption-controlled make([]byte, n) up to
-// 4 GiB before io.ReadFull ever gets a chance to fail on the short read. Only
-// readers that expose this — untrusted callers should pass one — get the
-// protection; a plain io.Reader (e.g. bufio.Reader) falls back to the same
-// allocate-then-fail behavior every other case here already has.
+// unread (e.g. *bytes.Reader). readValue's ValueRecord case uses it as an
+// EARLY out ahead of the maxRecordValueBytes check below, when available —
+// but the hard cap is the actual guarantee: every real production reader
+// (WAL, Restore, named, IVF — all bufio-wrapped) has no Len(), so relying on
+// this alone left every one of those paths exposed to a hostile length
+// prefix driving make([]byte, n) up to ~4 GiB before io.ReadFull ever got a
+// chance to fail on the short read.
 type sizedReader interface{ Len() int }
 
 func boundedRecordBytes(r io.Reader, n uint32) ([]byte, error) {
+	if n > maxRecordValueBytes {
+		return nil, fmt.Errorf("%w: record length %d exceeds %d byte cap", ErrSnapshotFormat, n, maxRecordValueBytes)
+	}
 	if sr, ok := r.(sizedReader); ok && uint64(n) > uint64(sr.Len()) {
 		return nil, fmt.Errorf("%w: record length %d exceeds %d remaining bytes", ErrSnapshotFormat, n, sr.Len())
 	}

--- a/vector/snapshot.go
+++ b/vector/snapshot.go
@@ -997,6 +997,7 @@ func readString(r io.Reader) (string, error) {
 //	ints:    [count:u32] then each [i64]
 //	floats:  [count:u32] then each [f64]
 //	geo:     [lat:f64][lon:f64]
+//	record:  [len:u32][bytes]
 func writeValue(w io.Writer, v Value) error {
 	if _, err := w.Write([]byte{byte(v.Kind)}); err != nil {
 		return err
@@ -1053,11 +1054,41 @@ func writeValue(w io.Writer, v Value) error {
 			return err
 		}
 		return writeF64(w, v.Lon)
+	case ValueRecord:
+		// [len:u32][bytes], mirroring ValueString above. This one function pair
+		// serves WAL, snapshot, and persist, so this case makes a record-bearing
+		// collection durable on every path.
+		if err := writeU32(w, uint32(len(v.Rec))); err != nil {
+			return err
+		}
+		_, err := w.Write(v.Rec)
+		return err
 	case ValueNone:
 		return nil
 	default:
 		return fmt.Errorf("%w: unknown value kind %d", ErrSnapshotFormat, v.Kind)
 	}
+}
+
+// sizedReader is implemented by readers that can report how many bytes remain
+// unread (e.g. *bytes.Reader). readValue's ValueRecord case uses it to reject
+// an oversized length prefix BEFORE allocating — a hostile or corrupt frame
+// otherwise drives an attacker/corruption-controlled make([]byte, n) up to
+// 4 GiB before io.ReadFull ever gets a chance to fail on the short read. Only
+// readers that expose this — untrusted callers should pass one — get the
+// protection; a plain io.Reader (e.g. bufio.Reader) falls back to the same
+// allocate-then-fail behavior every other case here already has.
+type sizedReader interface{ Len() int }
+
+func boundedRecordBytes(r io.Reader, n uint32) ([]byte, error) {
+	if sr, ok := r.(sizedReader); ok && uint64(n) > uint64(sr.Len()) {
+		return nil, fmt.Errorf("%w: record length %d exceeds %d remaining bytes", ErrSnapshotFormat, n, sr.Len())
+	}
+	buf := make([]byte, n)
+	if _, err := io.ReadFull(r, buf); err != nil {
+		return nil, err
+	}
+	return buf, nil
 }
 
 func readValue(r io.Reader) (Value, error) {
@@ -1142,6 +1173,16 @@ func readValue(r io.Reader) (Value, error) {
 		}
 		v.Lat = lat
 		v.Lon = lon
+	case ValueRecord:
+		n, err := readU32(r)
+		if err != nil {
+			return Value{}, err
+		}
+		buf, err := boundedRecordBytes(r, n)
+		if err != nil {
+			return Value{}, err
+		}
+		v.Rec = buf
 	case ValueNone:
 		// no payload
 	default:

--- a/vector/snapshot_test.go
+++ b/vector/snapshot_test.go
@@ -6,6 +6,7 @@ import (
 	"bytes"
 	"encoding/binary"
 	"errors"
+	"runtime"
 	"testing"
 	"time"
 )
@@ -420,4 +421,87 @@ func TestStatsSparseVectors(t *testing.T) {
 	if got := h.Stats().SparseVectors; got != 3 {
 		t.Errorf("Stats.SparseVectors = %d, want 3", got)
 	}
+}
+
+// TestValueCodecRecordRoundtrip covers the [len:u32][bytes] ValueRecord case
+// added to writeValue/readValue — the single codec shared by snapshot, WAL,
+// and persist, so this one round-trip test exercises all three durability
+// paths.
+func TestValueCodecRecordRoundtrip(t *testing.T) {
+	t.Run("roundtrip", func(t *testing.T) {
+		want := Value{Kind: ValueRecord, Rec: []byte{0xDE, 0xAD, 0xBE, 0xEF}}
+		var buf bytes.Buffer
+		if err := writeValue(&buf, want); err != nil {
+			t.Fatalf("writeValue: %v", err)
+		}
+		got, err := readValue(bytes.NewReader(buf.Bytes()))
+		if err != nil {
+			t.Fatalf("readValue: %v", err)
+		}
+		if got.Kind != ValueRecord {
+			t.Fatalf("Kind = %v, want ValueRecord", got.Kind)
+		}
+		if !bytes.Equal(got.Rec, want.Rec) {
+			t.Fatalf("Rec = %v, want %v", got.Rec, want.Rec)
+		}
+	})
+
+	t.Run("empty record roundtrip", func(t *testing.T) {
+		want := Value{Kind: ValueRecord, Rec: []byte{}}
+		var buf bytes.Buffer
+		if err := writeValue(&buf, want); err != nil {
+			t.Fatalf("writeValue: %v", err)
+		}
+		got, err := readValue(bytes.NewReader(buf.Bytes()))
+		if err != nil {
+			t.Fatalf("readValue: %v", err)
+		}
+		if len(got.Rec) != 0 {
+			t.Fatalf("Rec = %v, want empty", got.Rec)
+		}
+	})
+
+	t.Run("truncated frame errors", func(t *testing.T) {
+		want := Value{Kind: ValueRecord, Rec: []byte{1, 2, 3, 4, 5}}
+		var buf bytes.Buffer
+		if err := writeValue(&buf, want); err != nil {
+			t.Fatalf("writeValue: %v", err)
+		}
+		// Chop off the last two payload bytes: the length prefix still claims 5
+		// bytes, but only 3 are actually present.
+		truncated := buf.Bytes()[:buf.Len()-2]
+		if _, err := readValue(bytes.NewReader(truncated)); err == nil {
+			t.Fatal("readValue on truncated frame: got nil error, want one")
+		}
+	})
+
+	t.Run("oversized length errors without allocating", func(t *testing.T) {
+		// kind byte + a length prefix claiming ~4 GiB, with NO payload bytes
+		// behind it. bytes.Reader implements Len(), so boundedRecordBytes must
+		// reject this from the length prefix alone rather than attempting
+		// make([]byte, 0xFFFFFFF0) — which would otherwise blow the test's
+		// memory budget or the process's.
+		var frame bytes.Buffer
+		frame.WriteByte(byte(ValueRecord))
+		if err := writeU32(&frame, 0xFFFFFFF0); err != nil {
+			t.Fatalf("writeU32: %v", err)
+		}
+		frameBytes := frame.Bytes()
+
+		// testing.AllocsPerRun counts allocation EVENTS, not bytes — a single
+		// make([]byte, 4<<30) would show up as "1 alloc", not as a red flag. Measure
+		// heap bytes via runtime.MemStats instead, so a multi-GiB buffer can't hide.
+		var before, after runtime.MemStats
+		runtime.GC()
+		runtime.ReadMemStats(&before)
+		if _, err := readValue(bytes.NewReader(frameBytes)); err == nil {
+			t.Fatal("readValue on oversized length: got nil error, want one")
+		}
+		runtime.ReadMemStats(&after)
+
+		const budget = 1 << 20 // 1 MiB — generous headroom over the few bytes this path should touch, nowhere near the ~4 GiB it would need to actually allocate the claimed length
+		if got := after.TotalAlloc - before.TotalAlloc; got > budget {
+			t.Fatalf("readValue allocated %d bytes for an oversized length, want < %d (no ~4 GiB buffer)", got, budget)
+		}
+	})
 }

--- a/vector/snapshot_test.go
+++ b/vector/snapshot_test.go
@@ -3,6 +3,7 @@
 package vector
 
 import (
+	"bufio"
 	"bytes"
 	"encoding/binary"
 	"errors"
@@ -475,33 +476,79 @@ func TestValueCodecRecordRoundtrip(t *testing.T) {
 		}
 	})
 
-	t.Run("oversized length errors without allocating", func(t *testing.T) {
+	t.Run("oversized length errors without allocating (sized reader)", func(t *testing.T) {
 		// kind byte + a length prefix claiming ~4 GiB, with NO payload bytes
 		// behind it. bytes.Reader implements Len(), so boundedRecordBytes must
 		// reject this from the length prefix alone rather than attempting
 		// make([]byte, 0xFFFFFFF0) — which would otherwise blow the test's
 		// memory budget or the process's.
-		var frame bytes.Buffer
-		frame.WriteByte(byte(ValueRecord))
-		if err := writeU32(&frame, 0xFFFFFFF0); err != nil {
-			t.Fatalf("writeU32: %v", err)
-		}
-		frameBytes := frame.Bytes()
+		frameBytes := oversizedRecordFrame(t)
+		assertNoLargeAlloc(t, func() {
+			if _, err := readValue(bytes.NewReader(frameBytes)); err == nil {
+				t.Fatal("readValue on oversized length: got nil error, want one")
+			}
+		})
+	})
 
-		// testing.AllocsPerRun counts allocation EVENTS, not bytes — a single
-		// make([]byte, 4<<30) would show up as "1 alloc", not as a red flag. Measure
-		// heap bytes via runtime.MemStats instead, so a multi-GiB buffer can't hide.
-		var before, after runtime.MemStats
-		runtime.GC()
-		runtime.ReadMemStats(&before)
-		if _, err := readValue(bytes.NewReader(frameBytes)); err == nil {
-			t.Fatal("readValue on oversized length: got nil error, want one")
-		}
-		runtime.ReadMemStats(&after)
+	t.Run("oversized length errors without allocating (bufio reader, no Len())", func(t *testing.T) {
+		// Every production reader of a snapshot/WAL/persist stream is
+		// bufio-wrapped and does NOT implement Len() — this is the path the
+		// sizedReader early-out CANNOT protect, and the one a hostile or
+		// corrupt on-disk frame actually reaches. Only the hard
+		// maxRecordValueBytes cap in boundedRecordBytes (checked before any
+		// reader-type test) protects this path.
+		frameBytes := oversizedRecordFrame(t)
+		assertNoLargeAlloc(t, func() {
+			br := bufio.NewReader(bytes.NewReader(frameBytes))
+			if _, ok := interface{}(br).(sizedReader); ok {
+				t.Fatal("bufio.Reader unexpectedly implements sizedReader — this test no longer covers the unprotected path")
+			}
+			if _, err := readValue(br); err == nil {
+				t.Fatal("readValue on oversized length (bufio): got nil error, want one")
+			}
+		})
+	})
 
-		const budget = 1 << 20 // 1 MiB — generous headroom over the few bytes this path should touch, nowhere near the ~4 GiB it would need to actually allocate the claimed length
-		if got := after.TotalAlloc - before.TotalAlloc; got > budget {
-			t.Fatalf("readValue allocated %d bytes for an oversized length, want < %d (no ~4 GiB buffer)", got, budget)
+	t.Run("writeValue rejects a record above the cap", func(t *testing.T) {
+		// The write side must refuse what the read side would reject, so the
+		// bound is symmetric: nothing this process ever writes can trip its own
+		// read-side cap.
+		oversized := Value{Kind: ValueRecord, Rec: make([]byte, maxRecordValueBytes+1)}
+		var buf bytes.Buffer
+		if err := writeValue(&buf, oversized); err == nil {
+			t.Fatal("writeValue on a record above maxRecordValueBytes: got nil error, want one")
 		}
 	})
+}
+
+// oversizedRecordFrame builds a raw [kind:u8][len:u32] frame (kind ==
+// ValueRecord) whose length prefix claims ~4 GiB, with no payload bytes
+// behind it — used by both oversized-length subtests above.
+func oversizedRecordFrame(t *testing.T) []byte {
+	t.Helper()
+	var frame bytes.Buffer
+	frame.WriteByte(byte(ValueRecord))
+	if err := writeU32(&frame, 0xFFFFFFF0); err != nil {
+		t.Fatalf("writeU32: %v", err)
+	}
+	return frame.Bytes()
+}
+
+// assertNoLargeAlloc runs fn and fails if it allocated more than a small
+// constant budget of heap bytes. testing.AllocsPerRun counts allocation
+// EVENTS, not bytes — a single make([]byte, 4<<30) would show up as "1
+// alloc", not as a red flag — so this measures via runtime.MemStats instead,
+// which a multi-GiB buffer can't hide from.
+func assertNoLargeAlloc(t *testing.T, fn func()) {
+	t.Helper()
+	var before, after runtime.MemStats
+	runtime.GC()
+	runtime.ReadMemStats(&before)
+	fn()
+	runtime.ReadMemStats(&after)
+
+	const budget = 1 << 20 // 1 MiB — generous headroom over the few bytes this path should touch, nowhere near the ~4 GiB it would need to actually allocate the claimed length
+	if got := after.TotalAlloc - before.TotalAlloc; got > budget {
+		t.Fatalf("allocated %d bytes, want < %d (no multi-GiB buffer)", got, budget)
+	}
 }

--- a/vector/vtypes_aliases.go
+++ b/vector/vtypes_aliases.go
@@ -109,6 +109,8 @@ const (
 	FilterGeoRadius  = vtypes.FilterGeoRadius
 	FilterGeoBox     = vtypes.FilterGeoBox
 	FilterGeoPolygon = vtypes.FilterGeoPolygon
+	FilterRowExists  = vtypes.FilterRowExists
+	FilterRowAbsent  = vtypes.FilterRowAbsent
 
 	// Query leaf kinds.
 	LeafDense     = vtypes.LeafDense

--- a/vector/vtypes_aliases.go
+++ b/vector/vtypes_aliases.go
@@ -66,6 +66,7 @@ const (
 	ValueInts    = vtypes.ValueInts
 	ValueFloats  = vtypes.ValueFloats
 	ValueGeo     = vtypes.ValueGeo
+	ValueRecord  = vtypes.ValueRecord
 
 	Cosine     = vtypes.Cosine
 	L2         = vtypes.L2
@@ -162,6 +163,7 @@ var (
 	NewInts    = vtypes.NewInts
 	NewFloats  = vtypes.NewFloats
 	NewGeo     = vtypes.NewGeo
+	NewRecord  = vtypes.NewRecord
 
 	// DefaultConfig is re-exported as a function value so every DefaultConfig()
 	// call site is unchanged.

--- a/vector/wal.go
+++ b/vector/wal.go
@@ -199,7 +199,9 @@ func (w *wal) appendInsertStaged(id uint64, vec []float32, ttl time.Duration, me
 	for _, f := range vec {
 		_ = writeF32(&buf, f)
 	}
-	writeOptMeta(&buf, meta)
+	if err := writeOptMeta(&buf, meta); err != nil {
+		return 0, err
+	}
 	if sparse == nil {
 		buf.WriteByte(0)
 	} else {
@@ -250,17 +252,33 @@ func readOptVersion(r io.Reader) (uint64, bool) {
 // writeOptMeta writes the optional-metadata encoding shared by appendInsertStaged
 // and appendSetPayloadStaged: a 1-byte present flag, then (when present) a u32 key count
 // followed by each [string key][Value]. readOptMeta is its exact inverse.
-func writeOptMeta(buf *bytes.Buffer, meta Metadata) {
+//
+// IT RETURNS THE ENCODE ERROR, AND EVERY CALLER MUST FAIL THE APPEND ON IT.
+// writeValue can fail — today only for a ValueRecord above maxRecordValueBytes —
+// and it fails AFTER it has already emitted the value's kind byte, so a record
+// built past that point is self-inconsistent: readOptMeta answers false for it,
+// which replay reads as a torn record and answers with errStopReplay, DISCARDING
+// every acknowledged write logged after it. Discarding the error here (as this
+// function used to) turned one rejected value into unbounded acked-write loss on
+// the next restart. Callers build into a local bytes.Buffer and only hand it to
+// appendFramedStaged at the end, so returning early here means no byte of the
+// half-built record ever reaches the log. checkRecordValues rejects the same
+// payload at ingest, before any state change; this is the durability backstop for
+// any path that reaches the codec anyway (WAL replay, restore, reshard copy).
+func writeOptMeta(buf *bytes.Buffer, meta Metadata) error {
 	if meta == nil {
 		buf.WriteByte(0)
-		return
+		return nil
 	}
 	buf.WriteByte(1)
 	_ = writeU32(buf, uint32(len(meta))) //nolint:gosec
 	for k, v := range meta {
 		_ = writeString(buf, k)
-		_ = writeValue(buf, v)
+		if err := writeValue(buf, v); err != nil {
+			return err
+		}
 	}
+	return nil
 }
 
 // appendSetPayloadStaged logs an in-place payload mutation as the resulting full
@@ -294,7 +312,9 @@ func (w *wal) appendSetPayloadStaged(id uint64, meta Metadata, keyExpires map[st
 	var buf bytes.Buffer
 	buf.WriteByte(byte(walSetPayload))
 	_ = writeU64(&buf, id)
-	writeOptMeta(&buf, meta)
+	if err := writeOptMeta(&buf, meta); err != nil {
+		return 0, err
+	}
 	writeOptKeyExpires(&buf, keyExpires)
 	writeOptVersion(&buf, version) // trailing version block (byte-identical when 0)
 	return w.appendFramedStaged(buf.Bytes())


### PR DESCRIPTION
Makes `operate` records searchable inside vector payloads through one shared layer, so a filtered search can say "points whose session record has `rc > 100`" or "has a row for bidder 42" without a client read-modify-write. Phase 1 of the record-search design (record kind, shared resolver, vector filter paths, auto-index). `vector_operate` and the KV index/query are later phases.

## What this adds

**Payload record kind.** `ValueRecord` (kind 9, JSON `{"kind":"record","rec":"<base64>"}`) carries the exact bytes `operate` stores in KV, in schema or dynamic mode. A record value is bounded at 16 MiB: rejected at every vector ingest entry point, and the snapshot and WAL codecs enforce the same cap before allocation on both sides (the WAL append fails rather than writing a partial record). Every existing payload code path that cannot apply to a record declines explicitly (posting index, column sidecar, order/group, `is_empty`/`is_null`).

**`sdk/record` (new, engine-free leaf).** Path grammar `field`, `field/key`, `field/key/col`, `field#count` (`#N` positions; decimal or quoted FIXED row keys). A byte-level resolver over stored record bytes: schema mode by offset arithmetic through a bounded schema cache, dynamic mode by sorted walk; zero allocations on the numeric schema-mode path; a pure function of the bytes. Held to a tree oracle (`wire.DecodeRecord` + tree walk) by property tests over 40,000 random resolutions, plus hostile-bytes sweeps (every prefix and every single-byte mutation of both example records, input never mutated) and a seeded fuzz target. `CellValue`/`ResultValue` map cells to payload values (ints → int, U64 above MaxInt64 → float, floats → float, BYTES/FIXED → string, `#count` → int); `IndexEntries` extracts the top-level fields and table counts a collection indexes.

**Vector filters.** A filter leaf's `field` is first tried as an exact payload key, otherwise split at the first `/` into `payloadKey/path` and resolved per point, so `eq ne gt gte lt lte in` work unchanged on record cells. Two new leaf ops: `row_exists` and `row_absent` (kinds 22 and 23; `row_absent` is true only when the record and table exist and the row does not). A bad path, malformed record or non-record key evaluates as "no such field", never a search error. Filter paths are parsed once at compile time and resolved per point without allocation on the numeric schema-mode path; a quoted row key in a filter is bounded at 255 bytes, so a hostile filter cannot allocate per point.

**Auto-indexing.** Top-level scalar record fields by name and each table's `#count` are posted as synthetic payload fields `key/field` and `key/table#count` (equality postings and the numeric column, so eq/in/range are index-accelerated). Positional shapes, rows, columns and `contains`/`match`/`regex`/`row_*` on record paths are always evaluated on the live record. Rebuilt from primary data on restore, dense and id-keyed indexes alike.

## Three invariants the reviews forced

- **A record path with no postings is not "provably empty".** The planner graded a field with no postings as an exact empty match, which is right for literal keys and wrong for record paths. Record paths are now declined at the planner seam (the same mechanism as `$content`) except for exactly the shapes and ops the index posts, and a brute-force test holds `SearchFiltered` and the delete-by-filter selection equal to `CompileFilter` over a mixed corpus.
- **An oversize record is refused at the door.** The final review found that a record above the codec cap was accepted at ingest, which broke the WAL encoding for that point and would have discarded every later acknowledged write on replay. The bound is now enforced at ingest, and the WAL writer fails the append instead of discarding the encode error.
- **A partially malformed record fails closed per key.** `IndexEntries` rejects a record if any field is damaged, while `Resolve` reads only the bytes on its path and can still answer for an undamaged field, so such a point would be missing from postings but matched by the predicate. The index now counts, per payload key, the live slots whose record failed indexing and disables acceleration under that key until the point is repaired, cleared or reclaimed. One hostile point costs acceleration for one key, never correctness.

## Verification

Per-package tests, `GOARCH=386` for `sdk/...`, `-race -short` for `sdk/...` and `vector/`, 60 s `FuzzResolve`, golangci-lint, `mkdocs build --strict`, and the full suite (`-p 1`): 30 packages ok; the root package's `TestGRPCWritesFollowTheLeaderOnEveryNode` failed once under load and passes 3/3 in isolation (pre-existing flake, untouched here).

## Follow-ups (not in this PR)

- Ingest-time validation of `ValueRecord` bytes (metadata is unmarshalled straight into the value type; the fail-closed guard keeps search correct, rejecting bad records at the door is the better long-term fix).
- Literal payload keys shaped like a path (`a/b`) keep exact resolution but lose match/contains/geo index acceleration, since the planner cannot tell a literal key from a synthetic one per field.
- `reindex` resolves each indexed entry through `lookupPath` (exactness by construction); a cheaper variant exists when the key set has no literal collision.
- Phases 2 (`vector_operate`) and 3 (KV index definitions + `kv_query`).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Previously, `operate` records in vector payloads were opaque to filters; they can now be searched by paths like `session/rc` or `session/b/42/hi` without client-side read-modify-write. Records larger than 16 MiB are rejected before storage, and WAL writes no longer leave partial records.

**Record search**

- Adds the `ValueRecord` payload kind and the engine-free `sdk/record` resolver for schema and dynamic records.
- Supports scalar comparisons plus `row_exists`/`row_absent`; `row_absent` proves absence against table contents and both honor exact-key precedence.
- Auto-indexes top-level scalar fields and table counts; row, column, positional, and unsupported operators stay live-evaluated.
- Malformed records disable acceleration for their payload key until repaired or removed, preserving filter correctness.

**Validation and compatibility**

- Applies the size limit across normal, restore, bulk, multi-vector, snapshot, WAL, and build paths.
- Returns oversized-record errors as HTTP 400 and gRPC `InvalidArgument`; the stringified form a clustered apply produces is recognized by exact message shape, so unrelated internal errors stay redacted.
- Bounds path parsing, quoted keys, and error messages; compiled filter leaves resolve per point with zero allocations.
- Existing grouping, ordering, and unsupported payload-index operations decline record values explicitly.

<sup>Written for commit f742b5da07937d8c41f2c2a6c6b5c4f14c13a93f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rostamlabs/rostam/pull/102?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for storing record values in vector payloads and filtering their fields, rows, columns, and counts.
  * Added `row_exists` and `row_absent` filters for table-row presence checks.
  * Record fields support equality, range, membership, and other applicable filters.
  * Record-valued metadata is now included in tool results as JSON.

* **Bug Fixes**
  * Malformed records now fail closed during filtering.
  * Oversized records are rejected before writes and return a client error.

* **Documentation**
  * Added guidance for record paths, filtering, indexing, precedence, and size limits.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->