### PR TITLE
feat: vector_operate — atomic operate op-lists on a vector point's record

### DIFF
--- a/client.go
+++ b/client.go
@@ -833,33 +833,33 @@ func (n *networkedStore) VectorClearPayload(ctx context.Context, collection stri
 // write-consistency options, which is all it was ever carrying.
 func (n *networkedStore) vectorOperate(ctx context.Context, opName, collection string, id uint64, payloadKey string,
 	a *wire.OperateArgs, opts []WriteOpts,
-) (bool, *wire.OperateResult, error) {
+) (bool, *wire.OperateResult, uint64, error) {
 	wo := firstWriteOpts(opts)
 	exp, hasExp := wo.expectedVersion()
 	args, err := wire.EncodeVectorOperateArgs(collection, id, payloadKey, a, exp, hasExp)
 	if err != nil {
-		return false, nil, err
+		return false, nil, 0, err
 	}
 	body, err := n.wcCall(ctx, opName, args, wo)
 	if err != nil {
-		return false, nil, mapErr(err)
+		return false, nil, 0, mapErr(err)
 	}
 	return ops.DecodeVectorOperateResult(body)
 }
 
 // VectorOperate sends the dense operate op with the CAS precondition in the args.
 // See Store.VectorOperate.
-func (n *networkedStore) VectorOperate(ctx context.Context, collection string, id uint64, payloadKey string, a *wire.OperateArgs, opts ...WriteOpts) (bool, *wire.OperateResult, error) {
+func (n *networkedStore) VectorOperate(ctx context.Context, collection string, id uint64, payloadKey string, a *wire.OperateArgs, opts ...WriteOpts) (bool, *wire.OperateResult, uint64, error) {
 	return n.vectorOperate(ctx, "vector_operate", collection, id, payloadKey, a, opts)
 }
 
 // VectorNamedOperate is VectorOperate against the named family. See vectorOperate.
-func (n *networkedStore) VectorNamedOperate(ctx context.Context, name string, id uint64, payloadKey string, a *wire.OperateArgs, opts ...WriteOpts) (bool, *wire.OperateResult, error) {
+func (n *networkedStore) VectorNamedOperate(ctx context.Context, name string, id uint64, payloadKey string, a *wire.OperateArgs, opts ...WriteOpts) (bool, *wire.OperateResult, uint64, error) {
 	return n.vectorOperate(ctx, "vector_named_operate", name, id, payloadKey, a, opts)
 }
 
 // VectorMVOperate is VectorOperate against the multi-vector family. See vectorOperate.
-func (n *networkedStore) VectorMVOperate(ctx context.Context, name string, docID uint64, payloadKey string, a *wire.OperateArgs, opts ...WriteOpts) (bool, *wire.OperateResult, error) {
+func (n *networkedStore) VectorMVOperate(ctx context.Context, name string, docID uint64, payloadKey string, a *wire.OperateArgs, opts ...WriteOpts) (bool, *wire.OperateResult, uint64, error) {
 	return n.vectorOperate(ctx, "vector_mv_operate", name, docID, payloadKey, a, opts)
 }
 

--- a/client.go
+++ b/client.go
@@ -842,7 +842,10 @@ func (n *networkedStore) vectorOperate(ctx context.Context, opName, collection s
 	}
 	body, err := n.wcCall(ctx, opName, args, wo)
 	if err != nil {
-		return false, nil, 0, mapErr(err)
+		// mapVectorOperateErr AFTER mapErr: mapErr turns the transport's
+		// StatusNotFound into the root ErrNotFound, and the operate contract
+		// names ops.ErrVectorRecordAbsent for that outcome on every backend.
+		return false, nil, 0, mapVectorOperateErr(mapErr(err))
 	}
 	return ops.DecodeVectorOperateResult(body)
 }

--- a/client.go
+++ b/client.go
@@ -822,6 +822,47 @@ func (n *networkedStore) VectorClearPayload(ctx context.Context, collection stri
 	return ops.DecodePayloadResult(body)
 }
 
+// vectorOperate is the shared body of the three networked operate methods: the
+// families differ only in the op name, and the CAS threading is the part that
+// must not be re-derived per family.
+//
+// The CAS guard rides in the ARGS, not in opts. networkedStore.VectorSetPayload
+// encodes with ops.EncodeSetPayloadArgsOpts — the NON-CAS encoder — so its
+// caller's ExpectedVersion reaches wcCall and nothing else, and the write applies
+// unconditionally. Do not copy that here. wcCall still carries the
+// write-consistency options, which is all it was ever carrying.
+func (n *networkedStore) vectorOperate(ctx context.Context, opName, collection string, id uint64, payloadKey string,
+	a *wire.OperateArgs, opts []WriteOpts,
+) (bool, *wire.OperateResult, error) {
+	wo := firstWriteOpts(opts)
+	exp, hasExp := wo.expectedVersion()
+	args, err := wire.EncodeVectorOperateArgs(collection, id, payloadKey, a, exp, hasExp)
+	if err != nil {
+		return false, nil, err
+	}
+	body, err := n.wcCall(ctx, opName, args, wo)
+	if err != nil {
+		return false, nil, mapErr(err)
+	}
+	return ops.DecodeVectorOperateResult(body)
+}
+
+// VectorOperate sends the dense operate op with the CAS precondition in the args.
+// See Store.VectorOperate.
+func (n *networkedStore) VectorOperate(ctx context.Context, collection string, id uint64, payloadKey string, a *wire.OperateArgs, opts ...WriteOpts) (bool, *wire.OperateResult, error) {
+	return n.vectorOperate(ctx, "vector_operate", collection, id, payloadKey, a, opts)
+}
+
+// VectorNamedOperate is VectorOperate against the named family. See vectorOperate.
+func (n *networkedStore) VectorNamedOperate(ctx context.Context, name string, id uint64, payloadKey string, a *wire.OperateArgs, opts ...WriteOpts) (bool, *wire.OperateResult, error) {
+	return n.vectorOperate(ctx, "vector_named_operate", name, id, payloadKey, a, opts)
+}
+
+// VectorMVOperate is VectorOperate against the multi-vector family. See vectorOperate.
+func (n *networkedStore) VectorMVOperate(ctx context.Context, name string, docID uint64, payloadKey string, a *wire.OperateArgs, opts ...WriteOpts) (bool, *wire.OperateResult, error) {
+	return n.vectorOperate(ctx, "vector_mv_operate", name, docID, payloadKey, a, opts)
+}
+
 func (n *networkedStore) VectorNamedGet(ctx context.Context, name string, id uint64, withVector, withPayload bool) (bool, map[string][]float32, VectorMetadata, time.Duration, error) {
 	return n.VectorNamedGetExt(ctx, name, id, withVector, withPayload, ReadOpts{})
 }

--- a/client/client.go
+++ b/client/client.go
@@ -583,6 +583,16 @@ func nonReplayableCall(op string, args []byte) bool {
 	if !ok {
 		return true
 	}
+	// A NESTED envelope is non-replayable outright. The server's fanout
+	// dispatcher unwraps the envelope and dispatches whatever is inside, so a
+	// frame wrapping a second envelope eventually reaches some real write, and
+	// this guard cannot see which one without decoding an unbounded chain. This
+	// client never builds a nested frame — wcWire wraps exactly once — so
+	// declining is free, while recursing would let a hand-built frame choose how
+	// much work the classification does.
+	if inner == wire.WCEnvelopeOp {
+		return true
+	}
 	return nonReplayableOp(inner)
 }
 

--- a/client/client.go
+++ b/client/client.go
@@ -539,9 +539,16 @@ func (e *ambiguousError) Unwrap() error { return e.err }
 // server-side CAS), so a blind replay after an ambiguous post-commit failure
 // would apply every increment twice; it surfaces the ambiguous error instead,
 // exactly like "incr_ex".
+// "vector_operate" and its named / multi-vector twins are the SAME op-list
+// applied to a record held inside a POINT's payload instead of under a KV key,
+// so they inherit "operate"'s reasoning verbatim: a replayed ADD double-counts,
+// and a replayed CHECK is evaluated against a record the first attempt already
+// changed. They are listed individually rather than matched by a "vector_"
+// prefix so a future read-only vector op cannot be swept in by accident.
 func nonReplayableOp(op string) bool {
 	switch op {
-	case "set_nx", "cas", "cad", "getdel", "getset", "incr_ex", "caex", "persist", "flush", "__flush_shard__", "operate":
+	case "set_nx", "cas", "cad", "getdel", "getset", "incr_ex", "caex", "persist", "flush", "__flush_shard__", "operate",
+		"vector_operate", "vector_named_operate", "vector_mv_operate":
 		return true
 	}
 	return false

--- a/client/client.go
+++ b/client/client.go
@@ -210,7 +210,7 @@ func (c *Client) Call(ctx context.Context, op string, args []byte) ([]byte, erro
 		// another server and retry within the hop budget — but never
 		// replay a non-replayable conditional write across an ambiguous
 		// (post-transmission) failure, which could report a wrong outcome.
-		if isTransportError(err) && hop < maxHops && !(nonReplayableOp(op) && isAmbiguous(err)) {
+		if isTransportError(err) && hop < maxHops && !(nonReplayableCall(op, args) && isAmbiguous(err)) {
 			next := c.nextServer()
 			if next != "" && next != target {
 				target = next
@@ -554,6 +554,38 @@ func nonReplayableOp(op string) bool {
 	return false
 }
 
+// nonReplayableCall is nonReplayableOp seen THROUGH the write-consistency
+// envelope, and it is what the two retry decisions call — never nonReplayableOp
+// directly.
+//
+// WHY THE ENVELOPE HAD TO BE LOOKED THROUGH. A write issued with active
+// write-consistency options is not sent under its own name: the store wraps it
+// (wcWire, root package) so the server's fanout dispatcher can run the
+// post-commit barrier, and the name on the wire becomes wire.WCEnvelopeOp. A
+// guard keyed on that name alone answers false for EVERY op, so exactly the
+// conditional writes the guard exists for — a vector_operate ADD, an incr_ex, a
+// cas — were retried across an ambiguous post-transmission failure and could
+// apply twice. The envelope changes how a write is COMMITTED, never whether
+// replaying it is safe, so the classification has to follow the inner op.
+//
+// An envelope whose head does not decode is treated as non-replayable. This
+// client never builds such a frame, so it is either corruption or a caller
+// hand-rolling one; declining to retry it costs at most one retry, while
+// guessing "replayable" costs a double-applied write.
+func nonReplayableCall(op string, args []byte) bool {
+	if nonReplayableOp(op) {
+		return true
+	}
+	if op != wire.WCEnvelopeOp {
+		return false
+	}
+	inner, ok := wire.WCEnvelopeInnerOp(args)
+	if !ok {
+		return true
+	}
+	return nonReplayableOp(inner)
+}
+
 // isAmbiguous reports whether err is (or wraps) an ambiguousError — a
 // post-transmission transport failure that must not be blindly replayed for a
 // non-replayable op.
@@ -749,7 +781,7 @@ func (c *Client) CallFunc(ctx context.Context, op string, args []byte, fn func(p
 		}
 		// See Call: a non-replayable conditional write is not retried across
 		// an ambiguous (post-transmission) transport failure.
-		if isTransportError(err) && hop < maxHops && !(nonReplayableOp(op) && isAmbiguous(err)) {
+		if isTransportError(err) && hop < maxHops && !(nonReplayableCall(op, args) && isAmbiguous(err)) {
 			next := c.nextServer()
 			if next != "" && next != target {
 				target = next

--- a/client/operate_test.go
+++ b/client/operate_test.go
@@ -553,20 +553,3 @@ func TestOperateBuilderMigrateInstallsResolutionSchema(t *testing.T) {
 		t.Fatalf("Add path pos = %d, want 4 (the field only v2 declares)", got)
 	}
 }
-
-// TestVectorOperateNonReplayable checks that the three vector operate ops are
-// registered as non-replayable alongside the KV "operate". They are the SAME
-// non-idempotent op-list applied to a record held in a point's payload, so a
-// blind replay after an ambiguous post-commit failure would apply every ADD
-// twice — the exact hole the KV entry exists to close.
-func TestVectorOperateNonReplayable(t *testing.T) {
-	for _, op := range []string{"vector_operate", "vector_named_operate", "vector_mv_operate"} {
-		if !nonReplayableOp(op) {
-			t.Errorf("nonReplayableOp(%q) = false, want true", op)
-		}
-	}
-	// A read-only vector op must NOT be caught by the same switch.
-	if nonReplayableOp("vector_get") {
-		t.Error("nonReplayableOp(\"vector_get\") = true, want false")
-	}
-}

--- a/client/operate_test.go
+++ b/client/operate_test.go
@@ -553,3 +553,20 @@ func TestOperateBuilderMigrateInstallsResolutionSchema(t *testing.T) {
 		t.Fatalf("Add path pos = %d, want 4 (the field only v2 declares)", got)
 	}
 }
+
+// TestVectorOperateNonReplayable checks that the three vector operate ops are
+// registered as non-replayable alongside the KV "operate". They are the SAME
+// non-idempotent op-list applied to a record held in a point's payload, so a
+// blind replay after an ambiguous post-commit failure would apply every ADD
+// twice — the exact hole the KV entry exists to close.
+func TestVectorOperateNonReplayable(t *testing.T) {
+	for _, op := range []string{"vector_operate", "vector_named_operate", "vector_mv_operate"} {
+		if !nonReplayableOp(op) {
+			t.Errorf("nonReplayableOp(%q) = false, want true", op)
+		}
+	}
+	// A read-only vector op must NOT be caught by the same switch.
+	if nonReplayableOp("vector_get") {
+		t.Error("nonReplayableOp(\"vector_get\") = true, want false")
+	}
+}

--- a/client/vector_operate.go
+++ b/client/vector_operate.go
@@ -29,21 +29,32 @@ type OperateRequest struct {
 // found is false when the point is absent, tombstoned or expired — a FLAG, not
 // an error, exactly like every other point write. res is nil then.
 //
+// version is the point's version AFTER the call: bumped when the op-list
+// applied, and the CURRENT unbumped one when it was a deliberate no-op (a failed
+// CHECK). It is 0 when found is false. Feed it straight into the next call's
+// ExpectedVersion to run a CAS loop without re-reading the point:
+//
+//	found, res, v, err := col.Operate(ctx, OperateRequest{ID: id, PayloadKey: k, Args: a})
+//	// ... on ErrVersionConflict, retry with ExpectedVersion: v, HasExpectedVersion: true
+//
+// The re-read that would otherwise be needed is both a round trip and a race,
+// since another writer can land between it and the retry.
+//
 // The op is NOT replayable (nonReplayableOp): an ADD applied twice after an
 // ambiguous post-commit transport failure double-counts, so an ambiguous error
 // surfaces to the caller instead of being retried.
-func (col *Collection) Operate(ctx context.Context, req OperateRequest) (bool, *wire.OperateResult, error) {
+func (col *Collection) Operate(ctx context.Context, req OperateRequest) (found bool, res *wire.OperateResult, version uint64, err error) {
 	if req.Args == nil {
-		return false, nil, wire.ErrOperateArgs
+		return false, nil, 0, wire.ErrOperateArgs
 	}
 	args, err := wire.EncodeVectorOperateArgs(
 		col.name, req.ID, req.PayloadKey, req.Args, req.ExpectedVersion, req.HasExpectedVersion)
 	if err != nil {
-		return false, nil, err
+		return false, nil, 0, err
 	}
 	body, err := col.c.Call(ctx, "vector_operate", args)
 	if err != nil {
-		return false, nil, mapWriteErr(err)
+		return false, nil, 0, mapWriteErr(err)
 	}
 	return wire.DecodeVectorOperateResult(body)
 }

--- a/client/vector_operate.go
+++ b/client/vector_operate.go
@@ -32,13 +32,21 @@ type OperateRequest struct {
 // version is the point's version AFTER the call: bumped when the op-list
 // applied, and the CURRENT unbumped one when it was a deliberate no-op (a failed
 // CHECK). It is 0 when found is false. Feed it straight into the next call's
-// ExpectedVersion to run a CAS loop without re-reading the point:
+// ExpectedVersion to run a CAS loop without re-reading the point — a re-read is
+// both a round trip and a race, since another writer can land between it and the
+// retry:
 //
 //	found, res, v, err := col.Operate(ctx, OperateRequest{ID: id, PayloadKey: k, Args: a})
-//	// ... on ErrVersionConflict, retry with ExpectedVersion: v, HasExpectedVersion: true
+//	// ... next attempt: ExpectedVersion: v, HasExpectedVersion: true
 //
-// The re-read that would otherwise be needed is both a round trip and a race,
-// since another writer can land between it and the retry.
+// ONLY A CALL THAT RETURNED CARRIES A USABLE VERSION. A call that fails the
+// precondition returns (false, nil, 0, ErrVersionConflict): the server sends no
+// result frame for a refused write, so there is no version in it to report, and
+// 0 is not a placeholder — it is the value that means "expect an ABSENT point",
+// which conflicts again against a live one. After a conflict, retry with the
+// last version this collection handed back if the caller knows no one else
+// writes the point; otherwise re-read it, because the conflict says somebody
+// did.
 //
 // The op is NOT replayable (nonReplayableOp): an ADD applied twice after an
 // ambiguous post-commit transport failure double-counts, so an ambiguous error

--- a/client/vector_operate.go
+++ b/client/vector_operate.go
@@ -1,0 +1,49 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package client
+
+import (
+	"context"
+
+	"github.com/rostamlabs/rostam/sdk/wire"
+)
+
+// OperateRequest is the payload for Collection.Operate.
+type OperateRequest struct {
+	ID         uint64
+	PayloadKey string
+	Args       *wire.OperateArgs
+	// ExpectedVersion enables optimistic concurrency; HasExpectedVersion must be
+	// true for it to apply.
+	ExpectedVersion    uint64
+	HasExpectedVersion bool
+}
+
+// Operate applies one atomic operate op-list to the record stored under
+// req.PayloadKey in the point at req.ID (design doc for operate v2, §3-§3.5;
+// record search brief §3). Build req.Args with NewOperate(nil) — the call names
+// its target with Collection/ID/PayloadKey, so the builder's KEY stays empty and
+// the builder's TTL must stay unset: a point's TTL belongs to the point, and
+// EncodeVectorOperateArgs rejects a call that carries either.
+//
+// found is false when the point is absent, tombstoned or expired — a FLAG, not
+// an error, exactly like every other point write. res is nil then.
+//
+// The op is NOT replayable (nonReplayableOp): an ADD applied twice after an
+// ambiguous post-commit transport failure double-counts, so an ambiguous error
+// surfaces to the caller instead of being retried.
+func (col *Collection) Operate(ctx context.Context, req OperateRequest) (bool, *wire.OperateResult, error) {
+	if req.Args == nil {
+		return false, nil, wire.ErrOperateArgs
+	}
+	args, err := wire.EncodeVectorOperateArgs(
+		col.name, req.ID, req.PayloadKey, req.Args, req.ExpectedVersion, req.HasExpectedVersion)
+	if err != nil {
+		return false, nil, err
+	}
+	body, err := col.c.Call(ctx, "vector_operate", args)
+	if err != nil {
+		return false, nil, mapWriteErr(err)
+	}
+	return wire.DecodeVectorOperateResult(body)
+}

--- a/client/vector_operate.go
+++ b/client/vector_operate.go
@@ -54,7 +54,11 @@ func (col *Collection) Operate(ctx context.Context, req OperateRequest) (found b
 	}
 	body, err := col.c.Call(ctx, "vector_operate", args)
 	if err != nil {
-		return false, nil, 0, mapWriteErr(err)
+		// mapCollErr around mapWriteErr, the way the read siblings compose it: a
+		// call against a collection that does not exist must land on the
+		// ErrCollectionNotFound sentinel like every other Collection method,
+		// instead of handing back a raw RemoteError only this one API returns.
+		return false, nil, 0, mapCollErr(mapWriteErr(err))
 	}
 	return wire.DecodeVectorOperateResult(body)
 }

--- a/client/vector_operate_test.go
+++ b/client/vector_operate_test.go
@@ -343,3 +343,60 @@ func TestVectorOperateIsNonReplayable(t *testing.T) {
 		}
 	}
 }
+
+// TestCollectionOperateMissingCollectionMapsToSentinel: a call against a
+// collection the server does not know must land on ErrCollectionNotFound, the
+// same sentinel every other Collection method reports, rather than the raw
+// RemoteError this one API used to hand back. The fake server answers with the
+// message shape server/handlers.go lets across the wire verbatim.
+func TestCollectionOperateMissingCollectionMapsToSentinel(t *testing.T) {
+	addr, stop := startFakeServer(t, func(_ []byte) (uint8, []byte) {
+		return StatusError, encodeErrorMsgFrame("vector: no collection \"posts\"")
+	})
+	defer stop()
+
+	c, err := New(Config{Servers: []string{addr}})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	defer func() { _ = c.Close() }()
+
+	a, err := NewOperate(nil).Dynamic().AddT(F("rc"), wire.OperateTypeU32, 1).Args()
+	if err != nil {
+		t.Fatalf("build operate args: %v", err)
+	}
+	found, res, version, err := c.Collection("posts").Operate(context.Background(),
+		OperateRequest{ID: 1, PayloadKey: "session", Args: a})
+	if !errors.Is(err, ErrCollectionNotFound) {
+		t.Fatalf("err = %v, want ErrCollectionNotFound", err)
+	}
+	if found || res != nil || version != 0 {
+		t.Fatalf("failed call returned (found=%v, res=%v, version=%d); want the zero outcome", found, res, version)
+	}
+}
+
+// TestCollectionOperateVersionConflictStillMapped is the negative control for
+// the composition: wrapping mapCollErr around mapWriteErr must not swallow the
+// version-conflict mapping mapWriteErr already performs.
+func TestCollectionOperateVersionConflictStillMapped(t *testing.T) {
+	addr, stop := startFakeServer(t, func(_ []byte) (uint8, []byte) {
+		return StatusError, encodeErrorMsgFrame("vector: version conflict")
+	})
+	defer stop()
+
+	c, err := New(Config{Servers: []string{addr}})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	defer func() { _ = c.Close() }()
+
+	a, err := NewOperate(nil).Dynamic().AddT(F("rc"), wire.OperateTypeU32, 1).Args()
+	if err != nil {
+		t.Fatalf("build operate args: %v", err)
+	}
+	_, _, _, err = c.Collection("posts").Operate(context.Background(),
+		OperateRequest{ID: 1, PayloadKey: "session", Args: a, ExpectedVersion: 9, HasExpectedVersion: true})
+	if !errors.Is(err, ErrVersionConflict) {
+		t.Fatalf("err = %v, want ErrVersionConflict", err)
+	}
+}

--- a/client/vector_operate_test.go
+++ b/client/vector_operate_test.go
@@ -46,7 +46,7 @@ func TestCollectionOperateIncrements(t *testing.T) {
 		payload, err := wire.EncodeVectorOperateResult(true, &wire.OperateResult{
 			Status: wire.OperateStatusOK,
 			Values: [][]byte{wire.AppendTaggedCell(nil, wire.Cell{Type: wire.OperateTypeU32, U: uint64(n)})},
-		})
+		}, uint64(n))
 		if err != nil {
 			t.Fatalf("EncodeVectorOperateResult: %v", err)
 		}
@@ -70,12 +70,18 @@ func TestCollectionOperateIncrements(t *testing.T) {
 		if err != nil {
 			t.Fatalf("build operate args: %v", err)
 		}
-		found, res, err := col.Operate(ctx, OperateRequest{ID: 1, PayloadKey: "session", Args: a})
+		found, res, version, err := col.Operate(ctx, OperateRequest{ID: 1, PayloadKey: "session", Args: a})
 		if err != nil {
 			t.Fatalf("Operate: %v", err)
 		}
 		if !found {
 			t.Fatal("found = false, want true")
+		}
+		// The applied version rides back in the same frame: the fake server stamps
+		// it with the same counter it uses for the returned rc, so a wrong or
+		// dropped field shows up as a mismatch rather than as a plausible zero.
+		if version != uint64(want) {
+			t.Fatalf("version = %d, want %d", version, want)
 		}
 		cell, err := DecodeOperateValue(res.Values[0])
 		if err != nil {
@@ -117,7 +123,7 @@ func TestCollectionOperateBuilderKeyAndTTLRejected(t *testing.T) {
 	if err != nil {
 		t.Fatalf("build operate args (keyed): %v", err)
 	}
-	_, res, err := col.Operate(ctx, OperateRequest{ID: 1, PayloadKey: "session", Args: keyed})
+	_, res, _, err := col.Operate(ctx, OperateRequest{ID: 1, PayloadKey: "session", Args: keyed})
 	if !errors.Is(err, wire.ErrOperateArgs) {
 		t.Fatalf("err = %v, want wire.ErrOperateArgs", err)
 	}
@@ -132,7 +138,7 @@ func TestCollectionOperateBuilderKeyAndTTLRejected(t *testing.T) {
 	if err != nil {
 		t.Fatalf("build operate args (ttled): %v", err)
 	}
-	_, res, err = col.Operate(ctx, OperateRequest{ID: 1, PayloadKey: "session", Args: ttled})
+	_, res, _, err = col.Operate(ctx, OperateRequest{ID: 1, PayloadKey: "session", Args: ttled})
 	if !errors.Is(err, wire.ErrOperateArgs) {
 		t.Fatalf("err = %v, want wire.ErrOperateArgs", err)
 	}
@@ -150,7 +156,7 @@ func TestCollectionOperateBuilderKeyAndTTLRejected(t *testing.T) {
 // exactly like every other point write.
 func TestCollectionOperateMissingPoint(t *testing.T) {
 	addr, stop := startFakeServer(t, func(body []byte) (uint8, []byte) {
-		payload, err := wire.EncodeVectorOperateResult(false, nil)
+		payload, err := wire.EncodeVectorOperateResult(false, nil, 0)
 		if err != nil {
 			t.Fatalf("EncodeVectorOperateResult: %v", err)
 		}
@@ -169,7 +175,7 @@ func TestCollectionOperateMissingPoint(t *testing.T) {
 	if err != nil {
 		t.Fatalf("build operate args: %v", err)
 	}
-	found, res, err := col.Operate(context.Background(), OperateRequest{ID: 1, PayloadKey: "session", Args: a})
+	found, res, _, err := col.Operate(context.Background(), OperateRequest{ID: 1, PayloadKey: "session", Args: a})
 	if err != nil {
 		t.Fatalf("Operate: %v", err)
 	}
@@ -206,7 +212,7 @@ func TestCollectionOperateRecordAbsentIsErrNotFound(t *testing.T) {
 	if err != nil {
 		t.Fatalf("build operate args: %v", err)
 	}
-	found, res, err := col.Operate(context.Background(), OperateRequest{ID: 1, PayloadKey: "session", Args: a})
+	found, res, _, err := col.Operate(context.Background(), OperateRequest{ID: 1, PayloadKey: "session", Args: a})
 	if !errors.Is(err, ErrNotFound) {
 		t.Fatalf("err = %v, want ErrNotFound", err)
 	}
@@ -225,10 +231,12 @@ func TestCollectionOperateRecordAbsentIsErrNotFound(t *testing.T) {
 // normal outcome of a well-formed call, not a transport or CAS error.
 func TestCollectionOperateCheckFailedResult(t *testing.T) {
 	addr, stop := startFakeServer(t, func(body []byte) (uint8, []byte) {
+		// A failed CHECK still carries the point's CURRENT, unbumped version, so a
+		// caller can retry the whole read-modify-write without a re-read.
 		payload, err := wire.EncodeVectorOperateResult(true, &wire.OperateResult{
 			Status:   wire.OperateStatusCheckFailed,
 			FailedOp: 2,
-		})
+		}, 41)
 		if err != nil {
 			t.Fatalf("EncodeVectorOperateResult: %v", err)
 		}
@@ -250,7 +258,7 @@ func TestCollectionOperateCheckFailedResult(t *testing.T) {
 	if err != nil {
 		t.Fatalf("build operate args: %v", err)
 	}
-	found, res, err := col.Operate(context.Background(), OperateRequest{ID: 1, PayloadKey: "session", Args: a})
+	found, res, _, err := col.Operate(context.Background(), OperateRequest{ID: 1, PayloadKey: "session", Args: a})
 	if err != nil {
 		t.Fatalf("Operate: %v", err)
 	}
@@ -289,7 +297,7 @@ func TestCollectionOperateCASConflict(t *testing.T) {
 	if err != nil {
 		t.Fatalf("build operate args: %v", err)
 	}
-	_, res, err := col.Operate(context.Background(), OperateRequest{
+	_, res, _, err := col.Operate(context.Background(), OperateRequest{
 		ID: 1, PayloadKey: "session", Args: a,
 		ExpectedVersion: 999, HasExpectedVersion: true,
 	})
@@ -312,7 +320,7 @@ func TestCollectionOperateNilArgs(t *testing.T) {
 	defer func() { _ = c.Close() }()
 	col := c.Collection("posts")
 
-	found, res, err := col.Operate(context.Background(), OperateRequest{ID: 1, PayloadKey: "session"})
+	found, res, _, err := col.Operate(context.Background(), OperateRequest{ID: 1, PayloadKey: "session"})
 	if !errors.Is(err, wire.ErrOperateArgs) {
 		t.Fatalf("err = %v, want wire.ErrOperateArgs", err)
 	}

--- a/client/vector_operate_test.go
+++ b/client/vector_operate_test.go
@@ -1,0 +1,337 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package client
+
+import (
+	"context"
+	"encoding/binary"
+	"errors"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/rostamlabs/rostam/sdk/wire"
+)
+
+// encodeErrorMsgFrame mirrors client/protocol.go's decodeErrorMsg wire shape
+// ([2-byte length][message]) so a fake server can hand back a StatusError
+// payload the client decodes the same way a real server's does.
+func encodeErrorMsgFrame(msg string) []byte {
+	out := make([]byte, 2+len(msg))
+	binary.BigEndian.PutUint16(out[0:2], uint16(len(msg))) //nolint:gosec // test-only
+	copy(out[2:], msg)
+	return out
+}
+
+// TestCollectionOperateIncrements is the brief's canonical builder usage, run
+// twice against a fake server that plays back an incrementing counter — the
+// same round trip client.Operate performs for a KV key, but addressed at a
+// point's record via Collection.Operate.
+func TestCollectionOperateIncrements(t *testing.T) {
+	var calls, counter int32
+	addr, stop := startFakeServer(t, func(body []byte) (uint8, []byte) {
+		atomic.AddInt32(&calls, 1)
+		opName, argsBytes := decodeOpFrame(t, body)
+		if opName != "vector_operate" {
+			t.Fatalf("op = %q, want vector_operate", opName)
+		}
+		collection, id, payloadKey, _, _, hasExpected, err := wire.DecodeVectorOperateArgs(argsBytes)
+		if err != nil {
+			t.Fatalf("DecodeVectorOperateArgs: %v", err)
+		}
+		if collection != "posts" || id != 1 || payloadKey != "session" || hasExpected {
+			t.Fatalf("routing fields = (%q, %d, %q, hasExpected=%v), want (posts, 1, session, false)", collection, id, payloadKey, hasExpected)
+		}
+		n := atomic.AddInt32(&counter, 1)
+		payload, err := wire.EncodeVectorOperateResult(true, &wire.OperateResult{
+			Status: wire.OperateStatusOK,
+			Values: [][]byte{wire.AppendTaggedCell(nil, wire.Cell{Type: wire.OperateTypeU32, U: uint64(n)})},
+		})
+		if err != nil {
+			t.Fatalf("EncodeVectorOperateResult: %v", err)
+		}
+		return StatusOK, payload
+	})
+	defer stop()
+
+	c, err := New(Config{Servers: []string{addr}})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	defer func() { _ = c.Close() }()
+	col := c.Collection("posts")
+	ctx := context.Background()
+
+	for _, want := range []uint64{1, 2} {
+		a, err := NewOperate(nil).Dynamic().
+			AddT(F("rc"), wire.OperateTypeU32, 1).
+			Return(F("rc")).
+			Args()
+		if err != nil {
+			t.Fatalf("build operate args: %v", err)
+		}
+		found, res, err := col.Operate(ctx, OperateRequest{ID: 1, PayloadKey: "session", Args: a})
+		if err != nil {
+			t.Fatalf("Operate: %v", err)
+		}
+		if !found {
+			t.Fatal("found = false, want true")
+		}
+		cell, err := DecodeOperateValue(res.Values[0])
+		if err != nil {
+			t.Fatalf("DecodeOperateValue: %v", err)
+		}
+		if cell.U != want {
+			t.Fatalf("rc = %d, want %d", cell.U, want)
+		}
+	}
+	if got := atomic.LoadInt32(&calls); got != 2 {
+		t.Fatalf("server saw %d calls, want 2", got)
+	}
+}
+
+// TestCollectionOperateBuilderKeyAndTTLRejected checks the two shapes
+// EncodeVectorOperateArgs rejects — a non-empty builder Key and a TTL/TTLMode
+// carried on the inner OperateArgs — are caught by Collection.Operate BEFORE
+// any round trip: the target is named once by (collection, ID, PayloadKey),
+// and a point's TTL is the point's, never a record's.
+func TestCollectionOperateBuilderKeyAndTTLRejected(t *testing.T) {
+	var calls int32
+	addr, stop := startFakeServer(t, func(body []byte) (uint8, []byte) {
+		atomic.AddInt32(&calls, 1)
+		return StatusOK, []byte{0}
+	})
+	defer stop()
+
+	c, err := New(Config{Servers: []string{addr}})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	defer func() { _ = c.Close() }()
+	col := c.Collection("posts")
+	ctx := context.Background()
+
+	// A non-empty builder key.
+	keyed, err := NewOperate([]byte("k")).Dynamic().
+		AddT(F("rc"), wire.OperateTypeU32, 1).Args()
+	if err != nil {
+		t.Fatalf("build operate args (keyed): %v", err)
+	}
+	_, res, err := col.Operate(ctx, OperateRequest{ID: 1, PayloadKey: "session", Args: keyed})
+	if !errors.Is(err, wire.ErrOperateArgs) {
+		t.Fatalf("err = %v, want wire.ErrOperateArgs", err)
+	}
+	if res != nil {
+		t.Fatalf("res = %+v, want nil", res)
+	}
+
+	// A TTL carried on the inner args.
+	ttled, err := NewOperate(nil).Dynamic().
+		AddT(F("rc"), wire.OperateTypeU32, 1).
+		TTL(time.Second, wire.OperateTTLSet).Args()
+	if err != nil {
+		t.Fatalf("build operate args (ttled): %v", err)
+	}
+	_, res, err = col.Operate(ctx, OperateRequest{ID: 1, PayloadKey: "session", Args: ttled})
+	if !errors.Is(err, wire.ErrOperateArgs) {
+		t.Fatalf("err = %v, want wire.ErrOperateArgs", err)
+	}
+	if res != nil {
+		t.Fatalf("res = %+v, want nil", res)
+	}
+
+	if got := atomic.LoadInt32(&calls); got != 0 {
+		t.Fatalf("server saw %d calls, want 0 — the rejection must happen before any round trip", got)
+	}
+}
+
+// TestCollectionOperateMissingPoint checks the found=false, res=nil, err=nil
+// convention: a missing/tombstoned/expired point is a flag, not an error,
+// exactly like every other point write.
+func TestCollectionOperateMissingPoint(t *testing.T) {
+	addr, stop := startFakeServer(t, func(body []byte) (uint8, []byte) {
+		payload, err := wire.EncodeVectorOperateResult(false, nil)
+		if err != nil {
+			t.Fatalf("EncodeVectorOperateResult: %v", err)
+		}
+		return StatusOK, payload
+	})
+	defer stop()
+
+	c, err := New(Config{Servers: []string{addr}})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	defer func() { _ = c.Close() }()
+	col := c.Collection("posts")
+
+	a, err := NewOperate(nil).Dynamic().AddT(F("rc"), wire.OperateTypeU32, 1).Args()
+	if err != nil {
+		t.Fatalf("build operate args: %v", err)
+	}
+	found, res, err := col.Operate(context.Background(), OperateRequest{ID: 1, PayloadKey: "session", Args: a})
+	if err != nil {
+		t.Fatalf("Operate: %v", err)
+	}
+	if found {
+		t.Fatal("found = true, want false")
+	}
+	if res != nil {
+		t.Fatalf("res = %+v, want nil", res)
+	}
+}
+
+// TestCollectionOperateRecordAbsentIsErrNotFound checks the OTHER absent
+// shape a payload-key mutation can hit: the POINT exists, but create=NONE
+// against a payload key holding no record is ops.ErrVectorRecordAbsent, which
+// the server maps to StatusNotFound (server.TestMapResultVectorRecordAbsentIsNotFound).
+// Unlike a missing/expired POINT (TestCollectionOperateMissingPoint's
+// found=false/nil/nil convention), this is a StatusNotFound wire response —
+// Client.Call's ordinary not-found path — so Operate surfaces it as
+// client.ErrNotFound rather than a silent false.
+func TestCollectionOperateRecordAbsentIsErrNotFound(t *testing.T) {
+	addr, stop := startFakeServer(t, func(body []byte) (uint8, []byte) {
+		return StatusNotFound, nil
+	})
+	defer stop()
+
+	c, err := New(Config{Servers: []string{addr}})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	defer func() { _ = c.Close() }()
+	col := c.Collection("posts")
+
+	a, err := NewOperate(nil).AddT(F("rc"), wire.OperateTypeU32, 1).Args()
+	if err != nil {
+		t.Fatalf("build operate args: %v", err)
+	}
+	found, res, err := col.Operate(context.Background(), OperateRequest{ID: 1, PayloadKey: "session", Args: a})
+	if !errors.Is(err, ErrNotFound) {
+		t.Fatalf("err = %v, want ErrNotFound", err)
+	}
+	if found {
+		t.Fatal("found = true, want false")
+	}
+	if res != nil {
+		t.Fatalf("res = %+v, want nil", res)
+	}
+}
+
+// TestCollectionOperateCheckFailedResult checks that a CHECK-failed result
+// decodes as an ordinary (non-error) OperateResult — found=true, err=nil,
+// Status=OperateStatusCheckFailed, FailedOp naming the CHECK that aborted the
+// list — exactly like Client.Operate's KV counterpart. A failed CHECK is a
+// normal outcome of a well-formed call, not a transport or CAS error.
+func TestCollectionOperateCheckFailedResult(t *testing.T) {
+	addr, stop := startFakeServer(t, func(body []byte) (uint8, []byte) {
+		payload, err := wire.EncodeVectorOperateResult(true, &wire.OperateResult{
+			Status:   wire.OperateStatusCheckFailed,
+			FailedOp: 2,
+		})
+		if err != nil {
+			t.Fatalf("EncodeVectorOperateResult: %v", err)
+		}
+		return StatusOK, payload
+	})
+	defer stop()
+
+	c, err := New(Config{Servers: []string{addr}})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	defer func() { _ = c.Close() }()
+	col := c.Collection("posts")
+
+	a, err := NewOperate(nil).
+		Check(F("rc"), wire.OperateCmpGE, 999).
+		AddT(F("rc"), wire.OperateTypeU32, 1).
+		Args()
+	if err != nil {
+		t.Fatalf("build operate args: %v", err)
+	}
+	found, res, err := col.Operate(context.Background(), OperateRequest{ID: 1, PayloadKey: "session", Args: a})
+	if err != nil {
+		t.Fatalf("Operate: %v", err)
+	}
+	if !found {
+		t.Fatal("found = false, want true")
+	}
+	if res.Status != wire.OperateStatusCheckFailed || res.FailedOp != 2 {
+		t.Fatalf("res = %+v, want Status=CheckFailed FailedOp=2", res)
+	}
+}
+
+// TestCollectionOperateCASConflict checks that a wrong ExpectedVersion maps to
+// client.ErrVersionConflict through mapWriteErr, exactly like Upsert/Delete.
+func TestCollectionOperateCASConflict(t *testing.T) {
+	addr, stop := startFakeServer(t, func(body []byte) (uint8, []byte) {
+		_, argsBytes := decodeOpFrame(t, body)
+		_, _, _, _, expectedVersion, hasExpected, err := wire.DecodeVectorOperateArgs(argsBytes)
+		if err != nil {
+			t.Fatalf("DecodeVectorOperateArgs: %v", err)
+		}
+		if !hasExpected || expectedVersion != 999 {
+			t.Fatalf("hasExpected=%v expectedVersion=%d, want true/999", hasExpected, expectedVersion)
+		}
+		return StatusError, encodeErrorMsgFrame("vector: expected_version conflict: mismatch")
+	})
+	defer stop()
+
+	c, err := New(Config{Servers: []string{addr}})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	defer func() { _ = c.Close() }()
+	col := c.Collection("posts")
+
+	a, err := NewOperate(nil).Dynamic().AddT(F("rc"), wire.OperateTypeU32, 1).Args()
+	if err != nil {
+		t.Fatalf("build operate args: %v", err)
+	}
+	_, res, err := col.Operate(context.Background(), OperateRequest{
+		ID: 1, PayloadKey: "session", Args: a,
+		ExpectedVersion: 999, HasExpectedVersion: true,
+	})
+	if err != ErrVersionConflict {
+		t.Fatalf("err = %v, want ErrVersionConflict", err)
+	}
+	if res != nil {
+		t.Fatalf("res = %+v, want nil", res)
+	}
+}
+
+// TestCollectionOperateNilArgs checks the nil-args shape a caller lands on by
+// ignoring OperateBuilder.Args's error: wire.ErrOperateArgs, no panic, no
+// network call (the address is a closed port a dial would fail loudly on).
+func TestCollectionOperateNilArgs(t *testing.T) {
+	c, err := New(Config{Servers: []string{"127.0.0.1:1"}})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	defer func() { _ = c.Close() }()
+	col := c.Collection("posts")
+
+	found, res, err := col.Operate(context.Background(), OperateRequest{ID: 1, PayloadKey: "session"})
+	if !errors.Is(err, wire.ErrOperateArgs) {
+		t.Fatalf("err = %v, want wire.ErrOperateArgs", err)
+	}
+	if found {
+		t.Fatal("found = true, want false")
+	}
+	if res != nil {
+		t.Fatalf("res = %+v, want nil", res)
+	}
+}
+
+// TestVectorOperateIsNonReplayable checks that all three vector_operate op
+// names are registered as non-replayable: a blind replay after an ambiguous
+// post-commit transport failure would apply every ADD twice, or re-evaluate a
+// CHECK against a record the first attempt already changed.
+func TestVectorOperateIsNonReplayable(t *testing.T) {
+	for _, op := range []string{"vector_operate", "vector_named_operate", "vector_mv_operate"} {
+		if !nonReplayableOp(op) {
+			t.Errorf("nonReplayableOp(%q) = false, want true", op)
+		}
+	}
+}

--- a/client/vector_operate_test.go
+++ b/client/vector_operate_test.go
@@ -342,6 +342,11 @@ func TestVectorOperateIsNonReplayable(t *testing.T) {
 			t.Errorf("nonReplayableOp(%q) = false, want true", op)
 		}
 	}
+	// The three are listed individually rather than matched by a "vector_"
+	// prefix, so a read-only vector op must NOT be caught by the same switch.
+	if nonReplayableOp("vector_get") {
+		t.Error("nonReplayableOp(\"vector_get\") = true, want false")
+	}
 }
 
 // TestCollectionOperateMissingCollectionMapsToSentinel: a call against a

--- a/client/wc_envelope_replay_test.go
+++ b/client/wc_envelope_replay_test.go
@@ -1,0 +1,135 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package client
+
+import (
+	"context"
+	"encoding/binary"
+	"sync/atomic"
+	"testing"
+
+	"github.com/rostamlabs/rostam/sdk/wire"
+)
+
+// encodeWCEnvelopeFrame builds a write-consistency envelope the way the root
+// store's wcWire does (ops.EncodeWCEnvelope):
+//
+//	[wcf u8][wait u8][nameLen u8][name...][argsLen u32][args...]
+//
+// It is hand-built because ops lives in the root module and this one cannot
+// import it. The two are pinned against each other by
+// TestWCEnvelopeInnerOpMatchesTheStoreWire in the root module, which encodes
+// with the real producer and reads the name back with wire.WCEnvelopeInnerOp.
+func encodeWCEnvelopeFrame(wcf, wait uint8, innerName string, innerArgs []byte) []byte {
+	out := make([]byte, 0, 3+len(innerName)+4+len(innerArgs))
+	out = append(out, wcf, wait, byte(len(innerName)))
+	out = append(out, innerName...)
+	var hdr [4]byte
+	binary.BigEndian.PutUint32(hdr[:], uint32(len(innerArgs))) //nolint:gosec // test-only
+	out = append(out, hdr[:]...)
+	return append(out, innerArgs...)
+}
+
+// TestWCEnvelopedNonReplayableOpNotReplayed is the regression for the envelope
+// bypass: a write issued with write-consistency options travels under the name
+// wire.WCEnvelopeOp, so the retry guard used to answer "replayable" for every
+// one of them. Server A takes the request and drops the connection (the
+// committed-but-reply-lost shape → ambiguous EOF); server B must never be
+// contacted, because replaying a committed vector_operate ADD double-counts.
+func TestWCEnvelopedNonReplayableOpNotReplayed(t *testing.T) {
+	inner := []byte("inner-args")
+	for _, op := range []string{"vector_operate", "vector_named_operate", "vector_mv_operate", "operate", "cas"} {
+		t.Run(op, func(t *testing.T) {
+			var callA, callB atomic.Int32
+			addrA, stopA := startDropAfterReadServer(t, func() { callA.Add(1) })
+			defer stopA()
+			addrB, stopB := startFakeServer(t, func(_ []byte) (uint8, []byte) {
+				callB.Add(1)
+				return StatusOK, []byte{0}
+			})
+			defer stopB()
+
+			c, err := New(Config{Servers: []string{addrA, addrB}})
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer func() { _ = c.Close() }()
+
+			_, err = c.Call(context.Background(), wire.WCEnvelopeOp, encodeWCEnvelopeFrame(2, 1, op, inner))
+			if err == nil {
+				t.Fatalf("%s under the envelope returned nil; want an ambiguous transport error", op)
+			}
+			if !isAmbiguous(err) {
+				t.Fatalf("%s under the envelope: err = %v; want an ambiguous (post-transmission) error", op, err)
+			}
+			if n := callA.Load(); n != 1 {
+				t.Fatalf("%s: server A calls = %d, want 1", op, n)
+			}
+			if n := callB.Load(); n != 0 {
+				t.Fatalf("%s: server B calls = %d, want 0 (an enveloped non-replayable write must not replay)", op, n)
+			}
+		})
+	}
+}
+
+// TestWCEnvelopedReplayableOpStillReplays is the negative control: the guard
+// must look through the envelope, not blanket-refuse everything wearing it. An
+// idempotent inner op still fails over to server B.
+func TestWCEnvelopedReplayableOpStillReplays(t *testing.T) {
+	var callB atomic.Int32
+	addrA, stopA := startDropAfterReadServer(t, nil)
+	defer stopA()
+	addrB, stopB := startFakeServer(t, func(_ []byte) (uint8, []byte) {
+		callB.Add(1)
+		return StatusOK, []byte("ok")
+	})
+	defer stopB()
+
+	c, err := New(Config{Servers: []string{addrA, addrB}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = c.Close() }()
+
+	res, err := c.Call(context.Background(), wire.WCEnvelopeOp, encodeWCEnvelopeFrame(2, 1, "vector_insert", []byte("args")))
+	if err != nil {
+		t.Fatalf("enveloped vector_insert: %v; want transparent replay onto B", err)
+	}
+	if string(res) != "ok" {
+		t.Fatalf("result = %q, want ok", res)
+	}
+	if n := callB.Load(); n != 1 {
+		t.Fatalf("server B calls = %d, want 1 (idempotent inner op must still replay)", n)
+	}
+}
+
+// TestNonReplayableCallThroughEnvelope is the unit table for the guard itself,
+// including the frames wire.WCEnvelopeInnerOp cannot read. An undecodable
+// envelope is treated as non-replayable: this client never builds one, so
+// declining costs at most a retry while guessing costs a double-applied write.
+func TestNonReplayableCallThroughEnvelope(t *testing.T) {
+	cases := []struct {
+		name string
+		op   string
+		args []byte
+		want bool
+	}{
+		{"plain non-replayable", "vector_operate", nil, true},
+		{"plain replayable", "vector_get", nil, false},
+		{"envelope wrapping vector_operate", wire.WCEnvelopeOp, encodeWCEnvelopeFrame(1, 1, "vector_operate", nil), true},
+		{"envelope wrapping vector_named_operate", wire.WCEnvelopeOp, encodeWCEnvelopeFrame(1, 1, "vector_named_operate", nil), true},
+		{"envelope wrapping vector_mv_operate", wire.WCEnvelopeOp, encodeWCEnvelopeFrame(1, 1, "vector_mv_operate", nil), true},
+		{"envelope wrapping operate", wire.WCEnvelopeOp, encodeWCEnvelopeFrame(1, 1, "operate", nil), true},
+		{"envelope wrapping an idempotent op", wire.WCEnvelopeOp, encodeWCEnvelopeFrame(1, 1, "vector_insert", nil), false},
+		{"envelope too short for a header", wire.WCEnvelopeOp, []byte{1, 1}, true},
+		{"envelope truncated inside the name", wire.WCEnvelopeOp, []byte{1, 1, 8, 'v', 'e', 'c'}, true},
+		{"empty args under the envelope name", wire.WCEnvelopeOp, nil, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := nonReplayableCall(tc.op, tc.args); got != tc.want {
+				t.Fatalf("nonReplayableCall(%q) = %v, want %v", tc.op, got, tc.want)
+			}
+		})
+	}
+}

--- a/client/wc_envelope_replay_test.go
+++ b/client/wc_envelope_replay_test.go
@@ -121,6 +121,15 @@ func TestNonReplayableCallThroughEnvelope(t *testing.T) {
 		{"envelope wrapping vector_mv_operate", wire.WCEnvelopeOp, encodeWCEnvelopeFrame(1, 1, "vector_mv_operate", nil), true},
 		{"envelope wrapping operate", wire.WCEnvelopeOp, encodeWCEnvelopeFrame(1, 1, "operate", nil), true},
 		{"envelope wrapping an idempotent op", wire.WCEnvelopeOp, encodeWCEnvelopeFrame(1, 1, "vector_insert", nil), false},
+		// A NESTED envelope: the fanout dispatcher unwraps and dispatches what
+		// is inside, so the frame still reaches a real write. This client never
+		// builds one, so it is declined rather than followed.
+		{"envelope wrapping another envelope around vector_operate", wire.WCEnvelopeOp,
+			encodeWCEnvelopeFrame(1, 1, wire.WCEnvelopeOp,
+				encodeWCEnvelopeFrame(1, 1, "vector_operate", nil)), true},
+		{"envelope wrapping another envelope around an idempotent op", wire.WCEnvelopeOp,
+			encodeWCEnvelopeFrame(1, 1, wire.WCEnvelopeOp,
+				encodeWCEnvelopeFrame(1, 1, "vector_insert", nil)), true},
 		{"envelope too short for a header", wire.WCEnvelopeOp, []byte{1, 1}, true},
 		{"envelope truncated inside the name", wire.WCEnvelopeOp, []byte{1, 1, 8, 'v', 'e', 'c'}, true},
 		{"empty args under the envelope name", wire.WCEnvelopeOp, nil, true},
@@ -131,5 +140,37 @@ func TestNonReplayableCallThroughEnvelope(t *testing.T) {
 				t.Fatalf("nonReplayableCall(%q) = %v, want %v", tc.op, got, tc.want)
 			}
 		})
+	}
+}
+
+// TestNestedWCEnvelopeNotReplayed is the end-to-end half of the nested case: the
+// server's fanout dispatcher unwraps an envelope and dispatches what is inside,
+// so a doubly-wrapped vector_operate still reaches the real write. Server A takes
+// the request and drops the connection; server B must never be contacted.
+func TestNestedWCEnvelopeNotReplayed(t *testing.T) {
+	var callB atomic.Int32
+	addrA, stopA := startDropAfterReadServer(t, nil)
+	defer stopA()
+	addrB, stopB := startFakeServer(t, func(_ []byte) (uint8, []byte) {
+		callB.Add(1)
+		return StatusOK, []byte{0}
+	})
+	defer stopB()
+
+	c, err := New(Config{Servers: []string{addrA, addrB}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = c.Close() }()
+
+	nested := encodeWCEnvelopeFrame(2, 1, wire.WCEnvelopeOp,
+		encodeWCEnvelopeFrame(2, 1, "vector_operate", []byte("inner-args")))
+	if _, err := c.Call(context.Background(), wire.WCEnvelopeOp, nested); err == nil {
+		t.Fatal("a doubly-wrapped vector_operate returned nil; want an ambiguous transport error")
+	} else if !isAmbiguous(err) {
+		t.Fatalf("err = %v; want an ambiguous (post-transmission) error", err)
+	}
+	if n := callB.Load(); n != 0 {
+		t.Fatalf("server B calls = %d, want 0 (a nested envelope must not replay)", n)
 	}
 }

--- a/client_vector_operate_test.go
+++ b/client_vector_operate_test.go
@@ -1,4 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
+
 package rostam
 
 import (

--- a/client_vector_operate_test.go
+++ b/client_vector_operate_test.go
@@ -1,0 +1,182 @@
+// SPDX-License-Identifier: Apache-2.0
+package rostam
+
+import (
+	"context"
+	"encoding/binary"
+	"math/rand"
+	"testing"
+
+	"github.com/rostamlabs/rostam/client"
+	"github.com/rostamlabs/rostam/sdk/vtypes"
+	"github.com/rostamlabs/rostam/sdk/wire"
+	"github.com/rostamlabs/rostam/vector"
+)
+
+// su64 reinterprets a signed value as the uint64 bit pattern Cell.U stores for
+// a signed type. A constant expression like uint64(int64(-5)) does not compile
+// (constant overflow), so negative fixtures go through this helper — per the
+// phase-2 constraints, one su64 per package (vector/record_filter_test.go:17,
+// ops/operate_oracle_test.go).
+func su64(i int64) uint64 { return uint64(i) }
+
+// sessionRecordBytesRC mirrors vector/record_filter_test.go's helper of the
+// same name (design doc §4's session-record worked example): a schema-mode
+// record with StoreNames set, fields rc/bc/hist/bal/tag/b, rc caller-chosen.
+// Duplicated here because vector's test helpers are unexported and this file
+// lives in a different package — the same accepted precedent as
+// ops/record_malformed_test.go's fixture (phase-2 ledger, Task 5: "the
+// duplicated session fixture in ops tests accepted; vector test helpers are
+// not importable").
+func sessionRecordBytesRC(t *testing.T, rc uint8) []byte {
+	t.Helper()
+	leKey := func(v uint64) []byte {
+		b := make([]byte, 8)
+		binary.LittleEndian.PutUint64(b, v)
+		return b
+	}
+	s := &wire.Schema{
+		Version:    1,
+		StoreNames: true,
+		Fields: []wire.FieldDef{
+			{Name: "rc", Type: wire.OperateTypeU8},
+			{Name: "bc", Type: wire.OperateTypeU8},
+			{Name: "hist", Type: wire.OperateTypeU32},
+			{Name: "bal", Type: wire.OperateTypeI32},
+			{Name: "tag", Type: wire.OperateTypeBytes},
+			{Name: "b", Type: wire.OperateTypeTable, Table: &wire.TableDef{
+				KeyType: wire.OperateTypeU64,
+				Cols: []wire.ColumnDef{
+					{Name: "hi", Type: wire.OperateTypeU32},
+					{Name: "lo", Type: wire.OperateTypeU32},
+				},
+			}},
+		},
+	}
+	if err := s.Validate(); err != nil {
+		t.Fatalf("session schema invalid: %v", err)
+	}
+	rec := &wire.Record{Mode: wire.OperateModeSchema, Schema: s, Fields: []wire.Field{
+		{Cell: wire.Cell{Type: wire.OperateTypeU8, U: uint64(rc)}},
+		{Cell: wire.Cell{Type: wire.OperateTypeU8, U: 3}},
+		{Cell: wire.Cell{Type: wire.OperateTypeU32, U: 1234}},
+		{Cell: wire.Cell{Type: wire.OperateTypeI32, U: su64(-5)}},
+		{Cell: wire.Cell{Type: wire.OperateTypeBytes, B: []byte("de")}},
+		{Cell: wire.Cell{Type: wire.OperateTypeTable}, Table: &wire.Table{Rows: []wire.Row{
+			{Key: leKey(42), Cols: []wire.Col{
+				{Cell: wire.Cell{Type: wire.OperateTypeU32, U: 500}},
+				{Cell: wire.Cell{Type: wire.OperateTypeU32, U: 1}},
+			}},
+			{Key: leKey(99), Cols: []wire.Col{
+				{Cell: wire.Cell{Type: wire.OperateTypeU32, U: 7}},
+				{Cell: wire.Cell{Type: wire.OperateTypeU32, U: 2}},
+			}},
+		}}},
+	}}
+	enc := rec.Encode()
+	if enc == nil {
+		t.Fatal("session record failed to encode")
+	}
+	return enc
+}
+
+// TestOperateEndToEndKeepsTheIndexExact is the full-stack invariant behind
+// Collection.Operate: after a real mutation applied through the typed client,
+// the collection's accelerated record-path filter must answer off the
+// MUTATED value, not the value the point was inserted with. It is phase 1's
+// TestRecordFilterFirstEqualsBruteForce shape
+// (vector/payload_index_record_test.go), run after mutations rather than
+// after inserts, and driven end-to-end through a real server via the typed Go
+// client rather than the bare engine.
+//
+// Every point is inserted with rc=0 (below the threshold the filter below
+// tests) and then moved, via one Collection.Operate SET per point, to a
+// value spread across 0..19 — straddling the threshold. If the accelerated
+// filter path answered off the stale inserted value instead of the mutation,
+// this would surface as either a missing true match or a false one, not mere
+// noise.
+func TestOperateEndToEndKeepsTheIndexExact(t *testing.T) {
+	const n = 200
+	const threshold = 9
+
+	col, cleanup := mustCollection(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	rng := rand.New(rand.NewSource(11))
+	finalRC := make(map[uint64]uint8, n)
+
+	for i := 1; i <= n; i++ {
+		id := uint64(i) //nolint:gosec // bounded by n
+		vec := []float32{rng.Float32()*2 - 1, rng.Float32()*2 - 1, rng.Float32()*2 - 1, rng.Float32()*2 - 1}
+		if err := col.Upsert(ctx, client.WriteRequest{
+			ID: id, Vector: vec,
+			Metadata: vtypes.Metadata{"session": vtypes.NewRecord(sessionRecordBytesRC(t, 0))},
+		}); err != nil {
+			t.Fatalf("Upsert %d: %v", id, err)
+		}
+
+		target := uint8(i % 20) //nolint:gosec // bounded by 20
+		a, err := client.NewOperate(nil).
+			Set(client.F("rc"), int64(target)).
+			Return(client.F("rc")).
+			Args()
+		if err != nil {
+			t.Fatalf("build operate args for %d: %v", id, err)
+		}
+		found, res, err := col.Operate(ctx, client.OperateRequest{ID: id, PayloadKey: "session", Args: a})
+		if err != nil {
+			t.Fatalf("Operate %d: %v", id, err)
+		}
+		if !found {
+			t.Fatalf("Operate %d: found = false, want true", id)
+		}
+		cell, err := client.DecodeOperateValue(res.Values[0])
+		if err != nil {
+			t.Fatalf("DecodeOperateValue %d: %v", id, err)
+		}
+		if uint8(cell.U) != target { //nolint:gosec // U is a decoded U8 cell
+			t.Fatalf("point %d: server rc = %d, want %d", id, cell.U, target)
+		}
+		finalRC[id] = target
+	}
+
+	f := vtypes.Filter{Op: vtypes.FilterGt, Field: "session/rc", Value: vtypes.NewInt(threshold)}
+	pred, err := vector.CompileFilter(f)
+	if err != nil {
+		t.Fatalf("CompileFilter: %v", err)
+	}
+
+	want := make(map[uint64]bool, n)
+	for id, rc := range finalRC {
+		m := vtypes.Metadata{"session": vtypes.NewRecord(sessionRecordBytesRC(t, rc))}
+		if pred(m) {
+			want[id] = true
+		}
+	}
+	if len(want) == 0 || len(want) == n {
+		t.Fatalf("brute-force match set size %d — the fixture proves nothing (n=%d)", len(want), n)
+	}
+
+	resp, err := col.Search(ctx, client.SearchRequest{
+		Query: []float32{0.1, 0.1, 0.1, 0.1}, K: n + 100, Filter: f,
+	})
+	if err != nil {
+		t.Fatalf("Search: %v", err)
+	}
+	got := make(map[uint64]bool, len(resp.Results))
+	for _, r := range resp.Results {
+		got[r.ID] = true
+	}
+
+	for id := range want {
+		if !got[id] {
+			t.Errorf("Search is missing true match id %d (rc=%d)", id, finalRC[id])
+		}
+	}
+	for id := range got {
+		if !want[id] {
+			t.Errorf("Search returned id %d (rc=%d) the predicate rejects", id, finalRC[id])
+		}
+	}
+}

--- a/client_vector_operate_test.go
+++ b/client_vector_operate_test.go
@@ -125,7 +125,7 @@ func TestOperateEndToEndKeepsTheIndexExact(t *testing.T) {
 		if err != nil {
 			t.Fatalf("build operate args for %d: %v", id, err)
 		}
-		found, res, err := col.Operate(ctx, client.OperateRequest{ID: id, PayloadKey: "session", Args: a})
+		found, res, _, err := col.Operate(ctx, client.OperateRequest{ID: id, PayloadKey: "session", Args: a})
 		if err != nil {
 			t.Fatalf("Operate %d: %v", id, err)
 		}
@@ -179,5 +179,98 @@ func TestOperateEndToEndKeepsTheIndexExact(t *testing.T) {
 		if !want[id] {
 			t.Errorf("Search returned id %d (rc=%d) the predicate rejects", id, finalRC[id])
 		}
+	}
+}
+
+// TestOperateReturnedVersionDrivesACASLoopWithoutAReRead is the reason the
+// result frame carries the applied version at all: a CAS-looping caller can feed
+// the version this call returned straight into the next call's precondition and
+// never re-read the point.
+//
+// The re-read it replaces is not just a round trip, it is a race — another
+// writer can land between the read and the retry, so the loop can livelock on a
+// version that was already stale when it was read. The test therefore does the
+// thing that used to be impossible: after a CAS mismatch it recovers using ONLY
+// values the server handed back, with no Get anywhere in the loop.
+func TestOperateReturnedVersionDrivesACASLoopWithoutAReRead(t *testing.T) {
+	col, cleanup := mustCollection(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	const id = uint64(1)
+	if err := col.Upsert(ctx, client.WriteRequest{
+		ID: id, Vector: []float32{1, 0, 0, 0},
+		Metadata: vtypes.Metadata{"session": vtypes.NewRecord(sessionRecordBytesRC(t, 0))},
+	}); err != nil {
+		t.Fatalf("Upsert: %v", err)
+	}
+
+	bump := func(t *testing.T) *wire.OperateArgs {
+		t.Helper()
+		a, err := client.NewOperate(nil).Add(client.F("rc"), 1).Return(client.F("rc")).Args()
+		if err != nil {
+			t.Fatalf("build operate args: %v", err)
+		}
+		return a
+	}
+
+	// 1. An unconditional call: the version it returns is the ONLY thing the loop
+	//    below starts from.
+	found, res, version, err := col.Operate(ctx, client.OperateRequest{ID: id, PayloadKey: "session", Args: bump(t)})
+	if err != nil {
+		t.Fatalf("Operate: %v", err)
+	}
+	if !found {
+		t.Fatal("found = false, want true")
+	}
+	if version == 0 {
+		t.Fatal("version = 0 after an applied operate — the result frame did not carry it")
+	}
+	if cell, derr := client.DecodeOperateValue(res.Values[0]); derr != nil || cell.U != 1 {
+		t.Fatalf("rc = %+v (%v), want 1", cell, derr)
+	}
+
+	// 2. The CAS call with that version succeeds, and returns the NEXT version.
+	found, res, next, err := col.Operate(ctx, client.OperateRequest{
+		ID: id, PayloadKey: "session", Args: bump(t),
+		ExpectedVersion: version, HasExpectedVersion: true,
+	})
+	if err != nil {
+		t.Fatalf("CAS operate with the returned version: %v", err)
+	}
+	if !found {
+		t.Fatal("CAS operate: found = false, want true")
+	}
+	if next <= version {
+		t.Fatalf("version did not advance: %d -> %d", version, next)
+	}
+	if cell, derr := client.DecodeOperateValue(res.Values[0]); derr != nil || cell.U != 2 {
+		t.Fatalf("rc = %+v (%v), want 2", cell, derr)
+	}
+
+	// 3. A stale precondition still conflicts — the version is a real CAS token,
+	//    not a decorative field.
+	if _, _, _, err := col.Operate(ctx, client.OperateRequest{
+		ID: id, PayloadKey: "session", Args: bump(t),
+		ExpectedVersion: version, HasExpectedVersion: true,
+	}); err == nil {
+		t.Fatal("a stale expectedVersion was accepted — the precondition is not being honored")
+	}
+
+	// 4. Recover from that conflict with NO re-read: the version from step 2 is
+	//    still the newest one the server told us about, because the conflicting
+	//    call changed nothing.
+	found, res, _, err = col.Operate(ctx, client.OperateRequest{
+		ID: id, PayloadKey: "session", Args: bump(t),
+		ExpectedVersion: next, HasExpectedVersion: true,
+	})
+	if err != nil {
+		t.Fatalf("retry with the last returned version: %v", err)
+	}
+	if !found {
+		t.Fatal("retry: found = false, want true")
+	}
+	if cell, derr := client.DecodeOperateValue(res.Values[0]); derr != nil || cell.U != 3 {
+		t.Fatalf("rc = %+v (%v), want 3 — the loop lost an increment", cell, derr)
 	}
 }

--- a/cluster/vector_operate_determinism_test.go
+++ b/cluster/vector_operate_determinism_test.go
@@ -107,7 +107,7 @@ func TestVectorOperateReplicasAgreeByteForByte(t *testing.T) {
 	if err != nil {
 		t.Fatalf("vector_operate: %v", err)
 	}
-	found, res, err := wire.DecodeVectorOperateResult(body)
+	found, res, _, err := wire.DecodeVectorOperateResult(body)
 	if err != nil {
 		t.Fatalf("DecodeVectorOperateResult: %v", err)
 	}
@@ -303,7 +303,7 @@ func TestVectorOperateReplicasAgreeWithAPerKeyDeadline(t *testing.T) {
 		if err != nil {
 			t.Fatalf("vector_operate: %v", err)
 		}
-		found, res, err := wire.DecodeVectorOperateResult(body)
+		found, res, _, err := wire.DecodeVectorOperateResult(body)
 		if err != nil {
 			t.Fatalf("DecodeVectorOperateResult: %v", err)
 		}

--- a/cluster/vector_operate_determinism_test.go
+++ b/cluster/vector_operate_determinism_test.go
@@ -1,0 +1,205 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package cluster
+
+// Replica agreement for vector_operate.
+//
+// The op-list is applied INSIDE each replica's FSM, so every replica runs the
+// arithmetic itself rather than receiving the resulting bytes. That makes the
+// clock the whole risk: a STAMP op resolved from a wall clock would resolve to a
+// different millisecond on each node and the replicas would diverge silently,
+// with no error anywhere and nothing but a later byte comparison to reveal it.
+//
+// This test drives a STAMP-carrying op-list plus two ADDs through the replicated
+// apply path on a 3-node RF=3 cluster, then reads each node's OWN local replica
+// (CallPhysical with leaderOnly=false, the pattern TestClusterLinearizable* uses
+// for an AnyReplica read) and asserts the stored record bytes are IDENTICAL on
+// all three — the STAMPed field included.
+//
+// On the stamp's VALUE, see the note at the end of the test: shard's
+// EnableApplyStamp rollout flag is off cluster-wide, so the entries reach every
+// replica unstamped and STAMP resolves to 0 on all three. That does not weaken
+// what is being tested — a wall clock read inside the apply would still differ
+// per node and break byte identity — it only means this test cannot also assert
+// that the stamp is a real timestamp.
+
+import (
+	"bytes"
+	"context"
+	"testing"
+	"time"
+
+	"github.com/rostamlabs/rostam/ops"
+	"github.com/rostamlabs/rostam/sdk/wire"
+	"github.com/rostamlabs/rostam/vector"
+)
+
+// operateFieldPath addresses a dynamic-mode record field by name.
+func operateFieldPath(name string) wire.OperatePath {
+	return wire.OperatePath{Kind: wire.OperatePathField, Field: wire.OperateSeg{ByName: true, Name: name}}
+}
+
+// getFlagsPayloadOnly is the vector_get projection byte for payload-only (bit 1);
+// it mirrors ops' getFlagWithPayload.
+const getFlagsPayloadOnly uint8 = 1 << 1
+
+// readRecordFromNode reads the point's payload from n's OWN replica (no leader
+// routing) and returns the record bytes under key plus the point's version.
+func readRecordFromNode(t *testing.T, n *Node, physCol string, id uint64, key string) ([]byte, uint64) {
+	t.Helper()
+	body, err := n.CallPhysical(physCol, "vector_get", ops.EncodeVectorGetArgs(physCol, id, getFlagsPayloadOnly), false)
+	if err != nil {
+		t.Fatalf("CallPhysical vector_get: %v", err)
+	}
+	found, _, meta, _, _, version, err := ops.DecodeVectorGetResultV(body)
+	if err != nil {
+		t.Fatalf("DecodeVectorGetResultV: %v", err)
+	}
+	if !found {
+		return nil, 0
+	}
+	v, ok := meta[key]
+	if !ok {
+		return nil, version
+	}
+	return append([]byte(nil), v.Rec...), version
+}
+
+// TestVectorOperateReplicasAgreeByteForByte is the determinism proof at the
+// cluster level: the record every replica stores after a STAMP-carrying operate
+// must be byte-identical. A wall-clock leak in any replica's apply makes the
+// stamped field differ and fails this test.
+func TestVectorOperateReplicasAgreeByteForByte(t *testing.T) {
+	const numShards = 4
+	tc := newTestCluster(t, 3, numShards, 3) // RF=3: every node replicates every shard
+	ctx := context.Background()
+
+	// Single-partition physical name ⇒ one Raft group, deterministic routing.
+	const coll = "operate/docs"
+	physCol := string(ops.PartitionKeyGen(coll, 0, 0))
+	cfg := vector.Config{Dim: 4, Metric: vector.L2, M: 8, EfConstruction: 50, EfSearch: 64, Seed: 1}
+	if _, err := tc.client.Call(ctx, "vector_create_collection", ops.EncodeCreateCollectionArgs(physCol, cfg)); err != nil {
+		t.Fatalf("create collection: %v", err)
+	}
+
+	const id = uint64(7)
+	if _, err := tc.client.Call(ctx, "vector_upsert",
+		ops.EncodeVectorUpsertArgs(physCol, id, []float32{1, 0, 0, 0}, "", 0, nil, vector.SparseVector{})); err != nil {
+		t.Fatalf("upsert: %v", err)
+	}
+
+	// A STAMP plus two ADDs: the STAMP is the wall-clock trap, the ADDs prove the
+	// arithmetic itself replays identically.
+	opList := &wire.OperateArgs{
+		Create: wire.OperateCreateDynamic,
+		Ops: []wire.OperateOp{
+			{Opcode: wire.OperateOpSTAMP, Type: wire.OperateTypeU64, Aux: wire.OperateStampMs, Path: operateFieldPath("t")},
+			{Opcode: wire.OperateOpADD, Type: wire.OperateTypeU64, Path: operateFieldPath("rc"), A: 1},
+			{Opcode: wire.OperateOpADD, Type: wire.OperateTypeU64, Path: operateFieldPath("bc"), A: 5},
+		},
+	}
+	args, err := wire.EncodeVectorOperateArgs(physCol, id, "session", opList, 0, false)
+	if err != nil {
+		t.Fatalf("EncodeVectorOperateArgs: %v", err)
+	}
+	body, err := tc.client.Call(ctx, "vector_operate", args)
+	if err != nil {
+		t.Fatalf("vector_operate: %v", err)
+	}
+	found, res, err := wire.DecodeVectorOperateResult(body)
+	if err != nil {
+		t.Fatalf("DecodeVectorOperateResult: %v", err)
+	}
+	if !found || res == nil || res.Status != wire.OperateStatusOK {
+		t.Fatalf("vector_operate: found=%v res=%+v", found, res)
+	}
+
+	// Gate on the DATA, not on raft's applied_index: that counter advances at
+	// enqueue, so it is only a proxy for the apply having run. Poll every node's
+	// own replica until it carries a record for the point.
+	nodes := make([]*Node, 0, len(tc.nodes))
+	for _, n := range tc.nodes {
+		if n != nil {
+			nodes = append(nodes, n)
+		}
+	}
+	if len(nodes) != 3 {
+		t.Fatalf("expected 3 live nodes, got %d", len(nodes))
+	}
+
+	deadline := time.Now().Add(20 * time.Second)
+	var recs [][]byte
+	var versions []uint64
+	for {
+		recs = recs[:0]
+		versions = versions[:0]
+		ready := true
+		for _, n := range nodes {
+			rec, ver := readRecordFromNode(t, n, physCol, id, "session")
+			if len(rec) == 0 {
+				ready = false
+				break
+			}
+			recs = append(recs, rec)
+			versions = append(versions, ver)
+		}
+		if ready {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("timed out waiting for every replica to apply the operate")
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+
+	for i := 1; i < len(recs); i++ {
+		if versions[i] != versions[0] {
+			t.Fatalf("replica %d version = %d, replica 0 = %d — replicas disagree on the CAS version",
+				i, versions[i], versions[0])
+		}
+		if !bytes.Equal(recs[i], recs[0]) {
+			t.Fatalf("replica %d stored DIFFERENT record bytes than replica 0 — the apply is not deterministic "+
+				"(a wall clock leaked into STAMP?)\n replica0=%x\n replica%d=%x", i, recs[0], i, recs[i])
+		}
+	}
+
+	// Positive control: the bytes compared above are a REAL record carrying all
+	// three ops' results, not two empty payloads that trivially agree.
+	rec, err := wire.DecodeRecord(recs[0])
+	if err != nil {
+		t.Fatalf("DecodeRecord: %v", err)
+	}
+	// Dynamic-mode fields are stored sorted by name, so look each up by name.
+	fields := make(map[string]wire.Cell, len(rec.Fields))
+	for _, f := range rec.Fields {
+		fields[f.Name] = f.Cell
+	}
+	for _, want := range []struct {
+		name string
+		val  uint64
+	}{{"rc", 1}, {"bc", 5}} {
+		c, ok := fields[want.name]
+		if !ok {
+			t.Fatalf("record carries no field %q: %+v", want.name, rec.Fields)
+		}
+		if c.U != want.val {
+			t.Fatalf("field %q = %d, want %d — the op-list did not apply as written", want.name, c.U, want.val)
+		}
+	}
+	// The STAMPed field must EXIST — STAMP ran on every replica and its value is
+	// part of the byte-identity assertion above.
+	//
+	// Its value is 0 here, and that is the harness, not a bug: shard.Config's
+	// EnableApplyStamp is the two-phase rollout flag for the leader-stamped apply
+	// clock and it is OFF everywhere outside shard's own tests, so the leader emits
+	// unstamped log entries and every replica applies with stampMs = 0. The
+	// determinism property under test is unaffected — a wall clock consulted inside
+	// the apply would still resolve differently on each node and break the
+	// byte-identity assertion — but a non-zero assertion here would be asserting the
+	// rollout flag, not the op. The handler's own stamp threading is pinned by
+	// ops.TestVectorOperateIsDeterministicUnderTheStamp, which drives the stamp
+	// directly.
+	if _, ok := fields["t"]; !ok {
+		t.Fatalf("record carries no STAMPed field %q: %+v", "t", rec.Fields)
+	}
+}

--- a/cluster/vector_operate_determinism_test.go
+++ b/cluster/vector_operate_determinism_test.go
@@ -26,6 +26,7 @@ package cluster
 import (
 	"bytes"
 	"context"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -201,5 +202,202 @@ func TestVectorOperateReplicasAgreeByteForByte(t *testing.T) {
 	// directly.
 	if _, ok := fields["t"]; !ok {
 		t.Fatalf("record carries no STAMPed field %q: %+v", "t", rec.Fields)
+	}
+}
+
+// setNodeVectorClock pins n's TTL wall clock on every shard store it hosts. The
+// clock reaches only the NON-apply expiry sites plus the wall-clock branch of the
+// write paths (vector.CollectionStore.SetNowFunc's contract), which is exactly
+// what an unstamped replicated apply reads — so skewing it per node is how a
+// replica's local clock is put either side of a per-key deadline.
+func setNodeVectorClock(t *testing.T, n *Node, fn func() int64) {
+	t.Helper()
+	for _, s := range n.shards {
+		if s == nil {
+			continue
+		}
+		if vs := s.VectorStore(); vs != nil {
+			vs.SetNowFunc(fn)
+		}
+	}
+}
+
+// TestVectorOperateReplicasAgreeWithAPerKeyDeadline is the byte-agreement proof
+// for the case the STAMP test cannot reach: the record's payload key carries a
+// per-key DEADLINE, and the replicas' wall clocks straddle it.
+//
+// With the leader apply stamp off (it is off cluster-wide today) every replica
+// applies with its own wall clock. If the mutator were allowed to judge the key's
+// deadline against that clock, a replica past the deadline would read the record
+// as ABSENT and create a fresh one while a replica short of it would increment
+// the stored one — both commit, both bump the version, neither errors, and the
+// two replicas hold different bytes forever. The engines therefore refuse to
+// consult the clock for the key's deadline unless the apply is stamped (see
+// vector.recordKeyPastDeadline), which is what this test pins end to end.
+//
+// The clocks are pinned through CollectionStore.SetNowFunc on each node's shard
+// stores, including for the final read: a node whose clock is past the deadline
+// would otherwise hide the key from its own vector_get and the comparison would
+// read two empty payloads that trivially agree.
+func TestVectorOperateReplicasAgreeWithAPerKeyDeadline(t *testing.T) {
+	const numShards = 4
+	tc := newTestCluster(t, 3, numShards, 3) // RF=3: every node replicates every shard
+	ctx := context.Background()
+
+	const coll = "operate/ttl"
+	physCol := string(ops.PartitionKeyGen(coll, 0, 0))
+	cfg := vector.Config{Dim: 4, Metric: vector.L2, M: 8, EfConstruction: 50, EfSearch: 64, Seed: 1}
+	if _, err := tc.client.Call(ctx, "vector_create_collection", ops.EncodeCreateCollectionArgs(physCol, cfg)); err != nil {
+		t.Fatalf("create collection: %v", err)
+	}
+
+	nodes := make([]*Node, 0, len(tc.nodes))
+	for _, n := range tc.nodes {
+		if n != nil {
+			nodes = append(nodes, n)
+		}
+	}
+	if len(nodes) != 3 {
+		t.Fatalf("expected 3 live nodes, got %d", len(nodes))
+	}
+
+	// One pinned clock per node. base is a fixed instant so nothing below depends
+	// on what time.Now happened to return.
+	const base int64 = 1_700_000_000_000
+	const keyTTLMs int64 = 50_000
+	const deadline = base + keyTTLMs
+	clocks := make([]*atomic.Int64, len(nodes))
+	for i, n := range nodes {
+		clk := &atomic.Int64{}
+		clk.Store(base)
+		clocks[i] = clk
+		setNodeVectorClock(t, n, func() int64 { return clk.Load() })
+	}
+	// Re-pin after the collection exists so a store that built it lazily still
+	// inherits the override (SetNowFunc propagates to resident indexes).
+	pinAll := func(ms int64) {
+		for i, n := range nodes {
+			clocks[i].Store(ms)
+			setNodeVectorClock(t, n, func() int64 { return clocks[i].Load() })
+		}
+	}
+	pinAll(base)
+
+	const id = uint64(7)
+	if _, err := tc.client.Call(ctx, "vector_upsert",
+		ops.EncodeVectorUpsertArgs(physCol, id, []float32{1, 0, 0, 0}, "", 0, nil, vector.SparseVector{})); err != nil {
+		t.Fatalf("upsert: %v", err)
+	}
+
+	addRC := &wire.OperateArgs{
+		Create: wire.OperateCreateDynamic,
+		Ops:    []wire.OperateOp{{Opcode: wire.OperateOpADD, Type: wire.OperateTypeU64, Path: operateFieldPath("rc"), A: 1}},
+	}
+	operate := func(t *testing.T) {
+		t.Helper()
+		args, err := wire.EncodeVectorOperateArgs(physCol, id, "session", addRC, 0, false)
+		if err != nil {
+			t.Fatalf("EncodeVectorOperateArgs: %v", err)
+		}
+		body, err := tc.client.Call(ctx, "vector_operate", args)
+		if err != nil {
+			t.Fatalf("vector_operate: %v", err)
+		}
+		found, res, err := wire.DecodeVectorOperateResult(body)
+		if err != nil {
+			t.Fatalf("DecodeVectorOperateResult: %v", err)
+		}
+		if !found || res == nil || res.Status != wire.OperateStatusOK {
+			t.Fatalf("vector_operate: found=%v res=%+v", found, res)
+		}
+	}
+
+	// waitForVersion gates on the DATA reaching every replica: raft's applied_index
+	// advances at ENQUEUE, so it is only a proxy for the apply having run. The
+	// version is read rather than the record because a replica whose clock is past
+	// the deadline hides the key from its own read.
+	waitForVersion := func(t *testing.T, want uint64) {
+		t.Helper()
+		deadlineAt := time.Now().Add(20 * time.Second)
+		for {
+			ready := true
+			for _, n := range nodes {
+				if _, v := readRecordFromNode(t, n, physCol, id, "session"); v != want {
+					ready = false
+					break
+				}
+			}
+			if ready {
+				return
+			}
+			if time.Now().After(deadlineAt) {
+				t.Fatalf("timed out waiting for every replica to reach version %d", want)
+			}
+			time.Sleep(20 * time.Millisecond)
+		}
+	}
+
+	// 1. Create the record (rc=1). No deadline yet, so this step is clock-free.
+	operate(t)
+	waitForVersion(t, 2) // upsert=1, operate=2
+
+	// 2. Put a per-key deadline on the record key. An EMPTY patch with a keyTTL
+	//    only re-deadlines a key already in the payload (setPayloadBody), and with
+	//    every clock still at base every replica computes the SAME deadline.
+	if _, err := tc.client.Call(ctx, "vector_set_payload",
+		wire.EncodeSetPayloadArgsOpts(physCol, id, nil, map[string]int64{"session": keyTTLMs})); err != nil {
+		t.Fatalf("vector_set_payload: %v", err)
+	}
+	waitForVersion(t, 3)
+
+	// 3. Skew the replicas' clocks ACROSS the deadline: two past it, one short of
+	//    it. This is the state the divergence needs.
+	clocks[0].Store(deadline + 10_000)
+	clocks[1].Store(base + 10_000)
+	clocks[2].Store(deadline + 30_000)
+
+	// 4. The operate every replica now applies with its own clock.
+	operate(t)
+	waitForVersion(t, 4)
+
+	// 5. Read every replica at ONE common clock, short of the deadline, so the key
+	//    is visible everywhere and the comparison is of real stored bytes.
+	pinAll(base)
+	recs := make([][]byte, 0, len(nodes))
+	for _, n := range nodes {
+		rec, _ := readRecordFromNode(t, n, physCol, id, "session")
+		if len(rec) == 0 {
+			t.Fatalf("a replica holds no record under the payload key at the common probe clock — "+
+				"the mutation dropped the key or its deadline (node %p)", n)
+		}
+		recs = append(recs, rec)
+	}
+	for i := 1; i < len(recs); i++ {
+		if !bytes.Equal(recs[i], recs[0]) {
+			t.Fatalf("replica %d stored DIFFERENT record bytes than replica 0 — an unstamped apply judged the "+
+				"payload key's deadline against its OWN wall clock, so one replica recreated the record while "+
+				"another incremented it\n replica0=%x\n replica%d=%x", i, recs[0], i, recs[i])
+		}
+	}
+
+	// Positive control: the agreed bytes are the INCREMENTED record (rc=2), not a
+	// fresh rc=1 that every replica recreated identically because every clock
+	// happened to be past the deadline.
+	rec, err := wire.DecodeRecord(recs[0])
+	if err != nil {
+		t.Fatalf("DecodeRecord: %v", err)
+	}
+	var rc *wire.Cell
+	for i := range rec.Fields {
+		if rec.Fields[i].Name == "rc" {
+			rc = &rec.Fields[i].Cell
+		}
+	}
+	if rc == nil {
+		t.Fatalf("record carries no field %q: %+v", "rc", rec.Fields)
+	}
+	if rc.U != 2 {
+		t.Fatalf("rc = %d, want 2 — the second operate did not increment the EXISTING record, so the "+
+			"deadline-passed key was read as absent", rc.U)
 	}
 }

--- a/direct.go
+++ b/direct.go
@@ -873,32 +873,32 @@ func (d *directStore) VectorClearPayload(_ context.Context, collection string, i
 // why only ExpectedVersion is read.
 func (d *directStore) vectorOperate(opName, collection string, id uint64, payloadKey string,
 	a *wire.OperateArgs, opts []WriteOpts,
-) (bool, *wire.OperateResult, error) {
+) (bool, *wire.OperateResult, uint64, error) {
 	exp, hasExp := firstWriteOpts(opts).expectedVersion()
 	args, err := wire.EncodeVectorOperateArgs(collection, id, payloadKey, a, exp, hasExp)
 	if err != nil {
-		return false, nil, err
+		return false, nil, 0, err
 	}
 	body, err := d.Call(context.Background(), opName, args)
 	if err != nil {
-		return false, nil, err
+		return false, nil, 0, err
 	}
 	return ops.DecodeVectorOperateResult(body)
 }
 
 // VectorOperate runs the dense operate op against the single in-process shard,
 // honoring the CAS precondition. See Store.VectorOperate.
-func (d *directStore) VectorOperate(_ context.Context, collection string, id uint64, payloadKey string, a *wire.OperateArgs, opts ...WriteOpts) (bool, *wire.OperateResult, error) {
+func (d *directStore) VectorOperate(_ context.Context, collection string, id uint64, payloadKey string, a *wire.OperateArgs, opts ...WriteOpts) (bool, *wire.OperateResult, uint64, error) {
 	return d.vectorOperate("vector_operate", collection, id, payloadKey, a, opts)
 }
 
 // VectorNamedOperate is VectorOperate against the named family. See vectorOperate.
-func (d *directStore) VectorNamedOperate(_ context.Context, name string, id uint64, payloadKey string, a *wire.OperateArgs, opts ...WriteOpts) (bool, *wire.OperateResult, error) {
+func (d *directStore) VectorNamedOperate(_ context.Context, name string, id uint64, payloadKey string, a *wire.OperateArgs, opts ...WriteOpts) (bool, *wire.OperateResult, uint64, error) {
 	return d.vectorOperate("vector_named_operate", name, id, payloadKey, a, opts)
 }
 
 // VectorMVOperate is VectorOperate against the multi-vector family. See vectorOperate.
-func (d *directStore) VectorMVOperate(_ context.Context, name string, docID uint64, payloadKey string, a *wire.OperateArgs, opts ...WriteOpts) (bool, *wire.OperateResult, error) {
+func (d *directStore) VectorMVOperate(_ context.Context, name string, docID uint64, payloadKey string, a *wire.OperateArgs, opts ...WriteOpts) (bool, *wire.OperateResult, uint64, error) {
 	return d.vectorOperate("vector_mv_operate", name, docID, payloadKey, a, opts)
 }
 

--- a/direct.go
+++ b/direct.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/rostamlabs/rostam/cache"
 	"github.com/rostamlabs/rostam/ops"
+	"github.com/rostamlabs/rostam/sdk/wire"
 	"github.com/rostamlabs/rostam/server"
 	"github.com/rostamlabs/rostam/vector"
 	"github.com/rostamlabs/rostam/wasm"
@@ -859,6 +860,46 @@ func (d *directStore) VectorClearPayload(_ context.Context, collection string, i
 		return false, err
 	}
 	return ops.DecodePayloadResult(body)
+}
+
+// vectorOperate is the shared body of the three direct operate methods.
+//
+// opts is USED, not discarded: directStore.VectorSetPayload takes
+// `_ ...WriteOpts` and throws the caller's CAS precondition away outright. A
+// direct-mode store has no Raft layer and no other guard on a single-node write,
+// so the precondition in the args is the only thing standing between two
+// concurrent read-modify-writes and a lost update. The write-consistency knobs in
+// WriteOpts genuinely do not apply here (there is nothing to barrier), which is
+// why only ExpectedVersion is read.
+func (d *directStore) vectorOperate(opName, collection string, id uint64, payloadKey string,
+	a *wire.OperateArgs, opts []WriteOpts,
+) (bool, *wire.OperateResult, error) {
+	exp, hasExp := firstWriteOpts(opts).expectedVersion()
+	args, err := wire.EncodeVectorOperateArgs(collection, id, payloadKey, a, exp, hasExp)
+	if err != nil {
+		return false, nil, err
+	}
+	body, err := d.Call(context.Background(), opName, args)
+	if err != nil {
+		return false, nil, err
+	}
+	return ops.DecodeVectorOperateResult(body)
+}
+
+// VectorOperate runs the dense operate op against the single in-process shard,
+// honoring the CAS precondition. See Store.VectorOperate.
+func (d *directStore) VectorOperate(_ context.Context, collection string, id uint64, payloadKey string, a *wire.OperateArgs, opts ...WriteOpts) (bool, *wire.OperateResult, error) {
+	return d.vectorOperate("vector_operate", collection, id, payloadKey, a, opts)
+}
+
+// VectorNamedOperate is VectorOperate against the named family. See vectorOperate.
+func (d *directStore) VectorNamedOperate(_ context.Context, name string, id uint64, payloadKey string, a *wire.OperateArgs, opts ...WriteOpts) (bool, *wire.OperateResult, error) {
+	return d.vectorOperate("vector_named_operate", name, id, payloadKey, a, opts)
+}
+
+// VectorMVOperate is VectorOperate against the multi-vector family. See vectorOperate.
+func (d *directStore) VectorMVOperate(_ context.Context, name string, docID uint64, payloadKey string, a *wire.OperateArgs, opts ...WriteOpts) (bool, *wire.OperateResult, error) {
+	return d.vectorOperate("vector_mv_operate", name, docID, payloadKey, a, opts)
 }
 
 func (d *directStore) VectorNamedGet(ctx context.Context, name string, id uint64, withVector, withPayload bool) (bool, map[string][]float32, VectorMetadata, time.Duration, error) {

--- a/direct.go
+++ b/direct.go
@@ -881,7 +881,10 @@ func (d *directStore) vectorOperate(opName, collection string, id uint64, payloa
 	}
 	body, err := d.Call(context.Background(), opName, args)
 	if err != nil {
-		return false, nil, 0, err
+		// Identity survives in-process here, so this is a no-op on the happy
+		// path; it is applied anyway so all three backends run the SAME
+		// normalisation and none can drift.
+		return false, nil, 0, mapVectorOperateErr(err)
 	}
 	return ops.DecodeVectorOperateResult(body)
 }

--- a/docs/api/go-client.md
+++ b/docs/api/go-client.md
@@ -96,6 +96,37 @@ for _, e := range errs { // nil/empty slice means everything succeeded
 }
 ```
 
+### Operating on a record
+
+`Collection.Operate` applies one atomic
+[`operate` op-list](../kv/overview.md#atomic-multi-field-updates-operate) to
+the record stored under one payload key of one point — see
+[updating a record in place](../vector/filtering.md#updating-a-record-in-place)
+for the full contract (what's rejected, what `create` does, the reshard
+refusal). Build the op-list with `client.NewOperate`, a two-statement pattern:
+build the args, check the build error, then call:
+
+```go
+args, err := client.NewOperate(nil).Dynamic().
+	AddT(client.F("hits"), wire.OperateTypeI64, 1).
+	Return(client.F("hits")).
+	Args() // Args() reports a build-time error (bad path, wrong type); nothing sent yet
+if err != nil { ... }
+
+found, res, err := posts.Operate(ctx, client.OperateRequest{
+	ID: 1, PayloadKey: "session", Args: args,
+})
+// found: false if the point is absent/tombstoned/expired — res is nil then, not an error
+n, err := client.DecodeOperateValue(res.Values[0])
+```
+
+`Collection.Operate` is **not replayable**: an ambiguous post-commit transport
+failure (the call may or may not have landed) surfaces as an error instead of
+being retried automatically, because a retried `ADD` after an ambiguous
+failure would double-count. A caller that needs at-most-once semantics across
+a retry should use `CHECK` in the op-list, or `OperateRequest.ExpectedVersion`
+to fence on the point's version.
+
 ### Reading
 
 ```go

--- a/docs/api/go-client.md
+++ b/docs/api/go-client.md
@@ -116,17 +116,31 @@ if err != nil { ... }
 found, res, version, err := posts.Operate(ctx, client.OperateRequest{
 	ID: 1, PayloadKey: "session", Args: args,
 })
-// found: false if the point is absent/tombstoned/expired — res is nil then, not an error
-// version: the point's version AFTER the call (0 when found is false)
+if err != nil {
+	return err
+}
+// found: false if the point is absent/tombstoned/expired — res is nil then, not
+// an error. Guard on it before touching res.
+if !found {
+	return nil
+}
 n, err := client.DecodeOperateValue(res.Values[0])
 ```
 
-`version` is what a CAS loop retries with. It is the bumped version when the
-op-list applied and the current, unbumped one when the call was a deliberate
-no-op (a failed `CHECK`), so a caller that hits `ErrVersionConflict` can retry
-with `ExpectedVersion: version, HasExpectedVersion: true` **without re-reading
-the point** — a re-read is both a round trip and a race, since another writer
-can land between it and the retry.
+`version` is the point's version **after** the call, and it is what a CAS loop
+retries with. It is the bumped version when the op-list applied and the current,
+unbumped one when the call was a deliberate no-op (a failed `CHECK`). In both
+cases it can be fed straight into the next call's `ExpectedVersion` **without
+re-reading the point** — a re-read is both a round trip and a race, since another
+writer can land between it and the retry.
+
+Only a call that RETURNED carries a usable version. A call that fails with
+`ErrVersionConflict` returns `version == 0`: the server sends no result frame for
+a refused precondition, and `0` means "expect an absent point", so retrying with
+it conflicts again against a live point. Retry a conflict with the last version
+this collection handed you (from a successful or check-failed call) if you know
+no one else writes the point; otherwise re-read it, because the conflict means
+somebody did.
 
 `Collection.Operate` is **not replayable**: an ambiguous post-commit transport
 failure (the call may or may not have landed) surfaces as an error instead of

--- a/docs/api/go-client.md
+++ b/docs/api/go-client.md
@@ -113,12 +113,20 @@ args, err := client.NewOperate(nil).Dynamic().
 	Args() // Args() reports a build-time error (bad path, wrong type); nothing sent yet
 if err != nil { ... }
 
-found, res, err := posts.Operate(ctx, client.OperateRequest{
+found, res, version, err := posts.Operate(ctx, client.OperateRequest{
 	ID: 1, PayloadKey: "session", Args: args,
 })
 // found: false if the point is absent/tombstoned/expired — res is nil then, not an error
+// version: the point's version AFTER the call (0 when found is false)
 n, err := client.DecodeOperateValue(res.Values[0])
 ```
+
+`version` is what a CAS loop retries with. It is the bumped version when the
+op-list applied and the current, unbumped one when the call was a deliberate
+no-op (a failed `CHECK`), so a caller that hits `ErrVersionConflict` can retry
+with `ExpectedVersion: version, HasExpectedVersion: true` **without re-reading
+the point** — a re-read is both a round trip and a race, since another writer
+can land between it and the retry.
 
 `Collection.Operate` is **not replayable**: an ambiguous post-commit transport
 failure (the call may or may not have landed) surfaces as an error instead of

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -38,6 +38,32 @@ Notable user-visible changes. Entries that alter existing behaviour are marked
   [the KV overview](kv/overview.md#atomic-multi-field-updates-operate) for
   the full path/type/op vocabulary, caps, and worked examples.
 
+- **`vector_operate`: mutate a record stored in a vector payload in place.**
+  New built-in ops `vector_operate` / `vector_named_operate` / `vector_mv_operate`
+  apply the same `operate` op-list to the record held under one point's
+  payload key, atomically, under the collection's write lock, in one apply —
+  the read-back paths, types and `OperateResult` are exactly `operate`'s. A
+  point's TTL and the op-list's inner key don't apply here and are rejected
+  rather than silently ignored; `create` can still create the record, and
+  `create = NONE` against a missing one is an error, matching KV `operate`.
+  The mutated record's top-level fields are reindexed in the same apply, so a
+  filtered search sees the change immediately. The call is refused while its
+  collection is resharding (retryable after cutover) and is not replayable.
+  Available on the Go client via the typed `Collection.Operate` (dense
+  collections; named/MV have engine support with a typed client handle as a
+  follow-up). See
+  [updating a record in place](vector/filtering.md#updating-a-record-in-place).
+
+- **Malformed record payload values are now rejected at ingest.** Every entry
+  that stores a payload value of kind `record` — insert, insert-if-absent,
+  upsert, `set_payload`, `overwrite_payload`, and the bulk paths — now
+  validates the bytes decode as a well-formed `operate` record, not just that
+  they fit the size cap. A caller that hands in bytes no `operate` engine can
+  open now gets a 400 at write time instead of a payload that later poisons
+  that key's filter acceleration for the whole collection. Only a record
+  written by a version before this change can still be malformed; the
+  fail-closed indexing behaviour for that case is unchanged.
+
 - **New `-online-compaction` flag.** Opts every replicated mmap reject-writes
   shard into online relocating compaction, so a write/overwrite-heavy replicated
   shard reclaims dead ("ghost") bytes while the process runs instead of only at

--- a/docs/kv/overview.md
+++ b/docs/kv/overview.md
@@ -422,6 +422,14 @@ same stored bytes. See
 [record paths in filters](../vector/filtering.md#record-paths) for the path
 grammar, value mapping, and what a collection auto-indexes.
 
+The same `operate` op-list above also runs, unchanged, against a record held
+in a vector point's payload: `vector_operate` (and its `vector_named_operate`/
+`vector_mv_operate` twins) apply an op-list to the record under one payload
+key instead of one KV key, atomically and under the collection's write lock.
+See [updating a record in place](../vector/filtering.md#updating-a-record-in-place)
+for the call shape, what differs from a plain `operate` call, and a worked
+example.
+
 ## TTL semantics
 
 TTLs are absolute deadlines computed at write time. Expiry is enforced lazily on

--- a/docs/vector/filtering.md
+++ b/docs/vector/filtering.md
@@ -300,6 +300,109 @@ its SDK encoder, never by hand.
 - A positional field (`#N`) is always evaluated live, regardless of
   selectivity, per the indexing rule above.
 
+## Updating a record in place
+
+`vector_operate` runs the same
+[`operate` op-list](../kv/overview.md#atomic-multi-field-updates-operate) the
+KV store uses, but against the record held in one point's payload instead of
+a KV key: one atomic op-list, applied to one point's record, under the
+collection's write lock, in one apply. The op list, the paths into a record,
+the scalar types and the returns are **exactly** `operate`'s — this page does
+not repeat that grammar; see the KV page for the ops, types, `CHECK`/`SET`/
+`ADD`/table semantics, and the returned `OperateResult`.
+
+A call is named by four things: the **collection**, the point's **ID**, the
+**payload key** the record lives under, and the **op-list** (`*wire.OperateArgs`)
+to run. The Go typed client's [`Collection.Operate`](../api/go-client.md)
+also accepts an optional CAS precondition on the point's version, same as
+`SetPayload`.
+
+Two fields `operate` normally carries do not apply here and are **rejected**,
+not ignored:
+
+- The op-list's inner **key** must be empty. The target is already named once,
+  by `(collection, id, payloadKey)`; a caller who set it too would be a second,
+  silently-ignored source of truth for what the call touches.
+- **`ttlMode`/`ttl`** must stay at their zero values (`OperateTTLKeep`, `0`). A
+  point's TTL belongs to the point, set by `Upsert`/`Insert`/`Expire` — not to
+  a record living inside one of its payload values — so a caller who set a TTL
+  here expecting it to take effect would otherwise get silence.
+
+`create` still applies as it does for `operate`: `vector_operate` may create
+the record if the payload key is absent. `create = NONE` against a payload key
+that holds no record is an **error**, not a silent no-op — the caller declined
+to create one and there was none. A payload key that holds something other
+than a record (a plain string, number, or the reserved document-content key)
+is also an error: silently replacing a value the caller can still read through
+`get`/search would destroy data on a call the caller believes only touches a
+record.
+
+A stored record `vector_operate` cannot open fails the call and leaves the
+point exactly as it was — no partial mutation, no version bump. **From this
+release, every write that stores a record value is validated at ingest** (see
+[Record paths](#record-paths) above), so a malformed stored record can now
+only be one written by an earlier version, before that gate existed. The
+mutation path itself does not re-validate the bytes it produces on a
+successful op-list: they come from the same `operate` engine that already
+holds them well-formed by construction, and re-decoding them on every call
+would double the cost of a plain counter increment for a case that cannot
+arise from a well-formed input. A failed `CHECK` — the op-list's own
+conditional — leaves the record untouched: it bumps no version and writes no
+WAL record, exactly like a `CHECK`-failed `operate` against a KV key.
+
+A record's top-level fields are indexed the same way [Record paths](#record-paths)
+describes for any record-valued payload: a mutation reindexes the point in the
+same write-lock critical section that applies it, so a filtered search sees
+the new field values immediately — there is no separate reindex step to wait
+on. The record is still bound by the same 16 MiB storage cap every other
+record-writing entry point enforces.
+
+`vector_operate` is **refused while the collection is resharding** (a
+partitioned collection whose shard count is changing dual-writes every op to
+both the old and new shard generation; `set_payload`-style dual-writing is
+safe because storing the same payload twice is idempotent, but an op-list's
+`ADD`/`MUL`/`SHL` are not — the two copies could disagree by an arbitrary
+number of increments and the disagreement would survive cutover). The refusal
+is retryable after the reshard completes. It is a check against the local
+catalog, not a fence: a reshard that begins in the single dispatch between
+that check and the call's apply is not caught, so the refusal covers a
+reshard already in progress and races the instant one begins by one dispatch.
+
+```go
+schema := &wire.Schema{Version: 1, StoreNames: true, Fields: []wire.FieldDef{
+    {Name: "rc", Type: wire.OperateTypeU8},
+    {Name: "bc", Type: wire.OperateTypeU8},
+    {Name: "hist", Type: wire.OperateTypeU32},
+    {Name: "bal", Type: wire.OperateTypeI32},
+    {Name: "tag", Type: wire.OperateTypeBytes},
+    {Name: "b", Type: wire.OperateTypeTable, Table: &wire.TableDef{
+        KeyType: wire.OperateTypeU64,
+        Cols: []wire.ColumnDef{
+            {Name: "hi", Type: wire.OperateTypeU32},
+            {Name: "lo", Type: wire.OperateTypeU32},
+        },
+    }},
+}}
+
+args, err := client.NewOperate(nil).WithSchema(schema).
+    Add(client.F("rc"), 1).
+    Return(client.F("rc")).
+    Count(client.F("b")).
+    Args()
+if err != nil {
+    return err
+}
+found, res, err := posts.Operate(ctx, client.OperateRequest{
+    ID: 1, PayloadKey: "session", Args: args,
+})
+// found: false if the point is absent, tombstoned or expired (res is nil then)
+// res.Values[0]: the new "rc", res.Values[1]: the "b" table's row count
+```
+
+This mirrors `TestVectorOperateAgainstSchemaRecord` (`ops/vector_operate_test.go`):
+an `ADD` on a schema-mode `rc` field survives beside an untouched `b` table,
+and both are read back in the same round trip.
+
 ## Building filters from Python
 
 `rostam.filters` has helpers for the operators you reach for most:

--- a/docs/vector/filtering.md
+++ b/docs/vector/filtering.md
@@ -357,6 +357,31 @@ the new field values immediately — there is no separate reindex step to wait
 on. The record is still bound by the same 16 MiB storage cap every other
 record-writing entry point enforces.
 
+### Clocks and per-key deadlines
+
+The **only** clock any op consults is the applying transaction's stamp, exactly
+as for a KV [`operate`](../kv/overview.md#atomic-multi-field-updates-operate):
+never a wall clock. On an unreplicated or otherwise unstamped apply that stamp
+is `0`, so an unstamped `STAMP` writes `0` — the same caveat the KV page
+records, and with the same consequence for a `MIN_COL`/`MAX_COL` "LRU" column
+built on it.
+
+The payload key's own **per-key deadline** (set by `set_payload`'s `keyTTLMs`)
+is judged on the same terms. On a **stamped** apply a key whose deadline has
+passed reads as absent: the op-list starts a fresh record and the stale
+deadline is dropped. On an **unstamped** apply the deadline is not consulted at
+all — the record is mutated in place and its deadline is passed through
+unchanged.
+
+That asymmetry is deliberate. Every replica runs the op-list itself, so if an
+unstamped apply judged the deadline against its own wall clock, a replica past
+the deadline would create a fresh record while a replica short of it
+incremented the stored one, and the two would hold different bytes forever. A
+wall-clock read is only safe where it can move a deadline *value* (as
+`set_payload` does, at a bounded millisecond skew), not where it decides
+whether a record exists. The key remains invisible to reads until its deadline
+is refreshed either way.
+
 `vector_operate` is **refused while the collection is resharding** (a
 partitioned collection whose shard count is changing dual-writes every op to
 both the old and new shard generation; `set_payload`-style dual-writing is

--- a/docs/vector/filtering.md
+++ b/docs/vector/filtering.md
@@ -127,9 +127,10 @@ the slice if you need to keep or edit it.
 
 Every write that stores a record value is **validated at ingest** — insert,
 insert-if-absent, upsert, `set_payload`, `overwrite_payload` and the bulk
-paths alike. Bytes no operate engine could open are refused with a 400 before
-anything changes (`vector: record payload value is not a decodable operate
-record`), and so is a record above the 16 MiB storage cap. A mis-encoded `rec`
+paths alike. Bytes no operate engine could open are refused before
+anything changes — HTTP 400, gRPC `InvalidArgument`, or the binary protocol's
+remote error, carrying `vector: record payload value is not a decodable operate
+record` — and so is a record above the 16 MiB storage cap. A mis-encoded `rec`
 is therefore a rejected request, not a stored value that misbehaves later.
 
 ### Path grammar
@@ -359,12 +360,23 @@ record-writing entry point enforces.
 
 ### Clocks and per-key deadlines
 
-The **only** clock any op consults is the applying transaction's stamp, exactly
-as for a KV [`operate`](../kv/overview.md#atomic-multi-field-updates-operate):
-never a wall clock. On an unreplicated or otherwise unstamped apply that stamp
-is `0`, so an unstamped `STAMP` writes `0` — the same caveat the KV page
-records, and with the same consequence for a `MIN_COL`/`MAX_COL` "LRU" column
-built on it.
+The only clock the **op-list** consults is the applying transaction's stamp,
+exactly as for a KV
+[`operate`](../kv/overview.md#atomic-multi-field-updates-operate): `STAMP` and
+everything that reads it never see a wall clock. On an unreplicated or otherwise
+unstamped apply that stamp is `0`, so an unstamped `STAMP` writes `0` — the same
+caveat the KV page records, and with the same consequence for a
+`MIN_COL`/`MAX_COL` "LRU" column built on it.
+
+One gate outside the op-list is **not** covered by that rule, and it is worth
+knowing about: whether the POINT itself is still alive. On an unstamped apply
+that liveness check is judged against the node's wall clock, exactly as
+`set_payload`'s is, so near a point's own TTL expiry two replicas can disagree
+about whether the call applies at all. This is a pre-existing property of every
+unstamped write rather than something specific to `operate` — making record
+mutation disagree with its siblings about whether a point exists would be worse —
+and it goes away when leader apply stamps are enabled. The per-key deadline
+below, which decides the record's own content, IS covered.
 
 The payload key's own **per-key deadline** (set by `set_payload`'s `keyTTLMs`)
 is judged on the same terms. On a **stamped** apply a key whose deadline has
@@ -420,10 +432,16 @@ if err != nil {
 found, res, version, err := posts.Operate(ctx, client.OperateRequest{
     ID: 1, PayloadKey: "session", Args: args,
 })
-// found: false if the point is absent, tombstoned or expired (res is nil then)
+if err != nil {
+    return err
+}
+if !found {
+    return nil // the point is absent, tombstoned or expired; res is nil
+}
 // res.Values[0]: the new "rc", res.Values[1]: the "b" table's row count
 // version: the point's version AFTER the call — feed it to the next call's
-// ExpectedVersion to run a CAS loop without re-reading the point
+// ExpectedVersion to run a CAS loop without re-reading the point. A call that
+// failed with ErrVersionConflict returns 0, not the conflicting version.
 ```
 
 This mirrors `TestVectorOperateAgainstSchemaRecord` (`ops/vector_operate_test.go`):

--- a/docs/vector/filtering.md
+++ b/docs/vector/filtering.md
@@ -417,11 +417,13 @@ args, err := client.NewOperate(nil).WithSchema(schema).
 if err != nil {
     return err
 }
-found, res, err := posts.Operate(ctx, client.OperateRequest{
+found, res, version, err := posts.Operate(ctx, client.OperateRequest{
     ID: 1, PayloadKey: "session", Args: args,
 })
 // found: false if the point is absent, tombstoned or expired (res is nil then)
 // res.Values[0]: the new "rc", res.Values[1]: the "b" table's row count
+// version: the point's version AFTER the call — feed it to the next call's
+// ExpectedVersion to run a CAS loop without re-reading the point
 ```
 
 This mirrors `TestVectorOperateAgainstSchemaRecord` (`ops/vector_operate_test.go`):

--- a/docs/vector/filtering.md
+++ b/docs/vector/filtering.md
@@ -125,6 +125,13 @@ list-valued payload shares its slice. Read it, never write through it — mutati
 it changes the live record while the index still describes the old bytes. Copy
 the slice if you need to keep or edit it.
 
+Every write that stores a record value is **validated at ingest** — insert,
+insert-if-absent, upsert, `set_payload`, `overwrite_payload` and the bulk
+paths alike. Bytes no operate engine could open are refused with a 400 before
+anything changes (`vector: record payload value is not a decodable operate
+record`), and so is a record above the 16 MiB storage cap. A mis-encoded `rec`
+is therefore a rejected request, not a stored value that misbehaves later.
+
 ### Path grammar
 
 A filter's `field` string is tried as an exact payload key first. Only when
@@ -261,9 +268,14 @@ the index for **every point**, for as long as the malformed record survives:
 filtered search and delete/scroll selection fall back to evaluating the live
 record, which stays correct. The key regains acceleration automatically once
 the malformed point's payload is repaired, cleared, or the point itself is
-reclaimed; it is a tracked state, not a one-way trip. Since a hand-crafted
-byte string can trigger this, produce records only through `operate` or its
-SDK encoder, never by hand.
+reclaimed; it is a tracked state, not a one-way trip.
+
+Ingest validation (above) means a write can no longer put the collection into
+this state: every entry that stores a record value refuses one that cannot be
+decoded. The fail-closed machinery remains as the backstop for records written
+before that gate existed and for anything restored from an older snapshot or
+log, which replay must never refuse. Produce records only through `operate` or
+its SDK encoder, never by hand.
 
 ### Known limits
 

--- a/embedded.go
+++ b/embedded.go
@@ -19,6 +19,7 @@ import (
 	"github.com/rostamlabs/rostam/cache"
 	"github.com/rostamlabs/rostam/cluster"
 	"github.com/rostamlabs/rostam/ops"
+	"github.com/rostamlabs/rostam/sdk/wire"
 	"github.com/rostamlabs/rostam/shard"
 	"github.com/rostamlabs/rostam/vector"
 )
@@ -1605,6 +1606,99 @@ func (e *embedded) VectorClearPayload(_ context.Context, collection string, id u
 		return false, err
 	}
 	return ops.DecodePayloadResult(body)
+}
+
+// ErrOperateDuringReshard is returned by the three Store operate methods while a
+// reshard is dual-writing the target collection. It is RETRYABLE: the caller
+// should retry after cutover, when the collection has a single live generation
+// again.
+//
+// The refusal exists because operate is NOT idempotent. applyDualWrite sends the
+// SAME op to both the live and the target generation, which is safe for
+// set_payload (storing a payload twice stores the same payload) and is exactly
+// wrong for an op-list whose ADD/MUL/SHL accumulate and whose CHECK is evaluated
+// against whatever record each generation happens to hold. The reshard backfill
+// copies points between generations and can land before, between or after the two
+// legs, so the two copies can disagree by an arbitrary number of increments — and
+// the disagreement survives cutover, silently, forever.
+//
+// Refusing costs the caller the use of vector_operate on ONE collection for the
+// minutes a reshard runs, visibly. Dual-writing would cost a permanently
+// double-counted counter, invisibly.
+var ErrOperateDuringReshard = errors.New("rostam: vector_operate is refused while a reshard is dual-writing; retry after cutover")
+
+// vectorOperate is the shared body of VectorOperate / VectorNamedOperate /
+// VectorMVOperate: the three families differ only in the op name they dispatch,
+// so the alias resolution, the reshard refusal, the CAS threading and the
+// write-consistency barrier live here once rather than in three copies that can
+// drift apart (the same reason the set_payload family shares applyDualWrite).
+//
+// Two things it does that the set_payload family does NOT:
+//
+//   - It REFUSES rather than dual-writes when dualTargets reports a reshard. See
+//     ErrOperateDuringReshard.
+//   - It threads the CAS precondition into the ARGS. networkedStore and
+//     directStore's set_payload siblings drop the precondition on the floor
+//     (client.go's non-CAS encoder, direct.go's `_ ...WriteOpts`); every operate
+//     path honors it.
+//
+// The refusal is a CHECK, not a fence: dualTargets reads the LOCAL catalog, so a
+// reshard that begins between that read and the Raft apply lets one operate land
+// on the live generation only, and if the backfill already copied that point the
+// increment is lost at cutover. The window is one op's dispatch latency at the
+// instant a reshard starts — the same TOCTOU class set_payload's dual-write
+// already lives with. Closing it needs a catalog-epoch fence on the apply path
+// and is a recorded follow-up; this closes the STEADY-STATE reshard, which is the
+// part that lasts minutes rather than microseconds.
+func (e *embedded) vectorOperate(opName, collection string, id uint64, payloadKey string,
+	a *wire.OperateArgs, opts []WriteOpts,
+) (bool, *wire.OperateResult, error) {
+	collection = e.resolveAlias(collection)
+	live, _, dual := e.dualTargets(collection, id)
+	if dual {
+		return false, nil, fmt.Errorf("%w: collection %q", ErrOperateDuringReshard, collection)
+	}
+	if live != "" {
+		collection = live
+	}
+	wo := firstWriteOpts(opts)
+	exp, hasExp := wo.expectedVersion()
+	args, err := wire.EncodeVectorOperateArgs(collection, id, payloadKey, a, exp, hasExp)
+	if err != nil {
+		return false, nil, err
+	}
+	body, err := e.Call(context.Background(), opName, args)
+	if err != nil {
+		return false, nil, err
+	}
+	if wo.wcActive() {
+		if err := e.barrierPhys(collection, wo); err != nil {
+			return false, nil, err
+		}
+	}
+	return ops.DecodeVectorOperateResult(body)
+}
+
+// VectorOperate applies an operate op-list to the record under payloadKey in the
+// point's payload, on the live gen's owning physical partition. found=false (the
+// decoded flag) for an absent point — not an error.
+//
+// Unlike VectorSetPayload it does NOT dual-write during a reshard; see
+// vectorOperate and ErrOperateDuringReshard.
+func (e *embedded) VectorOperate(_ context.Context, collection string, id uint64, payloadKey string, a *wire.OperateArgs, opts ...WriteOpts) (bool, *wire.OperateResult, error) {
+	return e.vectorOperate("vector_operate", collection, id, payloadKey, a, opts)
+}
+
+// VectorNamedOperate is VectorOperate against a named-vector point's shared
+// payload. See vectorOperate.
+func (e *embedded) VectorNamedOperate(_ context.Context, name string, id uint64, payloadKey string, a *wire.OperateArgs, opts ...WriteOpts) (bool, *wire.OperateResult, error) {
+	return e.vectorOperate("vector_named_operate", name, id, payloadKey, a, opts)
+}
+
+// VectorMVOperate is VectorOperate against a multi-vector document's payload.
+// See vectorOperate.
+func (e *embedded) VectorMVOperate(_ context.Context, name string, docID uint64, payloadKey string, a *wire.OperateArgs, opts ...WriteOpts) (bool, *wire.OperateResult, error) {
+	return e.vectorOperate("vector_mv_operate", name, docID, payloadKey, a, opts)
 }
 
 func (e *embedded) CreateCollection(_ context.Context, name string, cfg VectorConfig) error {

--- a/embedded.go
+++ b/embedded.go
@@ -1625,7 +1625,11 @@ func (e *embedded) VectorClearPayload(_ context.Context, collection string, id u
 // Refusing costs the caller the use of vector_operate on ONE collection for the
 // minutes a reshard runs, visibly. Dual-writing would cost a permanently
 // double-counted counter, invisibly.
-var ErrOperateDuringReshard = errors.New("rostam: vector_operate is refused while a reshard is dual-writing; retry after cutover")
+// The sentinel itself is DECLARED in ops so server, httpapi and grpcapi — none
+// of which can import this package without a layering cycle — can classify the
+// refusal as retryable by identity rather than by substring. This name stays the
+// one callers of the root store use; it is the same error value.
+var ErrOperateDuringReshard = ops.ErrOperateDuringReshard
 
 // vectorOperate is the shared body of VectorOperate / VectorNamedOperate /
 // VectorMVOperate: the three families differ only in the op name they dispatch,
@@ -1656,7 +1660,10 @@ func (e *embedded) vectorOperate(opName, collection string, id uint64, payloadKe
 	collection = e.resolveAlias(collection)
 	live, _, dual := e.dualTargets(collection, id)
 	if dual {
-		return false, nil, fmt.Errorf("%w: collection %q", ErrOperateDuringReshard, collection)
+		// ops.OperateDuringReshardErr is the one producer of the detailed form:
+		// the shape the transport classifiers anchor on, with the caller's
+		// collection name bounded.
+		return false, nil, ops.OperateDuringReshardErr(collection)
 	}
 	if live != "" {
 		collection = live

--- a/embedded.go
+++ b/embedded.go
@@ -1656,14 +1656,14 @@ var ErrOperateDuringReshard = ops.ErrOperateDuringReshard
 // part that lasts minutes rather than microseconds.
 func (e *embedded) vectorOperate(opName, collection string, id uint64, payloadKey string,
 	a *wire.OperateArgs, opts []WriteOpts,
-) (bool, *wire.OperateResult, error) {
+) (bool, *wire.OperateResult, uint64, error) {
 	collection = e.resolveAlias(collection)
 	live, _, dual := e.dualTargets(collection, id)
 	if dual {
 		// ops.OperateDuringReshardErr is the one producer of the detailed form:
 		// the shape the transport classifiers anchor on, with the caller's
 		// collection name bounded.
-		return false, nil, ops.OperateDuringReshardErr(collection)
+		return false, nil, 0, ops.OperateDuringReshardErr(collection)
 	}
 	if live != "" {
 		collection = live
@@ -1672,15 +1672,15 @@ func (e *embedded) vectorOperate(opName, collection string, id uint64, payloadKe
 	exp, hasExp := wo.expectedVersion()
 	args, err := wire.EncodeVectorOperateArgs(collection, id, payloadKey, a, exp, hasExp)
 	if err != nil {
-		return false, nil, err
+		return false, nil, 0, err
 	}
 	body, err := e.Call(context.Background(), opName, args)
 	if err != nil {
-		return false, nil, err
+		return false, nil, 0, err
 	}
 	if wo.wcActive() {
 		if err := e.barrierPhys(collection, wo); err != nil {
-			return false, nil, err
+			return false, nil, 0, err
 		}
 	}
 	return ops.DecodeVectorOperateResult(body)
@@ -1692,19 +1692,19 @@ func (e *embedded) vectorOperate(opName, collection string, id uint64, payloadKe
 //
 // Unlike VectorSetPayload it does NOT dual-write during a reshard; see
 // vectorOperate and ErrOperateDuringReshard.
-func (e *embedded) VectorOperate(_ context.Context, collection string, id uint64, payloadKey string, a *wire.OperateArgs, opts ...WriteOpts) (bool, *wire.OperateResult, error) {
+func (e *embedded) VectorOperate(_ context.Context, collection string, id uint64, payloadKey string, a *wire.OperateArgs, opts ...WriteOpts) (bool, *wire.OperateResult, uint64, error) {
 	return e.vectorOperate("vector_operate", collection, id, payloadKey, a, opts)
 }
 
 // VectorNamedOperate is VectorOperate against a named-vector point's shared
 // payload. See vectorOperate.
-func (e *embedded) VectorNamedOperate(_ context.Context, name string, id uint64, payloadKey string, a *wire.OperateArgs, opts ...WriteOpts) (bool, *wire.OperateResult, error) {
+func (e *embedded) VectorNamedOperate(_ context.Context, name string, id uint64, payloadKey string, a *wire.OperateArgs, opts ...WriteOpts) (bool, *wire.OperateResult, uint64, error) {
 	return e.vectorOperate("vector_named_operate", name, id, payloadKey, a, opts)
 }
 
 // VectorMVOperate is VectorOperate against a multi-vector document's payload.
 // See vectorOperate.
-func (e *embedded) VectorMVOperate(_ context.Context, name string, docID uint64, payloadKey string, a *wire.OperateArgs, opts ...WriteOpts) (bool, *wire.OperateResult, error) {
+func (e *embedded) VectorMVOperate(_ context.Context, name string, docID uint64, payloadKey string, a *wire.OperateArgs, opts ...WriteOpts) (bool, *wire.OperateResult, uint64, error) {
 	return e.vectorOperate("vector_mv_operate", name, docID, payloadKey, a, opts)
 }
 

--- a/embedded.go
+++ b/embedded.go
@@ -1639,33 +1639,60 @@ var ErrOperateDuringReshard = ops.ErrOperateDuringReshard
 //
 // Two things it does that the set_payload family does NOT:
 //
-//   - It REFUSES rather than dual-writes when dualTargets reports a reshard. See
-//     ErrOperateDuringReshard.
+//   - It REFUSES rather than dual-writes for the whole time the catalog reports
+//     a reshard in progress. See ErrOperateDuringReshard.
 //   - It threads the CAS precondition into the ARGS. networkedStore and
 //     directStore's set_payload siblings drop the precondition on the floor
 //     (client.go's non-CAS encoder, direct.go's `_ ...WriteOpts`); every operate
 //     path honors it.
 //
-// The refusal is a CHECK, not a fence: dualTargets reads the LOCAL catalog, so a
-// reshard that begins between that read and the Raft apply lets one operate land
-// on the live generation only, and if the backfill already copied that point the
+// The refusal is a CHECK, not a fence: it reads the LOCAL catalog, so a reshard
+// that begins between that read and the Raft apply lets one operate land on the
+// live generation only, and if the backfill already copied that point the
 // increment is lost at cutover. The window is one op's dispatch latency at the
 // instant a reshard starts — the same TOCTOU class set_payload's dual-write
-// already lives with. Closing it needs a catalog-epoch fence on the apply path
-// and is a recorded follow-up; this closes the STEADY-STATE reshard, which is the
-// part that lasts minutes rather than microseconds.
+// already lives with.
+//
+// Closing it is NOT a matter of carrying the observed generation in the args and
+// re-checking inside the apply, which is the obvious-looking fix. The reshard
+// state lives in the META Raft log (cluster.Node's meta FSM) while the operate
+// entry travels in its shard group's OWN log, and two independent logs have no
+// defined relative order: replica A can have applied the reshard-begin entry
+// when it applies operate entry N while replica B has not, so an apply-time
+// check of that state would accept on one replica and reject on another —
+// permanent divergence, strictly worse than the lost increment. The only
+// deterministic closure is a marker entry proposed into each affected
+// partition's own shard log at reshard phase 1, which is a recorded follow-up
+// (it would close set_payload's identical window too). This closes the
+// STEADY-STATE reshard, which is the part that lasts minutes rather than
+// microseconds.
 func (e *embedded) vectorOperate(opName, collection string, id uint64, payloadKey string,
 	a *wire.OperateArgs, opts []WriteOpts,
 ) (bool, *wire.OperateResult, uint64, error) {
 	collection = e.resolveAlias(collection)
-	live, _, dual := e.dualTargets(collection, id)
-	if dual {
+	// The gate is the reshard STATUS, not dualTargets' `dual` answer. dual is a
+	// ROUTING decision and it collapses to false in two situations where the
+	// two generations still both matter:
+	//
+	//   - a reshard whose state carries no old-gen pin (a pre-upgrade meta
+	//     entry, dualTargets' OldP <= 0 branch) reports dual=false the moment
+	//     the catalog flips to the new gen, while meta-followers that have not
+	//     applied the flip still route READS to the old gen — a non-idempotent
+	//     op-list applied to the new gen only leaves the two holding different
+	//     record bytes until the old gen is dropped;
+	//   - the degenerate case where an id happens to hash to the same partition
+	//     in both generations, which says nothing about the backfill still
+	//     copying every OTHER point.
+	//
+	// Refusing for the whole reshard is the conservative reading and matches
+	// what the error says: retry after cutover.
+	if st, on := e.catalog.ReshardState(collection); on && st.Status == 1 {
 		// ops.OperateDuringReshardErr is the one producer of the detailed form:
 		// the shape the transport classifiers anchor on, with the caller's
 		// collection name bounded.
 		return false, nil, 0, ops.OperateDuringReshardErr(collection)
 	}
-	if live != "" {
+	if live, _, _ := e.dualTargets(collection, id); live != "" {
 		collection = live
 	}
 	wo := firstWriteOpts(opts)
@@ -1676,7 +1703,9 @@ func (e *embedded) vectorOperate(opName, collection string, id uint64, payloadKe
 	}
 	body, err := e.Call(context.Background(), opName, args)
 	if err != nil {
-		return false, nil, 0, err
+		// A replicated apply loses the sentinel's identity across the Raft
+		// boundary; mapVectorOperateErr restores the one the contract names.
+		return false, nil, 0, mapVectorOperateErr(err)
 	}
 	if wo.wcActive() {
 		if err := e.barrierPhys(collection, wo); err != nil {

--- a/errors.go
+++ b/errors.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/rostamlabs/rostam/cache"
 	"github.com/rostamlabs/rostam/client"
+	"github.com/rostamlabs/rostam/ops"
 	"github.com/rostamlabs/rostam/shard"
 )
 
@@ -38,4 +39,44 @@ func matchesNotLeader(err error) bool {
 	}
 	var nle *shard.NotLeaderError
 	return errors.As(err, &nle)
+}
+
+// mapVectorOperateErr normalizes the record-absent outcome of a vector_operate
+// to the ONE sentinel Store.VectorOperate documents, ops.ErrVectorRecordAbsent,
+// so `errors.Is(err, ops.ErrVectorRecordAbsent)` answers the same on every
+// backend. It is applied by all three Store implementations' shared operate
+// body and by nothing else.
+//
+// WHAT IT NORMALIZES, AND WHY THE THREE BACKENDS DISAGREED WITHOUT IT. The
+// engine raises the sentinel in one place (ops.vectorOperateMutator), but only
+// the direct path hands it back intact:
+//
+//   - DIRECT: the handler's error is returned in-process, identity intact —
+//     already the sentinel, and this function leaves it alone.
+//   - EMBEDDED, REPLICATED: an operate handler runs INSIDE the FSM apply, so
+//     shard.decodePBResult rebuilds the error with errors.New across the Raft
+//     boundary and errors.Is stops matching. The exact-form matcher
+//     ops.IsVectorRecordAbsentMessage is what recognises it — never a
+//     strings.Contains, which would also match an internal fault that merely
+//     mentions the sentinel text.
+//   - NETWORKED: server.mapResult answers StatusNotFound for it (deliberately:
+//     it is the vector twin of the KV operate's not-found, and the status is
+//     what carries the meaning), which the client turns into client.ErrNotFound
+//     and mapErr into the root ErrNotFound. Not-found is the ONLY thing that
+//     status can mean for these three ops — an absent POINT is the found=false
+//     FLAG, not an error — so mapping it back is unambiguous.
+//
+// The caller-visible contract is therefore the sentinel on every transport, and
+// the root ErrNotFound is no longer part of vector_operate's surface.
+func mapVectorOperateErr(err error) error {
+	if err == nil {
+		return nil
+	}
+	if errors.Is(err, ops.ErrVectorRecordAbsent) || ops.IsVectorRecordAbsentMessage(err.Error()) {
+		return ops.ErrVectorRecordAbsent
+	}
+	if errors.Is(err, ErrNotFound) || errors.Is(err, client.ErrNotFound) || errors.Is(err, cache.ErrNotFound) {
+		return ops.ErrVectorRecordAbsent
+	}
+	return err
 }

--- a/fanout_dispatcher.go
+++ b/fanout_dispatcher.go
@@ -992,7 +992,7 @@ func (f *fanoutDispatcher) fanMVOperate(name string, args []byte, r fanRoute) ([
 }
 
 // operateFn is the shape the three embedded operate methods share.
-type operateFn func(ctx context.Context, coll string, id uint64, payloadKey string, a *wire.OperateArgs, opts ...WriteOpts) (bool, *wire.OperateResult, error)
+type operateFn func(ctx context.Context, coll string, id uint64, payloadKey string, a *wire.OperateArgs, opts ...WriteOpts) (bool, *wire.OperateResult, uint64, error)
 
 // fanOperateVia is the shared body of the three operate fan handlers.
 func (f *fanoutDispatcher) fanOperateVia(name string, args []byte, r fanRoute, call operateFn) ([]byte, error) {
@@ -1008,11 +1008,11 @@ func (f *fanoutDispatcher) fanOperateVia(name string, args []byte, r fanRoute, c
 		v := exp
 		wo.ExpectedVersion = &v // WriteOpts carries the precondition as a *uint64
 	}
-	found, res, err := call(context.Background(), coll, id, pk, a, wo)
+	found, res, version, err := call(context.Background(), coll, id, pk, a, wo)
 	if err != nil {
 		return nil, err
 	}
-	return ops.EncodeVectorOperateResult(found, res)
+	return ops.EncodeVectorOperateResult(found, res, version)
 }
 
 // fanSetPayload merges a payload patch on the owning physical partition. Like

--- a/fanout_dispatcher.go
+++ b/fanout_dispatcher.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/rostamlabs/rostam/cluster"
 	"github.com/rostamlabs/rostam/ops"
+	"github.com/rostamlabs/rostam/sdk/wire"
 )
 
 // innerDispatcher is the minimal surface the decorator wraps. Both *cluster.Node
@@ -190,7 +191,7 @@ var dataPlaneAliasOps = map[string]struct{}{
 	"vector_insert": {}, "vector_upsert": {}, "vector_insert_if_absent": {},
 	"vector_delete": {}, "vector_exists": {}, "vector_get": {}, "vector_get_batch": {},
 	"vector_set_payload": {}, "vector_overwrite_payload": {},
-	"vector_delete_payload_keys": {}, "vector_clear_payload": {},
+	"vector_delete_payload_keys": {}, "vector_clear_payload": {}, "vector_operate": {},
 	"vector_mv_add": {}, "vector_mv_delete": {}, "vector_mv_search": {},
 	"vector_mv_hybrid_search": {},
 	"vector_mv_query":         {},
@@ -198,7 +199,7 @@ var dataPlaneAliasOps = map[string]struct{}{
 	"vector_mv_add_if_absent": {}, "vector_mv_exists": {}, "vector_mv_get": {},
 	"vector_mv_get_batch": {}, "vector_mv_scroll": {},
 	"vector_mv_set_payload": {}, "vector_mv_overwrite_payload": {},
-	"vector_mv_delete_payload_keys": {}, "vector_mv_clear_payload": {},
+	"vector_mv_delete_payload_keys": {}, "vector_mv_clear_payload": {}, "vector_mv_operate": {},
 	"vector_named_insert": {}, "vector_named_delete": {}, "vector_named_search": {},
 	"vector_named_sparse_search": {},
 	"vector_named_hybrid_search": {},
@@ -206,7 +207,7 @@ var dataPlaneAliasOps = map[string]struct{}{
 	"vector_named_search_docs":   {}, "vector_named_scroll": {}, "vector_named_get": {},
 	"vector_named_get_batch":   {},
 	"vector_named_set_payload": {}, "vector_named_overwrite_payload": {},
-	"vector_named_delete_payload_keys": {}, "vector_named_clear_payload": {},
+	"vector_named_delete_payload_keys": {}, "vector_named_clear_payload": {}, "vector_named_operate": {},
 }
 
 // Call routes a single op. Known read ops on a partitioned collection fan out
@@ -259,6 +260,8 @@ func (f *fanoutDispatcher) Call(name string, args []byte) ([]byte, error) {
 		return f.fanDeletePayloadKeys(name, args, r)
 	case "vector_clear_payload":
 		return f.fanClearPayload(name, args, r)
+	case "vector_operate":
+		return f.fanOperate(name, args, r)
 	case "vector_create_collection":
 		return f.fanCreateCollection(name, args, r)
 	case "vector_drop_collection":
@@ -281,6 +284,8 @@ func (f *fanoutDispatcher) Call(name string, args []byte) ([]byte, error) {
 		return f.fanMVDeletePayloadKeys(name, args, r)
 	case "vector_mv_clear_payload":
 		return f.fanMVClearPayload(name, args, r)
+	case "vector_mv_operate":
+		return f.fanMVOperate(name, args, r)
 	case "vector_mv_search":
 		return f.fanMVSearch(name, args, r)
 	case "vector_mv_scroll":
@@ -305,6 +310,8 @@ func (f *fanoutDispatcher) Call(name string, args []byte) ([]byte, error) {
 		return f.fanNamedDeletePayloadKeys(name, args, r)
 	case "vector_named_clear_payload":
 		return f.fanNamedClearPayload(name, args, r)
+	case "vector_named_operate":
+		return f.fanNamedOperate(name, args, r)
 	case "vector_named_search":
 		return f.fanNamedSearch(name, args, r)
 	case "vector_named_sparse_search":
@@ -952,6 +959,60 @@ func (f *fanoutDispatcher) fanGetBatch(name string, args []byte, r fanRoute) ([]
 		rows = append(rows, ops.GetBatchRow{ID: id, Found: false})
 	}
 	return ops.EncodeVectorGetBatchResult(rows), nil
+}
+
+// fanOperate applies an operate op-list to a record inside a point's payload on
+// the owning physical partition. It is the fan-out row for all three families:
+// one wire shape (EncodeVectorOperateArgs), one decoder, and the op NAME picks
+// which embedded method runs — so the three handlers below differ only in that
+// call and cannot drift apart in their CAS handling.
+//
+// The CAS precondition is REBUILT into a WriteOpts and handed to the embedded
+// method, which re-encodes it into the physical-partition args. fanSetPayload
+// decodes with ops.DecodeSetPayloadArgsOpts, the NON-CAS decoder, so a
+// partitioned set_payload silently loses the guard between the client and the
+// partition. Nothing else in this file can restore it once it is dropped here,
+// which is why the decode is the CAS-carrying one.
+//
+// It cannot recurse: resolveRoute short-circuits names containing '#'/'@' to
+// partitioned=false, and the embedded method substitutes the physical partition
+// name before its own Call.
+func (f *fanoutDispatcher) fanOperate(name string, args []byte, r fanRoute) ([]byte, error) {
+	return f.fanOperateVia(name, args, r, f.e.VectorOperate)
+}
+
+// fanNamedOperate is fanOperate for the named family. See fanOperate.
+func (f *fanoutDispatcher) fanNamedOperate(name string, args []byte, r fanRoute) ([]byte, error) {
+	return f.fanOperateVia(name, args, r, f.e.VectorNamedOperate)
+}
+
+// fanMVOperate is fanOperate for the multi-vector family. See fanOperate.
+func (f *fanoutDispatcher) fanMVOperate(name string, args []byte, r fanRoute) ([]byte, error) {
+	return f.fanOperateVia(name, args, r, f.e.VectorMVOperate)
+}
+
+// operateFn is the shape the three embedded operate methods share.
+type operateFn func(ctx context.Context, coll string, id uint64, payloadKey string, a *wire.OperateArgs, opts ...WriteOpts) (bool, *wire.OperateResult, error)
+
+// fanOperateVia is the shared body of the three operate fan handlers.
+func (f *fanoutDispatcher) fanOperateVia(name string, args []byte, r fanRoute, call operateFn) ([]byte, error) {
+	if !r.partitioned {
+		return f.inner.Call(name, args)
+	}
+	coll, id, pk, a, exp, hasExp, err := ops.DecodeVectorOperateArgs(args)
+	if err != nil {
+		return nil, err
+	}
+	var wo WriteOpts
+	if hasExp {
+		v := exp
+		wo.ExpectedVersion = &v // WriteOpts carries the precondition as a *uint64
+	}
+	found, res, err := call(context.Background(), coll, id, pk, a, wo)
+	if err != nil {
+		return nil, err
+	}
+	return ops.EncodeVectorOperateResult(found, res)
 }
 
 // fanSetPayload merges a payload patch on the owning physical partition. Like

--- a/grpcapi/error_findings_test.go
+++ b/grpcapi/error_findings_test.go
@@ -10,6 +10,7 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
+	"github.com/rostamlabs/rostam/ops"
 	"github.com/rostamlabs/rostam/vector"
 )
 
@@ -111,5 +112,65 @@ func TestGrpcErrorRecordTooLarge(t *testing.T) {
 		if got := status.Code(grpcError(tc.err)); got != codes.Internal {
 			t.Errorf("%s: grpcError = %v, want Internal", tc.name, got)
 		}
+	}
+}
+
+// TestGrpcErrorVectorRecordMalformedAndPayloadKeyNotRecord pins the gRPC
+// transport's classification of vector_operate's two ingest/shape refusals —
+// vector.ErrRecordMalformed and vector.ErrPayloadKeyNotRecord — as
+// InvalidArgument, mirroring server.clientFacingErr / httpapi.statusForError's
+// 400 bucket for the same sentinels (PR #102 found these unclassified here,
+// falling through to codes.Internal). vector.ErrRecordTooLarge shares the
+// bucket and is pinned by TestGrpcErrorRecordTooLarge above.
+//
+// Three arms per error, like server.TestClientFacingErrMalformedRecord /
+// httpapi.TestStatusForErrorMalformedRecord: sentinel, wrapped, and
+// stringified across the Raft boundary — shard.decodePBResult rebuilds op
+// errors with errors.New across replication, so errors.Is alone loses the
+// sentinel there and grpcError's string fallback is what keeps this
+// InvalidArgument instead of a redacted Internal.
+func TestGrpcErrorVectorRecordMalformedAndPayloadKeyNotRecord(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+	}{
+		{"malformed-sentinel", vector.ErrRecordMalformed},
+		{"malformed-wrapped", fmt.Errorf("%w: payload key %q: bad", vector.ErrRecordMalformed, "session")},
+		{"malformed-stringified", errors.New("apply: " + vector.ErrRecordMalformed.Error())},
+		{"not-record-sentinel", vector.ErrPayloadKeyNotRecord},
+		{"not-record-wrapped", fmt.Errorf("%w: payload key %q holds a value of kind %d", vector.ErrPayloadKeyNotRecord, "country", 2)},
+		{"not-record-stringified", errors.New("apply: " + vector.ErrPayloadKeyNotRecord.Error())},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := status.Code(grpcError(tc.err)); got != codes.InvalidArgument {
+				t.Errorf("grpcError(%v) = %v, want InvalidArgument", tc.err, got)
+			}
+		})
+	}
+}
+
+// TestGrpcErrorVectorRecordAbsentIsNotFound pins vector_operate's create=NONE
+// refusal (ops.ErrVectorRecordAbsent) as NotFound over gRPC, the same status
+// server.mapResult (StatusNotFound) and httpapi.statusForError (404) answer
+// for the identical signal — every transport tells the caller the same thing
+// for a record that simply is not there.
+//
+// Three arms, for the same clustered-apply stringification reason as above.
+func TestGrpcErrorVectorRecordAbsentIsNotFound(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+	}{
+		{"sentinel", ops.ErrVectorRecordAbsent},
+		{"wrapped", fmt.Errorf("shard 3: %w", ops.ErrVectorRecordAbsent)},
+		{"stringified", errors.New("apply: " + ops.ErrVectorRecordAbsent.Error())},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := status.Code(grpcError(tc.err)); got != codes.NotFound {
+				t.Errorf("grpcError(%v) = %v, want NotFound", tc.err, got)
+			}
+		})
 	}
 }

--- a/grpcapi/error_findings_test.go
+++ b/grpcapi/error_findings_test.go
@@ -115,6 +115,20 @@ func TestGrpcErrorRecordTooLarge(t *testing.T) {
 	}
 }
 
+// errRealMalformedSingle, errRealMalformedBulk and errRealNotRecordDetailed reproduce
+// the EXACT shapes checkRecordValues / checkRecordValuesAll (ErrRecordMalformed)
+// and currentRecordValue (ErrPayloadKeyNotRecord) actually produce in
+// production — see vector.IsRecordMalformedMessage / IsPayloadKeyNotRecordMessage
+// for the format strings these mirror. grpcapi cannot call those unexported
+// vector-package producers directly, so the shapes are reproduced by hand;
+// vector's own TestIsRecordMalformedMessage / TestIsPayloadKeyNotRecordMessage
+// pin them against the real producers.
+var (
+	errRealMalformedSingle   = fmt.Errorf("%w: payload key %q: %s", vector.ErrRecordMalformed, "session", "record: malformed record: wire: args too short")
+	errRealMalformedBulk     = fmt.Errorf("payload %d: %w", 7, errRealMalformedSingle)
+	errRealNotRecordDetailed = fmt.Errorf("%w: payload key %q holds a value of kind %d", vector.ErrPayloadKeyNotRecord, "country", 2)
+)
+
 // TestGrpcErrorVectorRecordMalformedAndPayloadKeyNotRecord pins the gRPC
 // transport's classification of vector_operate's two ingest/shape refusals —
 // vector.ErrRecordMalformed and vector.ErrPayloadKeyNotRecord — as
@@ -123,28 +137,51 @@ func TestGrpcErrorRecordTooLarge(t *testing.T) {
 // falling through to codes.Internal). vector.ErrRecordTooLarge shares the
 // bucket and is pinned by TestGrpcErrorRecordTooLarge above.
 //
-// Three arms per error, like server.TestClientFacingErrMalformedRecord /
-// httpapi.TestStatusForErrorMalformedRecord: sentinel, wrapped, and
-// stringified across the Raft boundary — shard.decodePBResult rebuilds op
-// errors with errors.New across replication, so errors.Is alone loses the
-// sentinel there and grpcError's string fallback is what keeps this
-// InvalidArgument instead of a redacted Internal.
+// Per error: the bare sentinel (errIs), the real %w-wrapped shape (matched by
+// errIs regardless of exact text — identity survives an in-process %w wrap),
+// and that same shape stringified across the Raft boundary (matched only by
+// the message-shape matcher, since shard.decodePBResult rebuilds a replicated
+// op error with errors.New and errors.Is stops matching there).
 func TestGrpcErrorVectorRecordMalformedAndPayloadKeyNotRecord(t *testing.T) {
 	cases := []struct {
 		name string
 		err  error
 	}{
 		{"malformed-sentinel", vector.ErrRecordMalformed},
-		{"malformed-wrapped", fmt.Errorf("%w: payload key %q: bad", vector.ErrRecordMalformed, "session")},
-		{"malformed-stringified", errors.New("apply: " + vector.ErrRecordMalformed.Error())},
+		{"malformed-wrapped, real single-payload shape", errRealMalformedSingle},
+		{"malformed-wrapped, real bulk shape", errRealMalformedBulk},
+		{"malformed-stringified across replication, real single-payload shape", errors.New(errRealMalformedSingle.Error())},
+		{"malformed-stringified across replication, real bulk shape", errors.New(errRealMalformedBulk.Error())},
 		{"not-record-sentinel", vector.ErrPayloadKeyNotRecord},
-		{"not-record-wrapped", fmt.Errorf("%w: payload key %q holds a value of kind %d", vector.ErrPayloadKeyNotRecord, "country", 2)},
-		{"not-record-stringified", errors.New("apply: " + vector.ErrPayloadKeyNotRecord.Error())},
+		{"not-record-wrapped, real detailed shape", errRealNotRecordDetailed},
+		{"not-record-stringified across replication, real detailed shape", errors.New(errRealNotRecordDetailed.Error())},
+		{"not-record-stringified across replication, bare shape", errors.New(vector.ErrPayloadKeyNotRecord.Error())},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			if got := status.Code(grpcError(tc.err)); got != codes.InvalidArgument {
 				t.Errorf("grpcError(%v) = %v, want InvalidArgument", tc.err, got)
+			}
+		})
+	}
+	// Negative controls: an unrelated internal fault must still be Internal,
+	// including one that merely CONTAINS the sentinel text inside an unrelated
+	// wrapper — the exact redaction bypass a bare strings.Contains classifier
+	// reintroduces (it would leak the WAL path below to the caller). Before this
+	// fix these two cases were misclassified InvalidArgument.
+	negatives := []struct {
+		name string
+		err  error
+	}{
+		{"unrelated fault wrapping ErrRecordMalformed (%v, no %w identity)",
+			fmt.Errorf("wal append failed at /var/lib/rostam/x: %v", vector.ErrRecordMalformed)},
+		{"unrelated fault wrapping ErrPayloadKeyNotRecord (%v, no %w identity)",
+			fmt.Errorf("wal append failed at /var/lib/rostam/x: %v", vector.ErrPayloadKeyNotRecord)},
+	}
+	for _, tc := range negatives {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := status.Code(grpcError(tc.err)); got != codes.Internal {
+				t.Errorf("grpcError(%v) = %v, want Internal", tc.err, got)
 			}
 		})
 	}
@@ -156,15 +193,21 @@ func TestGrpcErrorVectorRecordMalformedAndPayloadKeyNotRecord(t *testing.T) {
 // for the identical signal — every transport tells the caller the same thing
 // for a record that simply is not there.
 //
-// Three arms, for the same clustered-apply stringification reason as above.
+// ErrVectorRecordAbsent, unlike the vector-package sentinels above, has
+// exactly ONE production shape — bare, never wrapped (see
+// ops.IsVectorRecordAbsentMessage's doc: every caller propagates it verbatim).
+// "wrapped" here is therefore a synthetic %w wrap that exercises errIs's
+// identity match, not a real production shape; "stringified" is the bare form
+// re-created with errors.New, the real clustered-apply shape.
 func TestGrpcErrorVectorRecordAbsentIsNotFound(t *testing.T) {
 	cases := []struct {
 		name string
 		err  error
 	}{
 		{"sentinel", ops.ErrVectorRecordAbsent},
-		{"wrapped", fmt.Errorf("shard 3: %w", ops.ErrVectorRecordAbsent)},
-		{"stringified", errors.New("apply: " + ops.ErrVectorRecordAbsent.Error())},
+		{"wrapped (synthetic %w, exercises errIs identity — production never wraps this sentinel)",
+			fmt.Errorf("shard 3: %w", ops.ErrVectorRecordAbsent)},
+		{"stringified across replication, real bare shape", errors.New(ops.ErrVectorRecordAbsent.Error())},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -173,4 +216,15 @@ func TestGrpcErrorVectorRecordAbsentIsNotFound(t *testing.T) {
 			}
 		})
 	}
+	// Negative control: an unrelated internal fault that merely wraps the
+	// sentinel with its OWN prefix text must stay Internal — a bare
+	// strings.Contains classifier would leak it as NotFound instead (the exact
+	// redaction bypass this replaces "apply: "+err.Error() with an exact-form
+	// matcher to close).
+	t.Run("unrelated fault wrapping the sentinel with a foreign prefix", func(t *testing.T) {
+		err := errors.New("apply: " + ops.ErrVectorRecordAbsent.Error())
+		if got := status.Code(grpcError(err)); got != codes.Internal {
+			t.Errorf("grpcError(%v) = %v, want Internal", err, got)
+		}
+	})
 }

--- a/grpcapi/error_findings_test.go
+++ b/grpcapi/error_findings_test.go
@@ -277,6 +277,10 @@ func TestGrpcErrorMalformedOperateFrameIsInvalidArgument(t *testing.T) {
 	}{
 		{"sentinel", wire.ErrOperateArgs},
 		{"wrapped (%w, exercises errIs identity)", fmt.Errorf("vector_operate: %w", wire.ErrOperateArgs)},
+		// The clustered shape, and the one the sentinel arm cannot reach: an
+		// operate handler decodes inside the FSM apply, so shard.decodePBResult
+		// hands the error back rebuilt with errors.New and identity is gone.
+		{"stringified across replication, real bare shape", errors.New(wire.ErrOperateArgs.Error())},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			if got := status.Code(grpcError(tc.err)); got != codes.InvalidArgument {
@@ -284,4 +288,13 @@ func TestGrpcErrorMalformedOperateFrameIsInvalidArgument(t *testing.T) {
 			}
 		})
 	}
+	// Negative control: an unrelated internal fault that merely mentions the
+	// sentinel text must stay Internal — what exact equality buys over a
+	// strings.Contains arm.
+	t.Run("negative/unrelated fault wrapping the sentinel with a foreign prefix", func(t *testing.T) {
+		err := errors.New("apply: " + wire.ErrOperateArgs.Error())
+		if got := status.Code(grpcError(err)); got != codes.Internal {
+			t.Errorf("grpcError(%v) = %v, want Internal", err, got)
+		}
+	})
 }

--- a/grpcapi/error_findings_test.go
+++ b/grpcapi/error_findings_test.go
@@ -228,3 +228,38 @@ func TestGrpcErrorVectorRecordAbsentIsNotFound(t *testing.T) {
 		}
 	})
 }
+
+// TestGrpcErrorOperateDuringReshardIsUnavailable pins the reshard refusal as
+// Unavailable over gRPC — the code standard retry policies and service meshes DO
+// retry — matching HTTP's 503 and the binary transport's client-facing
+// StatusError for the identical signal. Unclassified it fell to Internal, which
+// those same policies hammer or hard-fail, for a condition that clears itself at
+// cutover.
+//
+// A negative control asserts an unrelated fault that merely wraps the refusal
+// text with a foreign prefix stays Internal.
+func TestGrpcErrorOperateDuringReshardIsUnavailable(t *testing.T) {
+	detailed := ops.OperateDuringReshardErr("docs")
+	for _, tc := range []struct {
+		name string
+		err  error
+	}{
+		{"sentinel", ops.ErrOperateDuringReshard},
+		{"production detailed form (names the collection)", detailed},
+		{"wrapped (%w, exercises errIs identity)", fmt.Errorf("shard 3: %w", ops.ErrOperateDuringReshard)},
+		{"stringified across replication, bare shape", errors.New(ops.ErrOperateDuringReshard.Error())},
+		{"stringified across replication, detailed shape", errors.New(detailed.Error())},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := status.Code(grpcError(tc.err)); got != codes.Unavailable {
+				t.Errorf("grpcError(%v) = %v, want Unavailable", tc.err, got)
+			}
+		})
+	}
+	t.Run("negative/unrelated fault wrapping the refusal with a foreign prefix", func(t *testing.T) {
+		err := errors.New("apply: " + detailed.Error())
+		if got := status.Code(grpcError(err)); got != codes.Internal {
+			t.Errorf("grpcError(%v) = %v, want Internal", err, got)
+		}
+	})
+}

--- a/grpcapi/error_findings_test.go
+++ b/grpcapi/error_findings_test.go
@@ -298,3 +298,32 @@ func TestGrpcErrorMalformedOperateFrameIsInvalidArgument(t *testing.T) {
 		}
 	})
 }
+
+// TestGrpcErrorTruncatedOperateFrameIsInvalidArgument is the parity guard for
+// wire.ErrVectorArgsTruncated: the sentinel DecodeVectorOperateArgs raises for a
+// frame shorter than the fields it declares, beside the ErrOperateArgs it raises
+// for a complete-but-invalid one. Both are the caller's framing mistake, so both
+// answer InvalidArgument here, matching HTTP's 400 and the binary transport's
+// client-facing message.
+func TestGrpcErrorTruncatedOperateFrameIsInvalidArgument(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		err  error
+	}{
+		{"sentinel", wire.ErrVectorArgsTruncated},
+		{"wrapped (%w, exercises errIs identity)", fmt.Errorf("vector_operate: %w", wire.ErrVectorArgsTruncated)},
+		{"stringified across replication, real bare shape", errors.New(wire.ErrVectorArgsTruncated.Error())},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := status.Code(grpcError(tc.err)); got != codes.InvalidArgument {
+				t.Errorf("grpcError(%v) = %v, want InvalidArgument", tc.err, got)
+			}
+		})
+	}
+	t.Run("negative/unrelated fault wrapping the sentinel with a foreign prefix", func(t *testing.T) {
+		err := errors.New("apply: " + wire.ErrVectorArgsTruncated.Error())
+		if got := status.Code(grpcError(err)); got != codes.Internal {
+			t.Errorf("grpcError(%v) = %v, want Internal", err, got)
+		}
+	})
+}

--- a/grpcapi/error_findings_test.go
+++ b/grpcapi/error_findings_test.go
@@ -11,6 +11,7 @@ import (
 	"google.golang.org/grpc/status"
 
 	"github.com/rostamlabs/rostam/ops"
+	"github.com/rostamlabs/rostam/sdk/wire"
 	"github.com/rostamlabs/rostam/vector"
 )
 
@@ -262,4 +263,25 @@ func TestGrpcErrorOperateDuringReshardIsUnavailable(t *testing.T) {
 			t.Errorf("grpcError(%v) = %v, want Internal", err, got)
 		}
 	})
+}
+
+// TestGrpcErrorMalformedOperateFrameIsInvalidArgument pins a malformed operate
+// frame as InvalidArgument, matching HTTP's 400 and the binary transport's
+// client-facing answer for the same sentinel. Unclassified it fell to Internal,
+// which reads as a server fault for a frame the caller built. KV operate raises
+// the same sentinel from the same decoder, so this arm covers both ops.
+func TestGrpcErrorMalformedOperateFrameIsInvalidArgument(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		err  error
+	}{
+		{"sentinel", wire.ErrOperateArgs},
+		{"wrapped (%w, exercises errIs identity)", fmt.Errorf("vector_operate: %w", wire.ErrOperateArgs)},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := status.Code(grpcError(tc.err)); got != codes.InvalidArgument {
+				t.Errorf("grpcError(%v) = %v, want InvalidArgument", tc.err, got)
+			}
+		})
+	}
 }

--- a/grpcapi/server.go
+++ b/grpcapi/server.go
@@ -226,8 +226,38 @@ func grpcError(err error) error {
 		// fallback uses vector.IsRecordTooLargeMessage, NOT strings.Contains — a
 		// bare substring check would also match an unrelated internal error that
 		// merely wraps the sentinel, leaking it to the caller unredacted.
-		vector.IsRecordTooLargeMessage(err.Error()):
+		vector.IsRecordTooLargeMessage(err.Error()),
+		errIs(err, vector.ErrRecordMalformed),
+		// vector.ErrRecordMalformed: a payload carrying record bytes no operate
+		// engine can open. A caller mistake with a clear remedy (send a
+		// well-formed record) whose message names only the payload key the
+		// caller chose, so the same InvalidArgument bucket as the cap above.
+		strings.Contains(err.Error(), vector.ErrRecordMalformed.Error()),
+		errIs(err, vector.ErrPayloadKeyNotRecord),
+		// vector.ErrPayloadKeyNotRecord: a vector_operate aimed at a payload
+		// key that holds a plain value rather than a record. Same
+		// InvalidArgument bucket and reasoning — the caller chose the key, the
+		// remedy is to name a record key, and the message discloses only that
+		// key and the kind stored under it.
+		//
+		// These last two matched by sentinel AND by string: shard.decodePBResult
+		// rebuilds op errors with errors.New(string(payload)) across
+		// replication, so a clustered apply loses errors.Is identity — the same
+		// reason server.clientFacingErr and httpapi.statusForError carry the
+		// string fallback. Comparing against the sentinel's own .Error() text
+		// cannot drift from it.
+		strings.Contains(err.Error(), vector.ErrPayloadKeyNotRecord.Error()):
 		return status.Error(codes.InvalidArgument, err.Error())
+	case errIs(err, ops.ErrVectorRecordAbsent),
+		// ops.ErrVectorRecordAbsent: vector_operate with create=NONE against a
+		// payload key that holds no record — the caller declined to create one
+		// and there was none, so the thing they named does not exist ->
+		// NotFound, mirroring server.mapResult's StatusNotFound and
+		// httpapi.statusForError's 404 for the same signal (both keep KV and
+		// vector operate telling every transport's caller the same thing).
+		// The substring arm covers the same clustered-apply stringification.
+		strings.Contains(err.Error(), ops.ErrVectorRecordAbsent.Error()):
+		return status.Error(codes.NotFound, err.Error())
 	case errIs(err, vector.ErrAPIKeyExists):
 		// Online key-admin: KeysAdd of an already-registered token. AlreadyExists
 		// (the etcd/gRPC create-conflict code) — the caller revokes first or picks a

--- a/grpcapi/server.go
+++ b/grpcapi/server.go
@@ -27,6 +27,7 @@ import (
 	"github.com/rostamlabs/rostam/grpcapi/grpcsvc"
 	"github.com/rostamlabs/rostam/ops"
 	"github.com/rostamlabs/rostam/sdk/pb"
+	"github.com/rostamlabs/rostam/sdk/wire"
 	"github.com/rostamlabs/rostam/vector"
 )
 
@@ -193,6 +194,19 @@ func grpcError(err error) error {
 		vector.ErrReservedVectorName, vector.ErrEmptyVectorName,
 		// TextSearch/HybridTextSearch on a collection without FullText: a usage error.
 		vector.ErrFullTextDisabled):
+		return status.Error(codes.InvalidArgument, err.Error())
+	case errIs(err, wire.ErrOperateArgs):
+		// wire.ErrOperateArgs: a malformed operate frame — a vector_operate or a KV
+		// operate whose args do not decode, or which names a second target or a
+		// TTL the op does not carry (DecodeVectorOperateArgs /
+		// ops.checkVectorOperateArgs / DecodeOperateArgs). The caller built the
+		// frame, so it is their mistake to fix; unclassified it read as a server
+		// fault. The message names no key, no path and no size — only that the
+		// arguments are invalid — so it is safe verbatim.
+		//
+		// Sentinel only, no message-shape arm: this error is raised by the
+		// decoder the handler itself calls, so it reaches the classifier with its
+		// identity intact.
 		return status.Error(codes.InvalidArgument, err.Error())
 	case errIs(err, vector.ErrInvalidDim, vector.ErrInvalidMetric, vector.ErrInvalidM,
 		vector.ErrInvalidQuant, vector.ErrInvalidIVFPQ, vector.ErrInvalidIVFPQM,

--- a/grpcapi/server.go
+++ b/grpcapi/server.go
@@ -218,21 +218,11 @@ func grpcError(err error) error {
 		// server.clientFacingErr and httpapi.statusForError's 400 bucket for the
 		// same sentinel. Unclassified it fell to codes.Internal, which reads as a
 		// server fault and which standard gRPC retry policies hammer.
-		//
-		// Matched by sentinel AND by exact message shape: shard.decodePBResult
-		// rebuilds an op error with errors.New(string(payload)) across
-		// replication, so a clustered apply loses errors.Is identity — the same
-		// reason the other two classifiers carry a message-shape fallback. The
-		// fallback uses vector.IsRecordTooLargeMessage, NOT strings.Contains — a
-		// bare substring check would also match an unrelated internal error that
-		// merely wraps the sentinel, leaking it to the caller unredacted.
-		vector.IsRecordTooLargeMessage(err.Error()),
 		errIs(err, vector.ErrRecordMalformed),
 		// vector.ErrRecordMalformed: a payload carrying record bytes no operate
 		// engine can open. A caller mistake with a clear remedy (send a
 		// well-formed record) whose message names only the payload key the
 		// caller chose, so the same InvalidArgument bucket as the cap above.
-		strings.Contains(err.Error(), vector.ErrRecordMalformed.Error()),
 		errIs(err, vector.ErrPayloadKeyNotRecord),
 		// vector.ErrPayloadKeyNotRecord: a vector_operate aimed at a payload
 		// key that holds a plain value rather than a record. Same
@@ -240,13 +230,17 @@ func grpcError(err error) error {
 		// remedy is to name a record key, and the message discloses only that
 		// key and the kind stored under it.
 		//
-		// These last two matched by sentinel AND by string: shard.decodePBResult
-		// rebuilds op errors with errors.New(string(payload)) across
-		// replication, so a clustered apply loses errors.Is identity — the same
-		// reason server.clientFacingErr and httpapi.statusForError carry the
-		// string fallback. Comparing against the sentinel's own .Error() text
-		// cannot drift from it.
-		strings.Contains(err.Error(), vector.ErrPayloadKeyNotRecord.Error()):
+		// All three matched by sentinel AND by exact message shape:
+		// shard.decodePBResult rebuilds op errors with
+		// errors.New(string(payload)) across replication, so a clustered apply
+		// loses errors.Is identity — the same reason server.clientFacingErr and
+		// httpapi.statusForError carry a message-shape fallback. Each fallback
+		// uses its own IsXMessage matcher, NOT strings.Contains — a bare
+		// substring check would also match an unrelated internal error that
+		// merely wraps the sentinel, leaking it to the caller unredacted.
+		vector.IsRecordTooLargeMessage(err.Error()),
+		vector.IsRecordMalformedMessage(err.Error()),
+		vector.IsPayloadKeyNotRecordMessage(err.Error()):
 		return status.Error(codes.InvalidArgument, err.Error())
 	case errIs(err, ops.ErrVectorRecordAbsent),
 		// ops.ErrVectorRecordAbsent: vector_operate with create=NONE against a
@@ -255,8 +249,10 @@ func grpcError(err error) error {
 		// NotFound, mirroring server.mapResult's StatusNotFound and
 		// httpapi.statusForError's 404 for the same signal (both keep KV and
 		// vector operate telling every transport's caller the same thing).
-		// The substring arm covers the same clustered-apply stringification.
-		strings.Contains(err.Error(), ops.ErrVectorRecordAbsent.Error()):
+		// The message-shape arm (ops.IsVectorRecordAbsentMessage, not
+		// strings.Contains — see the InvalidArgument bucket above for why)
+		// covers the same clustered-apply stringification.
+		ops.IsVectorRecordAbsentMessage(err.Error()):
 		return status.Error(codes.NotFound, err.Error())
 	case errIs(err, vector.ErrAPIKeyExists):
 		// Online key-admin: KeysAdd of an already-registered token. AlreadyExists

--- a/grpcapi/server.go
+++ b/grpcapi/server.go
@@ -204,7 +204,16 @@ func grpcError(err error) error {
 		// reach. wire.IsOperateArgsMessage, not strings.Contains: a bare
 		// substring check would also match an unrelated internal error that
 		// merely wraps the sentinel, leaking it unredacted.
-		wire.IsOperateArgsMessage(err.Error()):
+		//
+		// wire.ErrVectorArgsTruncated rides in the same bucket, by both arms, for
+		// the same reasons: DecodeVectorOperateArgs raises it for a frame shorter
+		// than the fields it declares, right beside the ErrOperateArgs it raises
+		// for a complete-but-invalid one. Both are the caller's framing mistake
+		// and both name nothing but "the arguments do not decode"; left
+		// unclassified, a truncated frame read as a server fault.
+		wire.IsOperateArgsMessage(err.Error()),
+		errIs(err, wire.ErrVectorArgsTruncated),
+		wire.IsVectorArgsTruncatedMessage(err.Error()):
 		// wire.ErrOperateArgs: a malformed operate frame — a vector_operate or a KV
 		// operate whose args do not decode, or which names a second target or a
 		// TTL the op does not carry (DecodeVectorOperateArgs /

--- a/grpcapi/server.go
+++ b/grpcapi/server.go
@@ -195,7 +195,16 @@ func grpcError(err error) error {
 		// TextSearch/HybridTextSearch on a collection without FullText: a usage error.
 		vector.ErrFullTextDisabled):
 		return status.Error(codes.InvalidArgument, err.Error())
-	case errIs(err, wire.ErrOperateArgs):
+	case errIs(err, wire.ErrOperateArgs),
+		// The clustered path stringifies the sentinel across the Raft boundary:
+		// an operate handler decodes its frame INSIDE the FSM apply, so
+		// shard.decodePBResult rebuilds the error with errors.New and errors.Is
+		// stops matching — which left a malformed frame from a clustered caller
+		// redacted as a server fault, the one case the sentinel arm above cannot
+		// reach. wire.IsOperateArgsMessage, not strings.Contains: a bare
+		// substring check would also match an unrelated internal error that
+		// merely wraps the sentinel, leaking it unredacted.
+		wire.IsOperateArgsMessage(err.Error()):
 		// wire.ErrOperateArgs: a malformed operate frame — a vector_operate or a KV
 		// operate whose args do not decode, or which names a second target or a
 		// TTL the op does not carry (DecodeVectorOperateArgs /

--- a/grpcapi/server.go
+++ b/grpcapi/server.go
@@ -299,6 +299,20 @@ func grpcError(err error) error {
 		// Internal (which retry policies hammer). String fallbacks cover the
 		// clustered/stringified path.
 		return status.Error(codes.ResourceExhausted, err.Error())
+	case errIs(err, ops.ErrOperateDuringReshard),
+		// ops.ErrOperateDuringReshard: a vector_operate against a collection a
+		// reshard is dual-writing. operate is not idempotent, so the store refuses
+		// rather than double-applying the op-list; the refusal lasts the minutes a
+		// reshard runs and the caller retries after cutover. Unavailable is the
+		// gRPC rendering of HTTP's 503 and the code standard retry policies and
+		// service meshes DO retry — unlike the Internal an unclassified sentinel
+		// fell to, which they hammer or hard-fail.
+		//
+		// Sentinel AND exact message shape, for the usual clustered-apply reason;
+		// ops.IsOperateDuringReshardMessage, not strings.Contains, so an internal
+		// fault that merely mentions the refusal is not leaked.
+		ops.IsOperateDuringReshardMessage(err.Error()):
+		return status.Error(codes.Unavailable, err.Error())
 	case strings.Contains(err.Error(), "not leader"),
 		strings.Contains(err.Error(), "no leader"),
 		strings.Contains(err.Error(), "no reachable owner"):

--- a/httpapi/error_findings_test.go
+++ b/httpapi/error_findings_test.go
@@ -333,3 +333,20 @@ func TestStatusForErrorRecordTooLarge(t *testing.T) {
 		}
 	}
 }
+
+// TestStatusForErrorMalformedRecord pins the ingest gate's shape rejection as a
+// 400. vector.ErrRecordMalformed is what every wire-reachable entry returns for
+// record bytes no operate engine can open, and it arrived with the phase-2
+// ingest validation — a sentinel that matched nothing here would have surfaced a
+// caller's own bad bytes as an opaque 500 with the message redacted, so this
+// keeps it in the same bucket as ErrRecordTooLarge and in sync with
+// server.clientFacingErr.
+func TestStatusForErrorMalformedRecord(t *testing.T) {
+	err := fmt.Errorf("%w: payload key %q: bad", vector.ErrRecordMalformed, "session")
+	if got := statusForError(err); got != http.StatusBadRequest {
+		t.Errorf("statusForError(ErrRecordMalformed) = %d, want 400", got)
+	}
+	if got := statusForError(vector.ErrRecordTooLarge); got != http.StatusBadRequest {
+		t.Errorf("statusForError(ErrRecordTooLarge) = %d, want 400 (the sibling bound)", got)
+	}
+}

--- a/httpapi/error_findings_test.go
+++ b/httpapi/error_findings_test.go
@@ -459,3 +459,41 @@ func TestStatusForErrorVectorRecordAbsent(t *testing.T) {
 		}
 	})
 }
+
+// TestStatusForErrorOperateDuringReshard pins the reshard refusal as a 503, the
+// HTTP rendering of the retryable answer the binary transport gives for the same
+// signal (server.TestMapResultOperateDuringReshardIsClientFacing). A
+// vector_operate against a collection a reshard is dual-writing is refused
+// because the op-list is not idempotent; the refusal lasts the minutes the
+// reshard runs and the caller retries after cutover. Unclassified it was a
+// redacted 500, so the retryability docs/vector/filtering.md promises never
+// reached the caller. No Retry-After: none of this transport's other retryable
+// buckets set one.
+//
+// A negative control asserts an unrelated fault that merely wraps the refusal
+// text with a foreign prefix stays a redacted 500.
+func TestStatusForErrorOperateDuringReshard(t *testing.T) {
+	detailed := ops.OperateDuringReshardErr("docs")
+	for _, tc := range []struct {
+		name string
+		err  error
+	}{
+		{"sentinel", ops.ErrOperateDuringReshard},
+		{"production detailed form (names the collection)", detailed},
+		{"wrapped (%w, exercises errors.Is identity)", fmt.Errorf("shard 3: %w", ops.ErrOperateDuringReshard)},
+		{"stringified across Raft, bare shape", errors.New(ops.ErrOperateDuringReshard.Error())},
+		{"stringified across Raft, detailed shape", errors.New(detailed.Error())},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := statusForError(tc.err); got != http.StatusServiceUnavailable {
+				t.Errorf("statusForError = %d, want 503", got)
+			}
+		})
+	}
+	t.Run("negative/unrelated fault wrapping the refusal with a foreign prefix", func(t *testing.T) {
+		err := errors.New("apply: " + detailed.Error())
+		if got := statusForError(err); got != http.StatusInternalServerError {
+			t.Errorf("statusForError(%v) = %d, want 500", err, got)
+		}
+	})
+}

--- a/httpapi/error_findings_test.go
+++ b/httpapi/error_findings_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/rostamlabs/rostam/ops"
+	"github.com/rostamlabs/rostam/sdk/wire"
 	"github.com/rostamlabs/rostam/vector"
 )
 
@@ -496,4 +497,26 @@ func TestStatusForErrorOperateDuringReshard(t *testing.T) {
 			t.Errorf("statusForError(%v) = %d, want 500", err, got)
 		}
 	})
+}
+
+// TestStatusForErrorMalformedOperateFrame pins a malformed operate frame as a
+// 400, matching the binary transport's client-facing answer for the same
+// sentinel (server.TestMapResultMalformedOperateFrameIsClientFacing). The caller
+// built the frame; unclassified it was a redacted 500 that read as a server
+// fault. KV operate raises the same sentinel from the same decoder, so this arm
+// covers both ops.
+func TestStatusForErrorMalformedOperateFrame(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		err  error
+	}{
+		{"sentinel", wire.ErrOperateArgs},
+		{"wrapped (%w, exercises errors.Is identity)", fmt.Errorf("vector_operate: %w", wire.ErrOperateArgs)},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := statusForError(tc.err); got != http.StatusBadRequest {
+				t.Errorf("statusForError = %d, want 400", got)
+			}
+		})
+	}
 }

--- a/httpapi/error_findings_test.go
+++ b/httpapi/error_findings_test.go
@@ -334,6 +334,20 @@ func TestStatusForErrorRecordTooLarge(t *testing.T) {
 	}
 }
 
+// errRealMalformedSingle, errRealMalformedBulk and errRealNotRecordDetailed reproduce
+// the EXACT shapes checkRecordValues / checkRecordValuesAll (ErrRecordMalformed)
+// and currentRecordValue (ErrPayloadKeyNotRecord) actually produce in
+// production — see vector.IsRecordMalformedMessage / IsPayloadKeyNotRecordMessage
+// for the format strings these mirror. httpapi cannot call those unexported
+// vector-package producers directly, so the shapes are reproduced by hand;
+// vector's own TestIsRecordMalformedMessage / TestIsPayloadKeyNotRecordMessage
+// pin them against the real producers.
+var (
+	errRealMalformedSingle   = fmt.Errorf("%w: payload key %q: %s", vector.ErrRecordMalformed, "session", "record: malformed record: wire: args too short")
+	errRealMalformedBulk     = fmt.Errorf("payload %d: %w", 7, errRealMalformedSingle)
+	errRealNotRecordDetailed = fmt.Errorf("%w: payload key %q holds a value of kind %d", vector.ErrPayloadKeyNotRecord, "country", 2)
+)
+
 // TestStatusForErrorMalformedRecord pins the ingest gate's shape rejection as a
 // 400. vector.ErrRecordMalformed is what every wire-reachable entry returns for
 // record bytes no operate engine can open, and it arrived with the phase-2
@@ -342,17 +356,23 @@ func TestStatusForErrorRecordTooLarge(t *testing.T) {
 // keeps it in the same bucket as ErrRecordTooLarge and in sync with
 // server.clientFacingErr.
 //
-// Three arms, like TestStatusForErrorVectorRecordAbsent: sentinel, wrapped, and
-// stringified across the Raft boundary, where errors.Is stops matching and the
-// substring fallback is what keeps this a 400 instead of a redacted 500.
+// Per shape: the bare sentinel, the real %w-wrapped single/bulk shapes (matched
+// by errors.Is regardless of exact text), and those shapes stringified across
+// the Raft boundary (matched only by vector.IsRecordMalformedMessage, since
+// shard.decodePBResult rebuilds a replicated op error with errors.New and
+// errors.Is stops matching there). A negative control asserts an unrelated
+// error that merely wraps the sentinel with a foreign prefix stays a redacted
+// 500 — the exact bug a bare strings.Contains classifier would reintroduce.
 func TestStatusForErrorMalformedRecord(t *testing.T) {
 	for _, tc := range []struct {
 		name string
 		err  error
 	}{
 		{"sentinel", vector.ErrRecordMalformed},
-		{"wrapped", fmt.Errorf("%w: payload key %q: bad", vector.ErrRecordMalformed, "session")},
-		{"stringified across Raft", errors.New("apply: " + vector.ErrRecordMalformed.Error())},
+		{"wrapped, real single-payload shape", errRealMalformedSingle},
+		{"wrapped, real bulk shape", errRealMalformedBulk},
+		{"stringified across Raft, real single-payload shape", errors.New(errRealMalformedSingle.Error())},
+		{"stringified across Raft, real bulk shape", errors.New(errRealMalformedBulk.Error())},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			if got := statusForError(tc.err); got != http.StatusBadRequest {
@@ -360,6 +380,12 @@ func TestStatusForErrorMalformedRecord(t *testing.T) {
 			}
 		})
 	}
+	t.Run("negative/unrelated fault wrapping the sentinel with a foreign prefix (%v, no %w identity)", func(t *testing.T) {
+		err := fmt.Errorf("wal append failed at /var/lib/rostam/x: %v", vector.ErrRecordMalformed)
+		if got := statusForError(err); got != http.StatusInternalServerError {
+			t.Errorf("statusForError(%v) = %d, want 500", err, got)
+		}
+	})
 }
 
 // TestStatusForErrorPayloadKeyNotRecord pins vector_operate's "that key does not
@@ -368,16 +394,19 @@ func TestStatusForErrorMalformedRecord(t *testing.T) {
 // unmatched sentinel here would have surfaced that as an opaque, redacted 500.
 // Kept in sync with server.clientFacingErr.
 //
-// Three arms, like TestStatusForErrorVectorRecordAbsent: sentinel, wrapped, and
-// stringified across the Raft boundary.
+// Per shape: the bare sentinel, the real %w-wrapped detailed shape, and that
+// shape stringified across the Raft boundary. A negative control asserts an
+// unrelated error that merely wraps the sentinel with a foreign prefix stays a
+// redacted 500.
 func TestStatusForErrorPayloadKeyNotRecord(t *testing.T) {
 	for _, tc := range []struct {
 		name string
 		err  error
 	}{
 		{"sentinel", vector.ErrPayloadKeyNotRecord},
-		{"wrapped", fmt.Errorf("%w: payload key %q holds a value of kind %d", vector.ErrPayloadKeyNotRecord, "country", 2)},
-		{"stringified across Raft", errors.New("apply: " + vector.ErrPayloadKeyNotRecord.Error())},
+		{"wrapped, real detailed shape", errRealNotRecordDetailed},
+		{"stringified across Raft, real detailed shape", errors.New(errRealNotRecordDetailed.Error())},
+		{"stringified across Raft, bare shape", errors.New(vector.ErrPayloadKeyNotRecord.Error())},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			if got := statusForError(tc.err); got != http.StatusBadRequest {
@@ -385,6 +414,12 @@ func TestStatusForErrorPayloadKeyNotRecord(t *testing.T) {
 			}
 		})
 	}
+	t.Run("negative/unrelated fault wrapping the sentinel with a foreign prefix (%v, no %w identity)", func(t *testing.T) {
+		err := fmt.Errorf("wal append failed at /var/lib/rostam/x: %v", vector.ErrPayloadKeyNotRecord)
+		if got := statusForError(err); got != http.StatusInternalServerError {
+			t.Errorf("statusForError(%v) = %d, want 500", err, got)
+		}
+	})
 }
 
 // TestStatusForErrorVectorRecordAbsent pins vector_operate's create=NONE refusal
@@ -394,16 +429,22 @@ func TestStatusForErrorPayloadKeyNotRecord(t *testing.T) {
 // named does not exist, which is what 404 means — not the redacted 500 an
 // unclassified sentinel would have produced.
 //
-// The substring arm covers the clustered path, where the sentinel is stringified
-// across the Raft boundary and errors.Is stops matching.
+// ErrVectorRecordAbsent has exactly ONE production shape — bare, never wrapped
+// (see ops.IsVectorRecordAbsentMessage's doc). "wrapped" here is a synthetic
+// %w wrap exercising errors.Is identity, not a real production shape;
+// "stringified" is the bare form re-created with errors.New, the real
+// clustered-apply shape. A negative control asserts an unrelated error that
+// wraps the sentinel with a foreign prefix (the OLD test's "stringified" case,
+// which a bare strings.Contains classifier used to accept) stays a redacted 500.
 func TestStatusForErrorVectorRecordAbsent(t *testing.T) {
 	for _, tc := range []struct {
 		name string
 		err  error
 	}{
 		{"sentinel", ops.ErrVectorRecordAbsent},
-		{"wrapped", fmt.Errorf("shard 3: %w", ops.ErrVectorRecordAbsent)},
-		{"stringified across Raft", errors.New("apply: " + ops.ErrVectorRecordAbsent.Error())},
+		{"wrapped (synthetic %w, exercises errors.Is identity — production never wraps this sentinel)",
+			fmt.Errorf("shard 3: %w", ops.ErrVectorRecordAbsent)},
+		{"stringified across Raft, real bare shape", errors.New(ops.ErrVectorRecordAbsent.Error())},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			if got := statusForError(tc.err); got != http.StatusNotFound {
@@ -411,4 +452,10 @@ func TestStatusForErrorVectorRecordAbsent(t *testing.T) {
 			}
 		})
 	}
+	t.Run("negative/unrelated fault wrapping the sentinel with a foreign prefix", func(t *testing.T) {
+		err := errors.New("apply: " + ops.ErrVectorRecordAbsent.Error())
+		if got := statusForError(err); got != http.StatusInternalServerError {
+			t.Errorf("statusForError(%v) = %d, want 500", err, got)
+		}
+	})
 }

--- a/httpapi/error_findings_test.go
+++ b/httpapi/error_findings_test.go
@@ -533,3 +533,33 @@ func TestStatusForErrorMalformedOperateFrame(t *testing.T) {
 		}
 	})
 }
+
+// TestStatusForErrorTruncatedOperateFrame is the parity guard for
+// wire.ErrVectorArgsTruncated: the sentinel DecodeVectorOperateArgs raises for a
+// frame shorter than the fields it declares, beside the ErrOperateArgs it raises
+// for a complete-but-invalid one. Both are the caller's framing mistake, so both
+// answer 400 here, matching the binary transport
+// (server.TestMapResultTruncatedOperateFrameIsClientFacing) and gRPC's
+// InvalidArgument.
+func TestStatusForErrorTruncatedOperateFrame(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		err  error
+	}{
+		{"sentinel", wire.ErrVectorArgsTruncated},
+		{"wrapped (%w, exercises errors.Is identity)", fmt.Errorf("vector_operate: %w", wire.ErrVectorArgsTruncated)},
+		{"stringified across Raft, real bare shape", errors.New(wire.ErrVectorArgsTruncated.Error())},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := statusForError(tc.err); got != http.StatusBadRequest {
+				t.Errorf("statusForError = %d, want 400", got)
+			}
+		})
+	}
+	t.Run("negative/unrelated fault wrapping the sentinel with a foreign prefix", func(t *testing.T) {
+		err := errors.New("apply: " + wire.ErrVectorArgsTruncated.Error())
+		if got := statusForError(err); got != http.StatusInternalServerError {
+			t.Errorf("statusForError(%v) = %d, want 500", err, got)
+		}
+	})
+}

--- a/httpapi/error_findings_test.go
+++ b/httpapi/error_findings_test.go
@@ -350,3 +350,15 @@ func TestStatusForErrorMalformedRecord(t *testing.T) {
 		t.Errorf("statusForError(ErrRecordTooLarge) = %d, want 400 (the sibling bound)", got)
 	}
 }
+
+// TestStatusForErrorPayloadKeyNotRecord pins vector_operate's "that key does not
+// hold a record" refusal as a 400. The op deliberately refuses rather than
+// overwriting a plain value with a record, so the caller has a key to fix; an
+// unmatched sentinel here would have surfaced that as an opaque, redacted 500.
+// Kept in sync with server.clientFacingErr.
+func TestStatusForErrorPayloadKeyNotRecord(t *testing.T) {
+	err := fmt.Errorf("%w: payload key %q holds a value of kind %d", vector.ErrPayloadKeyNotRecord, "country", 2)
+	if got := statusForError(err); got != http.StatusBadRequest {
+		t.Errorf("statusForError(ErrPayloadKeyNotRecord) = %d, want 400", got)
+	}
+}

--- a/httpapi/error_findings_test.go
+++ b/httpapi/error_findings_test.go
@@ -512,6 +512,10 @@ func TestStatusForErrorMalformedOperateFrame(t *testing.T) {
 	}{
 		{"sentinel", wire.ErrOperateArgs},
 		{"wrapped (%w, exercises errors.Is identity)", fmt.Errorf("vector_operate: %w", wire.ErrOperateArgs)},
+		// The clustered shape, and the one the sentinel arm cannot reach: an
+		// operate handler decodes inside the FSM apply, so shard.decodePBResult
+		// hands the error back rebuilt with errors.New and identity is gone.
+		{"stringified across Raft, real bare shape", errors.New(wire.ErrOperateArgs.Error())},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			if got := statusForError(tc.err); got != http.StatusBadRequest {
@@ -519,4 +523,13 @@ func TestStatusForErrorMalformedOperateFrame(t *testing.T) {
 			}
 		})
 	}
+	// Negative control: an unrelated internal fault that merely mentions the
+	// sentinel text must stay a redacted 500 — what exact equality buys over a
+	// strings.Contains arm.
+	t.Run("negative/unrelated fault wrapping the sentinel with a foreign prefix", func(t *testing.T) {
+		err := errors.New("apply: " + wire.ErrOperateArgs.Error())
+		if got := statusForError(err); got != http.StatusInternalServerError {
+			t.Errorf("statusForError(%v) = %d, want 500", err, got)
+		}
+	})
 }

--- a/httpapi/error_findings_test.go
+++ b/httpapi/error_findings_test.go
@@ -362,3 +362,29 @@ func TestStatusForErrorPayloadKeyNotRecord(t *testing.T) {
 		t.Errorf("statusForError(ErrPayloadKeyNotRecord) = %d, want 400", got)
 	}
 }
+
+// TestStatusForErrorVectorRecordAbsent pins vector_operate's create=NONE refusal
+// as a 404, the HTTP rendering of the not-found status the binary transport
+// answers for the same signal (server.TestMapResultVectorRecordAbsentIsNotFound).
+// The caller declined to create a record and there was none: the thing they
+// named does not exist, which is what 404 means — not the redacted 500 an
+// unclassified sentinel would have produced.
+//
+// The substring arm covers the clustered path, where the sentinel is stringified
+// across the Raft boundary and errors.Is stops matching.
+func TestStatusForErrorVectorRecordAbsent(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		err  error
+	}{
+		{"sentinel", ops.ErrVectorRecordAbsent},
+		{"wrapped", fmt.Errorf("shard 3: %w", ops.ErrVectorRecordAbsent)},
+		{"stringified across Raft", errors.New("apply: " + ops.ErrVectorRecordAbsent.Error())},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := statusForError(tc.err); got != http.StatusNotFound {
+				t.Errorf("statusForError = %d, want 404", got)
+			}
+		})
+	}
+}

--- a/httpapi/error_findings_test.go
+++ b/httpapi/error_findings_test.go
@@ -341,13 +341,24 @@ func TestStatusForErrorRecordTooLarge(t *testing.T) {
 // caller's own bad bytes as an opaque 500 with the message redacted, so this
 // keeps it in the same bucket as ErrRecordTooLarge and in sync with
 // server.clientFacingErr.
+//
+// Three arms, like TestStatusForErrorVectorRecordAbsent: sentinel, wrapped, and
+// stringified across the Raft boundary, where errors.Is stops matching and the
+// substring fallback is what keeps this a 400 instead of a redacted 500.
 func TestStatusForErrorMalformedRecord(t *testing.T) {
-	err := fmt.Errorf("%w: payload key %q: bad", vector.ErrRecordMalformed, "session")
-	if got := statusForError(err); got != http.StatusBadRequest {
-		t.Errorf("statusForError(ErrRecordMalformed) = %d, want 400", got)
-	}
-	if got := statusForError(vector.ErrRecordTooLarge); got != http.StatusBadRequest {
-		t.Errorf("statusForError(ErrRecordTooLarge) = %d, want 400 (the sibling bound)", got)
+	for _, tc := range []struct {
+		name string
+		err  error
+	}{
+		{"sentinel", vector.ErrRecordMalformed},
+		{"wrapped", fmt.Errorf("%w: payload key %q: bad", vector.ErrRecordMalformed, "session")},
+		{"stringified across Raft", errors.New("apply: " + vector.ErrRecordMalformed.Error())},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := statusForError(tc.err); got != http.StatusBadRequest {
+				t.Errorf("statusForError(ErrRecordMalformed) = %d, want 400", got)
+			}
+		})
 	}
 }
 
@@ -356,10 +367,23 @@ func TestStatusForErrorMalformedRecord(t *testing.T) {
 // overwriting a plain value with a record, so the caller has a key to fix; an
 // unmatched sentinel here would have surfaced that as an opaque, redacted 500.
 // Kept in sync with server.clientFacingErr.
+//
+// Three arms, like TestStatusForErrorVectorRecordAbsent: sentinel, wrapped, and
+// stringified across the Raft boundary.
 func TestStatusForErrorPayloadKeyNotRecord(t *testing.T) {
-	err := fmt.Errorf("%w: payload key %q holds a value of kind %d", vector.ErrPayloadKeyNotRecord, "country", 2)
-	if got := statusForError(err); got != http.StatusBadRequest {
-		t.Errorf("statusForError(ErrPayloadKeyNotRecord) = %d, want 400", got)
+	for _, tc := range []struct {
+		name string
+		err  error
+	}{
+		{"sentinel", vector.ErrPayloadKeyNotRecord},
+		{"wrapped", fmt.Errorf("%w: payload key %q holds a value of kind %d", vector.ErrPayloadKeyNotRecord, "country", 2)},
+		{"stringified across Raft", errors.New("apply: " + vector.ErrPayloadKeyNotRecord.Error())},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := statusForError(tc.err); got != http.StatusBadRequest {
+				t.Errorf("statusForError(ErrPayloadKeyNotRecord) = %d, want 400", got)
+			}
+		})
 	}
 }
 

--- a/httpapi/httpapi.go
+++ b/httpapi/httpapi.go
@@ -585,6 +585,15 @@ func statusForError(err error) int {
 		// Sentinel only, no message-shape arm: this error is raised by the
 		// decoder the handler itself calls, so it reaches the classifier with its
 		// identity intact.
+		// The clustered path stringifies the sentinel across the Raft boundary:
+		// an operate handler decodes its frame INSIDE the FSM apply, so
+		// shard.decodePBResult rebuilds the error with errors.New and errors.Is
+		// stops matching — which left a malformed frame from a clustered caller
+		// redacted as a server fault, the one case the sentinel arm above cannot
+		// reach. wire.IsOperateArgsMessage, not strings.Contains: a bare
+		// substring check would also match an unrelated internal error that
+		// merely wraps the sentinel, leaking it unredacted.
+		wire.IsOperateArgsMessage(err.Error()),
 		errors.Is(err, wire.ErrOperateArgs):
 		return http.StatusBadRequest
 	case errors.Is(err, ops.ErrVectorRecordAbsent),

--- a/httpapi/httpapi.go
+++ b/httpapi/httpapi.go
@@ -500,8 +500,8 @@ func statusForError(err error) int {
 		// Matched by sentinel AND by exact message shape: a clustered apply
 		// rebuilds the op error with errors.New across the replication boundary
 		// (shard.decodePBResult), so errors.Is alone loses it there and the error
-		// would fall through to the redacted 500 bucket. The message-shape arm
-		// uses vector.IsRecordTooLargeMessage, NOT strings.Contains — a bare
+		// would fall through to the redacted 500 bucket. The message-shape arms
+		// use vector.IsRecordTooLargeMessage, NOT strings.Contains — a bare
 		// substring check would also match an unrelated internal error that
 		// merely wraps the sentinel, leaking it to the caller unredacted.
 		errors.Is(err, vector.ErrRecordTooLarge),
@@ -510,16 +510,18 @@ func statusForError(err error) int {
 		// would poison every accelerated filter under that payload key for the
 		// whole collection, so refusing at the door is the client-fixable
 		// mistake. Keeps this classifier in sync with server.clientFacingErr.
-		// Same sentinel-plus-string matching, for the same clustered-apply reason.
+		// Same sentinel-plus-message-shape matching, for the same
+		// clustered-apply reason.
 		errors.Is(err, vector.ErrRecordMalformed),
-		strings.Contains(err.Error(), vector.ErrRecordMalformed.Error()),
+		vector.IsRecordMalformedMessage(err.Error()),
 		// A vector_operate against a payload key holding a non-record value: 400,
 		// not 500. Silently replacing that value would destroy data the caller can
 		// still read, so the op refuses — a client-fixable mistake. Keeps this
 		// classifier in sync with server.clientFacingErr.
-		// Same sentinel-plus-string matching, for the same clustered-apply reason.
+		// Same sentinel-plus-message-shape matching, for the same
+		// clustered-apply reason.
 		errors.Is(err, vector.ErrPayloadKeyNotRecord),
-		strings.Contains(err.Error(), vector.ErrPayloadKeyNotRecord.Error()),
+		vector.IsPayloadKeyNotRecordMessage(err.Error()),
 		errors.Is(err, vector.ErrEmptyFilter),
 		errors.Is(err, vector.ErrEmptyGroupBy),
 		errors.Is(err, vector.ErrSparseMismatch),
@@ -574,8 +576,10 @@ func statusForError(err error) int {
 		return http.StatusBadRequest
 	case errors.Is(err, ops.ErrVectorRecordAbsent),
 		// The clustered path stringifies the sentinel across the Raft boundary, so
-		// errors.Is stops matching there; the sentinel's own text cannot drift.
-		strings.Contains(err.Error(), ops.ErrVectorRecordAbsent.Error()):
+		// errors.Is stops matching there. ops.IsVectorRecordAbsentMessage, not
+		// strings.Contains: a bare substring check would also match an unrelated
+		// internal error that merely wraps the sentinel, leaking it unredacted.
+		ops.IsVectorRecordAbsentMessage(err.Error()):
 		// vector_operate with create = NONE against a payload key that holds no
 		// record: the caller declined to create one and there was none, so the
 		// thing they named does not exist → 404. This is the HTTP rendering of the

--- a/httpapi/httpapi.go
+++ b/httpapi/httpapi.go
@@ -582,10 +582,11 @@ func statusForError(err error) int {
 		// fault. The message names no key, no path and no size — only that the
 		// arguments are invalid — so it is safe verbatim.
 		//
-		// Sentinel only, no message-shape arm: this error is raised by the
-		// decoder the handler itself calls, so it reaches the classifier with its
-		// identity intact.
-		// The clustered path stringifies the sentinel across the Raft boundary:
+		// Sentinel AND exact message shape, both arms load-bearing. The sentinel
+		// arm covers the direct path, where the decoder the handler itself calls
+		// hands the error back with its identity intact.
+		// The message-shape arm covers the clustered path, which stringifies the
+		// sentinel across the Raft boundary:
 		// an operate handler decodes its frame INSIDE the FSM apply, so
 		// shard.decodePBResult rebuilds the error with errors.New and errors.Is
 		// stops matching — which left a malformed frame from a clustered caller
@@ -593,8 +594,17 @@ func statusForError(err error) int {
 		// reach. wire.IsOperateArgsMessage, not strings.Contains: a bare
 		// substring check would also match an unrelated internal error that
 		// merely wraps the sentinel, leaking it unredacted.
+		//
+		// wire.ErrVectorArgsTruncated rides in the same bucket, by both arms, for
+		// the same reasons: DecodeVectorOperateArgs raises it for a frame shorter
+		// than the fields it declares, right beside the ErrOperateArgs it raises
+		// for a complete-but-invalid one. Both are the caller's framing mistake
+		// and both name nothing but "the arguments do not decode"; left
+		// unclassified, a truncated frame read as a server fault.
 		wire.IsOperateArgsMessage(err.Error()),
-		errors.Is(err, wire.ErrOperateArgs):
+		errors.Is(err, wire.ErrOperateArgs),
+		wire.IsVectorArgsTruncatedMessage(err.Error()),
+		errors.Is(err, wire.ErrVectorArgsTruncated):
 		return http.StatusBadRequest
 	case errors.Is(err, ops.ErrVectorRecordAbsent),
 		// The clustered path stringifies the sentinel across the Raft boundary, so

--- a/httpapi/httpapi.go
+++ b/httpapi/httpapi.go
@@ -506,6 +506,11 @@ func statusForError(err error) int {
 		// merely wraps the sentinel, leaking it to the caller unredacted.
 		errors.Is(err, vector.ErrRecordTooLarge),
 		vector.IsRecordTooLargeMessage(err.Error()),
+		// Record bytes no operate engine can open: 400, not 500. Storing them
+		// would poison every accelerated filter under that payload key for the
+		// whole collection, so refusing at the door is the client-fixable
+		// mistake. Keeps this classifier in sync with server.clientFacingErr.
+		errors.Is(err, vector.ErrRecordMalformed),
 		errors.Is(err, vector.ErrEmptyFilter),
 		errors.Is(err, vector.ErrEmptyGroupBy),
 		errors.Is(err, vector.ErrSparseMismatch),

--- a/httpapi/httpapi.go
+++ b/httpapi/httpapi.go
@@ -18,6 +18,7 @@ import (
 	"github.com/rostamlabs/rostam/authz"
 	"github.com/rostamlabs/rostam/dashboard"
 	"github.com/rostamlabs/rostam/ops"
+	"github.com/rostamlabs/rostam/sdk/wire"
 	"github.com/rostamlabs/rostam/vector"
 )
 
@@ -572,7 +573,19 @@ func statusForError(err error) int {
 		// mistakes with obvious remedies → 400, message unredacted (it names only
 		// sizes and the op the caller sent). Kept in sync with
 		// server.clientFacingErr by the shared const.
-		strings.Contains(err.Error(), ops.WASMRegistrationRefusedMsg):
+		strings.Contains(err.Error(), ops.WASMRegistrationRefusedMsg),
+		// wire.ErrOperateArgs: a malformed operate frame — a vector_operate or a KV
+		// operate whose args do not decode, or which names a second target or a
+		// TTL the op does not carry (DecodeVectorOperateArgs /
+		// ops.checkVectorOperateArgs / DecodeOperateArgs). The caller built the
+		// frame, so it is their mistake to fix; unclassified it read as a server
+		// fault. The message names no key, no path and no size — only that the
+		// arguments are invalid — so it is safe verbatim.
+		//
+		// Sentinel only, no message-shape arm: this error is raised by the
+		// decoder the handler itself calls, so it reaches the classifier with its
+		// identity intact.
+		errors.Is(err, wire.ErrOperateArgs):
 		return http.StatusBadRequest
 	case errors.Is(err, ops.ErrVectorRecordAbsent),
 		// The clustered path stringifies the sentinel across the Raft boundary, so

--- a/httpapi/httpapi.go
+++ b/httpapi/httpapi.go
@@ -511,6 +511,11 @@ func statusForError(err error) int {
 		// whole collection, so refusing at the door is the client-fixable
 		// mistake. Keeps this classifier in sync with server.clientFacingErr.
 		errors.Is(err, vector.ErrRecordMalformed),
+		// A vector_operate against a payload key holding a non-record value: 400,
+		// not 500. Silently replacing that value would destroy data the caller can
+		// still read, so the op refuses — a client-fixable mistake. Keeps this
+		// classifier in sync with server.clientFacingErr.
+		errors.Is(err, vector.ErrPayloadKeyNotRecord),
 		errors.Is(err, vector.ErrEmptyFilter),
 		errors.Is(err, vector.ErrEmptyGroupBy),
 		errors.Is(err, vector.ErrSparseMismatch),

--- a/httpapi/httpapi.go
+++ b/httpapi/httpapi.go
@@ -684,6 +684,22 @@ func statusForError(err error) int {
 		// policies hammer, and which pages operators on client-side throttling). String
 		// fallbacks cover the clustered/stringified path.
 		return http.StatusTooManyRequests
+	case errors.Is(err, ops.ErrOperateDuringReshard),
+		// ops.ErrOperateDuringReshard: a vector_operate against a collection a
+		// reshard is dual-writing. operate is not idempotent, so the store refuses
+		// rather than double-applying the op-list, and the refusal is transient —
+		// it lasts the minutes a reshard runs and the caller retries after
+		// cutover. 503, the same bucket as the leadership/ownership transients
+		// below and the same one the other retryable conditions on this transport
+		// use (no Retry-After: none of them set one). Unclassified it was a
+		// redacted 500, so the retryability docs/vector/filtering.md promises
+		// never reached the caller.
+		//
+		// Sentinel AND exact message shape, for the usual clustered-apply reason;
+		// ops.IsOperateDuringReshardMessage, not strings.Contains, so an internal
+		// fault that merely mentions the refusal is not leaked.
+		ops.IsOperateDuringReshardMessage(err.Error()):
+		return http.StatusServiceUnavailable
 	case strings.Contains(err.Error(), "not leader"),
 		strings.Contains(err.Error(), "no leader"),
 		strings.Contains(err.Error(), "no reachable owner"):

--- a/httpapi/httpapi.go
+++ b/httpapi/httpapi.go
@@ -568,6 +568,18 @@ func statusForError(err error) int {
 		// server.clientFacingErr by the shared const.
 		strings.Contains(err.Error(), ops.WASMRegistrationRefusedMsg):
 		return http.StatusBadRequest
+	case errors.Is(err, ops.ErrVectorRecordAbsent),
+		// The clustered path stringifies the sentinel across the Raft boundary, so
+		// errors.Is stops matching there; the sentinel's own text cannot drift.
+		strings.Contains(err.Error(), ops.ErrVectorRecordAbsent.Error()):
+		// vector_operate with create = NONE against a payload key that holds no
+		// record: the caller declined to create one and there was none, so the
+		// thing they named does not exist → 404. This is the HTTP rendering of the
+		// StatusNotFound the binary transport answers for the same signal (see
+		// server.mapResult), which in turn matches what KV operate answers for
+		// create = NONE against an absent key. Unclassified it was a redacted 500,
+		// which reads as a server fault for an ordinary miss.
+		return http.StatusNotFound
 	case errors.Is(err, vector.ErrAPIKeyExists):
 		// Online key-admin: POST /v1/admin/keys with an already-registered token.
 		// 409 Conflict (the standard create-conflict code).

--- a/httpapi/httpapi.go
+++ b/httpapi/httpapi.go
@@ -510,12 +510,16 @@ func statusForError(err error) int {
 		// would poison every accelerated filter under that payload key for the
 		// whole collection, so refusing at the door is the client-fixable
 		// mistake. Keeps this classifier in sync with server.clientFacingErr.
+		// Same sentinel-plus-string matching, for the same clustered-apply reason.
 		errors.Is(err, vector.ErrRecordMalformed),
+		strings.Contains(err.Error(), vector.ErrRecordMalformed.Error()),
 		// A vector_operate against a payload key holding a non-record value: 400,
 		// not 500. Silently replacing that value would destroy data the caller can
 		// still read, so the op refuses — a client-fixable mistake. Keeps this
 		// classifier in sync with server.clientFacingErr.
+		// Same sentinel-plus-string matching, for the same clustered-apply reason.
 		errors.Is(err, vector.ErrPayloadKeyNotRecord),
+		strings.Contains(err.Error(), vector.ErrPayloadKeyNotRecord.Error()),
 		errors.Is(err, vector.ErrEmptyFilter),
 		errors.Is(err, vector.ErrEmptyGroupBy),
 		errors.Is(err, vector.ErrSparseMismatch),

--- a/ops/builtin.go
+++ b/ops/builtin.go
@@ -209,7 +209,7 @@ var builtinHandlers = map[string]Handler{
 //   - "vector_operate" / "vector_named_operate" / "vector_mv_operate" (read-write)
 //     args: see sdk/wire/vector_operate.go — the SAME operate call, wrapped in
 //     [colLen u8][col][id u64][pkLen u16][payloadKey][casPresent u8][?expectedVersion u64][argsLen u32][operateArgs],
-//     applied to the record under a POINT's payload key → [found u8](+[resLen u32][operateResult] if found)
+//     applied to the record under a POINT's payload key → [found u8](+[resLen u32][operateResult][version u64] if found)
 //   - "flush"   (read-write) args: (ignored)                               → empty (wipes the ENTIRE keyspace; broadcast to every shard group in cluster mode)
 //   - "__ping__" (read-only) args: (ignored)                             → empty
 //

--- a/ops/builtin.go
+++ b/ops/builtin.go
@@ -122,6 +122,7 @@ var builtinHandlers = map[string]Handler{
 	"vector_get":                       handleVectorGet,
 	"vector_get_batch":                 handleVectorGetBatch,
 	"vector_set_payload":               handleVectorSetPayload,
+	"vector_operate":                   handleVectorOperate,
 	"vector_overwrite_payload":         handleVectorOverwritePayload,
 	"vector_delete_payload_keys":       handleVectorDeletePayloadKeys,
 	"vector_clear_payload":             handleVectorClearPayload,
@@ -158,6 +159,7 @@ var builtinHandlers = map[string]Handler{
 	"vector_mv_get":                    handleMVGet,
 	"vector_mv_get_batch":              handleMVGetBatch,
 	"vector_mv_set_payload":            handleMVSetPayload,
+	"vector_mv_operate":                handleMVVectorOperate,
 	"vector_mv_overwrite_payload":      handleMVOverwritePayload,
 	"vector_mv_delete_payload_keys":    handleMVDeletePayloadKeys,
 	"vector_mv_clear_payload":          handleMVClearPayload,
@@ -172,6 +174,7 @@ var builtinHandlers = map[string]Handler{
 	"vector_named_get":                 handleNamedGet,
 	"vector_named_get_batch":           handleNamedGetBatch,
 	"vector_named_set_payload":         handleNamedSetPayload,
+	"vector_named_operate":             handleNamedVectorOperate,
 	"vector_named_overwrite_payload":   handleNamedOverwritePayload,
 	"vector_named_delete_payload_keys": handleNamedDeletePayloadKeys,
 	"vector_named_clear_payload":       handleNamedClearPayload,
@@ -203,6 +206,10 @@ var builtinHandlers = map[string]Handler{
 //   - "caex"    (read-write) args: [keyLen u16][key][expLen u32][expected][ttlMs u64] → 1-byte 1=TTL refreshed/0=mismatch|absent
 //   - "mget"    (read-only)  args: [count u16]([keyLen u16][key])*         → [count u16]([found u8](+[valLen u32][val] if found))*
 //   - "operate" (read-write) args: see sdk/wire/operate.go → [status u8][failedOp u16?][nRet u16]{[vlen u32][value]}*
+//   - "vector_operate" / "vector_named_operate" / "vector_mv_operate" (read-write)
+//     args: see sdk/wire/vector_operate.go — the SAME operate call, wrapped in
+//     [colLen u8][col][id u64][pkLen u16][payloadKey][casPresent u8][?expectedVersion u64][argsLen u32][operateArgs],
+//     applied to the record under a POINT's payload key → [found u8](+[resLen u32][operateResult] if found)
 //   - "flush"   (read-write) args: (ignored)                               → empty (wipes the ENTIRE keyspace; broadcast to every shard group in cluster mode)
 //   - "__ping__" (read-only) args: (ignored)                             → empty
 //

--- a/ops/hostile_decode_test.go
+++ b/ops/hostile_decode_test.go
@@ -190,6 +190,8 @@ var hostileDecoders = []struct {
 	{"DecodeVectorInsertArgsCAS", DecodeVectorInsertArgsCAS},
 	{"DecodeVectorInsertArgsKeyExpires", DecodeVectorInsertArgsKeyExpires},
 	{"DecodeVectorInsertArgsKeyTTL", DecodeVectorInsertArgsKeyTTL},
+	{"DecodeVectorOperateArgs", DecodeVectorOperateArgs},
+	{"DecodeVectorOperateResult", DecodeVectorOperateResult},
 	{"DecodeVectorSearchArgs", DecodeVectorSearchArgs},
 	{"DecodeVectorSearchArgsOpts", DecodeVectorSearchArgsOpts},
 	{"DecodeVectorSearchResults", DecodeVectorSearchResults},
@@ -250,7 +252,7 @@ func TestNoDecoderPanicsOnHostileBytes(t *testing.T) {
 	// A floor on the roster, because the failure mode of this sweep is silent:
 	// deleting entries makes it pass faster, not fail. Raise it when decoders are
 	// added; only lower it deliberately, when an op is genuinely removed.
-	const minDecoders = 148
+	const minDecoders = 150
 	if len(hostileDecoders) < minDecoders {
 		t.Fatalf("only %d decoders in the sweep (floor %d) — entries were removed, "+
 			"which narrows the coverage without failing anything", len(hostileDecoders), minDecoders)

--- a/ops/operate_apply.go
+++ b/ops/operate_apply.go
@@ -240,6 +240,12 @@ func openMode(es engines, buf []byte, existed bool) (modeEngine, error) {
 // the bytes. A stored value that big cannot be a valid operate record, so it
 // is wire.ErrOperateRecord — a malformed stored record — rather than
 // wire.ErrOperateCap, which means "this call would grow the record too far".
+//
+// FRESHNESS IS LOAD-BEARING FOR A CALLER OUTSIDE THIS PACKAGE. vector's
+// RecordMutator contract hands ownership of the returned bytes to the engine,
+// which stores them by reference in the arena. That is sound only because this
+// function allocates a new buffer per call (and createRecord allocates fresh).
+// Do not turn this into a pooled or reused buffer without changing that contract.
 func copyRecord(cur []byte) ([]byte, error) {
 	if len(cur) > maxOperateRecordBytes {
 		return nil, wire.ErrOperateRecord

--- a/ops/operate_during_reshard_message_test.go
+++ b/ops/operate_during_reshard_message_test.go
@@ -104,6 +104,14 @@ func TestIsOperateDuringReshardMessage(t *testing.T) {
 		{"clipped form whose byte count equals the bound",
 			prefix + strconv.Quote(strings.Repeat("c", maxClippedNameBytes)) +
 				fmt.Sprintf("… (%d bytes)", maxClippedNameBytes)},
+		// clipOperateName formats the count with %d, which never pads, so a
+		// zero-padded count is a shape it cannot emit even though the digits
+		// parse to a legal value.
+		{"clipped form with a zero-padded byte count",
+			prefix + strconv.Quote(strings.Repeat("c", maxClippedNameBytes)) + "… (0200 bytes)"},
+		{"clipped form with a leading zero on a single-digit-padded count",
+			prefix + strconv.Quote(strings.Repeat("c", maxClippedNameBytes)) + "… (0" +
+				strconv.Itoa(maxClippedNameBytes+1) + " bytes)"},
 		// strconv.Quote renders "A" as "A", never as an escape.
 		{"noncanonical escape in the quoted name", prefix + `"\x41"`},
 		{"noncanonical escape in a clipped name's prefix",

--- a/ops/operate_during_reshard_message_test.go
+++ b/ops/operate_during_reshard_message_test.go
@@ -1,0 +1,80 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package ops
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+)
+
+// TestIsOperateDuringReshardMessage pins IsOperateDuringReshardMessage against
+// the shapes OperateDuringReshardErr actually produces, and against the class it
+// exists to REJECT: an unrelated internal fault whose message merely contains the
+// refusal text. A bare strings.Contains would accept every case in the reject
+// table, which is the redaction bypass the exact-form matchers were introduced to
+// close.
+func TestIsOperateDuringReshardMessage(t *testing.T) {
+	short := OperateDuringReshardErr("docs").Error()
+	if !strings.HasPrefix(short, ErrOperateDuringReshard.Error()+": collection \"docs\"") {
+		t.Fatalf("fixture drifted from OperateDuringReshardErr: %q", short)
+	}
+	longName := strings.Repeat("c", 200)
+	long := OperateDuringReshardErr(longName).Error()
+	if !strings.HasSuffix(long, " bytes)") {
+		t.Fatalf("long-name fixture did not take clipOperateName's truncated branch: %q", long)
+	}
+	// A name needing escapes, so the quoted rendering is not a plain identifier.
+	quoted := OperateDuringReshardErr("a\"b\nc").Error()
+
+	accept := []struct {
+		name string
+		msg  string
+	}{
+		{"bare sentinel text", ErrOperateDuringReshard.Error()},
+		{"detailed form, short name", short},
+		{"detailed form, long/clipped name", long},
+		{"detailed form, name needing escapes", quoted},
+		{"detailed form re-stringified (simulates decodePBResult)", errors.New(short).Error()},
+		{"clipped form re-stringified (simulates decodePBResult)", errors.New(long).Error()},
+	}
+	for _, tc := range accept {
+		t.Run("accept/"+tc.name, func(t *testing.T) {
+			if !IsOperateDuringReshardMessage(tc.msg) {
+				t.Errorf("IsOperateDuringReshardMessage(%q) = false, want true", tc.msg)
+			}
+		})
+	}
+
+	reject := []struct {
+		name string
+		msg  string
+	}{
+		{"empty string", ""},
+		{"unrelated fault containing the refusal text (%v wrap)",
+			fmt.Errorf("wal append failed at /var/lib/rostam/x: %v", ErrOperateDuringReshard).Error()},
+		{"unrelated fault containing the refusal text (%w wrap, op-name prefixed)",
+			fmt.Errorf("vector_operate: %w", ErrOperateDuringReshard).Error()},
+		{"refusal text with unrelated trailing content",
+			short + " (retrying on shard 3)"},
+		{"refusal text embedded mid-message",
+			"apply failed: " + ErrOperateDuringReshard.Error() + " on shard 3"},
+		{"detailed form with a byte cut off the front", strings.TrimPrefix(short, "r")},
+		{"collection name not quoted at all",
+			ErrOperateDuringReshard.Error() + ": collection docs"},
+		{"collection name with a stray byte after the closing quote",
+			ErrOperateDuringReshard.Error() + ": collection \"docs\"!"},
+		{"clipped form with the byte count missing",
+			ErrOperateDuringReshard.Error() + ": collection \"docs\"… ( bytes)"},
+		{"oversize input beyond the length bound",
+			strings.Repeat(short+" ", 64)},
+	}
+	for _, tc := range reject {
+		t.Run("reject/"+tc.name, func(t *testing.T) {
+			if IsOperateDuringReshardMessage(tc.msg) {
+				t.Errorf("IsOperateDuringReshardMessage(%q) = true, want false", tc.msg)
+			}
+		})
+	}
+}

--- a/ops/operate_during_reshard_message_test.go
+++ b/ops/operate_during_reshard_message_test.go
@@ -5,16 +5,32 @@ package ops
 import (
 	"errors"
 	"fmt"
+	"strconv"
 	"strings"
 	"testing"
 )
 
 // TestIsOperateDuringReshardMessage pins IsOperateDuringReshardMessage against
 // the shapes OperateDuringReshardErr actually produces, and against the class it
-// exists to REJECT: an unrelated internal fault whose message merely contains the
-// refusal text. A bare strings.Contains would accept every case in the reject
-// table, which is the redaction bypass the exact-form matchers were introduced to
-// close.
+// exists to REJECT.
+//
+// Two kinds of rejection are in the table, and they are rejected for different
+// reasons. The first kind is the redaction bypass the exact-form matchers were
+// introduced to close: a message that DOES contain the refusal text — an
+// unrelated internal fault that wrapped it, or the refusal with a fault's own
+// trailing context — which a bare strings.Contains would wave through and this
+// matcher declines because the text is not anchored where the producer puts it.
+// The second kind never contains the sentinel text at all (the empty string, a
+// form with a byte cut off the front) and is rejected by the length bound or the
+// prefix anchor; those rows guard the matcher's edges rather than demonstrating
+// anything about Contains.
+//
+// The rows about the clipped rendering pin clipOperateName's INVARIANTS, not
+// just its punctuation: at most 64 decoded bytes when there is no length tail,
+// and exactly 64 with a count greater than 64 when there is. A quoted name is
+// also required to be CANONICAL — the rendering strconv.Quote itself produces —
+// so a message carrying an equivalent-but-different escape is a shape no
+// producer in this tree can emit.
 func TestIsOperateDuringReshardMessage(t *testing.T) {
 	short := OperateDuringReshardErr("docs").Error()
 	if !strings.HasPrefix(short, ErrOperateDuringReshard.Error()+": collection \"docs\"") {
@@ -28,6 +44,12 @@ func TestIsOperateDuringReshardMessage(t *testing.T) {
 	// A name needing escapes, so the quoted rendering is not a plain identifier.
 	quoted := OperateDuringReshardErr("a\"b\nc").Error()
 
+	// The two boundary names: exactly maxClippedNameBytes takes the untruncated
+	// branch, one more takes the truncated one.
+	atBound := OperateDuringReshardErr(strings.Repeat("c", maxClippedNameBytes)).Error()
+	overBound := OperateDuringReshardErr(strings.Repeat("c", maxClippedNameBytes+1)).Error()
+	prefix := ErrOperateDuringReshard.Error() + ": collection "
+
 	accept := []struct {
 		name string
 		msg  string
@@ -38,6 +60,8 @@ func TestIsOperateDuringReshardMessage(t *testing.T) {
 		{"detailed form, name needing escapes", quoted},
 		{"detailed form re-stringified (simulates decodePBResult)", errors.New(short).Error()},
 		{"clipped form re-stringified (simulates decodePBResult)", errors.New(long).Error()},
+		{"name of exactly the shown-byte bound", atBound},
+		{"name one byte over the bound (shortest truncated form)", overBound},
 	}
 	for _, tc := range accept {
 		t.Run("accept/"+tc.name, func(t *testing.T) {
@@ -69,6 +93,21 @@ func TestIsOperateDuringReshardMessage(t *testing.T) {
 			ErrOperateDuringReshard.Error() + ": collection \"docs\"… ( bytes)"},
 		{"oversize input beyond the length bound",
 			strings.Repeat(short+" ", 64)},
+		// clipOperateName quotes a name this long only WITH a length tail, so an
+		// untruncated form carrying one is a shape it cannot produce.
+		{"quoted name one byte over the bound with no length tail",
+			prefix + strconv.Quote(strings.Repeat("c", maxClippedNameBytes+1))},
+		// The truncated branch always shows exactly the bound's worth of bytes.
+		{"clipped form whose shown prefix is one byte short of the bound",
+			prefix + strconv.Quote(strings.Repeat("c", maxClippedNameBytes-1)) + "… (200 bytes)"},
+		// It is only reached when the full name is LONGER than what it shows.
+		{"clipped form whose byte count equals the bound",
+			prefix + strconv.Quote(strings.Repeat("c", maxClippedNameBytes)) +
+				fmt.Sprintf("… (%d bytes)", maxClippedNameBytes)},
+		// strconv.Quote renders "A" as "A", never as an escape.
+		{"noncanonical escape in the quoted name", prefix + `"\x41"`},
+		{"noncanonical escape in a clipped name's prefix",
+			prefix + `"\x41` + strings.Repeat("c", maxClippedNameBytes-1) + `"… (200 bytes)`},
 	}
 	for _, tc := range reject {
 		t.Run("reject/"+tc.name, func(t *testing.T) {

--- a/ops/record_malformed_test.go
+++ b/ops/record_malformed_test.go
@@ -1,0 +1,81 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package ops
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/rostamlabs/rostam/sdk/vtypes"
+	"github.com/rostamlabs/rostam/vector"
+)
+
+// malformedRecordBytes is a schema mode byte followed by a torn schema blob: no
+// operate engine can open it, and IndexEntries cannot enumerate it while Resolve
+// still answers from a record shaped like it — the asymmetry that poisons a
+// payload key for the whole collection.
+var malformedRecordBytes = []byte{0x01, 0xFF}
+
+// TestVectorInsertMalformedRecordRejectedOnBothWirePaths is the shape sibling of
+// TestVectorInsertOversizeRecordRejectedOnBothWirePaths, and it exists for the
+// same reason: handleVectorInsert has TWO downstream paths and both carry the
+// CALLER's metadata.
+//
+// A non-zero `version` in the decoded wire args routes the insert to
+// Collection.RestoreInsert/RestoreInsertAt, whose doc comment reads like a
+// replay-only primitive but which any client that sets a version reaches. The
+// phase-2 pre-flight scan called this out: the engine-level restore BODIES stay
+// size-only so WAL replay can never refuse an acked write, while these two
+// wire-reachable entries validate shape like every other ingest entry. Both
+// branches must answer the same way, so the test drives both through the real op
+// handler.
+func TestVectorInsertMalformedRecordRejectedOnBothWirePaths(t *testing.T) {
+	tx := newVecTx(t)
+	cfg := vector.Config{Dim: 2, M: 4, EfConstruction: 10, EfSearch: 10, Seed: 1, Metric: vector.L2}
+	if _, err := handleVectorCreateCollection(tx, EncodeCreateCollectionArgs("docs", cfg)); err != nil {
+		t.Fatalf("create collection: %v", err)
+	}
+	malformed := vtypes.Metadata{"session": vtypes.NewRecord(malformedRecordBytes)}
+	vec := []float32{1, 0}
+
+	for _, tc := range []struct {
+		name    string
+		id      uint64
+		version uint64
+	}{
+		{"ordinary insert (version 0)", 1, 0},
+		{"version-preserving reinsert (version != 0)", 2, 7},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := handleVectorInsert(tx, EncodeVectorInsertArgsVersioned(
+				"docs", tc.id, vec, 0, malformed, vtypes.SparseVector{}, tc.version))
+			if err == nil {
+				t.Fatal("insert with a malformed record: got nil error, want ErrRecordMalformed")
+			}
+			if !errors.Is(err, vector.ErrRecordMalformed) {
+				t.Fatalf("err = %v, want vector.ErrRecordMalformed", err)
+			}
+			eb, eerr := handleVectorExists(tx, EncodeExistsArgs("docs", tc.id))
+			if eerr != nil {
+				t.Fatalf("exists: %v", eerr)
+			}
+			if ex, _ := DecodeExistsResult(eb); ex {
+				t.Fatalf("rejected insert still created point %d", tc.id)
+			}
+		})
+	}
+
+	// The gate is not over-broad: the same version-preserving reinsert carrying
+	// a well-formed payload still lands.
+	if _, err := handleVectorInsert(tx, EncodeVectorInsertArgsVersioned(
+		"docs", 3, vec, 0, vtypes.Metadata{"rc": vtypes.NewInt(1)}, vtypes.SparseVector{}, 7)); err != nil {
+		t.Fatalf("version-preserving reinsert with an ordinary payload: %v, want nil", err)
+	}
+	eb, err := handleVectorExists(tx, EncodeExistsArgs("docs", 3))
+	if err != nil {
+		t.Fatalf("exists: %v", err)
+	}
+	if ex, _ := DecodeExistsResult(eb); !ex {
+		t.Fatal("the legitimate version-preserving reinsert did not land")
+	}
+}

--- a/ops/record_malformed_test.go
+++ b/ops/record_malformed_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/rostamlabs/rostam/sdk/vtypes"
+	"github.com/rostamlabs/rostam/sdk/wire"
 	"github.com/rostamlabs/rostam/vector"
 )
 
@@ -15,6 +16,27 @@ import (
 // still answers from a record shaped like it — the asymmetry that poisons a
 // payload key for the whole collection.
 var malformedRecordBytes = []byte{0x01, 0xFF}
+
+// sessionRecordForOps is a small well-formed schema-mode record, so the tests
+// below can show the gate accepting as well as rejecting.
+func sessionRecordForOps(t *testing.T) []byte {
+	t.Helper()
+	sch := &wire.Schema{Version: 1, StoreNames: true, Fields: []wire.FieldDef{
+		{Name: "rc", Type: wire.OperateTypeU8},
+		{Name: "tag", Type: wire.OperateTypeBytes},
+	}}
+	if err := sch.Validate(); err != nil {
+		t.Fatalf("schema invalid: %v", err)
+	}
+	enc := (&wire.Record{Mode: wire.OperateModeSchema, Schema: sch, Fields: []wire.Field{
+		{Cell: wire.Cell{Type: wire.OperateTypeU8, U: 7}},
+		{Cell: wire.Cell{Type: wire.OperateTypeBytes, B: []byte("de")}},
+	}}).Encode()
+	if enc == nil {
+		t.Fatal("session record failed to encode")
+	}
+	return enc
+}
 
 // TestVectorInsertMalformedRecordRejectedOnBothWirePaths is the shape sibling of
 // TestVectorInsertOversizeRecordRejectedOnBothWirePaths, and it exists for the
@@ -77,5 +99,93 @@ func TestVectorInsertMalformedRecordRejectedOnBothWirePaths(t *testing.T) {
 	}
 	if ex, _ := DecodeExistsResult(eb); !ex {
 		t.Fatal("the legitimate version-preserving reinsert did not land")
+	}
+}
+
+// TestMVAddBatchGatesRecordValuesOnBothPaths is the handler-level regression for
+// the fix-round-1 finding: vector_mv_add_batch has TWO downstream paths and only
+// one of them was gated.
+//
+// handleMVAddBatch calls MultiBulkBuild first — a concurrent whole-batch build
+// that only runs when the target index is EMPTY — and falls through to the
+// per-record MultiRestoreAddSparse when documents already exist. MultiBulkBuild
+// wrote the caller's metadata into docMeta and reindexed it with no record gate
+// at all, so the SAME op accepted or refused a malformed record depending on
+// whether the target happened to be empty. The empty case is not the rare one: an
+// offline MV resplit copies into fresh partitions, which is precisely it.
+//
+// Both paths, both bounds, are driven through the real handler.
+func TestMVAddBatchGatesRecordValuesOnBothPaths(t *testing.T) {
+	good := vtypes.Metadata{"session": vtypes.NewRecord(sessionRecordForOps(t))}
+	tokens := [][]float32{{1, 0}}
+
+	for _, path := range []struct {
+		name string
+		seed bool // seed a document first, so MultiBulkBuild declines and the
+		// per-record MultiRestoreAddSparse path runs instead
+	}{
+		{"empty target (MultiBulkBuild fast path)", false},
+		{"non-empty target (MultiRestoreAddSparse path)", true},
+	} {
+		for _, bad := range []struct {
+			name string
+			meta vtypes.Metadata
+			want error
+		}{
+			{"malformed", vtypes.Metadata{"session": vtypes.NewRecord(malformedRecordBytes)}, vector.ErrRecordMalformed},
+			{"oversize", vtypes.Metadata{"session": vtypes.NewRecord(make([]byte, overCapRecordBytes))}, vector.ErrRecordTooLarge},
+		} {
+			t.Run(path.name+"/"+bad.name, func(t *testing.T) {
+				tx := newVecTx(t)
+				cfg := vector.MultiVectorConfig{Dim: 2, M: 4, EfConstruction: 10, EfSearch: 10, Seed: 1}
+				if _, err := handleMVCreate(tx, EncodeMVCreateArgs("mv", cfg)); err != nil {
+					t.Fatalf("create MV: %v", err)
+				}
+				if path.seed {
+					if _, err := handleMVAdd(tx, EncodeMVAddArgs("mv", 100, tokens, good)); err != nil {
+						t.Fatalf("seed add: %v", err)
+					}
+				}
+				// The BAD record comes first on the non-empty path, where the
+				// handler applies records one at a time and a later failure would
+				// leave the earlier ones stored (ordinary batch semantics). On the
+				// empty path the whole batch is refused regardless of order, which
+				// the vector-level test pins directly.
+				recs := []vtypes.MultiScanRecord{
+					{ID: 1, Tokens: tokens, Metadata: bad.meta},
+					{ID: 2, Tokens: tokens, Metadata: good},
+				}
+				_, err := handleMVAddBatch(tx, EncodeMVAddBatchArgs("mv", recs))
+				if err == nil {
+					t.Fatalf("batch carrying a %s record: got nil error, want %v", bad.name, bad.want)
+				}
+				if !errors.Is(err, bad.want) {
+					t.Fatalf("err = %v, want %v", err, bad.want)
+				}
+				for _, id := range []uint64{1, 2} {
+					eb, eerr := handleMVExists(tx, EncodeMVExistsArgs("mv", id))
+					if eerr != nil {
+						t.Fatalf("mv exists(%d): %v", id, eerr)
+					}
+					if ex, _ := DecodeExistsResult(eb); ex {
+						t.Errorf("refused batch still stored doc %d", id)
+					}
+				}
+				// The gate is not over-broad: an all-good batch still lands on
+				// whichever path this case exercises.
+				if _, err := handleMVAddBatch(tx, EncodeMVAddBatchArgs("mv", []vtypes.MultiScanRecord{
+					{ID: 3, Tokens: tokens, Metadata: good},
+				})); err != nil {
+					t.Fatalf("all-good batch: %v, want nil", err)
+				}
+				eb, eerr := handleMVExists(tx, EncodeMVExistsArgs("mv", 3))
+				if eerr != nil {
+					t.Fatalf("mv exists(3): %v", eerr)
+				}
+				if ex, _ := DecodeExistsResult(eb); !ex {
+					t.Fatal("the all-good batch did not land")
+				}
+			})
+		}
 	}
 }

--- a/ops/record_malformed_test.go
+++ b/ops/record_malformed_test.go
@@ -155,13 +155,15 @@ func TestMVAddBatchGatesRecordValuesOnBothPaths(t *testing.T) {
 						t.Fatalf("seed add: %v", err)
 					}
 				}
-				// The bad record comes FIRST and a good one follows it, so a
-				// gate that only looked at the first record and a gate that
-				// walked the whole batch are told apart by the assertion below
-				// that NEITHER document was stored.
+				// The GOOD record comes first and the bad one second, which is
+				// what makes the "neither document was stored" assertion below
+				// a real check: a gate that stopped after the first record
+				// would validate the good one, store it, and fail. With the bad
+				// record first, that broken gate would refuse too and the test
+				// would pass anyway.
 				recs := []vtypes.MultiScanRecord{
-					{ID: 1, Tokens: tokens, Metadata: bad.meta},
-					{ID: 2, Tokens: tokens, Metadata: good},
+					{ID: 1, Tokens: tokens, Metadata: good},
+					{ID: 2, Tokens: tokens, Metadata: bad.meta},
 				}
 				_, err := handleMVAddBatch(tx, EncodeMVAddBatchArgs("mv", recs))
 				if err == nil {

--- a/ops/record_malformed_test.go
+++ b/ops/record_malformed_test.go
@@ -119,13 +119,22 @@ func TestMVAddBatchGatesRecordValuesOnBothPaths(t *testing.T) {
 	good := vtypes.Metadata{"session": vtypes.NewRecord(sessionRecordForOps(t))}
 	tokens := [][]float32{{1, 0}}
 
+	// BOTH ROWS REJECT INSIDE MultiBulkBuild, AND THAT IS THE POINT. Its
+	// whole-batch validation runs BEFORE it looks at whether the target is empty
+	// (vector/multivector.go: the record gate is in the loop above m.mu.Lock,
+	// the emptiness check is after it), so through this handler a bad record
+	// never reaches the per-record MultiRestoreAddSparse below. The seeded row
+	// therefore pins that the answer does not depend on the target's state — the
+	// exact asymmetry the fix closed — rather than exercising a second gate.
+	// MultiRestoreAddSparse's own gate is driven directly by
+	// TestMVAddVersionedGatesRecordValues, through the other wire op that
+	// reaches it.
 	for _, path := range []struct {
 		name string
-		seed bool // seed a document first, so MultiBulkBuild declines and the
-		// per-record MultiRestoreAddSparse path runs instead
+		seed bool // seed a document, so the target is non-empty
 	}{
-		{"empty target (MultiBulkBuild fast path)", false},
-		{"non-empty target (MultiRestoreAddSparse path)", true},
+		{"empty target", false},
+		{"non-empty target", true},
 	} {
 		for _, bad := range []struct {
 			name string
@@ -146,11 +155,10 @@ func TestMVAddBatchGatesRecordValuesOnBothPaths(t *testing.T) {
 						t.Fatalf("seed add: %v", err)
 					}
 				}
-				// The BAD record comes first on the non-empty path, where the
-				// handler applies records one at a time and a later failure would
-				// leave the earlier ones stored (ordinary batch semantics). On the
-				// empty path the whole batch is refused regardless of order, which
-				// the vector-level test pins directly.
+				// The bad record comes FIRST and a good one follows it, so a
+				// gate that only looked at the first record and a gate that
+				// walked the whole batch are told apart by the assertion below
+				// that NEITHER document was stored.
 				recs := []vtypes.MultiScanRecord{
 					{ID: 1, Tokens: tokens, Metadata: bad.meta},
 					{ID: 2, Tokens: tokens, Metadata: good},
@@ -187,5 +195,72 @@ func TestMVAddBatchGatesRecordValuesOnBothPaths(t *testing.T) {
 				}
 			})
 		}
+	}
+}
+
+// TestMVAddVersionedGatesRecordValues drives MultiRestoreAddSparse's OWN record
+// gate through the wire op that actually reaches it.
+//
+// vector_mv_add_batch cannot: handleMVAddBatch calls MultiBulkBuild first, and
+// that validates the whole batch before it checks whether the target is empty,
+// so a malformed record is refused there and the per-record restore-add below is
+// never entered. vector_mv_add_versioned — the offline MV-resplit backfill
+// primitive — calls MultiRestoreAddSparse directly, which is where the gate that
+// protects the incremental path has to be proven.
+//
+// A refused record must leave the document absent: the gate runs before any
+// state change, not after a partial one.
+func TestMVAddVersionedGatesRecordValues(t *testing.T) {
+	tokens := [][]float32{{1, 0}}
+	good := vtypes.Metadata{"session": vtypes.NewRecord(sessionRecordForOps(t))}
+
+	for _, bad := range []struct {
+		name string
+		meta vtypes.Metadata
+		want error
+	}{
+		{"malformed", vtypes.Metadata{"session": vtypes.NewRecord(malformedRecordBytes)}, vector.ErrRecordMalformed},
+		{"oversize", vtypes.Metadata{"session": vtypes.NewRecord(make([]byte, overCapRecordBytes))}, vector.ErrRecordTooLarge},
+	} {
+		t.Run(bad.name, func(t *testing.T) {
+			tx := newVecTx(t)
+			cfg := vector.MultiVectorConfig{Dim: 2, M: 4, EfConstruction: 10, EfSearch: 10, Seed: 1}
+			if _, err := handleMVCreate(tx, EncodeMVCreateArgs("mv", cfg)); err != nil {
+				t.Fatalf("create MV: %v", err)
+			}
+			// A seeded document, so this is the INCREMENTAL path and not a
+			// bulk build.
+			if _, err := handleMVAdd(tx, EncodeMVAddArgs("mv", 100, tokens, good)); err != nil {
+				t.Fatalf("seed add: %v", err)
+			}
+
+			_, err := handleMVAddVersioned(tx, EncodeMVAddArgsVersioned("mv", 1, tokens, bad.meta, 7))
+			if err == nil {
+				t.Fatalf("versioned add carrying a %s record: got nil error, want %v", bad.name, bad.want)
+			}
+			if !errors.Is(err, bad.want) {
+				t.Fatalf("err = %v, want %v", err, bad.want)
+			}
+			eb, eerr := handleMVExists(tx, EncodeMVExistsArgs("mv", 1))
+			if eerr != nil {
+				t.Fatalf("mv exists(1): %v", eerr)
+			}
+			if ex, _ := DecodeExistsResult(eb); ex {
+				t.Error("the refused versioned add still stored the document")
+			}
+
+			// The gate is not over-broad: a good record on the same path lands,
+			// with the verbatim version the op exists to preserve.
+			if _, err := handleMVAddVersioned(tx, EncodeMVAddArgsVersioned("mv", 2, tokens, good, 7)); err != nil {
+				t.Fatalf("all-good versioned add: %v, want nil", err)
+			}
+			eb, eerr = handleMVExists(tx, EncodeMVExistsArgs("mv", 2))
+			if eerr != nil {
+				t.Fatalf("mv exists(2): %v", eerr)
+			}
+			if ex, _ := DecodeExistsResult(eb); !ex {
+				t.Fatal("the all-good versioned add did not land")
+			}
+		})
 	}
 }

--- a/ops/vector_operate.go
+++ b/ops/vector_operate.go
@@ -16,6 +16,24 @@ import (
 // nothing.
 var ErrVectorRecordAbsent = errors.New("ops: vector_operate: create=NONE and no record under the payload key")
 
+// IsVectorRecordAbsentMessage reports whether s is the EXACT serialised form
+// of ErrVectorRecordAbsent — anchored the same way vector.IsRecordTooLargeMessage
+// and its Phase 2 twins are for their own sentinels, and for the same reason:
+// shard.decodePBResult rebuilds a replicated op error with errors.New, losing
+// errors.Is identity, and a bare strings.Contains fallback would make any
+// error that merely mentions the sentinel text client-facing.
+//
+// Unlike the vector-package sentinels this one has exactly ONE shape: bare
+// equality, no detail suffix and no bulk wrapper. vectorOperateMutator returns
+// it verbatim (return nil, vector.RecordUnchanged, ErrVectorRecordAbsent), and
+// every one of its three callers — handleVectorOperate, handleNamedVectorOperate,
+// handleMVVectorOperate — propagates whatever the engine returned unwrapped
+// ("return nil, err"), so no call site ever attaches a key, a kind, or a bulk
+// index to it.
+func IsVectorRecordAbsentMessage(s string) bool {
+	return s == ErrVectorRecordAbsent.Error()
+}
+
 // vectorOperateMutator builds the RecordMutator the three handlers hand to the
 // engine, plus the pointer the decoded result lands in.
 //

--- a/ops/vector_operate.go
+++ b/ops/vector_operate.go
@@ -125,15 +125,21 @@ func handleVectorOperate(tx *TxContext, args []byte) ([]byte, error) {
 	fn := vectorOperateMutator(a, stampMs, &res)
 
 	var applied bool
+	var version uint64
 	if stamped {
-		applied, _, err = tx.vectors.MutatePayloadRecordCASAt(name, id, pk, fn, cas, stampMs)
+		applied, version, err = tx.vectors.MutatePayloadRecordCASAt(name, id, pk, fn, cas, stampMs)
 	} else {
-		applied, _, err = tx.vectors.MutatePayloadRecordCAS(name, id, pk, fn, cas)
+		applied, version, err = tx.vectors.MutatePayloadRecordCAS(name, id, pk, fn, cas)
 	}
 	if err != nil {
 		return nil, err // incl. ErrVersionConflict, ErrPayloadKeyNotRecord, ErrRecordTooLarge
 	}
-	return wire.EncodeVectorOperateResult(applied, res)
+	// version is the point's version AFTER the call — bumped when the op-list
+	// applied, and the CURRENT unbumped one when it was a deliberate no-op (a
+	// failed CHECK). Returning it lets a CAS loop feed the next attempt straight
+	// from this result instead of re-reading the point, which is both a round trip
+	// and a race.
+	return wire.EncodeVectorOperateResult(applied, res, version)
 }
 
 // handleNamedVectorOperate is handleVectorOperate against a named-vector
@@ -156,15 +162,21 @@ func handleNamedVectorOperate(tx *TxContext, args []byte) ([]byte, error) {
 	fn := vectorOperateMutator(a, stampMs, &res)
 
 	var applied bool
+	var version uint64
 	if stamped {
-		applied, _, err = tx.vectors.NamedMutatePayloadRecordCASAt(name, id, pk, fn, cas, stampMs)
+		applied, version, err = tx.vectors.NamedMutatePayloadRecordCASAt(name, id, pk, fn, cas, stampMs)
 	} else {
-		applied, _, err = tx.vectors.NamedMutatePayloadRecordCAS(name, id, pk, fn, cas)
+		applied, version, err = tx.vectors.NamedMutatePayloadRecordCAS(name, id, pk, fn, cas)
 	}
 	if err != nil {
 		return nil, err // incl. ErrVersionConflict, ErrPayloadKeyNotRecord, ErrRecordTooLarge
 	}
-	return wire.EncodeVectorOperateResult(applied, res)
+	// version is the point's version AFTER the call — bumped when the op-list
+	// applied, and the CURRENT unbumped one when it was a deliberate no-op (a
+	// failed CHECK). Returning it lets a CAS loop feed the next attempt straight
+	// from this result instead of re-reading the point, which is both a round trip
+	// and a race.
+	return wire.EncodeVectorOperateResult(applied, res, version)
 }
 
 // handleMVVectorOperate is handleVectorOperate against a multi-vector
@@ -187,15 +199,21 @@ func handleMVVectorOperate(tx *TxContext, args []byte) ([]byte, error) {
 	fn := vectorOperateMutator(a, stampMs, &res)
 
 	var applied bool
+	var version uint64
 	if stamped {
-		applied, _, err = tx.vectors.MVMutatePayloadRecordCASAt(name, docID, pk, fn, cas, stampMs)
+		applied, version, err = tx.vectors.MVMutatePayloadRecordCASAt(name, docID, pk, fn, cas, stampMs)
 	} else {
-		applied, _, err = tx.vectors.MVMutatePayloadRecordCAS(name, docID, pk, fn, cas)
+		applied, version, err = tx.vectors.MVMutatePayloadRecordCAS(name, docID, pk, fn, cas)
 	}
 	if err != nil {
 		return nil, err // incl. ErrVersionConflict, ErrPayloadKeyNotRecord, ErrRecordTooLarge
 	}
-	return wire.EncodeVectorOperateResult(applied, res)
+	// version is the point's version AFTER the call — bumped when the op-list
+	// applied, and the CURRENT unbumped one when it was a deliberate no-op (a
+	// failed CHECK). Returning it lets a CAS loop feed the next attempt straight
+	// from this result instead of re-reading the point, which is both a round trip
+	// and a race.
+	return wire.EncodeVectorOperateResult(applied, res, version)
 }
 
 // checkVectorOperateArgs re-asserts, at the handler boundary, the two rules the

--- a/ops/vector_operate.go
+++ b/ops/vector_operate.go
@@ -1,0 +1,202 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package ops
+
+import (
+	"errors"
+
+	"github.com/rostamlabs/rostam/sdk/wire"
+	"github.com/rostamlabs/rostam/vector"
+)
+
+// ErrVectorRecordAbsent is the vector twin of handleOperate's cache.ErrNotFound
+// mapping: the point exists, but its payload key holds no record and the call
+// asked for create = NONE. A caller who declined to create a record and found
+// none is told so, rather than silently getting an OK for a call that changed
+// nothing.
+var ErrVectorRecordAbsent = errors.New("ops: vector_operate: create=NONE and no record under the payload key")
+
+// vectorOperateMutator builds the RecordMutator the three handlers hand to the
+// engine, plus the pointer the decoded result lands in.
+//
+// The mutator is the ONLY place any operate semantics happen, and all of it is
+// applyRecordBytes — the same pure function the KV handler drives, with the same
+// leader stamp as its only clock. What is left here is the translation between
+// applyRecordBytes's (out, deleted, res, err) and vector's three-outcome
+// RecordMutation contract:
+//
+//	failed CHECK → RecordUnchanged   (the point must stay byte-identical AND
+//	                                  unbumped, which "store these bytes" cannot
+//	                                  express)
+//	deleted      → RecordDelete      (the op list emptied the record; the payload
+//	                                  key goes away entirely)
+//	otherwise    → RecordStore
+//
+// errOperateAbsent — create = NONE against an absent record — is mapped at this
+// boundary to ErrVectorRecordAbsent, exactly as handleOperate maps it to
+// cache.ErrNotFound. Every other error is returned verbatim so the engine can
+// leave the point exactly as it was and the caller sees the real reason.
+//
+// Both error returns pass vector.RecordUnchanged explicitly. The engine tests
+// err != nil first, so the action is never read on an error — but a bare zero
+// would silently read as RecordStore if that order ever changed.
+func vectorOperateMutator(a *wire.OperateArgs, stampMs int64, res **wire.OperateResult) vector.RecordMutator {
+	return func(old []byte, exists bool) ([]byte, vector.RecordMutation, error) {
+		var cur []byte
+		if exists {
+			cur = old
+		}
+		out, deleted, r, aerr := applyRecordBytes(cur, a, stampMs)
+		if aerr != nil {
+			if errors.Is(aerr, errOperateAbsent) {
+				return nil, vector.RecordUnchanged, ErrVectorRecordAbsent
+			}
+			return nil, vector.RecordUnchanged, aerr
+		}
+		*res = r
+		switch {
+		case r.Status == wire.OperateStatusCheckFailed:
+			return nil, vector.RecordUnchanged, nil
+		case deleted:
+			return nil, vector.RecordDelete, nil
+		default:
+			return out, vector.RecordStore, nil
+		}
+	}
+}
+
+// handleVectorOperate applies one operate op-list to the record held in a
+// point's payload under payloadKey. It is handleOperate's vector twin: the SAME
+// applyRecordBytes decides everything semantic, and this handler only supplies
+// the record bytes, the leader-stamped clock, and the reply frame.
+//
+// The op-list runs INSIDE the collection's write lock, as the mutator the engine
+// calls. That is what makes the read-modify-write atomic, and it is bounded by
+// the same caps a KV operate is (OperateMaxOps ops, a bounded record), so the
+// lock is held for a bounded, caller-declared amount of work.
+//
+// A missing/dead point is the not-found FLAG (found=0), never an op error, so a
+// fan-out treats it the way it treats a set_payload against a missing point
+// (payloadAppliedV). A point that exists but whose payload key holds no record
+// and create = NONE is ErrVectorRecordAbsent — a real error, mirroring
+// handleOperate's cache.ErrNotFound mapping.
+//
+// Determinism: the stamp is the ONLY clock, exactly as in handleOperate —
+// unstamped (single-node) calls pass 0, which is what a KV operate does too, and
+// route to the wall-clock engine variant exactly as SetPayload does beside
+// SetPayloadAt.
+//
+// The decoder already rejects an inner Key and any ttlMode other than KEEP (a
+// point's TTL is the point's), but the handler defends anyway: a future decoder
+// change, or a direct call, must not be able to smuggle a second target or a
+// silently-ignored TTL past this boundary.
+func handleVectorOperate(tx *TxContext, args []byte) ([]byte, error) {
+	if tx.vectors == nil {
+		return nil, ErrVectorsNotAvailable
+	}
+	name, id, pk, a, expected, hasExpected, err := wire.DecodeVectorOperateArgs(args)
+	if err != nil {
+		return nil, err
+	}
+	if err := checkVectorOperateArgs(a); err != nil {
+		return nil, err
+	}
+	cas := vector.CASCond{Expected: expected, Has: hasExpected}
+	stampMs, stamped := tx.applyStamp()
+	var res *wire.OperateResult
+	fn := vectorOperateMutator(a, stampMs, &res)
+
+	var applied bool
+	if stamped {
+		applied, _, err = tx.vectors.MutatePayloadRecordCASAt(name, id, pk, fn, cas, stampMs)
+	} else {
+		applied, _, err = tx.vectors.MutatePayloadRecordCAS(name, id, pk, fn, cas)
+	}
+	if err != nil {
+		return nil, err // incl. ErrVersionConflict, ErrPayloadKeyNotRecord, ErrRecordTooLarge
+	}
+	return wire.EncodeVectorOperateResult(applied, res)
+}
+
+// handleNamedVectorOperate is handleVectorOperate against a named-vector
+// collection's shared payload. See handleVectorOperate for the whole contract;
+// only the engine entry point differs.
+func handleNamedVectorOperate(tx *TxContext, args []byte) ([]byte, error) {
+	if tx.vectors == nil {
+		return nil, ErrVectorsNotAvailable
+	}
+	name, id, pk, a, expected, hasExpected, err := wire.DecodeVectorOperateArgs(args)
+	if err != nil {
+		return nil, err
+	}
+	if err := checkVectorOperateArgs(a); err != nil {
+		return nil, err
+	}
+	cas := vector.CASCond{Expected: expected, Has: hasExpected}
+	stampMs, stamped := tx.applyStamp()
+	var res *wire.OperateResult
+	fn := vectorOperateMutator(a, stampMs, &res)
+
+	var applied bool
+	if stamped {
+		applied, _, err = tx.vectors.NamedMutatePayloadRecordCASAt(name, id, pk, fn, cas, stampMs)
+	} else {
+		applied, _, err = tx.vectors.NamedMutatePayloadRecordCAS(name, id, pk, fn, cas)
+	}
+	if err != nil {
+		return nil, err // incl. ErrVersionConflict, ErrPayloadKeyNotRecord, ErrRecordTooLarge
+	}
+	return wire.EncodeVectorOperateResult(applied, res)
+}
+
+// handleMVVectorOperate is handleVectorOperate against a multi-vector
+// collection's document payload. See handleVectorOperate for the whole contract;
+// only the engine entry point differs.
+func handleMVVectorOperate(tx *TxContext, args []byte) ([]byte, error) {
+	if tx.vectors == nil {
+		return nil, ErrVectorsNotAvailable
+	}
+	name, docID, pk, a, expected, hasExpected, err := wire.DecodeVectorOperateArgs(args)
+	if err != nil {
+		return nil, err
+	}
+	if err := checkVectorOperateArgs(a); err != nil {
+		return nil, err
+	}
+	cas := vector.CASCond{Expected: expected, Has: hasExpected}
+	stampMs, stamped := tx.applyStamp()
+	var res *wire.OperateResult
+	fn := vectorOperateMutator(a, stampMs, &res)
+
+	var applied bool
+	if stamped {
+		applied, _, err = tx.vectors.MVMutatePayloadRecordCASAt(name, docID, pk, fn, cas, stampMs)
+	} else {
+		applied, _, err = tx.vectors.MVMutatePayloadRecordCAS(name, docID, pk, fn, cas)
+	}
+	if err != nil {
+		return nil, err // incl. ErrVersionConflict, ErrPayloadKeyNotRecord, ErrRecordTooLarge
+	}
+	return wire.EncodeVectorOperateResult(applied, res)
+}
+
+// checkVectorOperateArgs re-asserts, at the handler boundary, the two rules the
+// vector_operate codec already enforces on both sides of the wire: the target is
+// named exactly once by (collection, id, payloadKey) — so the inner Key must be
+// empty — and a point's TTL is the point's, so ttlMode must be KEEP with no ttl.
+//
+// This is defence in depth, not belt-and-braces duplication. Rejecting beats
+// ignoring for both rules (a caller who set either expecting it to work would
+// otherwise get silence), and the decoder is not the only way an OperateArgs can
+// reach these handlers — a future codec revision or an in-process caller must
+// fail loudly rather than quietly acquire a second source of truth for the
+// target key, or a TTL that is silently dropped.
+func checkVectorOperateArgs(a *wire.OperateArgs) error {
+	if a == nil {
+		return wire.ErrOperateArgs
+	}
+	if len(a.Key) != 0 || a.TTLMode != wire.OperateTTLKeep || a.TTL != 0 {
+		return wire.ErrOperateArgs
+	}
+	return nil
+}

--- a/ops/vector_operate.go
+++ b/ops/vector_operate.go
@@ -109,6 +109,57 @@ func vectorOperateMutator(a *wire.OperateArgs, stampMs int64, res **wire.Operate
 // change, or a direct call, must not be able to smuggle a second target or a
 // silently-ignored TTL past this boundary.
 func handleVectorOperate(tx *TxContext, args []byte) ([]byte, error) {
+	return vectorOperateBody(tx, args, applyDenseRecordMutation)
+}
+
+// recordMutateApply is a family's ENGINE ENTRY, and the only thing the three
+// vector_operate handlers do not share. It picks the stamped or unstamped
+// variant, which is the same decision in every family: only a stamped apply has
+// a clock every replica agrees on (see vector.recordKeyPastDeadline).
+//
+// The three implementations are package-level functions, not closures, so
+// passing one costs no allocation on the apply path.
+type recordMutateApply func(v *vector.CollectionStore, name string, id uint64, pk string,
+	fn vector.RecordMutator, cas vector.CASCond, stampMs int64, stamped bool) (applied bool, version uint64, err error)
+
+func applyDenseRecordMutation(v *vector.CollectionStore, name string, id uint64, pk string,
+	fn vector.RecordMutator, cas vector.CASCond, stampMs int64, stamped bool,
+) (bool, uint64, error) {
+	if stamped {
+		return v.MutatePayloadRecordCASAt(name, id, pk, fn, cas, stampMs)
+	}
+	return v.MutatePayloadRecordCAS(name, id, pk, fn, cas)
+}
+
+func applyNamedRecordMutation(v *vector.CollectionStore, name string, id uint64, pk string,
+	fn vector.RecordMutator, cas vector.CASCond, stampMs int64, stamped bool,
+) (bool, uint64, error) {
+	if stamped {
+		return v.NamedMutatePayloadRecordCASAt(name, id, pk, fn, cas, stampMs)
+	}
+	return v.NamedMutatePayloadRecordCAS(name, id, pk, fn, cas)
+}
+
+func applyMVRecordMutation(v *vector.CollectionStore, name string, docID uint64, pk string,
+	fn vector.RecordMutator, cas vector.CASCond, stampMs int64, stamped bool,
+) (bool, uint64, error) {
+	if stamped {
+		return v.MVMutatePayloadRecordCASAt(name, docID, pk, fn, cas, stampMs)
+	}
+	return v.MVMutatePayloadRecordCAS(name, docID, pk, fn, cas)
+}
+
+// vectorOperateBody is the whole of a vector_operate handler except its engine
+// entry: the decode, the argument re-assertion, the CAS threading, the mutator
+// construction and the result frame.
+//
+// It exists as ONE copy because the three families' handlers were three copies
+// of it, and a validation or result-format fix landing in only two of them is a
+// silent divergence between ops that are documented as identical. This is the
+// same reasoning the Store layer already follows, where one shared body serves
+// nine methods — that duplication is how set_payload lost its CAS precondition
+// on three of its four paths.
+func vectorOperateBody(tx *TxContext, args []byte, apply recordMutateApply) ([]byte, error) {
 	if tx.vectors == nil {
 		return nil, ErrVectorsNotAvailable
 	}
@@ -124,13 +175,7 @@ func handleVectorOperate(tx *TxContext, args []byte) ([]byte, error) {
 	var res *wire.OperateResult
 	fn := vectorOperateMutator(a, stampMs, &res)
 
-	var applied bool
-	var version uint64
-	if stamped {
-		applied, version, err = tx.vectors.MutatePayloadRecordCASAt(name, id, pk, fn, cas, stampMs)
-	} else {
-		applied, version, err = tx.vectors.MutatePayloadRecordCAS(name, id, pk, fn, cas)
-	}
+	applied, version, err := apply(tx.vectors, name, id, pk, fn, cas, stampMs, stamped)
 	if err != nil {
 		return nil, err // incl. ErrVersionConflict, ErrPayloadKeyNotRecord, ErrRecordTooLarge
 	}
@@ -146,74 +191,14 @@ func handleVectorOperate(tx *TxContext, args []byte) ([]byte, error) {
 // collection's shared payload. See handleVectorOperate for the whole contract;
 // only the engine entry point differs.
 func handleNamedVectorOperate(tx *TxContext, args []byte) ([]byte, error) {
-	if tx.vectors == nil {
-		return nil, ErrVectorsNotAvailable
-	}
-	name, id, pk, a, expected, hasExpected, err := wire.DecodeVectorOperateArgs(args)
-	if err != nil {
-		return nil, err
-	}
-	if err := checkVectorOperateArgs(a); err != nil {
-		return nil, err
-	}
-	cas := vector.CASCond{Expected: expected, Has: hasExpected}
-	stampMs, stamped := tx.applyStamp()
-	var res *wire.OperateResult
-	fn := vectorOperateMutator(a, stampMs, &res)
-
-	var applied bool
-	var version uint64
-	if stamped {
-		applied, version, err = tx.vectors.NamedMutatePayloadRecordCASAt(name, id, pk, fn, cas, stampMs)
-	} else {
-		applied, version, err = tx.vectors.NamedMutatePayloadRecordCAS(name, id, pk, fn, cas)
-	}
-	if err != nil {
-		return nil, err // incl. ErrVersionConflict, ErrPayloadKeyNotRecord, ErrRecordTooLarge
-	}
-	// version is the point's version AFTER the call — bumped when the op-list
-	// applied, and the CURRENT unbumped one when it was a deliberate no-op (a
-	// failed CHECK). Returning it lets a CAS loop feed the next attempt straight
-	// from this result instead of re-reading the point, which is both a round trip
-	// and a race.
-	return wire.EncodeVectorOperateResult(applied, res, version)
+	return vectorOperateBody(tx, args, applyNamedRecordMutation)
 }
 
 // handleMVVectorOperate is handleVectorOperate against a multi-vector
 // collection's document payload. See handleVectorOperate for the whole contract;
 // only the engine entry point differs.
 func handleMVVectorOperate(tx *TxContext, args []byte) ([]byte, error) {
-	if tx.vectors == nil {
-		return nil, ErrVectorsNotAvailable
-	}
-	name, docID, pk, a, expected, hasExpected, err := wire.DecodeVectorOperateArgs(args)
-	if err != nil {
-		return nil, err
-	}
-	if err := checkVectorOperateArgs(a); err != nil {
-		return nil, err
-	}
-	cas := vector.CASCond{Expected: expected, Has: hasExpected}
-	stampMs, stamped := tx.applyStamp()
-	var res *wire.OperateResult
-	fn := vectorOperateMutator(a, stampMs, &res)
-
-	var applied bool
-	var version uint64
-	if stamped {
-		applied, version, err = tx.vectors.MVMutatePayloadRecordCASAt(name, docID, pk, fn, cas, stampMs)
-	} else {
-		applied, version, err = tx.vectors.MVMutatePayloadRecordCAS(name, docID, pk, fn, cas)
-	}
-	if err != nil {
-		return nil, err // incl. ErrVersionConflict, ErrPayloadKeyNotRecord, ErrRecordTooLarge
-	}
-	// version is the point's version AFTER the call — bumped when the op-list
-	// applied, and the CURRENT unbumped one when it was a deliberate no-op (a
-	// failed CHECK). Returning it lets a CAS loop feed the next attempt straight
-	// from this result instead of re-reading the point, which is both a round trip
-	// and a race.
-	return wire.EncodeVectorOperateResult(applied, res, version)
+	return vectorOperateBody(tx, args, applyMVRecordMutation)
 }
 
 // checkVectorOperateArgs re-asserts, at the handler boundary, the two rules the

--- a/ops/vector_operate_reshard.go
+++ b/ops/vector_operate_reshard.go
@@ -137,8 +137,14 @@ func isClippedName(s string) bool {
 		// only reached for when it exceeds the shown prefix. ParseUint (not
 		// Atoi) so the width does not depend on GOARCH; an overflowing run of
 		// digits is a shape clipOperateName cannot produce either.
-		n, perr := strconv.ParseUint(rest[i:], 10, 64)
-		if perr != nil || n <= maxClippedNameBytes {
+		//
+		// The digits must also be the CANONICAL decimal rendering of the number
+		// they encode. clipOperateName formats with %d, which never pads, so
+		// "0064" is a count no producer can emit even though it parses to a
+		// legal value — the same reason the quoted name has to be canonical.
+		digits := rest[i:]
+		n, perr := strconv.ParseUint(digits, 10, 64)
+		if perr != nil || n <= maxClippedNameBytes || strconv.FormatUint(n, 10) != digits {
 			return false
 		}
 		quoted, ok := strings.CutSuffix(rest[:i], "… (")

--- a/ops/vector_operate_reshard.go
+++ b/ops/vector_operate_reshard.go
@@ -47,12 +47,16 @@ func OperateDuringReshardErr(collection string) error {
 // two in step: the bound is what stops a caller-chosen name from setting the
 // size of an error message, and of the classification scan that reads it.
 func clipOperateName(s string) string {
-	const maxShown = 64
-	if len(s) <= maxShown {
+	if len(s) <= maxClippedNameBytes {
 		return strconv.Quote(s)
 	}
-	return fmt.Sprintf("%s… (%d bytes)", strconv.Quote(s[:maxShown]), len(s))
+	return fmt.Sprintf("%s… (%d bytes)", strconv.Quote(s[:maxClippedNameBytes]), len(s))
 }
+
+// maxClippedNameBytes is the number of SOURCE bytes clipOperateName shows
+// before it truncates. It is shared with isClippedName so the matcher enforces
+// the producer's own bound rather than a second copy of the number.
+const maxClippedNameBytes = 64
 
 // IsOperateDuringReshardMessage reports whether s is the EXACT serialised form
 // of an ErrOperateDuringReshard error — anchored the way
@@ -104,10 +108,22 @@ var operateDuringReshardPrefix = ErrOperateDuringReshard.Error() + ": collection
 // truncated form, after the decimal byte count.
 const clippedNameLengthTail = " bytes)"
 
-// isClippedName reports whether s is exactly what clipOperateName renders: a
-// Go-quoted string, or a Go-quoted 64-byte prefix followed by "… (N bytes)".
-// Anything after that — an internal fault's own trailing context — makes it
-// false, which is what keeps the matcher from leaking an unrelated error.
+// isClippedName reports whether s is exactly what clipOperateName renders, and
+// enforces the producer's own INVARIANTS rather than merely its punctuation:
+//
+//   - untruncated form: a canonical Go-quoted string whose DECODED length is at
+//     most maxClippedNameBytes. clipOperateName only takes this branch for a
+//     name that short, so a longer one is a shape it can never emit.
+//   - truncated form: a canonical Go-quoted prefix of EXACTLY
+//     maxClippedNameBytes decoded bytes, then "… (N bytes)" with N strictly
+//     greater than maxClippedNameBytes — the branch is only taken when the full
+//     name is longer than the prefix it shows.
+//
+// Without the two length rules the matcher accepted forms the producer cannot
+// emit (a 65-byte quoted name with no length tail, a truncated form whose prefix
+// is 63 bytes), which is how an unrelated internal error carrying the fixed
+// refusal prefix could be classified as the retryable refusal and cross the
+// wire verbatim instead of being redacted.
 func isClippedName(s string) bool {
 	if rest, ok := strings.CutSuffix(s, clippedNameLengthTail); ok {
 		i := len(rest)
@@ -117,23 +133,45 @@ func isClippedName(s string) bool {
 		if i == len(rest) {
 			return false // no digits where the byte count belongs
 		}
+		// The count is the FULL source length, which the truncated branch is
+		// only reached for when it exceeds the shown prefix. ParseUint (not
+		// Atoi) so the width does not depend on GOARCH; an overflowing run of
+		// digits is a shape clipOperateName cannot produce either.
+		n, perr := strconv.ParseUint(rest[i:], 10, 64)
+		if perr != nil || n <= maxClippedNameBytes {
+			return false
+		}
 		quoted, ok := strings.CutSuffix(rest[:i], "… (")
 		if !ok {
 			return false
 		}
-		return isGoQuoted(quoted)
+		dec, ok := goQuoted(quoted)
+		return ok && len(dec) == maxClippedNameBytes
 	}
-	return isGoQuoted(s)
+	dec, ok := goQuoted(s)
+	return ok && len(dec) <= maxClippedNameBytes
 }
 
-// isGoQuoted reports whether s is a single, complete strconv.Quote rendering.
-// Unquote does the whole job: it rejects an unterminated quote, a stray trailing
-// byte after the closing quote, and an invalid escape, none of which
-// strconv.Quote can produce.
-func isGoQuoted(s string) bool {
+// goQuoted reports whether s is a CANONICAL strconv.Quote rendering, and
+// returns what it decodes to so the caller can bound the decoded length.
+//
+// Unquote alone is not enough. It accepts renderings strconv.Quote never
+// produces — "\x41" for "A", say, or an escaped character Quote would leave
+// literal — and a matcher that accepted those would be accepting text no
+// producer in this tree can emit. Re-quoting the decoded string and requiring
+// byte equality is the whole canonicality check, and it subsumes Unquote's own
+// rejections (an unterminated quote, a stray byte after the closing quote, an
+// invalid escape).
+func goQuoted(s string) (string, bool) {
 	if len(s) < 2 || s[0] != '"' {
-		return false
+		return "", false
 	}
-	_, err := strconv.Unquote(s)
-	return err == nil
+	dec, err := strconv.Unquote(s)
+	if err != nil {
+		return "", false
+	}
+	if strconv.Quote(dec) != s {
+		return "", false
+	}
+	return dec, true
 }

--- a/ops/vector_operate_reshard.go
+++ b/ops/vector_operate_reshard.go
@@ -1,0 +1,139 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package ops
+
+import (
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+// ErrOperateDuringReshard is the refusal the root store raises when a
+// vector_operate targets a collection a reshard is currently dual-writing. It is
+// RETRYABLE: the caller retries after cutover, when the collection has a single
+// live generation again. rostam.ErrOperateDuringReshard is this same value — see
+// there for WHY operate refuses where set_payload dual-writes.
+//
+// WHY IT IS DECLARED HERE and not beside the code that raises it. The refusal is
+// only useful if the caller is told to retry, and that means every transport
+// classifier has to recognise it. server, httpapi and grpcapi cannot import the
+// root package without a layering cycle — which is why the alias and key-admin
+// errors in those classifiers are matched by message prefix. Declaring the
+// sentinel in a package all four already import lets them match by IDENTITY,
+// with the message shape only as the clustered-stringification fallback, so a
+// rewording is a compile-time concern rather than a silent regression to
+// "internal error". Same reason WASMUpdateUnsupportedMsg is a const here.
+//
+// The message keeps the "rostam: " prefix because the ROOT store is what
+// refuses; the text is the caller-visible contract docs/vector/filtering.md
+// quotes.
+var ErrOperateDuringReshard = errors.New("rostam: vector_operate is refused while a reshard is dual-writing; retry after cutover")
+
+// OperateDuringReshardErr is the ONE producer of the refusal's detailed form,
+// naming the collection so an operator reading a log knows which reshard to wait
+// on. The collection name goes through clipOperateName, not %q: it is
+// caller-supplied and bounded only by the route body cap at this point (the
+// 255-byte wire cap is applied later, by EncodeVectorOperateArgs), and this
+// message is returned VERBATIM to the caller on every transport.
+func OperateDuringReshardErr(collection string) error {
+	return fmt.Errorf("%w: collection %s", ErrOperateDuringReshard, clipOperateName(collection))
+}
+
+// clipOperateName renders a caller-supplied name for an error message: the whole
+// thing quoted when it is short, otherwise a 64-byte quoted prefix plus the full
+// length. It is vector.clipField's rule, restated here because that one is
+// unexported and this package must not widen vector's API to borrow it. Keep the
+// two in step: the bound is what stops a caller-chosen name from setting the
+// size of an error message, and of the classification scan that reads it.
+func clipOperateName(s string) string {
+	const maxShown = 64
+	if len(s) <= maxShown {
+		return strconv.Quote(s)
+	}
+	return fmt.Sprintf("%s… (%d bytes)", strconv.Quote(s[:maxShown]), len(s))
+}
+
+// IsOperateDuringReshardMessage reports whether s is the EXACT serialised form
+// of an ErrOperateDuringReshard error — anchored the way
+// vector.IsRecordTooLargeMessage and IsVectorRecordAbsentMessage are for their
+// sentinels, and for the same reason: shard.decodePBResult rebuilds a replicated
+// op error with errors.New, losing errors.Is identity, and a bare
+// strings.Contains fallback would make any error that merely mentions the
+// sentinel text client-facing.
+//
+// The two recognized shapes (<name> is clipOperateName's bounded rendering of
+// the caller's collection name):
+//
+//	rostam: vector_operate is refused while a reshard is dual-writing; retry after cutover
+//	rostam: vector_operate is refused while a reshard is dual-writing; retry after cutover: collection <name>
+//
+// The bare form exists only for a caller that stringifies the sentinel itself;
+// every production site goes through OperateDuringReshardErr. The far end is
+// anchored as tightly as the clipped rendering allows: what follows the fixed
+// prefix must LOOK like clipOperateName's output — a quoted string, optionally
+// followed by the "… (N bytes)" length tail — so an internal fault that appends
+// its own trailing context ("... : collection \"c\" (shard 3 apply failed)") is
+// declined rather than leaked.
+func IsOperateDuringReshardMessage(s string) bool {
+	if len(s) == 0 || len(s) > maxOperateDuringReshardMessageLen {
+		return false
+	}
+	if s == ErrOperateDuringReshard.Error() {
+		return true
+	}
+	rest, ok := strings.CutPrefix(s, operateDuringReshardPrefix)
+	if !ok {
+		return false
+	}
+	return isClippedName(rest)
+}
+
+// maxOperateDuringReshardMessageLen bounds the input
+// IsOperateDuringReshardMessage scans, so classification cost cannot scale with
+// an attacker-chosen collection name. clipOperateName already bounds the name to
+// 64 source bytes (worst-case quoted/escaped well under 300), so every real
+// message sits far below this; mirrors maxRecordTooLargeMessageLen's reasoning.
+const maxOperateDuringReshardMessageLen = 512
+
+// operateDuringReshardPrefix is the fixed text that opens the detailed form,
+// ending right before the caller-controlled clipOperateName rendering.
+var operateDuringReshardPrefix = ErrOperateDuringReshard.Error() + ": collection "
+
+// clippedNameLengthTail is the fixed text that closes clipOperateName's
+// truncated form, after the decimal byte count.
+const clippedNameLengthTail = " bytes)"
+
+// isClippedName reports whether s is exactly what clipOperateName renders: a
+// Go-quoted string, or a Go-quoted 64-byte prefix followed by "… (N bytes)".
+// Anything after that — an internal fault's own trailing context — makes it
+// false, which is what keeps the matcher from leaking an unrelated error.
+func isClippedName(s string) bool {
+	if rest, ok := strings.CutSuffix(s, clippedNameLengthTail); ok {
+		i := len(rest)
+		for i > 0 && rest[i-1] >= '0' && rest[i-1] <= '9' {
+			i--
+		}
+		if i == len(rest) {
+			return false // no digits where the byte count belongs
+		}
+		quoted, ok := strings.CutSuffix(rest[:i], "… (")
+		if !ok {
+			return false
+		}
+		return isGoQuoted(quoted)
+	}
+	return isGoQuoted(s)
+}
+
+// isGoQuoted reports whether s is a single, complete strconv.Quote rendering.
+// Unquote does the whole job: it rejects an unterminated quote, a stray trailing
+// byte after the closing quote, and an invalid escape, none of which
+// strconv.Quote can produce.
+func isGoQuoted(s string) bool {
+	if len(s) < 2 || s[0] != '"' {
+		return false
+	}
+	_, err := strconv.Unquote(s)
+	return err == nil
+}

--- a/ops/vector_operate_test.go
+++ b/ops/vector_operate_test.go
@@ -1,0 +1,598 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package ops
+
+// Handler-level tests for vector_operate / vector_named_operate /
+// vector_mv_operate: the operate op applied to a record held inside a POINT's
+// payload rather than under a KV key.
+//
+// The op's apply semantics are not re-derived here — applyRecordBytes is the
+// same pure function handleOperate drives, and operate_semantics_test.go covers
+// it exhaustively. What these tests pin is everything the vector wrapper adds:
+// the not-found FLAG for a missing point, the create=NONE error, the non-record
+// payload key error, the three-outcome mutator mapping (store / delete /
+// unchanged), CAS, and that the leader stamp is the only clock.
+
+import (
+	"bytes"
+	"encoding/binary"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/rostamlabs/rostam/sdk/wire"
+	"github.com/rostamlabs/rostam/vector"
+)
+
+// vecOperateHandler is the shape the three family handlers share, so one table
+// can drive dense, named and multi-vector through the same case.
+type vecOperateHandler func(*TxContext, []byte) ([]byte, error)
+
+// callVecOperate encodes a vector_operate call, runs it through h under the
+// given apply stamp, and decodes the reply frame. stampMs == 0 means unstamped
+// (the single-node path), matching applyStamp's contract everywhere else in this
+// package.
+func callVecOperate(t *testing.T, tx *TxContext, h vecOperateHandler, stampMs int64,
+	col string, id uint64, pk string, a *wire.OperateArgs, expected uint64, hasExpected bool,
+) (bool, *wire.OperateResult, error) {
+	t.Helper()
+	args, err := EncodeVectorOperateArgs(col, id, pk, a, expected, hasExpected)
+	if err != nil {
+		t.Fatalf("EncodeVectorOperateArgs: %v", err)
+	}
+	tx.SetApplyStamp(uint64(stampMs), stampMs != 0) //nolint:gosec // test stamps are small positive millis
+	defer tx.SetApplyStamp(0, false)
+	body, herr := h(tx, args)
+	if herr != nil {
+		return false, nil, herr
+	}
+	found, res, derr := DecodeVectorOperateResult(body)
+	if derr != nil {
+		t.Fatalf("DecodeVectorOperateResult: %v", derr)
+	}
+	return found, res, nil
+}
+
+// mustVecOperate is callVecOperate for the calls that must not error.
+func mustVecOperate(t *testing.T, tx *TxContext, h vecOperateHandler, stampMs int64,
+	col string, id uint64, pk string, a *wire.OperateArgs,
+) (bool, *wire.OperateResult) {
+	t.Helper()
+	found, res, err := callVecOperate(t, tx, h, stampMs, col, id, pk, a, 0, false)
+	if err != nil {
+		t.Fatalf("handler: %v", err)
+	}
+	return found, res
+}
+
+// setDyn is the simplest create-and-write call: SET a by-name U64 field on a
+// dynamic-mode record, creating the record if the payload key is empty.
+func setDyn(field string, v int64) *wire.OperateArgs {
+	return &wire.OperateArgs{Create: wire.OperateCreateDynamic, Ops: []wire.OperateOp{
+		{Opcode: wire.OperateOpSET, Type: wire.OperateTypeU64, Path: namePath(field), A: v}}}
+}
+
+// addDynRet bumps a by-name U64 field and returns its value.
+func addDynRet(field string, delta int64) *wire.OperateArgs {
+	return &wire.OperateArgs{Create: wire.OperateCreateDynamic,
+		Ops:  []wire.OperateOp{{Opcode: wire.OperateOpADD, Type: wire.OperateTypeU64, Path: namePath(field), A: delta}},
+		Rets: []wire.OperateRet{{Mode: wire.OperateRetValue, Path: namePath(field)}}}
+}
+
+// vecSessionSchema mirrors vector/record_filter_test.go's canonical session
+// fixture (the constraints name it the one record shape these phases test
+// against). It is rebuilt here because package vector's test helpers are not
+// importable from ops — the SHAPE is what must match, not the code:
+//
+//	#0 rc U8 #1 bc U8 #2 hist U32 #3 bal I32 #4 tag BYTES
+//	#5 b TABLE(key U64; hi U32, lo U32)
+func vecSessionSchema(t *testing.T) *wire.Schema {
+	t.Helper()
+	s := &wire.Schema{Version: 1, StoreNames: true, Fields: []wire.FieldDef{
+		{Name: "rc", Type: wire.OperateTypeU8},
+		{Name: "bc", Type: wire.OperateTypeU8},
+		{Name: "hist", Type: wire.OperateTypeU32},
+		{Name: "bal", Type: wire.OperateTypeI32},
+		{Name: "tag", Type: wire.OperateTypeBytes},
+		{Name: "b", Type: wire.OperateTypeTable, Table: &wire.TableDef{
+			KeyType: wire.OperateTypeU64,
+			Cols: []wire.ColumnDef{
+				{Name: "hi", Type: wire.OperateTypeU32},
+				{Name: "lo", Type: wire.OperateTypeU32},
+			},
+		}},
+	}}
+	if err := s.Validate(); err != nil {
+		t.Fatalf("session schema invalid: %v", err)
+	}
+	return s
+}
+
+// vecSessionRecordBytes is vecSessionSchema's record with rc = 7 and two rows in
+// table b, matching vector/record_filter_test.go's sessionRecordBytes.
+func vecSessionRecordBytes(t *testing.T) []byte {
+	t.Helper()
+	leKey := func(v uint64) []byte { return binary.LittleEndian.AppendUint64(nil, v) }
+	rec := &wire.Record{Mode: wire.OperateModeSchema, Schema: vecSessionSchema(t), Fields: []wire.Field{
+		{Cell: wire.Cell{Type: wire.OperateTypeU8, U: 7}},
+		{Cell: wire.Cell{Type: wire.OperateTypeU8, U: 3}},
+		{Cell: wire.Cell{Type: wire.OperateTypeU32, U: 1234}},
+		{Cell: wire.Cell{Type: wire.OperateTypeI32, U: su64(-5)}},
+		{Cell: wire.Cell{Type: wire.OperateTypeBytes, B: []byte("de")}},
+		{Cell: wire.Cell{Type: wire.OperateTypeTable}, Table: &wire.Table{Rows: []wire.Row{
+			{Key: leKey(42), Cols: []wire.Col{
+				{Cell: wire.Cell{Type: wire.OperateTypeU32, U: 500}},
+				{Cell: wire.Cell{Type: wire.OperateTypeU32, U: 1}},
+			}},
+			{Key: leKey(99), Cols: []wire.Col{
+				{Cell: wire.Cell{Type: wire.OperateTypeU32, U: 7}},
+				{Cell: wire.Cell{Type: wire.OperateTypeU32, U: 2}},
+			}},
+		}}},
+	}}
+	enc := rec.Encode()
+	if enc == nil {
+		t.Fatal("session record failed to encode")
+	}
+	return enc
+}
+
+// newDenseOperateTx creates a dense collection "docs" holding point 1 with the
+// given payload, and returns the TxContext over it.
+func newDenseOperateTx(t *testing.T, meta vector.Metadata) *TxContext {
+	t.Helper()
+	tx := newVecTx(t)
+	cfg := vector.Config{Dim: 2, M: 4, EfConstruction: 10, EfSearch: 10, Seed: 1, Metric: vector.L2}
+	if _, err := handleVectorCreateCollection(tx, EncodeCreateCollectionArgs("docs", cfg)); err != nil {
+		t.Fatalf("create collection: %v", err)
+	}
+	if _, err := handleVectorInsert(tx, EncodeVectorInsertArgsExt(
+		"docs", 1, []float32{1, 0}, 0, meta, vector.SparseVector{})); err != nil {
+		t.Fatalf("insert: %v", err)
+	}
+	return tx
+}
+
+// densePayload reads point 1's payload and version back through the real get op.
+func densePayload(t *testing.T, tx *TxContext, id uint64) (vector.Metadata, uint64) {
+	t.Helper()
+	body, err := handleVectorGet(tx, EncodeVectorGetArgs("docs", id, GetFlagsBoth))
+	if err != nil {
+		t.Fatalf("vector_get: %v", err)
+	}
+	found, _, meta, _, _, version, err := DecodeVectorGetResultV(body)
+	if err != nil {
+		t.Fatalf("DecodeVectorGetResultV: %v", err)
+	}
+	if !found {
+		t.Fatalf("point %d not found", id)
+	}
+	return meta, version
+}
+
+// cellU decodes a returned tagged cell and reports its unsigned value.
+func cellU(t *testing.T, b []byte) uint64 {
+	t.Helper()
+	c, _, err := wire.DecodeTaggedCell(b)
+	if err != nil {
+		t.Fatalf("DecodeTaggedCell(%x): %v", b, err)
+	}
+	return c.U
+}
+
+func TestVectorOperateCreatesAndIncrements(t *testing.T) {
+	tx := newDenseOperateTx(t, vector.Metadata{"lang": vector.NewString("en")})
+
+	found, res := mustVecOperate(t, tx, handleVectorOperate, 0, "docs", 1, "session", setDyn("rc", 1))
+	if !found {
+		t.Fatal("call 1: found = false, want true (the point exists)")
+	}
+	if res == nil || res.Status != wire.OperateStatusOK {
+		t.Fatalf("call 1: res = %+v, want OperateStatusOK", res)
+	}
+
+	found, res = mustVecOperate(t, tx, handleVectorOperate, 0, "docs", 1, "session", addDynRet("rc", 1))
+	if !found || res == nil || res.Status != wire.OperateStatusOK {
+		t.Fatalf("call 2: found=%v res=%+v", found, res)
+	}
+	if len(res.Values) != 1 {
+		t.Fatalf("call 2: %d return values, want 1", len(res.Values))
+	}
+	if got := cellU(t, res.Values[0]); got != 2 {
+		t.Fatalf("rc = %d, want 2 (created at 1, then incremented)", got)
+	}
+
+	meta, _ := densePayload(t, tx, 1)
+	v, ok := meta["session"]
+	if !ok {
+		t.Fatalf("payload = %+v, want a session key", meta)
+	}
+	if v.Kind != vector.ValueRecord {
+		t.Fatalf("session kind = %v, want ValueRecord", v.Kind)
+	}
+	if meta["lang"].Str != "en" {
+		t.Fatalf("payload = %+v, want the pre-existing lang key untouched", meta)
+	}
+}
+
+func TestVectorOperateAgainstSchemaRecord(t *testing.T) {
+	tx := newDenseOperateTx(t, vector.Metadata{"session": vector.NewRecord(vecSessionRecordBytes(t))})
+	s := vecSessionSchema(t)
+
+	a := &wire.OperateArgs{Create: wire.OperateCreateSchema, Schema: s.Encode(),
+		Ops: []wire.OperateOp{{Opcode: wire.OperateOpADD, Type: opFromSchema, Path: fieldPath(0), A: 1}},
+		Rets: []wire.OperateRet{
+			{Mode: wire.OperateRetValue, Path: fieldPath(0)},
+			{Mode: wire.OperateRetCount, Path: fieldPath(5)},
+		}}
+	found, res := mustVecOperate(t, tx, handleVectorOperate, 0, "docs", 1, "session", a)
+	if !found || res == nil || res.Status != wire.OperateStatusOK {
+		t.Fatalf("found=%v res=%+v", found, res)
+	}
+	if got := cellU(t, res.Values[0]); got != 8 {
+		t.Fatalf("rc = %d, want 8 (7 + 1)", got)
+	}
+	if got := cellU(t, res.Values[1]); got != 2 {
+		t.Fatalf("COUNT b = %d, want 2 (the table's rows survive a scalar ADD)", got)
+	}
+}
+
+func TestVectorOperateMissingPointIsAFlag(t *testing.T) {
+	tx := newDenseOperateTx(t, nil)
+
+	found, res, err := callVecOperate(t, tx, handleVectorOperate, 0, "docs", 999, "session", setDyn("rc", 1), 0, false)
+	if err != nil {
+		t.Fatalf("missing point: err = %v, want nil (a not-found FLAG, not an op error)", err)
+	}
+	if found {
+		t.Fatal("missing point: found = true, want false")
+	}
+	if res != nil {
+		t.Fatalf("missing point: res = %+v, want nil (the mutator never ran)", res)
+	}
+}
+
+func TestVectorOperateCreateNoneAgainstAbsentRecord(t *testing.T) {
+	tx := newDenseOperateTx(t, vector.Metadata{"lang": vector.NewString("en")})
+
+	a := &wire.OperateArgs{Create: wire.OperateCreateNone, Ops: []wire.OperateOp{
+		{Opcode: wire.OperateOpADD, Type: wire.OperateTypeU64, Path: namePath("rc"), A: 1}}}
+	_, _, err := callVecOperate(t, tx, handleVectorOperate, 0, "docs", 1, "session", a, 0, false)
+	if !errors.Is(err, ErrVectorRecordAbsent) {
+		t.Fatalf("err = %v, want ErrVectorRecordAbsent", err)
+	}
+
+	meta, _ := densePayload(t, tx, 1)
+	if len(meta) != 1 || meta["lang"].Str != "en" {
+		t.Fatalf("payload = %+v, want the point's other keys untouched", meta)
+	}
+}
+
+func TestVectorOperateNonRecordKeyErrors(t *testing.T) {
+	tx := newDenseOperateTx(t, vector.Metadata{"country": vector.NewString("de")})
+
+	_, _, err := callVecOperate(t, tx, handleVectorOperate, 0, "docs", 1, "country", setDyn("rc", 1), 0, false)
+	if !errors.Is(err, vector.ErrPayloadKeyNotRecord) {
+		t.Fatalf("err = %v, want vector.ErrPayloadKeyNotRecord", err)
+	}
+	meta, _ := densePayload(t, tx, 1)
+	if meta["country"].Str != "de" {
+		t.Fatalf("payload = %+v, want the string value preserved, not replaced by a record", meta)
+	}
+}
+
+func TestVectorOperateCheckFailedIsANoOp(t *testing.T) {
+	tx := newDenseOperateTx(t, nil)
+	mustVecOperate(t, tx, handleVectorOperate, 0, "docs", 1, "session", setDyn("rc", 1))
+	before, versionBefore := densePayload(t, tx, 1)
+	recBefore := append([]byte(nil), before["session"].Rec...)
+
+	// Op 0 succeeds, op 1's CHECK fails: the whole list aborts and NOTHING is
+	// written, so op 0's increment must not survive either.
+	a := &wire.OperateArgs{Create: wire.OperateCreateDynamic, Ops: []wire.OperateOp{
+		{Opcode: wire.OperateOpADD, Type: wire.OperateTypeU64, Path: namePath("rc"), A: 1},
+		{Opcode: wire.OperateOpCHECK, Aux: wire.OperateCmpEQ, Path: namePath("rc"), A: 99},
+	}}
+	found, res := mustVecOperate(t, tx, handleVectorOperate, 0, "docs", 1, "session", a)
+	if !found {
+		t.Fatal("found = false, want true (the point exists; only the CHECK failed)")
+	}
+	if res == nil || res.Status != wire.OperateStatusCheckFailed {
+		t.Fatalf("res = %+v, want OperateStatusCheckFailed", res)
+	}
+	if res.FailedOp != 1 {
+		t.Fatalf("FailedOp = %d, want 1 (the CHECK's index in the op list)", res.FailedOp)
+	}
+
+	after, versionAfter := densePayload(t, tx, 1)
+	if !bytes.Equal(recBefore, after["session"].Rec) {
+		t.Fatalf("record changed on a failed CHECK: %x -> %x", recBefore, after["session"].Rec)
+	}
+	if versionAfter != versionBefore {
+		t.Fatalf("version = %d, want %d (a failed CHECK bumps nothing)", versionAfter, versionBefore)
+	}
+}
+
+func TestVectorOperateDeletesTheRecord(t *testing.T) {
+	tx := newDenseOperateTx(t, vector.Metadata{"session": vector.NewRecord(vecSessionRecordBytes(t))})
+
+	// The record path is indexed before the delete: rc = 7 is findable.
+	hits := searchRecordPath(t, tx, 7)
+	if len(hits) != 1 || hits[0] != 1 {
+		t.Fatalf("filter session/rc == 7 before the delete = %v, want [1]", hits)
+	}
+
+	a := &wire.OperateArgs{Create: wire.OperateCreateSchema, Schema: vecSessionSchema(t).Encode(),
+		Ops: []wire.OperateOp{{Opcode: wire.OperateOpDEL, Path: recPath()}}}
+	found, res := mustVecOperate(t, tx, handleVectorOperate, 0, "docs", 1, "session", a)
+	if !found || res == nil || res.Status != wire.OperateStatusOK {
+		t.Fatalf("found=%v res=%+v", found, res)
+	}
+
+	meta, _ := densePayload(t, tx, 1)
+	if _, ok := meta["session"]; ok {
+		t.Fatalf("payload = %+v, want the session key gone", meta)
+	}
+	if hits := searchRecordPath(t, tx, 7); len(hits) != 0 {
+		t.Fatalf("filter session/rc == 7 after the delete = %v, want no hits (the posting is gone)", hits)
+	}
+}
+
+// searchRecordPath runs a filtered search over "docs" for session/rc == rc and
+// returns the matching ids — the record posting the payload index maintains.
+func searchRecordPath(t *testing.T, tx *TxContext, rc int64) []uint64 {
+	t.Helper()
+	body, err := handleVectorSearch(tx, EncodeVectorSearchArgsExt("docs", 10, []float32{1, 0},
+		vector.Filter{Op: vector.FilterEq, Field: "session/rc", Value: vector.NewInt(rc)}))
+	if err != nil {
+		t.Fatalf("vector_search: %v", err)
+	}
+	rs, derr := DecodeVectorSearchResults(body)
+	if derr != nil {
+		t.Fatalf("DecodeVectorSearchResults: %v", derr)
+	}
+	out := make([]uint64, 0, len(rs))
+	for _, r := range rs {
+		out = append(out, r.ID)
+	}
+	return out
+}
+
+func TestVectorOperateCAS(t *testing.T) {
+	tx := newDenseOperateTx(t, nil)
+	mustVecOperate(t, tx, handleVectorOperate, 0, "docs", 1, "session", setDyn("rc", 1))
+	before, version := densePayload(t, tx, 1)
+	recBefore := append([]byte(nil), before["session"].Rec...)
+
+	_, _, err := callVecOperate(t, tx, handleVectorOperate, 0, "docs", 1, "session", addDynRet("rc", 1), version+999, true)
+	if !errors.Is(err, vector.ErrVersionConflict) {
+		t.Fatalf("stale CAS: err = %v, want vector.ErrVersionConflict", err)
+	}
+	after, versionAfter := densePayload(t, tx, 1)
+	if !bytes.Equal(recBefore, after["session"].Rec) || versionAfter != version {
+		t.Fatal("a rejected CAS mutated the point")
+	}
+
+	found, res, err := callVecOperate(t, tx, handleVectorOperate, 0, "docs", 1, "session", addDynRet("rc", 1), version, true)
+	if err != nil {
+		t.Fatalf("matching CAS: %v", err)
+	}
+	if !found || res == nil || res.Status != wire.OperateStatusOK {
+		t.Fatalf("matching CAS: found=%v res=%+v", found, res)
+	}
+	if got := cellU(t, res.Values[0]); got != 2 {
+		t.Fatalf("rc = %d, want 2", got)
+	}
+}
+
+// TestVectorOperateIsDeterministicUnderTheStamp proves the handler threads the
+// leader apply stamp into applyRecordBytes and nowhere consults a wall clock:
+// two INDEPENDENT collections, in independent stores, running the same
+// STAMP-carrying op-list under the same stamp must store byte-identical record
+// bytes — and, run under two DIFFERENT stamps, must not. The second half is what
+// stops the test passing by the stamp being ignored altogether.
+//
+// (The leader-vs-follower proof is Task 6's replica test; this is the handler's
+// half of it.)
+func TestVectorOperateIsDeterministicUnderTheStamp(t *testing.T) {
+	stampOp := &wire.OperateArgs{Create: wire.OperateCreateDynamic, Ops: []wire.OperateOp{
+		{Opcode: wire.OperateOpSTAMP, Type: wire.OperateTypeU64, Aux: wire.OperateStampMs, Path: namePath("t")},
+		{Opcode: wire.OperateOpADD, Type: wire.OperateTypeU64, Path: namePath("rc"), A: 1},
+	}}
+	run := func(t *testing.T, stampMs int64) []byte {
+		t.Helper()
+		tx := newDenseOperateTx(t, nil)
+		if found, res := mustVecOperate(t, tx, handleVectorOperate, stampMs, "docs", 1, "session", stampOp); !found ||
+			res.Status != wire.OperateStatusOK {
+			t.Fatalf("stamp %d: found=%v res=%+v", stampMs, found, res)
+		}
+		meta, _ := densePayload(t, tx, 1)
+		return append([]byte(nil), meta["session"].Rec...)
+	}
+
+	const stampA = int64(1_700_000_000_000)
+	const stampB = int64(1_700_000_777_000)
+
+	a1 := run(t, stampA)
+	a2 := run(t, stampA)
+	if !bytes.Equal(a1, a2) {
+		t.Fatalf("two collections under the SAME stamp stored different bytes:\n%x\n%x", a1, a2)
+	}
+	b := run(t, stampB)
+	if bytes.Equal(a1, b) {
+		t.Fatal("two DIFFERENT stamps stored identical bytes — the stamp is not reaching applyRecordBytes")
+	}
+}
+
+// TestVectorOperateNamedAndMV runs the create/increment, failed-CHECK and
+// missing-point cases against the named and multi-vector families, whose
+// handlers differ from the dense one only in the engine entry point.
+func TestVectorOperateNamedAndMV(t *testing.T) {
+	for _, fam := range []struct {
+		name    string
+		col     string
+		handler vecOperateHandler
+		setup   func(t *testing.T, tx *TxContext)
+		payload func(t *testing.T, tx *TxContext, id uint64) vector.Metadata
+	}{
+		{
+			name: "named", col: "named", handler: handleNamedVectorOperate,
+			setup: func(t *testing.T, tx *TxContext) {
+				t.Helper()
+				cfg := map[string]vector.NamedVectorParams{"title": {Dim: 2, Metric: vector.Cosine}}
+				if _, err := handleNamedCreate(tx, EncodeNamedCreateArgs("named", cfg, 0)); err != nil {
+					t.Fatalf("named create: %v", err)
+				}
+				if _, err := handleNamedInsert(tx, EncodeNamedInsertArgs("named", 1,
+					map[string][]float32{"title": {1, 0}}, nil, 0)); err != nil {
+					t.Fatalf("named insert: %v", err)
+				}
+			},
+			payload: func(t *testing.T, tx *TxContext, id uint64) vector.Metadata {
+				t.Helper()
+				body, err := handleNamedGet(tx, EncodeVectorGetArgs("named", id, GetFlagsBoth))
+				if err != nil {
+					t.Fatalf("named get: %v", err)
+				}
+				found, _, meta, _, _, derr := DecodeNamedGetResultV(body)
+				if derr != nil || !found {
+					t.Fatalf("named get: found=%v err=%v", found, derr)
+				}
+				return meta
+			},
+		},
+		{
+			name: "mv", col: "mv", handler: handleMVVectorOperate,
+			setup: func(t *testing.T, tx *TxContext) {
+				t.Helper()
+				if _, err := handleMVCreate(tx, EncodeMVCreateArgs("mv", vector.MultiVectorConfig{
+					Dim: 2, M: 4, EfConstruction: 10, EfSearch: 10, Seed: 1})); err != nil {
+					t.Fatalf("mv create: %v", err)
+				}
+				if _, err := handleMVAdd(tx, EncodeMVAddArgs("mv", 1, [][]float32{{1, 0}}, nil)); err != nil {
+					t.Fatalf("mv add: %v", err)
+				}
+			},
+			payload: func(t *testing.T, tx *TxContext, id uint64) vector.Metadata {
+				t.Helper()
+				body, err := handleMVGet(tx, EncodeVectorGetArgs("mv", id, GetFlagsBoth))
+				if err != nil {
+					t.Fatalf("mv get: %v", err)
+				}
+				found, _, meta, _, derr := DecodeMVGetResultV(body)
+				if derr != nil || !found {
+					t.Fatalf("mv get: found=%v err=%v", found, derr)
+				}
+				return meta
+			},
+		},
+	} {
+		t.Run(fam.name, func(t *testing.T) {
+			tx := newVecTx(t)
+			fam.setup(t, tx)
+
+			// create + increment
+			if found, res := mustVecOperate(t, tx, fam.handler, 0, fam.col, 1, "session", setDyn("rc", 1)); !found ||
+				res.Status != wire.OperateStatusOK {
+				t.Fatalf("create: found=%v res=%+v", found, res)
+			}
+			found, res := mustVecOperate(t, tx, fam.handler, 0, fam.col, 1, "session", addDynRet("rc", 1))
+			if !found || res.Status != wire.OperateStatusOK {
+				t.Fatalf("increment: found=%v res=%+v", found, res)
+			}
+			if got := cellU(t, res.Values[0]); got != 2 {
+				t.Fatalf("rc = %d, want 2", got)
+			}
+			meta := fam.payload(t, tx, 1)
+			if meta["session"].Kind != vector.ValueRecord {
+				t.Fatalf("payload = %+v, want a ValueRecord under session", meta)
+			}
+			recBefore := append([]byte(nil), meta["session"].Rec...)
+
+			// failed CHECK: no-op
+			check := &wire.OperateArgs{Create: wire.OperateCreateDynamic, Ops: []wire.OperateOp{
+				{Opcode: wire.OperateOpADD, Type: wire.OperateTypeU64, Path: namePath("rc"), A: 1},
+				{Opcode: wire.OperateOpCHECK, Aux: wire.OperateCmpEQ, Path: namePath("rc"), A: 99},
+			}}
+			found, res = mustVecOperate(t, tx, fam.handler, 0, fam.col, 1, "session", check)
+			if !found || res.Status != wire.OperateStatusCheckFailed || res.FailedOp != 1 {
+				t.Fatalf("check: found=%v res=%+v", found, res)
+			}
+			if after := fam.payload(t, tx, 1); !bytes.Equal(recBefore, after["session"].Rec) {
+				t.Fatal("a failed CHECK changed the stored record")
+			}
+
+			// missing point: the not-found flag, not an error
+			found, res, err := callVecOperate(t, tx, fam.handler, 0, fam.col, 999, "session", setDyn("rc", 1), 0, false)
+			if err != nil {
+				t.Fatalf("missing point: err = %v, want nil", err)
+			}
+			if found || res != nil {
+				t.Fatalf("missing point: found=%v res=%+v, want false/nil", found, res)
+			}
+		})
+	}
+}
+
+// TestVectorOperateRegistered pins the three ops into the builtin registry. It
+// also covers ops/builtin.go's handler-count equality gate: a row added to
+// wire.BuiltinOps without its handler (or the reverse) fails RegisterBuiltins.
+func TestVectorOperateRegistered(t *testing.T) {
+	r := NewRegistry()
+	if err := RegisterBuiltins(r); err != nil {
+		t.Fatalf("RegisterBuiltins: %v", err)
+	}
+	a := &wire.OperateArgs{Create: wire.OperateCreateDynamic, Ops: []wire.OperateOp{
+		{Opcode: wire.OperateOpADD, Type: wire.OperateTypeU64, Path: namePath("rc"), A: 1}}}
+	args, err := EncodeVectorOperateArgs("docs", 7, "session", a, 0, false)
+	if err != nil {
+		t.Fatalf("EncodeVectorOperateArgs: %v", err)
+	}
+	for _, op := range []string{"vector_operate", "vector_named_operate", "vector_mv_operate"} {
+		_, kind, ke, ok := r.Lookup(op)
+		if !ok {
+			t.Errorf("%s not registered", op)
+			continue
+		}
+		if kind != OpReadWrite {
+			t.Errorf("%s kind = %v, want OpReadWrite", op, kind)
+		}
+		if ke == nil {
+			t.Fatalf("%s has a nil key extractor (it would route to shard 0)", op)
+		}
+		key, found := ke(args)
+		if !found || string(key) != "default/docs" {
+			t.Errorf("%s key extractor = (%q,%v), want (default/docs,true)", op, key, found)
+		}
+	}
+}
+
+// TestVectorOperateHandlerDefendsInnerKeyAndTTL pins the handler's own guard.
+// The codec already rejects both on the wire (sdk/wire's
+// TestVectorOperateArgsRejectsInnerKey / RejectsTTLMode), so this is defence in
+// depth: the target is named exactly once, by (collection, id, payloadKey), and
+// a point's TTL is the point's. Neither may become a silently-ignored second
+// source of truth if a future codec revision, or an in-process caller, hands the
+// handler an OperateArgs the decoder never saw.
+func TestVectorOperateHandlerDefendsInnerKeyAndTTL(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		a    *wire.OperateArgs
+	}{
+		{"nil args", nil},
+		{"inner key", &wire.OperateArgs{Key: []byte("k"), Create: wire.OperateCreateDynamic}},
+		{"ttl mode set", &wire.OperateArgs{Create: wire.OperateCreateDynamic, TTLMode: wire.OperateTTLSet, TTL: time.Minute}},
+		{"ttl without a mode", &wire.OperateArgs{Create: wire.OperateCreateDynamic, TTL: time.Minute}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if err := checkVectorOperateArgs(tc.a); !errors.Is(err, wire.ErrOperateArgs) {
+				t.Fatalf("err = %v, want wire.ErrOperateArgs", err)
+			}
+		})
+	}
+	ok := &wire.OperateArgs{Create: wire.OperateCreateDynamic, Ops: []wire.OperateOp{
+		{Opcode: wire.OperateOpADD, Type: wire.OperateTypeU64, Path: namePath("rc"), A: 1}}}
+	if err := checkVectorOperateArgs(ok); err != nil {
+		t.Fatalf("a well-formed call was rejected: %v", err)
+	}
+}

--- a/ops/vector_operate_test.go
+++ b/ops/vector_operate_test.go
@@ -46,7 +46,7 @@ func callVecOperate(t *testing.T, tx *TxContext, h vecOperateHandler, stampMs in
 	if herr != nil {
 		return false, nil, herr
 	}
-	found, res, derr := DecodeVectorOperateResult(body)
+	found, res, _, derr := DecodeVectorOperateResult(body)
 	if derr != nil {
 		t.Fatalf("DecodeVectorOperateResult: %v", derr)
 	}
@@ -594,5 +594,79 @@ func TestVectorOperateHandlerDefendsInnerKeyAndTTL(t *testing.T) {
 		{Opcode: wire.OperateOpADD, Type: wire.OperateTypeU64, Path: namePath("rc"), A: 1}}}
 	if err := checkVectorOperateArgs(ok); err != nil {
 		t.Fatalf("a well-formed call was rejected: %v", err)
+	}
+}
+
+// callVecOperateV is callVecOperate keeping the version the reply frame now
+// carries, which callVecOperate drops so its many callers stay unchanged.
+func callVecOperateV(t *testing.T, tx *TxContext, h vecOperateHandler, stampMs int64,
+	col string, id uint64, pk string, a *wire.OperateArgs,
+) (bool, *wire.OperateResult, uint64) {
+	t.Helper()
+	args, err := EncodeVectorOperateArgs(col, id, pk, a, 0, false)
+	if err != nil {
+		t.Fatalf("EncodeVectorOperateArgs: %v", err)
+	}
+	tx.SetApplyStamp(uint64(stampMs), stampMs != 0) //nolint:gosec // test stamps are small positive millis
+	defer tx.SetApplyStamp(0, false)
+	body, herr := h(tx, args)
+	if herr != nil {
+		t.Fatalf("handler: %v", herr)
+	}
+	found, res, version, derr := DecodeVectorOperateResult(body)
+	if derr != nil {
+		t.Fatalf("DecodeVectorOperateResult: %v", derr)
+	}
+	return found, res, version
+}
+
+// TestVectorOperateReturnsTheAppliedVersion pins the handler's version
+// threading, which is what lets a CAS loop retry from the reply frame instead of
+// re-reading the point. Three properties, all of them checkable only here
+// because only the handler sees both the engine's version and the wire frame:
+// an applied call reports the point's NEW version, a failed CHECK reports the
+// CURRENT unbumped one (so the retry has something to fence on), and a
+// not-found point reports 0.
+//
+// Each version is cross-checked against what a real get op reports, so a
+// plausible-looking but wrong number fails.
+func TestVectorOperateReturnsTheAppliedVersion(t *testing.T) {
+	tx := newDenseOperateTx(t, nil)
+
+	found, _, v1 := callVecOperateV(t, tx, handleVectorOperate, 0, "docs", 1, "session", setDyn("rc", 1))
+	if !found {
+		t.Fatal("found = false, want true")
+	}
+	_, getV1 := densePayload(t, tx, 1)
+	if v1 == 0 || v1 != getV1 {
+		t.Fatalf("version = %d, want the point's version %d (non-zero)", v1, getV1)
+	}
+
+	_, _, v2 := callVecOperateV(t, tx, handleVectorOperate, 0, "docs", 1, "session", setDyn("rc", 2))
+	_, getV2 := densePayload(t, tx, 1)
+	if v2 <= v1 || v2 != getV2 {
+		t.Fatalf("version = %d after a second apply, want > %d and == the point's %d", v2, v1, getV2)
+	}
+
+	// A failed CHECK writes nothing and bumps nothing, and must still report the
+	// version a caller would retry against.
+	checkFails := &wire.OperateArgs{Create: wire.OperateCreateDynamic, Ops: []wire.OperateOp{
+		{Opcode: wire.OperateOpCHECK, Aux: wire.OperateCmpEQ, Path: namePath("rc"), A: 99},
+	}}
+	found, res, vFail := callVecOperateV(t, tx, handleVectorOperate, 0, "docs", 1, "session", checkFails)
+	if !found || res == nil || res.Status != wire.OperateStatusCheckFailed {
+		t.Fatalf("found=%v res=%+v, want a CheckFailed result", found, res)
+	}
+	if vFail != v2 {
+		t.Fatalf("version = %d on a failed CHECK, want the current unbumped %d", vFail, v2)
+	}
+
+	// An absent point is the not-found flag, and carries no version.
+	found, _, vMissing := callVecOperateV(t, tx, handleVectorOperate, 0, "docs", 9999, "session", setDyn("rc", 1))
+	if found {
+		t.Fatal("found = true for an absent point")
+	}
+	if vMissing != 0 {
+		t.Fatalf("version = %d for an absent point, want 0", vMissing)
 	}
 }

--- a/ops/vector_record_absent_message_test.go
+++ b/ops/vector_record_absent_message_test.go
@@ -1,0 +1,56 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package ops
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+)
+
+// TestIsVectorRecordAbsentMessage pins IsVectorRecordAbsentMessage against
+// ErrVectorRecordAbsent's one production shape (bare, no wrapping — see the
+// function's doc comment for why), and against the class of input it exists to
+// REJECT: an unrelated error whose message merely contains the sentinel text. A
+// bare strings.Contains would pass every case in the reject table below, which
+// is exactly the bug this replaces.
+func TestIsVectorRecordAbsentMessage(t *testing.T) {
+	accept := []struct {
+		name string
+		msg  string
+	}{
+		{"bare sentinel text", ErrVectorRecordAbsent.Error()},
+		{"re-stringified (simulates decodePBResult)", errors.New(ErrVectorRecordAbsent.Error()).Error()},
+	}
+	for _, tc := range accept {
+		t.Run("accept/"+tc.name, func(t *testing.T) {
+			if !IsVectorRecordAbsentMessage(tc.msg) {
+				t.Errorf("IsVectorRecordAbsentMessage(%q) = false, want true", tc.msg)
+			}
+		})
+	}
+
+	reject := []struct {
+		name string
+		msg  string
+	}{
+		{"empty string", ""},
+		{"unrelated error containing the sentinel text (%v wrap)",
+			fmt.Errorf("wal append failed at /var/lib/rostam/x: %v", ErrVectorRecordAbsent).Error()},
+		{"unrelated error containing the sentinel text (%w wrap, op-name prefixed)",
+			fmt.Errorf("vector_operate: %w", ErrVectorRecordAbsent).Error()},
+		{"sentinel text embedded mid-message with unrelated trailing content",
+			"apply failed: " + ErrVectorRecordAbsent.Error() + " (retrying on shard 3)"},
+		{"sentinel text with a byte cut off the front",
+			ErrVectorRecordAbsent.Error()[1:]},
+		{"sentinel text with trailing garbage appended",
+			ErrVectorRecordAbsent.Error() + " extra"},
+	}
+	for _, tc := range reject {
+		t.Run("reject/"+tc.name, func(t *testing.T) {
+			if IsVectorRecordAbsentMessage(tc.msg) {
+				t.Errorf("IsVectorRecordAbsentMessage(%q) = true, want false", tc.msg)
+			}
+		})
+	}
+}

--- a/ops/wire_aliases.go
+++ b/ops/wire_aliases.go
@@ -263,6 +263,8 @@ var (
 	DecodeVectorInsertArgsKeyExpires          = wire.DecodeVectorInsertArgsKeyExpires
 	DecodeVectorInsertArgsKeyExpiresInto      = wire.DecodeVectorInsertArgsKeyExpiresInto
 	DecodeVectorInsertArgsKeyTTL              = wire.DecodeVectorInsertArgsKeyTTL
+	DecodeVectorOperateArgs                   = wire.DecodeVectorOperateArgs
+	DecodeVectorOperateResult                 = wire.DecodeVectorOperateResult
 	DecodeVectorSearchArgs                    = wire.DecodeVectorSearchArgs
 	DecodeVectorSearchArgsInto                = wire.DecodeVectorSearchArgsInto
 	DecodeVectorSearchArgsOpts                = wire.DecodeVectorSearchArgsOpts
@@ -426,6 +428,8 @@ var (
 	EncodeVectorInsertArgsKeyTTL              = wire.EncodeVectorInsertArgsKeyTTL
 	EncodeVectorInsertArgsVersioned           = wire.EncodeVectorInsertArgsVersioned
 	EncodeVectorInsertArgsVersionedKeyExpires = wire.EncodeVectorInsertArgsVersionedKeyExpires
+	EncodeVectorOperateArgs                   = wire.EncodeVectorOperateArgs
+	EncodeVectorOperateResult                 = wire.EncodeVectorOperateResult
 	EncodeVectorSearchArgs                    = wire.EncodeVectorSearchArgs
 	AppendVectorSearchArgs                    = wire.AppendVectorSearchArgs
 	AppendVectorSearchArgsExt                 = wire.AppendVectorSearchArgsExt

--- a/ops/write_consistency.go
+++ b/ops/write_consistency.go
@@ -6,6 +6,8 @@ import (
 	"encoding/binary"
 	"errors"
 	"fmt"
+
+	"github.com/rostamlabs/rostam/sdk/wire"
 )
 
 // WCEnvelopeOp is the reserved name of the write-consistency envelope virtual-op.
@@ -15,7 +17,13 @@ import (
 // normal routing/Raft path 100% unchanged, then runs the post-commit barrier.
 // Because the inner op's name + args are byte-identical to a plain write, no
 // existing data-op codec, FSM handler, decoder, or routing path is touched.
-const WCEnvelopeOp = "__wc__"
+//
+// The constant itself lives in sdk/wire (wire.WCEnvelopeOp) because the
+// standalone client module has to agree on it too — it must recognise its own
+// envelope to classify a wrapped write's retryability — and that module can see
+// wire but not ops. This alias keeps every server-side reference reading as
+// ops.WCEnvelopeOp.
+const WCEnvelopeOp = wire.WCEnvelopeOp
 
 // errWCEnvelopeTruncated is returned by DecodeWCEnvelope when the args bytes are
 // shorter than the layout requires (fail-loud, mirroring errAliasArgsTruncated /

--- a/sdk/record/validate.go
+++ b/sdk/record/validate.go
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package record
+
+import (
+	"fmt"
+
+	"github.com/rostamlabs/rostam/sdk/wire"
+)
+
+// Validate reports whether rec is a record the operate engines can open: its
+// acceptance set is EXACTLY wire.DecodeRecord's, wrapped so callers outside the
+// sdk module's wire package (the vector engine) do not need to import it. It
+// returns nil, or an error wrapping ErrRecord.
+//
+// It is the INGEST gate. Every wire-reachable entry that stores a ValueRecord
+// runs it before any state changes, so from this phase onward no stored record
+// can be one the operate engine, IndexEntries or DecodeRecord would refuse.
+//
+// It is STRICTER than Resolve, deliberately. Resolve reads only the bytes on
+// its own path and is documented as answering Absent for shapes DecodeRecord
+// rejects (an unsorted row block, for one), and IndexEntries — which walks
+// every field — rejects records Resolve still answers from. That asymmetry is
+// what poisons a payload key: a record that indexes nothing while it still
+// resolves makes every empty-set inference under that key a lie, so phase 1 had
+// to fail closed on it. Validating at ingest makes the divergence unreachable
+// for anything stored from here on, WITHOUT changing Resolve, which must stay
+// lenient for bytes written before it.
+//
+// WHY IT DECODES RATHER THAN WALKING. A validate-only pass that did not build
+// the tree would be a SECOND acceptance set to hold in step with DecodeRecord's
+// — and two readers disagreeing about one record is the exact failure this gate
+// exists to prevent, so the cheaper walk would reintroduce the class it closes.
+// wire exposes no such walk today (sdk/wire/operate_record.go: DecodeRecord is
+// the only entry) and adding one is not worth that risk.
+//
+// COST. DecodeRecord builds the full tree, so this is O(len(rec)) with
+// allocations proportional to the record's rows and fields, paid once per
+// ingested record VALUE on the write path — not per point and not per read.
+// Records are capped at 16 MiB (vector's maxRecordValueBytes, checked first so
+// an oversize value is refused without being decoded) and the caller is already
+// copying them. BenchmarkValidate measures both ends of the range.
+func Validate(rec []byte) error {
+	if _, err := wire.DecodeRecord(rec); err != nil {
+		return fmt.Errorf("%w: %w", ErrRecord, err)
+	}
+	return nil
+}

--- a/sdk/record/validate_test.go
+++ b/sdk/record/validate_test.go
@@ -1,0 +1,255 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package record
+
+import (
+	"bytes"
+	"errors"
+	"math/rand"
+	"testing"
+
+	"github.com/rostamlabs/rostam/sdk/wire"
+)
+
+// TestValidateAcceptsBothModes pins the positive half: the two canonical
+// fixtures the resolver is tested against — a schema-mode record with and
+// without stored names, and a dynamic-mode one — are records the operate
+// engines open, so the ingest gate must let them through.
+func TestValidateAcceptsBothModes(t *testing.T) {
+	named, _ := sessionRecord(t, true)
+	nameless, _ := sessionRecord(t, false)
+	dyn, _ := dynamicRecord(t)
+
+	for _, c := range []struct {
+		name string
+		rec  []byte
+	}{
+		{"schema mode, names stored", named},
+		{"schema mode, names omitted", nameless},
+		{"dynamic mode", dyn},
+	} {
+		t.Run(c.name, func(t *testing.T) {
+			before := append([]byte(nil), c.rec...)
+			if err := Validate(c.rec); err != nil {
+				t.Fatalf("Validate = %v, want nil", err)
+			}
+			if !bytes.Equal(before, c.rec) {
+				t.Fatal("Validate mutated its input")
+			}
+		})
+	}
+}
+
+// TestValidateRejectsEmpty covers the shapes that carry no record at all: nil,
+// empty, a bare mode byte with nothing behind it, and the two mode bytes no
+// record uses. Each must be an error wrapping ErrRecord — never a panic, and
+// never a silent accept, because these are exactly the bytes a caller reaches
+// the ingest path with when it stores a truncated or foreign value.
+func TestValidateRejectsEmpty(t *testing.T) {
+	for _, c := range []struct {
+		name string
+		rec  []byte
+	}{
+		{"nil", nil},
+		{"empty", []byte{}},
+		{"bare schema mode byte", []byte{byte(wire.OperateModeSchema)}},
+		{"bare dynamic mode byte", []byte{byte(wire.OperateModeDynamic)}},
+		{"mode byte 0", []byte{0x00, 0x01}},
+		{"mode byte past the enum", []byte{0xFF, 0x01}},
+	} {
+		t.Run(c.name, func(t *testing.T) {
+			err := Validate(c.rec)
+			if err == nil {
+				t.Fatal("Validate = nil, want an error")
+			}
+			if !errors.Is(err, ErrRecord) {
+				t.Fatalf("Validate = %v, want an error wrapping ErrRecord", err)
+			}
+		})
+	}
+}
+
+// TestValidateRejectsHostileBytes drives every single-byte mutation and every
+// prefix of both canonical fixtures through Validate. The only two acceptable
+// outcomes are "nil" and "an error wrapping ErrRecord": a panic inside the
+// ingest gate would be reachable from any client that stores a payload, and an
+// error that does NOT wrap ErrRecord would escape the caller's errors.Is test
+// and be reported as an internal fault rather than a bad request.
+func TestValidateRejectsHostileBytes(t *testing.T) {
+	sess, _ := sessionRecord(t, true)
+	dyn, _ := dynamicRecord(t)
+
+	run := func(name string, in []byte) {
+		before := append([]byte(nil), in...)
+		err := Validate(in)
+		if err != nil && !errors.Is(err, ErrRecord) {
+			t.Fatalf("%s: error outside ErrRecord: %v", name, err)
+		}
+		if !bytes.Equal(before, in) {
+			t.Fatalf("%s: Validate mutated its input", name)
+		}
+	}
+
+	for _, base := range [][]byte{sess, dyn} {
+		for n := 0; n <= len(base); n++ {
+			run("prefix", base[:n:n])
+		}
+		mut := append([]byte(nil), base...)
+		for i := range base {
+			orig := mut[i]
+			for v := 0; v < 256; v++ {
+				mut[i] = byte(v)
+				run("mutation", mut)
+			}
+			mut[i] = orig
+		}
+	}
+
+	rng := rand.New(rand.NewSource(23))
+	n := 4000
+	if testing.Short() {
+		n = 500
+	}
+	for i := 0; i < n; i++ {
+		buf := make([]byte, rng.Intn(40))
+		for j := range buf {
+			buf[j] = byte(rng.Intn(256))
+		}
+		run("random", buf)
+	}
+}
+
+// TestValidateMatchesDecodeRecord is the equivalence the doc comment claims:
+// Validate's acceptance set is EXACTLY wire.DecodeRecord's, over the random
+// record generators the resolver oracle uses and over damaged versions of what
+// they produce. If Validate ever grows a second, hand-written walk, this is the
+// test that catches it diverging — and a divergence is the whole poison class
+// phase 1 had to fail closed around: two readers disagreeing about one record.
+func TestValidateMatchesDecodeRecord(t *testing.T) {
+	rng := rand.New(rand.NewSource(4242))
+	iters := 400
+	if testing.Short() {
+		iters = 60
+	}
+	check := func(b []byte) {
+		t.Helper()
+		_, decErr := wire.DecodeRecord(b)
+		valErr := Validate(b)
+		if (decErr == nil) != (valErr == nil) {
+			t.Fatalf("DecodeRecord err = %v but Validate err = %v on % x", decErr, valErr, b)
+		}
+		if valErr != nil && !errors.Is(valErr, ErrRecord) {
+			t.Fatalf("Validate = %v, want an error wrapping ErrRecord", valErr)
+		}
+	}
+	for i := 0; i < iters; i++ {
+		var enc []byte
+		var err error
+		if i%2 == 0 {
+			enc, _, err = randomSchemaRecord(rng)
+		} else {
+			enc, _, err = randomDynamicRecord(rng)
+		}
+		if err != nil {
+			continue // the generator drew a shape the encoder rejects
+		}
+		check(enc)
+		if len(enc) == 0 {
+			continue
+		}
+		// Damage it three ways: truncate, extend, and flip one byte. All three
+		// are shapes a torn or forged payload value really arrives in.
+		check(enc[:rng.Intn(len(enc)):len(enc)])
+		check(append(append([]byte(nil), enc...), byte(rng.Intn(256))))
+		mut := append([]byte(nil), enc...)
+		mut[rng.Intn(len(mut))] ^= byte(1 + rng.Intn(255))
+		check(mut)
+	}
+}
+
+// BenchmarkValidate reports what the ingest gate costs per record value: the
+// session fixture (a small schema-mode record with a two-row table) and a
+// table-heavy 64 KiB one, since DecodeRecord's cost is dominated by the rows
+// it materialises.
+func BenchmarkValidate(b *testing.B) {
+	small := benchSessionRecord(b)
+	large := benchTableRecord(b, 64<<10)
+
+	for _, c := range []struct {
+		name string
+		rec  []byte
+	}{
+		{"session", small},
+		{"table-64KiB", large},
+	} {
+		b.Run(c.name, func(b *testing.B) {
+			b.ReportAllocs()
+			b.SetBytes(int64(len(c.rec)))
+			for i := 0; i < b.N; i++ {
+				if err := Validate(c.rec); err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
+}
+
+// benchSessionRecord is sessionRecord for a benchmark (which has no *testing.T).
+func benchSessionRecord(b *testing.B) []byte {
+	b.Helper()
+	s := &wire.Schema{Version: 3, StoreNames: true, Fields: []wire.FieldDef{
+		{Name: "rc", Type: wire.OperateTypeU8},
+		{Name: "bal", Type: wire.OperateTypeI32},
+		{Name: "tag", Type: wire.OperateTypeBytes},
+	}}
+	if err := s.Validate(); err != nil {
+		b.Fatalf("schema invalid: %v", err)
+	}
+	enc := (&wire.Record{Mode: wire.OperateModeSchema, Schema: s, Fields: []wire.Field{
+		{Cell: wire.Cell{Type: wire.OperateTypeU8, U: 7}},
+		{Cell: wire.Cell{Type: wire.OperateTypeI32, U: su64(-5)}},
+		{Cell: wire.Cell{Type: wire.OperateTypeBytes, B: []byte("de")}},
+	}}).Encode()
+	if enc == nil {
+		b.Fatal("bench session record failed to encode")
+	}
+	return enc
+}
+
+// benchTableRecord builds a schema-mode record whose single TABLE field holds
+// enough rows to reach roughly size bytes — the shape whose decode cost grows,
+// so the benchmark shows the gate's cost as a function of record size.
+func benchTableRecord(b *testing.B, size int) []byte {
+	b.Helper()
+	s := &wire.Schema{Version: 1, StoreNames: true, Fields: []wire.FieldDef{
+		{Name: "t", Type: wire.OperateTypeTable, Table: &wire.TableDef{
+			KeyType: wire.OperateTypeU64,
+			Cols: []wire.ColumnDef{
+				{Name: "hi", Type: wire.OperateTypeU32},
+				{Name: "lo", Type: wire.OperateTypeU32},
+			},
+		}},
+	}}
+	if err := s.Validate(); err != nil {
+		b.Fatalf("schema invalid: %v", err)
+	}
+	const rowWidth = 16 // 8-byte key + two U32 columns
+	rows := make([]wire.Row, 0, size/rowWidth)
+	for i := 0; i < size/rowWidth; i++ {
+		key := make([]byte, 8)
+		for j := 0; j < 8; j++ {
+			key[j] = byte(uint64(i) >> (8 * j)) //nolint:gosec // bounded loop counter
+		}
+		rows = append(rows, wire.Row{Key: key, Cols: []wire.Col{
+			{Cell: wire.Cell{Type: wire.OperateTypeU32, U: uint64(i)}},     //nolint:gosec // bounded
+			{Cell: wire.Cell{Type: wire.OperateTypeU32, U: uint64(i) + 3}}, //nolint:gosec // bounded
+		}})
+	}
+	enc := (&wire.Record{Mode: wire.OperateModeSchema, Schema: s, Fields: []wire.Field{
+		{Cell: wire.Cell{Type: wire.OperateTypeTable}, Table: &wire.Table{Rows: rows}},
+	}}).Encode()
+	if enc == nil {
+		b.Fatal("bench table record failed to encode")
+	}
+	return enc
+}

--- a/sdk/wire/builtin_routing.go
+++ b/sdk/wire/builtin_routing.go
@@ -91,6 +91,11 @@ var BuiltinOps = []BuiltinOp{
 	{"vector_overwrite_payload", OpReadWrite, routeAt1.ke, routeAt1.layout, false},
 	{"vector_delete_payload_keys", OpReadWrite, routeAt1.ke, routeAt1.layout, false},
 	{"vector_clear_payload", OpReadWrite, routeAt1.ke, routeAt1.layout, false},
+	// vector_operate applies an operate op-list to a record inside a point's
+	// payload. Its args lead with [colLen:u8][col][id:u64] — the At1 layout of the
+	// payload-mutation family — so it routes by collection like every other point
+	// write and PointIDFor can read its id for the __wc__ barrier.
+	{"vector_operate", OpReadWrite, routeAt1.ke, routeAt1.layout, false},
 	{"vector_search", OpReadOnly, routeAt2.ke, routeAt2.layout, false},
 	{"vector_hybrid_search", OpReadOnly, routeAt2.ke, routeAt2.layout, false},
 	{"vector_hybrid_lanes", OpReadOnly, routeAt2.ke, routeAt2.layout, false},
@@ -142,6 +147,9 @@ var BuiltinOps = []BuiltinOp{
 	{"vector_mv_overwrite_payload", OpReadWrite, routeAt1.ke, routeAt1.layout, false},
 	{"vector_mv_delete_payload_keys", OpReadWrite, routeAt1.ke, routeAt1.layout, false},
 	{"vector_mv_clear_payload", OpReadWrite, routeAt1.ke, routeAt1.layout, false},
+	// vector_mv_operate: the multi-vector twin of vector_operate, sharing its exact
+	// arg wire ([colLen:u8][col][docID:u64]...) — At1, routed by collection.
+	{"vector_mv_operate", OpReadWrite, routeAt1.ke, routeAt1.layout, false},
 	{"vector_mv_get_config", OpReadOnly, routeAt1.ke, routeAt1.layout, false},
 	{"vector_mv_scan_vectors", OpReadOnly, routeAt1.ke, routeAt1.layout, false},
 	{"vector_mv_scroll", OpReadOnly, routeAt1.ke, routeAt1.layout, false},
@@ -160,6 +168,9 @@ var BuiltinOps = []BuiltinOp{
 	{"vector_named_overwrite_payload", OpReadWrite, routeAt1.ke, routeAt1.layout, false},
 	{"vector_named_delete_payload_keys", OpReadWrite, routeAt1.ke, routeAt1.layout, false},
 	{"vector_named_clear_payload", OpReadWrite, routeAt1.ke, routeAt1.layout, false},
+	// vector_named_operate: the named-collection twin of vector_operate, sharing its
+	// exact arg wire ([colLen:u8][col][id:u64]...) — At1, routed by collection.
+	{"vector_named_operate", OpReadWrite, routeAt1.ke, routeAt1.layout, false},
 	{"vector_named_search", OpReadOnly, routeAt1.ke, routeAt1.layout, false},
 	{"vector_named_sparse_search", OpReadOnly, routeAt1.ke, routeAt1.layout, false},
 	{"vector_named_hybrid_search", OpReadOnly, routeAt2.ke, routeAt2.layout, false},

--- a/sdk/wire/operate.go
+++ b/sdk/wire/operate.go
@@ -393,14 +393,37 @@ func EncodeOperateArgs(a *OperateArgs) ([]byte, error) {
 // allows, over the byte budget is a truncated or lying frame. Decoded
 // Key/Schema/Bytes/Name/path-Key fields may alias b: the apply path only
 // reads them during one call and never retains them past it.
+//
+// TRAILING BYTES ARE REJECTED. A frame that decodes and leaves bytes over is not
+// the frame it claims to be, and the slack is not inert: the vector families
+// carry this blob inside a length-declared envelope
+// (DecodeVectorOperateArgs's [argsLen u32][args...]), so a caller could declare
+// a longer inner blob than it actually wrote and smuggle bytes past every
+// structural check into a frame the server otherwise accepted. Following
+// raft/logstore's decodeInto, the check is exact consumption rather than a
+// bound, and it closes the KV operate path (where args is the whole request
+// body) at the same time.
 func DecodeOperateArgs(b []byte) (*OperateArgs, error) {
+	a, n, err := decodeOperateArgsN(b)
+	if err != nil {
+		return nil, err
+	}
+	if n != len(b) {
+		return nil, ErrOperateArgs
+	}
+	return a, nil
+}
+
+// decodeOperateArgsN is DecodeOperateArgs' body, reporting how many bytes it
+// consumed so the exported wrapper can insist that be all of them.
+func decodeOperateArgsN(b []byte) (*OperateArgs, int, error) {
 	if len(b) < 2 {
-		return nil, ErrShortArgs
+		return nil, 0, ErrShortArgs
 	}
 	klen := int(binary.BigEndian.Uint16(b[0:2]))
 	off := 2
 	if len(b)-off < klen {
-		return nil, ErrShortArgs
+		return nil, 0, ErrShortArgs
 	}
 	var key []byte
 	if klen > 0 {
@@ -409,11 +432,11 @@ func DecodeOperateArgs(b []byte) (*OperateArgs, error) {
 	off += klen
 
 	if len(b)-off < 8+1+1+2 { // ttlMs(8) + ttlMode(1) + create(1) + schemaLen(2)
-		return nil, ErrShortArgs
+		return nil, 0, ErrShortArgs
 	}
 	ttl, err := ttlFromMs(binary.BigEndian.Uint64(b[off : off+8]))
 	if err != nil {
-		return nil, err
+		return nil, 0, err
 	}
 	off += 8
 	ttlMode := b[off]
@@ -421,16 +444,16 @@ func DecodeOperateArgs(b []byte) (*OperateArgs, error) {
 	create := b[off]
 	off++
 	if ttlMode > OperateTTLCreateOnly {
-		return nil, ErrOperateArgs
+		return nil, 0, ErrOperateArgs
 	}
 	if create > OperateCreateDynamic {
-		return nil, ErrOperateArgs
+		return nil, 0, ErrOperateArgs
 	}
 
 	schemaLen := int(binary.BigEndian.Uint16(b[off : off+2]))
 	off += 2
 	if len(b)-off < schemaLen {
-		return nil, ErrShortArgs
+		return nil, 0, ErrShortArgs
 	}
 	var schema []byte
 	if schemaLen > 0 {
@@ -439,7 +462,7 @@ func DecodeOperateArgs(b []byte) (*OperateArgs, error) {
 	off += schemaLen
 
 	if len(b)-off < 2 {
-		return nil, ErrShortArgs
+		return nil, 0, ErrShortArgs
 	}
 	nOps := int(binary.BigEndian.Uint16(b[off : off+2]))
 	off += 2
@@ -448,10 +471,10 @@ func DecodeOperateArgs(b []byte) (*OperateArgs, error) {
 	// than a call may carry), while a count the remaining bytes cannot
 	// possibly hold is a truncated frame.
 	if nOps > OperateMaxOps {
-		return nil, ErrOperateCap
+		return nil, 0, ErrOperateCap
 	}
 	if !CountFitsIn(nOps, len(b)-off, minOpBytes) {
-		return nil, ErrShortArgs
+		return nil, 0, ErrShortArgs
 	}
 	var ops []OperateOp
 	if nOps > 0 {
@@ -459,7 +482,7 @@ func DecodeOperateArgs(b []byte) (*OperateArgs, error) {
 		for i := 0; i < nOps; i++ {
 			op, n, oerr := decodeOp(b[off:])
 			if oerr != nil {
-				return nil, oerr
+				return nil, 0, oerr
 			}
 			ops = append(ops, op)
 			off += n
@@ -467,15 +490,15 @@ func DecodeOperateArgs(b []byte) (*OperateArgs, error) {
 	}
 
 	if len(b)-off < 2 {
-		return nil, ErrShortArgs
+		return nil, 0, ErrShortArgs
 	}
 	nRet := int(binary.BigEndian.Uint16(b[off : off+2]))
 	off += 2
 	if nRet > OperateMaxRet {
-		return nil, ErrOperateCap
+		return nil, 0, ErrOperateCap
 	}
 	if !CountFitsIn(nRet, len(b)-off, minRetBytes) {
-		return nil, ErrShortArgs
+		return nil, 0, ErrShortArgs
 	}
 	var rets []OperateRet
 	if nRet > 0 {
@@ -483,7 +506,7 @@ func DecodeOperateArgs(b []byte) (*OperateArgs, error) {
 		for i := 0; i < nRet; i++ {
 			ret, n, rerr := decodeRet(b[off:])
 			if rerr != nil {
-				return nil, rerr
+				return nil, 0, rerr
 			}
 			rets = append(rets, ret)
 			off += n
@@ -498,7 +521,7 @@ func DecodeOperateArgs(b []byte) (*OperateArgs, error) {
 		Schema:  schema,
 		Ops:     ops,
 		Rets:    rets,
-	}, nil
+	}, off, nil
 }
 
 // EncodeOperateResult encodes an operate result frame (design doc §3.4):
@@ -532,31 +555,47 @@ func EncodeOperateResult(r *OperateResult) ([]byte, error) {
 }
 
 // DecodeOperateResult reads a frame produced by EncodeOperateResult, with
-// the same truncation and bounded-count discipline as DecodeOperateArgs.
-// Decoded values may alias b.
+// the same truncation and bounded-count discipline as DecodeOperateArgs, and
+// the same exact-consumption rule: a frame that decodes and leaves bytes over
+// is rejected. DecodeVectorOperateResult carries this blob inside a declared
+// [resLen u32], so without the rule a result frame could over-declare its inner
+// length and carry bytes no decoder ever looks at. Decoded values may alias b.
 func DecodeOperateResult(b []byte) (*OperateResult, error) {
+	r, n, err := decodeOperateResultN(b)
+	if err != nil {
+		return nil, err
+	}
+	if n != len(b) {
+		return nil, ErrOperateArgs
+	}
+	return r, nil
+}
+
+// decodeOperateResultN is DecodeOperateResult's body, reporting how many bytes
+// it consumed so the exported wrapper can insist that be all of them.
+func decodeOperateResultN(b []byte) (*OperateResult, int, error) {
 	if len(b) < 1 {
-		return nil, ErrShortArgs
+		return nil, 0, ErrShortArgs
 	}
 	status := b[0]
 	if status != OperateStatusOK && status != OperateStatusCheckFailed {
 		// An unknown status byte changes the frame's own shape (only
 		// CHECK_FAILED carries failedOp), so accepting one would mean
 		// guessing at the layout of the bytes behind it.
-		return nil, ErrOperateArgs
+		return nil, 0, ErrOperateArgs
 	}
 	off := 1
 	var failedOp uint16
 	if status == OperateStatusCheckFailed {
 		if len(b)-off < 2 {
-			return nil, ErrShortArgs
+			return nil, 0, ErrShortArgs
 		}
 		failedOp = binary.BigEndian.Uint16(b[off : off+2])
 		off += 2
 	}
 
 	if len(b)-off < 2 {
-		return nil, ErrShortArgs
+		return nil, 0, ErrShortArgs
 	}
 	nRet := int(binary.BigEndian.Uint16(b[off : off+2]))
 	off += 2
@@ -564,22 +603,22 @@ func DecodeOperateResult(b []byte) (*OperateResult, error) {
 	// cap is a frame declaring more values than a call may return,
 	// over the byte budget is a truncated or lying frame.
 	if nRet > OperateMaxRet {
-		return nil, ErrOperateCap
+		return nil, 0, ErrOperateCap
 	}
 	if !CountFitsIn(nRet, len(b)-off, 4) {
-		return nil, ErrShortArgs
+		return nil, 0, ErrShortArgs
 	}
 	var values [][]byte
 	if nRet > 0 {
 		values = make([][]byte, 0, nRet)
 		for i := 0; i < nRet; i++ {
 			if len(b)-off < 4 {
-				return nil, ErrShortArgs
+				return nil, 0, ErrShortArgs
 			}
 			vlen := int(binary.BigEndian.Uint32(b[off : off+4]))
 			off += 4
 			if vlen < 0 || len(b)-off < vlen {
-				return nil, ErrShortArgs
+				return nil, 0, ErrShortArgs
 			}
 			var val []byte
 			if vlen > 0 {
@@ -590,5 +629,5 @@ func DecodeOperateResult(b []byte) (*OperateResult, error) {
 		}
 	}
 
-	return &OperateResult{Status: status, FailedOp: failedOp, Values: values}, nil
+	return &OperateResult{Status: status, FailedOp: failedOp, Values: values}, off, nil
 }

--- a/sdk/wire/operate.go
+++ b/sdk/wire/operate.go
@@ -16,6 +16,32 @@ import (
 // DecodeOperateArgs (a wire frame carrying one) — see design doc §3.5.
 var ErrOperateArgs = errors.New("wire: operate call arguments invalid")
 
+// IsOperateArgsMessage reports whether s is the EXACT serialised form of an
+// ErrOperateArgs error — the same exact-form matching ops.IsVectorRecordAbsent-
+// Message and vector.IsRecordTooLargeMessage do for their sentinels, and for the
+// same reason: an operate handler decodes its frame INSIDE the FSM apply, so on
+// a cluster the error comes back through shard.decodePBResult rebuilt with
+// errors.New, errors.Is identity is gone, and a sentinel-only classifier
+// redacts a client protocol mistake to "internal error".
+//
+// This sentinel has exactly ONE serialised shape: bare, no detail suffix and no
+// wrapper. Every server-side producer returns it unadorned — the wire decoders
+// and encoders in this package (DecodeOperateArgs, DecodeVectorOperateArgs and
+// their encoders) and ops (operate_apply.go's three guards,
+// checkVectorOperateArgs) all `return ..., ErrOperateArgs`. So exact equality is
+// the whole matcher, and it is deliberately not a strings.Contains: a bare
+// substring check would make any internal fault that merely mentions the
+// sentinel text client-facing.
+//
+// The ONE %w wrap in the tree, client.DecodeOperateValue's "N bytes left after
+// the tagged cell", is raised in the CLIENT process on a reply it is decoding.
+// It never reaches a server classifier, so it is correctly not matched here; if
+// a future server-side site does wrap the sentinel with context, add that exact
+// shape here, anchored, rather than loosening this to a substring.
+func IsOperateArgsMessage(s string) bool {
+	return s == ErrOperateArgs.Error()
+}
+
 // OperateSeg addresses one hop of an OperatePath (design doc §2.4/§3.5): a
 // field or column identified by its schema position, or, for a record that
 // stores names, by name.

--- a/sdk/wire/vector.go
+++ b/sdk/wire/vector.go
@@ -32,11 +32,16 @@ var ErrVectorArgsTruncated = errors.New("ops: vector args truncated")
 // structurally wrong. Both are the caller's mistake, so both belong in the same
 // classification bucket on every transport.
 //
-// This sentinel has exactly ONE serialised shape: bare, no detail suffix and no
-// wrapper — every producer in sdk/wire returns it unadorned and no site in the
-// tree wraps it. So exact equality is the whole matcher, and it is deliberately
-// not a strings.Contains: a bare substring check would make any internal fault
-// that merely mentions the sentinel text client-facing.
+// This sentinel has exactly ONE serialised shape as a server classifier sees it:
+// bare, no detail suffix and no wrapper. Every producer in sdk/wire returns it
+// unadorned, and no SERVER-SIDE site wraps it with context — the %w wraps that
+// exist are in tests, constructing the shape a wrapped error would have so the
+// negative controls can prove it is declined. So exact equality is the whole
+// matcher, and it is deliberately not a strings.Contains: a bare substring check
+// would make any internal fault that merely mentions the sentinel text
+// client-facing. If a future server-side site does wrap it, add that exact
+// shape here, anchored, rather than loosening this to a substring — the same
+// rule IsOperateArgsMessage states for its own sentinel.
 func IsVectorArgsTruncatedMessage(s string) bool {
 	return s == ErrVectorArgsTruncated.Error()
 }

--- a/sdk/wire/vector.go
+++ b/sdk/wire/vector.go
@@ -19,6 +19,28 @@ import (
 // shorter than the layout requires.
 var ErrVectorArgsTruncated = errors.New("ops: vector args truncated")
 
+// IsVectorArgsTruncatedMessage reports whether s is the EXACT serialised form of
+// an ErrVectorArgsTruncated error. It is IsOperateArgsMessage's twin, for the
+// same reason and with the same shape: the operate handlers decode their frame
+// INSIDE the FSM apply, so on a cluster shard.decodePBResult rebuilds the error
+// with errors.New, errors.Is identity is gone, and a classifier matching only
+// the sentinel redacts a caller's framing mistake to "internal error".
+//
+// The two sentinels are raised by the SAME decoder, side by side:
+// DecodeVectorOperateArgs answers ErrVectorArgsTruncated for a frame shorter
+// than its declared fields and ErrOperateArgs for a frame that is complete but
+// structurally wrong. Both are the caller's mistake, so both belong in the same
+// classification bucket on every transport.
+//
+// This sentinel has exactly ONE serialised shape: bare, no detail suffix and no
+// wrapper — every producer in sdk/wire returns it unadorned and no site in the
+// tree wraps it. So exact equality is the whole matcher, and it is deliberately
+// not a strings.Contains: a bare substring check would make any internal fault
+// that merely mentions the sentinel text client-facing.
+func IsVectorArgsTruncatedMessage(s string) bool {
+	return s == ErrVectorArgsTruncated.Error()
+}
+
 // ErrMalformedPayloadJSON marks a per-point payload blob that is well-FRAMED —
 // its length prefix is consistent with the body, so the transport streamed it
 // through without looking inside — but is not a metadata object.

--- a/sdk/wire/vector_operate.go
+++ b/sdk/wire/vector_operate.go
@@ -167,11 +167,25 @@ func DecodeVectorOperateArgs(args []byte) (collection string, id uint64, payload
 }
 
 // EncodeVectorOperateResult encodes a vector_operate result frame.
-// Wire: [found u8] | [1][resLen u32][operateResult]. found=false writes just
-// the zero byte and r is ignored entirely — there is nothing else to say
-// about a call that found no record. found=true with r == nil is
-// ErrOperateArgs: a caller claiming a result exists must supply one.
-func EncodeVectorOperateResult(found bool, r *OperateResult) ([]byte, error) {
+// Wire: [found u8] | [1][resLen u32][operateResult][version u64]. found=false
+// writes just the zero byte and r and version are ignored entirely — there is
+// nothing else to say about a call that found no record, and an absent point has
+// no version. found=true with r == nil is ErrOperateArgs: a caller claiming a
+// result exists must supply one.
+//
+// version is the point's version AFTER the call: bumped when the op-list
+// applied, and the CURRENT unbumped one when it was a deliberate no-op (a failed
+// CHECK). It exists so a CAS loop can feed the next call's expectedVersion
+// straight from this result instead of re-reading the point — the re-read is
+// both a round trip and a race, since another writer can land between it and the
+// retry.
+//
+// APPEND-ONLY. The version is written LAST, after the inner blob the previous
+// shape ended with, and DecodeVectorOperateResult reads it only if it is there.
+// A frame from before this field decodes as version 0. Any future field goes at
+// the end too, read the same way: this frame has an exact trailing-bytes check,
+// so a field inserted anywhere else is a wire break, not an extension.
+func EncodeVectorOperateResult(found bool, r *OperateResult, version uint64) ([]byte, error) {
 	if !found {
 		return []byte{0}, nil
 	}
@@ -182,10 +196,11 @@ func EncodeVectorOperateResult(found bool, r *OperateResult) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	buf := make([]byte, 0, 1+4+len(inner))
+	buf := make([]byte, 0, 1+4+len(inner)+8)
 	buf = append(buf, 1)
 	buf = binary.BigEndian.AppendUint32(buf, uint32(len(inner))) //nolint:gosec // inner is bounded well under 4G by OperateMaxRet
 	buf = append(buf, inner...)
+	buf = binary.BigEndian.AppendUint64(buf, version)
 	return buf, nil
 }
 
@@ -194,40 +209,52 @@ func EncodeVectorOperateResult(found bool, r *OperateResult) ([]byte, error) {
 // DecodeVectorOperateArgs: found is read and validated against {0,1} first,
 // resLen is a raw-uint32-before-int-conversion length check, the inner blob is
 // handed to DecodeOperateResult verbatim, and a frame with bytes left over
-// after the declared inner blob is ErrOperateArgs.
-func DecodeVectorOperateResult(b []byte) (found bool, r *OperateResult, err error) {
+// after the declared inner blob and the optional trailing version is
+// ErrOperateArgs.
+//
+// The trailing version is the frame's ONE optional field and it is read the only
+// way an append-only field can be: exactly 8 bytes after the inner blob, or
+// nothing at all. Zero remaining bytes is a pre-version frame and yields
+// version 0; any other remainder — 1..7 bytes, or 9+ — is a frame that is not
+// what it claims to be, so it is rejected rather than silently truncated. That
+// keeps the trailing-bytes guarantee the rest of this codec relies on.
+func DecodeVectorOperateResult(b []byte) (found bool, r *OperateResult, version uint64, err error) {
 	if len(b) < 1 {
-		return false, nil, ErrVectorArgsTruncated
+		return false, nil, 0, ErrVectorArgsTruncated
 	}
 	flag := b[0]
 	if flag > 1 {
-		return false, nil, ErrOperateArgs
+		return false, nil, 0, ErrOperateArgs
 	}
 	if flag == 0 {
 		if len(b) != 1 {
-			return false, nil, ErrOperateArgs
+			return false, nil, 0, ErrOperateArgs
 		}
-		return false, nil, nil
+		return false, nil, 0, nil
 	}
 
 	off := 1
 	if len(b)-off < 4 {
-		return false, nil, ErrVectorArgsTruncated
+		return false, nil, 0, ErrVectorArgsTruncated
 	}
 	rawResLen := binary.BigEndian.Uint32(b[off:])
 	off += 4
 	if uint64(rawResLen) > uint64(len(b)-off) {
-		return false, nil, ErrVectorArgsTruncated
+		return false, nil, 0, ErrVectorArgsTruncated
 	}
 	resLen := int(rawResLen)
 
 	res, derr := DecodeOperateResult(b[off : off+resLen])
 	if derr != nil {
-		return false, nil, derr
+		return false, nil, 0, derr
 	}
 	off += resLen
-	if off != len(b) {
-		return false, nil, ErrOperateArgs
+	switch len(b) - off {
+	case 0:
+		return true, res, 0, nil // a frame written before the version field existed
+	case 8:
+		return true, res, binary.BigEndian.Uint64(b[off:]), nil
+	default:
+		return false, nil, 0, ErrOperateArgs
 	}
-	return true, res, nil
 }

--- a/sdk/wire/vector_operate.go
+++ b/sdk/wire/vector_operate.go
@@ -1,0 +1,233 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package wire
+
+import "encoding/binary"
+
+// EncodeVectorOperateArgs serializes a vector_operate / vector_named_operate /
+// vector_mv_operate request (one wire shape, the OP NAME selects the family).
+//
+// Wire: [colLen u8][col][id u64][pkLen u16][payloadKey]
+//
+//	[casPresent u8][?expectedVersion u64][argsLen u32][operateArgs]
+//
+// The collection sits at offset 0 and the point id immediately after it, which
+// is what makes this the At1 routing layout (VectorKeyColAt1) and lets
+// PointIDFor read the id without a full decode.
+//
+// a.Key must be EMPTY and a.TTLMode must be OperateTTLKeep with a.TTL == 0:
+// the target is named once, by (collection, id, payloadKey), and a point's TTL
+// is the point's, never a record's (brief §3). Both are ErrOperateArgs here and
+// again in the decoder, so a hand-built frame cannot smuggle either past the
+// encoder.
+//
+// The wrapped inner frame therefore always carries a u16 zero key length and a
+// u64 zero ttlMs — ten bytes that are structurally always zero. That is
+// DELIBERATE: reusing EncodeOperateArgs verbatim keeps exactly one operate-args
+// encoder in the tree. Do not "optimise" it into a second, divergent shape.
+func EncodeVectorOperateArgs(collection string, id uint64, payloadKey string, a *OperateArgs, expectedVersion uint64, hasExpected bool) ([]byte, error) {
+	if a == nil {
+		return nil, ErrOperateArgs
+	}
+	if len(collection) == 0 || len(collection) > 255 {
+		return nil, ErrOperateCap
+	}
+	if len(payloadKey) == 0 || len(payloadKey) > 0xFFFF {
+		return nil, ErrOperateCap
+	}
+	if len(a.Key) != 0 || a.TTLMode != OperateTTLKeep || a.TTL != 0 {
+		return nil, ErrOperateArgs
+	}
+	inner, err := EncodeOperateArgs(a)
+	if err != nil {
+		return nil, err
+	}
+
+	n := 1 + len(collection) + 8 + 2 + len(payloadKey) + 1
+	if hasExpected {
+		n += 8
+	}
+	n += 4 + len(inner)
+
+	buf := make([]byte, 0, n)
+	buf = append(buf, byte(len(collection))) //nolint:gosec // bounded by the check above
+	buf = append(buf, collection...)
+	buf = binary.BigEndian.AppendUint64(buf, id)
+	buf = binary.BigEndian.AppendUint16(buf, uint16(len(payloadKey))) //nolint:gosec // bounded by the check above
+	buf = append(buf, payloadKey...)
+	if hasExpected {
+		buf = append(buf, 1)
+		buf = binary.BigEndian.AppendUint64(buf, expectedVersion)
+	} else {
+		buf = append(buf, 0)
+	}
+	buf = binary.BigEndian.AppendUint32(buf, uint32(len(inner))) //nolint:gosec // inner is bounded well under 4G by OperateMaxOps/Rets/Bytes/Schema caps
+	buf = append(buf, inner...)
+	return buf, nil
+}
+
+// DecodeVectorOperateArgs reads args produced by EncodeVectorOperateArgs.
+// Decoder discipline, in order, every read truncation-checked before it
+// happens: colLen (an outer frame the encoder never produces with colLen==0,
+// so a hostile/corrupt frame is the only source — ErrVectorArgsTruncated),
+// col, id, pkLen (0 is ErrOperateArgs — a well-formed-but-empty declared
+// name), payloadKey, casPresent (a value outside {0,1} is ErrOperateArgs),
+// the optional 8-byte expectedVersion, then argsLen.
+//
+// argsLen is read as a raw uint32 and compared against the remaining length
+// BEFORE any conversion to int: a value like 0xFFFFFFFF or 0x80000000 must
+// never reach an int conversion first, because on a 32-bit build int is
+// itself 32 bits and the conversion can produce a negative count that then
+// slips past a naive "< 0" guard's sibling check. Comparing as uint64 up
+// front is correct on every GOARCH and costs nothing extra on 64-bit.
+//
+// The sliced inner blob is handed to the already-hardened DecodeOperateArgs
+// verbatim — this function adds no second parser for that shape. After it
+// decodes, the same three post-conditions the encoder enforces are checked
+// again (Key empty, TTLMode == OperateTTLKeep, TTL == 0), because a
+// hand-built frame can carry an inner blob the encoder would have rejected.
+// Finally a trailing-bytes check (off+argsLen != len(args)) rejects a frame
+// with slack after the declared inner blob — it is not the frame it claims
+// to be.
+func DecodeVectorOperateArgs(args []byte) (collection string, id uint64, payloadKey string, a *OperateArgs, expectedVersion uint64, hasExpected bool, err error) {
+	if len(args) < 1 {
+		return "", 0, "", nil, 0, false, ErrVectorArgsTruncated
+	}
+	colLen := int(args[0])
+	if colLen == 0 {
+		return "", 0, "", nil, 0, false, ErrVectorArgsTruncated
+	}
+	off := 1
+	if len(args)-off < colLen {
+		return "", 0, "", nil, 0, false, ErrVectorArgsTruncated
+	}
+	collection = string(args[off : off+colLen])
+	off += colLen
+
+	if len(args)-off < 8 {
+		return "", 0, "", nil, 0, false, ErrVectorArgsTruncated
+	}
+	id = binary.BigEndian.Uint64(args[off:])
+	off += 8
+
+	if len(args)-off < 2 {
+		return "", 0, "", nil, 0, false, ErrVectorArgsTruncated
+	}
+	pkLen := int(binary.BigEndian.Uint16(args[off:]))
+	off += 2
+	if pkLen == 0 {
+		return "", 0, "", nil, 0, false, ErrOperateArgs
+	}
+	if len(args)-off < pkLen {
+		return "", 0, "", nil, 0, false, ErrVectorArgsTruncated
+	}
+	payloadKey = string(args[off : off+pkLen])
+	off += pkLen
+
+	if len(args)-off < 1 {
+		return "", 0, "", nil, 0, false, ErrVectorArgsTruncated
+	}
+	casPresent := args[off]
+	off++
+	if casPresent > 1 {
+		return "", 0, "", nil, 0, false, ErrOperateArgs
+	}
+	if casPresent == 1 {
+		if len(args)-off < 8 {
+			return "", 0, "", nil, 0, false, ErrVectorArgsTruncated
+		}
+		expectedVersion = binary.BigEndian.Uint64(args[off:])
+		hasExpected = true
+		off += 8
+	}
+
+	if len(args)-off < 4 {
+		return "", 0, "", nil, 0, false, ErrVectorArgsTruncated
+	}
+	rawArgsLen := binary.BigEndian.Uint32(args[off:])
+	off += 4
+	if uint64(rawArgsLen) > uint64(len(args)-off) {
+		return "", 0, "", nil, 0, false, ErrVectorArgsTruncated
+	}
+	argsLen := int(rawArgsLen)
+
+	inner, derr := DecodeOperateArgs(args[off : off+argsLen])
+	if derr != nil {
+		return "", 0, "", nil, 0, false, derr
+	}
+	if len(inner.Key) != 0 || inner.TTLMode != OperateTTLKeep || inner.TTL != 0 {
+		return "", 0, "", nil, 0, false, ErrOperateArgs
+	}
+	off += argsLen
+	if off != len(args) {
+		return "", 0, "", nil, 0, false, ErrOperateArgs
+	}
+
+	return collection, id, payloadKey, inner, expectedVersion, hasExpected, nil
+}
+
+// EncodeVectorOperateResult encodes a vector_operate result frame.
+// Wire: [found u8] | [1][resLen u32][operateResult]. found=false writes just
+// the zero byte and r is ignored entirely — there is nothing else to say
+// about a call that found no record. found=true with r == nil is
+// ErrOperateArgs: a caller claiming a result exists must supply one.
+func EncodeVectorOperateResult(found bool, r *OperateResult) ([]byte, error) {
+	if !found {
+		return []byte{0}, nil
+	}
+	if r == nil {
+		return nil, ErrOperateArgs
+	}
+	inner, err := EncodeOperateResult(r)
+	if err != nil {
+		return nil, err
+	}
+	buf := make([]byte, 0, 1+4+len(inner))
+	buf = append(buf, 1)
+	buf = binary.BigEndian.AppendUint32(buf, uint32(len(inner))) //nolint:gosec // inner is bounded well under 4G by OperateMaxRet
+	buf = append(buf, inner...)
+	return buf, nil
+}
+
+// DecodeVectorOperateResult reads a frame produced by EncodeVectorOperateResult,
+// with the same truncation and trailing-bytes discipline as
+// DecodeVectorOperateArgs: found is read and validated against {0,1} first,
+// resLen is a raw-uint32-before-int-conversion length check, the inner blob is
+// handed to DecodeOperateResult verbatim, and a frame with bytes left over
+// after the declared inner blob is ErrOperateArgs.
+func DecodeVectorOperateResult(b []byte) (found bool, r *OperateResult, err error) {
+	if len(b) < 1 {
+		return false, nil, ErrVectorArgsTruncated
+	}
+	flag := b[0]
+	if flag > 1 {
+		return false, nil, ErrOperateArgs
+	}
+	if flag == 0 {
+		if len(b) != 1 {
+			return false, nil, ErrOperateArgs
+		}
+		return false, nil, nil
+	}
+
+	off := 1
+	if len(b)-off < 4 {
+		return false, nil, ErrVectorArgsTruncated
+	}
+	rawResLen := binary.BigEndian.Uint32(b[off:])
+	off += 4
+	if uint64(rawResLen) > uint64(len(b)-off) {
+		return false, nil, ErrVectorArgsTruncated
+	}
+	resLen := int(rawResLen)
+
+	res, derr := DecodeOperateResult(b[off : off+resLen])
+	if derr != nil {
+		return false, nil, derr
+	}
+	off += resLen
+	if off != len(b) {
+		return false, nil, ErrOperateArgs
+	}
+	return true, res, nil
+}

--- a/sdk/wire/vector_operate_fuzz_test.go
+++ b/sdk/wire/vector_operate_fuzz_test.go
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package wire
+
+import (
+	"reflect"
+	"testing"
+)
+
+// FuzzDecodeVectorOperateArgs extends the FuzzDecodeOperateArgs identity to
+// the outer vector_operate frame: DecodeVectorOperateArgs must never panic on
+// any input, and any successfully decoded call must re-encode to bytes that
+// decode back to an identical call.
+func FuzzDecodeVectorOperateArgs(f *testing.F) {
+	seed := func(collection string, id uint64, payloadKey string, a *OperateArgs, ev uint64, has bool) {
+		b, err := EncodeVectorOperateArgs(collection, id, payloadKey, a, ev, has)
+		if err == nil {
+			f.Add(b)
+		}
+	}
+	seed("docs", 42, "body", vecOpArgs(), 0, false)
+	seed("docs", 42, "body", vecOpArgs(), 7, true)
+	seed("c", 0, "k", &OperateArgs{Create: OperateCreateSchema, Schema: sessionSchema().Encode()}, 0, false)
+	f.Add([]byte{})
+	f.Add([]byte{0})
+	f.Add([]byte{1})
+
+	f.Fuzz(func(t *testing.T, b []byte) {
+		collection, id, payloadKey, a, ev, has, err := DecodeVectorOperateArgs(b)
+		if err != nil {
+			return
+		}
+		b2, err := EncodeVectorOperateArgs(collection, id, payloadKey, a, ev, has)
+		if err != nil {
+			t.Fatal("decoded args do not re-encode:", err)
+		}
+		collection2, id2, payloadKey2, a2, ev2, has2, err := DecodeVectorOperateArgs(b2)
+		if err != nil {
+			t.Fatal("re-encoded frame failed to decode:", err)
+		}
+		if collection2 != collection || id2 != id || payloadKey2 != payloadKey || ev2 != ev || has2 != has || !reflect.DeepEqual(a, a2) {
+			t.Fatal("not stable")
+		}
+	})
+}

--- a/sdk/wire/vector_operate_fuzz_test.go
+++ b/sdk/wire/vector_operate_fuzz_test.go
@@ -43,3 +43,52 @@ func FuzzDecodeVectorOperateArgs(f *testing.F) {
 		}
 	})
 }
+
+// FuzzDecodeVectorOperateResult is FuzzDecodeVectorOperateArgs for the RESULT
+// frame: DecodeVectorOperateResult must never panic on any input, and any frame
+// it accepts must re-encode to bytes that decode back to the same (found,
+// result, version) triple.
+//
+// The version is in the identity deliberately. It is an APPEND-ONLY trailing
+// field, which is the one place a frame can silently lose information: a decoder
+// that ignored a short remainder, or an encoder that dropped the field, would
+// still round-trip the result and pass a laxer check.
+func FuzzDecodeVectorOperateResult(f *testing.F) {
+	seed := func(found bool, r *OperateResult, version uint64) {
+		if b, err := EncodeVectorOperateResult(found, r, version); err == nil {
+			f.Add(b)
+		}
+	}
+	rOK := &OperateResult{Status: OperateStatusOK, Values: [][]byte{AppendTaggedCell(nil, Cell{Type: OperateTypeU8, U: 9}), {OperateTypeUnset}}}
+	seed(false, nil, 0)
+	seed(true, rOK, 0)
+	seed(true, rOK, 42)
+	seed(true, rOK, ^uint64(0))
+	seed(true, &OperateResult{Status: OperateStatusCheckFailed, FailedOp: 3}, 7)
+	// A pre-version frame: the same bytes with the trailing 8 stripped.
+	if b, err := EncodeVectorOperateResult(true, rOK, 42); err == nil {
+		f.Add(b[:len(b)-8])
+	}
+	f.Add([]byte{})
+	f.Add([]byte{0})
+	f.Add([]byte{1})
+	f.Add([]byte{2})
+
+	f.Fuzz(func(t *testing.T, b []byte) {
+		found, r, version, err := DecodeVectorOperateResult(b)
+		if err != nil {
+			return
+		}
+		b2, err := EncodeVectorOperateResult(found, r, version)
+		if err != nil {
+			t.Fatal("decoded result does not re-encode:", err)
+		}
+		found2, r2, version2, err := DecodeVectorOperateResult(b2)
+		if err != nil {
+			t.Fatal("re-encoded frame failed to decode:", err)
+		}
+		if found2 != found || version2 != version || !reflect.DeepEqual(r, r2) {
+			t.Fatal("not stable")
+		}
+	})
+}

--- a/sdk/wire/vector_operate_fuzz_test.go
+++ b/sdk/wire/vector_operate_fuzz_test.go
@@ -3,6 +3,8 @@
 package wire
 
 import (
+	"encoding/binary"
+	"errors"
 	"reflect"
 	"testing"
 )
@@ -24,6 +26,13 @@ func FuzzDecodeVectorOperateArgs(f *testing.F) {
 	f.Add([]byte{})
 	f.Add([]byte{0})
 	f.Add([]byte{1})
+	// A frame whose declared inner blob is LONGER than the operate args behind
+	// it: every outer field decodes, the outer trailing-bytes check passes
+	// because the slack sits INSIDE the declared length, and only the inner
+	// decoder's exact-consumption rule catches it.
+	if b := overDeclaredInnerBlob(); b != nil {
+		f.Add(b)
+	}
 
 	f.Fuzz(func(t *testing.T, b []byte) {
 		collection, id, payloadKey, a, ev, has, err := DecodeVectorOperateArgs(b)
@@ -91,4 +100,97 @@ func FuzzDecodeVectorOperateResult(f *testing.F) {
 			t.Fatal("not stable")
 		}
 	})
+}
+
+// overDeclaredInnerBlob builds a vector_operate frame whose [argsLen u32]
+// declares four bytes more than the inner operate blob actually occupies, with
+// four zero bytes of slack sitting behind it. Every outer field is well formed
+// and the OUTER trailing-bytes check passes, because the slack is inside the
+// declared length — the frame is only refused because the inner decoder must
+// consume its blob exactly.
+func overDeclaredInnerBlob() []byte {
+	b, err := EncodeVectorOperateArgs("docs", 42, "body", vecOpArgs(), 0, false)
+	if err != nil {
+		return nil
+	}
+	// Walk the outer header to the [argsLen u32] the encoder wrote:
+	// [colLen u8][col][id u64][pkLen u16][payloadKey][casPresent u8].
+	off := 1 + int(b[0]) + 8
+	off += 2 + int(binary.BigEndian.Uint16(b[off:]))
+	off++ // casPresent == 0 for this fixture
+	inner := binary.BigEndian.Uint32(b[off:])
+	out := append([]byte(nil), b...)
+	binary.BigEndian.PutUint32(out[off:], inner+4)
+	return append(out, 0, 0, 0, 0)
+}
+
+// TestVectorOperateArgsRejectsSlackInsideTheDeclaredBlob is the regression for
+// the frame overDeclaredInnerBlob builds: bytes hidden inside an over-declared
+// inner length used to be accepted, because the inner decoder stopped where the
+// call ended and never checked that it had reached the end of its slice.
+func TestVectorOperateArgsRejectsSlackInsideTheDeclaredBlob(t *testing.T) {
+	good, err := EncodeVectorOperateArgs("docs", 42, "body", vecOpArgs(), 0, false)
+	if err != nil {
+		t.Fatalf("encode: %v", err)
+	}
+	if _, _, _, _, _, _, err := DecodeVectorOperateArgs(good); err != nil {
+		t.Fatalf("the honest frame must decode: %v", err)
+	}
+	bad := overDeclaredInnerBlob()
+	if bad == nil {
+		t.Fatal("fixture failed to build")
+	}
+	if len(bad) != len(good)+4 {
+		t.Fatalf("fixture is %d bytes, want %d (the honest frame plus four bytes of slack)", len(bad), len(good)+4)
+	}
+	if _, _, _, _, _, _, err := DecodeVectorOperateArgs(bad); !errors.Is(err, ErrOperateArgs) {
+		t.Fatalf("frame with slack inside the declared inner blob = %v, want ErrOperateArgs", err)
+	}
+}
+
+// TestVectorOperateResultRejectsSlackInsideTheDeclaredBlob is the same rule on
+// the RESULT frame, whose inner blob is bounded by its own declared [resLen u32].
+func TestVectorOperateResultRejectsSlackInsideTheDeclaredBlob(t *testing.T) {
+	good, err := EncodeVectorOperateResult(true, &OperateResult{Status: OperateStatusOK}, 9)
+	if err != nil {
+		t.Fatalf("encode: %v", err)
+	}
+	if _, _, _, err := DecodeVectorOperateResult(good); err != nil {
+		t.Fatalf("the honest frame must decode: %v", err)
+	}
+	// [found u8][resLen u32][inner][version u64]: grow resLen by four and slide
+	// four zero bytes in behind the inner blob, leaving the version where the
+	// decoder expects it.
+	resLen := binary.BigEndian.Uint32(good[1:])
+	bad := make([]byte, 0, len(good)+4)
+	bad = append(bad, good[0])
+	bad = binary.BigEndian.AppendUint32(bad, resLen+4)
+	bad = append(bad, good[5:5+resLen]...)
+	bad = append(bad, 0, 0, 0, 0)
+	bad = append(bad, good[5+resLen:]...)
+	if _, _, _, err := DecodeVectorOperateResult(bad); !errors.Is(err, ErrOperateArgs) {
+		t.Fatalf("result frame with slack inside the declared inner blob = %v, want ErrOperateArgs", err)
+	}
+}
+
+// TestOperateArgsRejectsTrailingBytes is the same rule at the KV entry point,
+// where the blob is the whole request body rather than a declared sub-slice.
+func TestOperateArgsRejectsTrailingBytes(t *testing.T) {
+	good, err := EncodeOperateArgs(vecOpArgs())
+	if err != nil {
+		t.Fatalf("encode: %v", err)
+	}
+	if _, err := DecodeOperateArgs(good); err != nil {
+		t.Fatalf("the honest frame must decode: %v", err)
+	}
+	if _, err := DecodeOperateArgs(append(append([]byte(nil), good...), 0)); !errors.Is(err, ErrOperateArgs) {
+		t.Fatalf("operate args with a trailing byte = %v, want ErrOperateArgs", err)
+	}
+	goodRes, err := EncodeOperateResult(&OperateResult{Status: OperateStatusOK})
+	if err != nil {
+		t.Fatalf("encode result: %v", err)
+	}
+	if _, err := DecodeOperateResult(append(append([]byte(nil), goodRes...), 0)); !errors.Is(err, ErrOperateArgs) {
+		t.Fatalf("operate result with a trailing byte = %v, want ErrOperateArgs", err)
+	}
 }

--- a/sdk/wire/vector_operate_test.go
+++ b/sdk/wire/vector_operate_test.go
@@ -3,6 +3,7 @@
 package wire
 
 import (
+	"bytes"
 	"encoding/binary"
 	"errors"
 	"reflect"
@@ -266,5 +267,55 @@ func TestVectorOperateResultRoundtrip(t *testing.T) {
 
 	if _, err := EncodeVectorOperateResult(true, nil); !errors.Is(err, ErrOperateArgs) {
 		t.Fatalf("found=true r=nil: err = %v, want ErrOperateArgs", err)
+	}
+}
+
+// TestVectorOperateRoutesByCollectionAndID pins the routing half of the op: the
+// args layout is the At1 payload-mutation shape ([colLen:u8][col][id:u64]...),
+// so all three families must appear in CollectionNameFor, CollectionNameOffset
+// and singlePointWriteOps. A MISSING row here is silent: the op would route to
+// shard 0 for every collection, and the __wc__ barrier would target the wrong
+// partition — neither fails loudly anywhere else.
+func TestVectorOperateRoutesByCollectionAndID(t *testing.T) {
+	args, err := EncodeVectorOperateArgs("docs", 42, "session", vecOpArgs(), 0, false)
+	if err != nil {
+		t.Fatalf("EncodeVectorOperateArgs: %v", err)
+	}
+	for _, op := range []string{"vector_operate", "vector_named_operate", "vector_mv_operate"} {
+		t.Run(op, func(t *testing.T) {
+			name, ok := CollectionNameFor(op, args)
+			if !ok || name != "default/docs" {
+				t.Fatalf("CollectionNameFor = (%q,%v), want (default/docs,true)", name, ok)
+			}
+			off, ok := CollectionNameOffset(op)
+			if !ok || off != 0 {
+				t.Fatalf("CollectionNameOffset = (%d,%v), want (0,true)", off, ok)
+			}
+			id, ok := PointIDFor(op, args)
+			if !ok || id != 42 {
+				t.Fatalf("PointIDFor = (%d,%v), want (42,true)", id, ok)
+			}
+			// RewriteCollectionName swaps the name in place and preserves every
+			// other byte, so the alias pass-through path cannot corrupt the call.
+			out, ok := RewriteCollectionName(op, args, "acme/docs")
+			if !ok {
+				t.Fatal("RewriteCollectionName: ok = false")
+			}
+			gotCol, gotID, gotKey, inner, _, hasExpected, derr := DecodeVectorOperateArgs(out)
+			if derr != nil {
+				t.Fatalf("rewritten args do not decode: %v", derr)
+			}
+			if gotCol != "acme/docs" || gotID != 42 || gotKey != "session" || hasExpected {
+				t.Fatalf("rewritten args = (%q,%d,%q,hasExpected=%v)", gotCol, gotID, gotKey, hasExpected)
+			}
+			if len(inner.Ops) != 1 || inner.Ops[0].Opcode != OperateOpADD {
+				t.Fatalf("rewritten inner op list = %+v", inner.Ops)
+			}
+			// The tail past the name field is byte-identical.
+			tail := args[1+len("docs"):]
+			if !bytes.Equal(out[1+len("acme/docs"):], tail) {
+				t.Fatal("RewriteCollectionName altered bytes after the collection name")
+			}
+		})
 	}
 }

--- a/sdk/wire/vector_operate_test.go
+++ b/sdk/wire/vector_operate_test.go
@@ -236,37 +236,82 @@ func TestVectorOperateArgsLyingArgsLen(t *testing.T) {
 }
 
 func TestVectorOperateResultRoundtrip(t *testing.T) {
-	enc, err := EncodeVectorOperateResult(false, nil)
+	enc, err := EncodeVectorOperateResult(false, nil, 0)
 	if err != nil {
 		t.Fatal(err)
 	}
-	found, r, err := DecodeVectorOperateResult(enc)
-	if err != nil || found || r != nil {
-		t.Fatalf("found=false: got (%v,%+v,%v)", found, r, err)
+	found, r, v, err := DecodeVectorOperateResult(enc)
+	if err != nil || found || r != nil || v != 0 {
+		t.Fatalf("found=false: got (%v,%+v,%d,%v)", found, r, v, err)
+	}
+	// found=false ignores the version entirely: an absent point has none, and the
+	// frame stays the single zero byte it has always been.
+	if enc2, err := EncodeVectorOperateResult(false, nil, 7); err != nil || len(enc2) != 1 {
+		t.Fatalf("found=false with a version: enc=%x err=%v, want the 1-byte frame", enc2, err)
 	}
 
 	rOK := &OperateResult{Status: OperateStatusOK, Values: [][]byte{AppendTaggedCell(nil, Cell{Type: OperateTypeU8, U: 9}), {OperateTypeUnset}}}
-	enc, err = EncodeVectorOperateResult(true, rOK)
+	enc, err = EncodeVectorOperateResult(true, rOK, 42)
 	if err != nil {
 		t.Fatal(err)
 	}
-	found, got, err := DecodeVectorOperateResult(enc)
-	if err != nil || !found || !reflect.DeepEqual(got, rOK) {
-		t.Fatalf("found=true OK: got (%v,%+v,%v) want %+v", found, got, err, rOK)
+	found, got, v, err := DecodeVectorOperateResult(enc)
+	if err != nil || !found || !reflect.DeepEqual(got, rOK) || v != 42 {
+		t.Fatalf("found=true OK: got (%v,%+v,%d,%v) want %+v/42", found, got, v, err, rOK)
 	}
 
 	rFail := &OperateResult{Status: OperateStatusCheckFailed, FailedOp: 3}
-	enc, err = EncodeVectorOperateResult(true, rFail)
+	enc, err = EncodeVectorOperateResult(true, rFail, 41)
 	if err != nil {
 		t.Fatal(err)
 	}
-	found, got, err = DecodeVectorOperateResult(enc)
-	if err != nil || !found || !reflect.DeepEqual(got, rFail) {
-		t.Fatalf("found=true CheckFailed: got (%v,%+v,%v) want %+v", found, got, err, rFail)
+	found, got, v, err = DecodeVectorOperateResult(enc)
+	if err != nil || !found || !reflect.DeepEqual(got, rFail) || v != 41 {
+		t.Fatalf("found=true CheckFailed: got (%v,%+v,%d,%v) want %+v/41", found, got, v, err, rFail)
 	}
 
-	if _, err := EncodeVectorOperateResult(true, nil); !errors.Is(err, ErrOperateArgs) {
+	// The full uint64 range survives, not just small versions.
+	enc, err = EncodeVectorOperateResult(true, rOK, ^uint64(0))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, _, v, err = DecodeVectorOperateResult(enc); err != nil || v != ^uint64(0) {
+		t.Fatalf("max version: got (%d,%v)", v, err)
+	}
+
+	if _, err := EncodeVectorOperateResult(true, nil, 0); !errors.Is(err, ErrOperateArgs) {
 		t.Fatalf("found=true r=nil: err = %v, want ErrOperateArgs", err)
+	}
+}
+
+// TestVectorOperateResultVersionIsAppendOnly pins the two halves of the
+// append-only contract the version field was added under: a frame written
+// BEFORE the field existed (the inner blob and nothing after it) still decodes,
+// as version 0; and a remainder that is neither 0 nor exactly 8 bytes is
+// REJECTED rather than silently truncated, so the frame keeps the exact
+// trailing-bytes guarantee the rest of this codec relies on.
+func TestVectorOperateResultVersionIsAppendOnly(t *testing.T) {
+	rOK := &OperateResult{Status: OperateStatusOK, Values: [][]byte{AppendTaggedCell(nil, Cell{Type: OperateTypeU8, U: 9})}}
+	enc, err := EncodeVectorOperateResult(true, rOK, 42)
+	if err != nil {
+		t.Fatal(err)
+	}
+	preVersion := enc[:len(enc)-8] // exactly what the pre-version encoder produced
+
+	found, got, v, err := DecodeVectorOperateResult(preVersion)
+	if err != nil || !found || !reflect.DeepEqual(got, rOK) || v != 0 {
+		t.Fatalf("pre-version frame: got (%v,%+v,%d,%v), want the result and version 0", found, got, v, err)
+	}
+
+	for _, extra := range []int{1, 2, 7, 9, 16} {
+		frame := append(append([]byte(nil), preVersion...), make([]byte, extra)...)
+		if _, _, _, err := DecodeVectorOperateResult(frame); !errors.Is(err, ErrOperateArgs) {
+			t.Errorf("%d trailing bytes: err = %v, want ErrOperateArgs", extra, err)
+		}
+	}
+	// One byte short of the full version is truncation, not a pre-version frame.
+	if _, _, _, err := DecodeVectorOperateResult(enc[:len(enc)-1]); !errors.Is(err, ErrOperateArgs) {
+		t.Errorf("version truncated by one byte: err = %v, want ErrOperateArgs", err)
 	}
 }
 

--- a/sdk/wire/vector_operate_test.go
+++ b/sdk/wire/vector_operate_test.go
@@ -1,0 +1,270 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package wire
+
+import (
+	"encoding/binary"
+	"errors"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+)
+
+// vecOpArgs returns a minimal, valid vector_operate inner call: create=DYNAMIC,
+// one ADD op against a by-name field. Key/TTL/TTLMode are left at their zero
+// values, which is the only shape EncodeVectorOperateArgs accepts.
+func vecOpArgs() *OperateArgs {
+	return &OperateArgs{
+		Create: OperateCreateDynamic,
+		Ops: []OperateOp{
+			{Opcode: OperateOpADD, Type: OperateTypeU32, Path: OperatePath{Kind: OperatePathField, Field: OperateSeg{ByName: true, Name: "rc"}}, A: 1},
+		},
+	}
+}
+
+// buildRawVectorOperateArgsFrame hand-builds a vector_operate args frame
+// around an arbitrary inner blob, bypassing EncodeVectorOperateArgs's own
+// guards entirely. Used to prove the decoder enforces its rules independently
+// of the encoder (a hostile peer never calls the encoder).
+func buildRawVectorOperateArgsFrame(collection string, id uint64, payloadKey string, hasExpected bool, expectedVersion uint64, inner []byte) []byte {
+	buf := []byte{byte(len(collection))} //nolint:gosec // test helper, collection length controlled by the caller
+	buf = append(buf, collection...)
+	buf = binary.BigEndian.AppendUint64(buf, id)
+	buf = binary.BigEndian.AppendUint16(buf, uint16(len(payloadKey))) //nolint:gosec // test helper
+	buf = append(buf, payloadKey...)
+	if hasExpected {
+		buf = append(buf, 1)
+		buf = binary.BigEndian.AppendUint64(buf, expectedVersion)
+	} else {
+		buf = append(buf, 0)
+	}
+	buf = binary.BigEndian.AppendUint32(buf, uint32(len(inner))) //nolint:gosec // test helper
+	buf = append(buf, inner...)
+	return buf
+}
+
+func TestVectorOperateArgsRoundtrip(t *testing.T) {
+	twoRets := vecOpArgs()
+	twoRets.Rets = []OperateRet{
+		{Mode: OperateRetValue, Path: OperatePath{Kind: OperatePathRecord}},
+		{Mode: OperateRetCount, Path: OperatePath{Kind: OperatePathField, Field: OperateSeg{Pos: 3}}},
+	}
+	schemaCall := &OperateArgs{
+		Create: OperateCreateSchema,
+		Schema: sessionSchema().Encode(),
+		Ops: []OperateOp{
+			{Opcode: OperateOpSET, Type: OperateTypeFromSchema, Path: OperatePath{Kind: OperatePathField, Field: OperateSeg{Pos: 0}}, A: 5},
+		},
+	}
+
+	cases := []struct {
+		name            string
+		collection      string
+		id              uint64
+		payloadKey      string
+		args            *OperateArgs
+		expectedVersion uint64
+		hasExpected     bool
+	}{
+		{"no CAS", "docs", 42, "body", vecOpArgs(), 0, false},
+		{"CAS present", "docs", 42, "body", vecOpArgs(), 7, true},
+		{"two rets", "docs", 99, "meta", twoRets, 0, false},
+		{"schema call", "docs", 5, "rec", schemaCall, 3, true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			enc, err := EncodeVectorOperateArgs(tc.collection, tc.id, tc.payloadKey, tc.args, tc.expectedVersion, tc.hasExpected)
+			if err != nil {
+				t.Fatalf("encode: %v", err)
+			}
+			gotCol, gotID, gotPK, gotArgs, gotVer, gotHas, err := DecodeVectorOperateArgs(enc)
+			if err != nil {
+				t.Fatalf("decode: %v", err)
+			}
+			if gotCol != tc.collection || gotID != tc.id || gotPK != tc.payloadKey || gotVer != tc.expectedVersion || gotHas != tc.hasExpected {
+				t.Fatalf("got (%q,%d,%q,%d,%v) want (%q,%d,%q,%d,%v)",
+					gotCol, gotID, gotPK, gotVer, gotHas, tc.collection, tc.id, tc.payloadKey, tc.expectedVersion, tc.hasExpected)
+			}
+			if !reflect.DeepEqual(gotArgs, tc.args) {
+				t.Fatalf("args mismatch:\n got %+v\nwant %+v", gotArgs, tc.args)
+			}
+		})
+	}
+}
+
+func TestVectorOperateArgsRejectsInnerKey(t *testing.T) {
+	a := vecOpArgs()
+	a.Key = []byte("k")
+	if _, err := EncodeVectorOperateArgs("docs", 1, "body", a, 0, false); !errors.Is(err, ErrOperateArgs) {
+		t.Fatalf("encoder err = %v, want ErrOperateArgs", err)
+	}
+
+	inner, err := EncodeOperateArgs(&OperateArgs{Key: []byte("k"), Create: OperateCreateDynamic})
+	if err != nil {
+		t.Fatal(err)
+	}
+	frame := buildRawVectorOperateArgsFrame("docs", 1, "body", false, 0, inner)
+	if _, _, _, _, _, _, err := DecodeVectorOperateArgs(frame); !errors.Is(err, ErrOperateArgs) {
+		t.Fatalf("decoder err = %v, want ErrOperateArgs", err)
+	}
+}
+
+func TestVectorOperateArgsRejectsTTLMode(t *testing.T) {
+	byMode := vecOpArgs()
+	byMode.TTLMode = OperateTTLSet
+	if _, err := EncodeVectorOperateArgs("docs", 1, "body", byMode, 0, false); !errors.Is(err, ErrOperateArgs) {
+		t.Fatalf("encoder err (TTLMode) = %v, want ErrOperateArgs", err)
+	}
+
+	byTTL := vecOpArgs()
+	byTTL.TTL = time.Second
+	if _, err := EncodeVectorOperateArgs("docs", 1, "body", byTTL, 0, false); !errors.Is(err, ErrOperateArgs) {
+		t.Fatalf("encoder err (TTL) = %v, want ErrOperateArgs", err)
+	}
+
+	innerMode, err := EncodeOperateArgs(&OperateArgs{TTLMode: OperateTTLSet, Create: OperateCreateDynamic})
+	if err != nil {
+		t.Fatal(err)
+	}
+	frameMode := buildRawVectorOperateArgsFrame("docs", 1, "body", false, 0, innerMode)
+	if _, _, _, _, _, _, err := DecodeVectorOperateArgs(frameMode); !errors.Is(err, ErrOperateArgs) {
+		t.Fatalf("decoder err (TTLMode) = %v, want ErrOperateArgs", err)
+	}
+
+	innerTTL, err := EncodeOperateArgs(&OperateArgs{TTL: time.Second, Create: OperateCreateDynamic})
+	if err != nil {
+		t.Fatal(err)
+	}
+	frameTTL := buildRawVectorOperateArgsFrame("docs", 1, "body", false, 0, innerTTL)
+	if _, _, _, _, _, _, err := DecodeVectorOperateArgs(frameTTL); !errors.Is(err, ErrOperateArgs) {
+		t.Fatalf("decoder err (TTL) = %v, want ErrOperateArgs", err)
+	}
+}
+
+func TestVectorOperateArgsRejectsEmptyNames(t *testing.T) {
+	a := vecOpArgs()
+	if _, err := EncodeVectorOperateArgs("", 1, "body", a, 0, false); !errors.Is(err, ErrOperateCap) {
+		t.Fatalf("empty collection: err = %v, want ErrOperateCap", err)
+	}
+	if _, err := EncodeVectorOperateArgs(strings.Repeat("x", 256), 1, "body", a, 0, false); !errors.Is(err, ErrOperateCap) {
+		t.Fatalf("256-byte collection: err = %v, want ErrOperateCap", err)
+	}
+	if _, err := EncodeVectorOperateArgs("docs", 1, "", a, 0, false); !errors.Is(err, ErrOperateCap) {
+		t.Fatalf("empty payload key: err = %v, want ErrOperateCap", err)
+	}
+}
+
+// TestVectorOperateArgsHostileFlags covers the decoder-only branches a
+// well-behaved encoder never reaches: a wire frame declaring an empty
+// collection, an empty payload key, or a casPresent byte outside {0,1}. Each
+// is necessarily a hostile or corrupt frame at decode time, mirroring
+// TestDecodeOperateArgsHostileCounts's discipline for the inner codec.
+func TestVectorOperateArgsHostileFlags(t *testing.T) {
+	inner, err := EncodeOperateArgs(vecOpArgs())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if _, _, _, _, _, _, err := DecodeVectorOperateArgs([]byte{0}); !errors.Is(err, ErrVectorArgsTruncated) {
+		t.Fatalf("colLen=0: err = %v, want ErrVectorArgsTruncated", err)
+	}
+
+	pkZero := buildRawVectorOperateArgsFrame("docs", 1, "", false, 0, inner)
+	if _, _, _, _, _, _, err := DecodeVectorOperateArgs(pkZero); !errors.Is(err, ErrOperateArgs) {
+		t.Fatalf("pkLen=0: err = %v, want ErrOperateArgs", err)
+	}
+
+	badCAS := buildRawVectorOperateArgsFrame("docs", 1, "body", false, 0, inner)
+	// casPresent sits right after payloadKey: colLen(1)+col+id(8)+pkLen(2)+payloadKey.
+	off := 1 + len("docs") + 8 + 2 + len("body")
+	badCAS[off] = 2
+	if _, _, _, _, _, _, err := DecodeVectorOperateArgs(badCAS); !errors.Is(err, ErrOperateArgs) {
+		t.Fatalf("casPresent=2: err = %v, want ErrOperateArgs", err)
+	}
+}
+
+func TestVectorOperateArgsTruncation(t *testing.T) {
+	good, err := EncodeVectorOperateArgs("docs", 42, "body", vecOpArgs(), 7, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for i := 0; i < len(good); i++ {
+		if _, _, _, _, _, _, err := DecodeVectorOperateArgs(good[:i]); err == nil {
+			t.Fatalf("prefix %d accepted", i)
+		}
+	}
+}
+
+func TestVectorOperateArgsTrailingBytes(t *testing.T) {
+	good, err := EncodeVectorOperateArgs("docs", 42, "body", vecOpArgs(), 0, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	bad := append(good[:len(good):len(good)], 0)
+	if _, _, _, _, _, _, err := DecodeVectorOperateArgs(bad); !errors.Is(err, ErrOperateArgs) {
+		t.Fatalf("err = %v, want ErrOperateArgs", err)
+	}
+}
+
+// TestVectorOperateArgsLyingArgsLen covers the 386 widening guard: argsLen
+// overwritten with a value that would go negative under a 32-bit int
+// conversion (0xFFFFFFFF, 0x80000000) must be rejected by a raw-uint32
+// comparison against the remaining length, before any int conversion or
+// allocation happens.
+func TestVectorOperateArgsLyingArgsLen(t *testing.T) {
+	good, err := EncodeVectorOperateArgs("docs", 42, "body", vecOpArgs(), 0, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// argsLen sits right after casPresent (hasExpected=false, so no version
+	// block): colLen(1)+col+id(8)+pkLen(2)+payloadKey+casPresent(1).
+	off := 1 + len("docs") + 8 + 2 + len("body") + 1
+
+	for _, lying := range []uint32{0xFFFFFFFF, 0x80000000} {
+		frame := append([]byte(nil), good...)
+		binary.BigEndian.PutUint32(frame[off:], lying)
+		if _, _, _, _, _, _, err := DecodeVectorOperateArgs(frame); !errors.Is(err, ErrVectorArgsTruncated) {
+			t.Fatalf("argsLen=%#x: err = %v, want ErrVectorArgsTruncated", lying, err)
+		}
+		if n := testing.AllocsPerRun(20, func() { _, _, _, _, _, _, _ = DecodeVectorOperateArgs(frame) }); n > 4 {
+			t.Fatalf("argsLen=%#x allocated %v times; the length must be validated before any allocation", lying, n)
+		}
+	}
+}
+
+func TestVectorOperateResultRoundtrip(t *testing.T) {
+	enc, err := EncodeVectorOperateResult(false, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	found, r, err := DecodeVectorOperateResult(enc)
+	if err != nil || found || r != nil {
+		t.Fatalf("found=false: got (%v,%+v,%v)", found, r, err)
+	}
+
+	rOK := &OperateResult{Status: OperateStatusOK, Values: [][]byte{AppendTaggedCell(nil, Cell{Type: OperateTypeU8, U: 9}), {OperateTypeUnset}}}
+	enc, err = EncodeVectorOperateResult(true, rOK)
+	if err != nil {
+		t.Fatal(err)
+	}
+	found, got, err := DecodeVectorOperateResult(enc)
+	if err != nil || !found || !reflect.DeepEqual(got, rOK) {
+		t.Fatalf("found=true OK: got (%v,%+v,%v) want %+v", found, got, err, rOK)
+	}
+
+	rFail := &OperateResult{Status: OperateStatusCheckFailed, FailedOp: 3}
+	enc, err = EncodeVectorOperateResult(true, rFail)
+	if err != nil {
+		t.Fatal(err)
+	}
+	found, got, err = DecodeVectorOperateResult(enc)
+	if err != nil || !found || !reflect.DeepEqual(got, rFail) {
+		t.Fatalf("found=true CheckFailed: got (%v,%+v,%v) want %+v", found, got, err, rFail)
+	}
+
+	if _, err := EncodeVectorOperateResult(true, nil); !errors.Is(err, ErrOperateArgs) {
+		t.Fatalf("found=true r=nil: err = %v, want ErrOperateArgs", err)
+	}
+}

--- a/sdk/wire/vector_routing.go
+++ b/sdk/wire/vector_routing.go
@@ -206,7 +206,11 @@ func CollectionNameFor(op string, args []byte) (name string, ok bool) {
 		// vector_query (unified Query API) leads with [colLen:u8][col] — the
 		// QuerySpec blob is opaque to routing, so the collection sits at offset 0.
 		// vector_named_query / vector_mv_query share the exact same arg wire (At1).
-		"vector_query", "vector_named_query", "vector_mv_query":
+		"vector_query", "vector_named_query", "vector_mv_query",
+		// The operate family leads with [colLen:u8][col][id:u64] — the same At1
+		// layout as the set_payload rows above. All three families share one arg
+		// wire (EncodeVectorOperateArgs); the op NAME selects the family.
+		"vector_operate", "vector_named_operate", "vector_mv_operate":
 		ke = VectorKeyColAt1
 	default:
 		return "", false
@@ -253,7 +257,10 @@ func CollectionNameOffset(op string) (off int, ok bool) {
 		// vector_bm25_stats: [colLen:u8][col]... — collection at offset 0 (At1).
 		"vector_bm25_stats",
 		// vector_query / vector_named_query / vector_mv_query: [colLen:u8][col]... — collection at offset 0.
-		"vector_query", "vector_named_query", "vector_mv_query":
+		"vector_query", "vector_named_query", "vector_mv_query",
+		// The operate family: [colLen:u8][col][id:u64]... — collection at offset 0,
+		// the same At1 layout as the set_payload rows above.
+		"vector_operate", "vector_named_operate", "vector_mv_operate":
 		return 0, true
 	default:
 		return 0, false
@@ -312,6 +319,7 @@ var singlePointWriteOps = map[string]struct{}{
 	// At1 layout (offset 0): [colLen:u8][col][id:u64]...
 	"vector_delete":                    {},
 	"vector_set_payload":               {},
+	"vector_operate":                   {},
 	"vector_overwrite_payload":         {},
 	"vector_delete_payload_keys":       {},
 	"vector_clear_payload":             {},
@@ -319,12 +327,14 @@ var singlePointWriteOps = map[string]struct{}{
 	"vector_mv_add_versioned":          {},
 	"vector_mv_delete":                 {},
 	"vector_mv_set_payload":            {},
+	"vector_mv_operate":                {},
 	"vector_mv_overwrite_payload":      {},
 	"vector_mv_delete_payload_keys":    {},
 	"vector_mv_clear_payload":          {},
 	"vector_named_insert":              {},
 	"vector_named_delete":              {},
 	"vector_named_set_payload":         {},
+	"vector_named_operate":             {},
 	"vector_named_overwrite_payload":   {},
 	"vector_named_delete_payload_keys": {},
 	"vector_named_clear_payload":       {},

--- a/sdk/wire/wc_envelope.go
+++ b/sdk/wire/wc_envelope.go
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package wire
+
+// WCEnvelopeOp is the reserved name of the write-consistency envelope
+// virtual-op. It is declared in this leaf package, not beside its codec in
+// ops, because THREE layers have to agree on it and only two of them can see
+// ops: the server-side fanout dispatcher (root module), the store that builds
+// the envelope (root module), and the standalone client module, which imports
+// this package and nothing else of the tree.
+//
+// ops.WCEnvelopeOp is this same constant — see ops/write_consistency.go for the
+// envelope's full wire layout and its codec.
+const WCEnvelopeOp = "__wc__"
+
+// WCEnvelopeInnerOp peeks the inner op NAME out of a write-consistency envelope
+// without decoding the rest of the frame. It exists for the retry decision in
+// the client: a write wrapped in the envelope is sent under the op name
+// "__wc__", so a guard keyed on the op name alone stops seeing the write it is
+// meant to protect — a non-replayable conditional write would be retried across
+// an ambiguous post-transmission failure and could apply twice.
+//
+// The layout it reads is the head of ops.EncodeWCEnvelope's frame:
+//
+//	[wcf u8][wait u8][nameLen u8][name...][argsLen u32][args...]
+//
+// Only the first three bytes and the name are touched; the inner args are not
+// examined, so this costs one bounds check and one string header on a path that
+// runs once per failed call. ok is false for any buffer too short to hold the
+// declared name — a frame this client did not build — and the caller decides
+// what an unreadable envelope means (client.nonReplayableCall treats it as
+// non-replayable, which can only cost a retry).
+//
+// Keep in step with ops.DecodeWCEnvelope: TestWCEnvelopeInnerOpMatchesOpsCodec
+// (root module, which can see both) pins the two against each other.
+func WCEnvelopeInnerOp(args []byte) (name string, ok bool) {
+	if len(args) < 3 {
+		return "", false
+	}
+	nameLen := int(args[2])
+	if len(args)-3 < nameLen {
+		return "", false
+	}
+	return string(args[3 : 3+nameLen]), true
+}

--- a/server/handlers.go
+++ b/server/handlers.go
@@ -155,9 +155,11 @@ func mapResult(disp Dispatcher, result []byte, err error, reqID string) (uint8, 
 		// client-facing error message.
 		errors.Is(err, ops.ErrVectorRecordAbsent),
 		// The clustered path stringifies the sentinel across the Raft boundary, so
-		// errors.Is stops matching — the same reason clientFacingErr carries string
-		// fallbacks. Comparing against the sentinel's own text cannot drift from it.
-		strings.Contains(err.Error(), ops.ErrVectorRecordAbsent.Error()):
+		// errors.Is stops matching — the same reason clientFacingErr carries a
+		// message-shape fallback. ops.IsVectorRecordAbsentMessage, not
+		// strings.Contains: a bare substring check would also match an unrelated
+		// internal error that merely wraps the sentinel, leaking it unredacted.
+		ops.IsVectorRecordAbsentMessage(err.Error()):
 		return StatusNotFound, nil
 	case errors.Is(err, shard.ErrNotLeader):
 		var nle *shard.NotLeaderError
@@ -212,8 +214,8 @@ func clientFacingErr(err error) bool {
 		// Matched by sentinel AND by exact message shape: shard.decodePBResult
 		// rebuilds an op error with errors.New across replication, so a
 		// clustered apply loses errors.Is identity and the error would fall
-		// through to the redacted internal-fault bucket. The message-shape arm
-		// uses vector.IsRecordTooLargeMessage, NOT strings.Contains — a bare
+		// through to the redacted internal-fault bucket. The message-shape arms
+		// use vector.IsRecordTooLargeMessage, NOT strings.Contains — a bare
 		// substring check would also match an unrelated internal error that
 		// merely wraps the sentinel (e.g. a WAL/path error), leaking it to the
 		// caller unredacted.
@@ -223,17 +225,19 @@ func clientFacingErr(err error) bool {
 		// engine can open. Same bucket and same reasoning as the cap above — the
 		// caller sent those bytes, the remedy is to send a well-formed record,
 		// and the message names only the payload key the caller chose. Same
-		// sentinel-plus-string matching, for the same clustered-apply reason.
+		// sentinel-plus-message-shape matching, for the same clustered-apply
+		// reason.
 		errors.Is(err, vector.ErrRecordMalformed),
-		strings.Contains(err.Error(), vector.ErrRecordMalformed.Error()),
+		vector.IsRecordMalformedMessage(err.Error()),
 		// vector.ErrPayloadKeyNotRecord: a vector_operate aimed at a payload key
 		// that holds a plain value (or the reserved content key) rather than a
 		// record. Same bucket and same reasoning as the two above — the caller
 		// chose the key, the remedy is to name a record key, and the message
 		// discloses only that key and the kind stored under it. Same
-		// sentinel-plus-string matching, for the same clustered-apply reason.
+		// sentinel-plus-message-shape matching, for the same clustered-apply
+		// reason.
 		errors.Is(err, vector.ErrPayloadKeyNotRecord),
-		strings.Contains(err.Error(), vector.ErrPayloadKeyNotRecord.Error()),
+		vector.IsPayloadKeyNotRecordMessage(err.Error()),
 		errors.Is(err, vector.ErrEmptyFilter),
 		errors.Is(err, vector.ErrEmptyGroupBy),
 		errors.Is(err, vector.ErrSparseMismatch),

--- a/server/handlers.go
+++ b/server/handlers.go
@@ -222,14 +222,18 @@ func clientFacingErr(err error) bool {
 		// vector.ErrRecordMalformed: a payload carrying record bytes no operate
 		// engine can open. Same bucket and same reasoning as the cap above — the
 		// caller sent those bytes, the remedy is to send a well-formed record,
-		// and the message names only the payload key the caller chose.
+		// and the message names only the payload key the caller chose. Same
+		// sentinel-plus-string matching, for the same clustered-apply reason.
 		errors.Is(err, vector.ErrRecordMalformed),
+		strings.Contains(err.Error(), vector.ErrRecordMalformed.Error()),
 		// vector.ErrPayloadKeyNotRecord: a vector_operate aimed at a payload key
 		// that holds a plain value (or the reserved content key) rather than a
 		// record. Same bucket and same reasoning as the two above — the caller
 		// chose the key, the remedy is to name a record key, and the message
-		// discloses only that key and the kind stored under it.
+		// discloses only that key and the kind stored under it. Same
+		// sentinel-plus-string matching, for the same clustered-apply reason.
 		errors.Is(err, vector.ErrPayloadKeyNotRecord),
+		strings.Contains(err.Error(), vector.ErrPayloadKeyNotRecord.Error()),
 		errors.Is(err, vector.ErrEmptyFilter),
 		errors.Is(err, vector.ErrEmptyGroupBy),
 		errors.Is(err, vector.ErrSparseMismatch),

--- a/server/handlers.go
+++ b/server/handlers.go
@@ -139,7 +139,25 @@ func mapResult(disp Dispatcher, result []byte, err error, reqID string) (uint8, 
 	switch {
 	case err == nil:
 		return StatusOK, result
-	case errors.Is(err, cache.ErrNotFound):
+	case errors.Is(err, cache.ErrNotFound),
+		// ops.ErrVectorRecordAbsent: vector_operate with create = NONE against a
+		// payload key that holds no record. It is the vector twin of the signal
+		// handleOperate raises for the same call against an absent KV key —
+		// handleOperate maps that one to cache.ErrNotFound (ops.handleOperate's
+		// doc comment; TestOperateCreateNoneOnAbsent pins it), which this very
+		// case already answers StatusNotFound for. Answering the same status for
+		// the vector twin is what keeps KV and vector operate telling a caller the
+		// same thing; classified nowhere, it fell through to the redacted
+		// StatusError bucket and read as a server fault.
+		//
+		// It is classified HERE rather than in clientFacingErr because the status
+		// is what carries the meaning: not-found is its own wire status, not a
+		// client-facing error message.
+		errors.Is(err, ops.ErrVectorRecordAbsent),
+		// The clustered path stringifies the sentinel across the Raft boundary, so
+		// errors.Is stops matching — the same reason clientFacingErr carries string
+		// fallbacks. Comparing against the sentinel's own text cannot drift from it.
+		strings.Contains(err.Error(), ops.ErrVectorRecordAbsent.Error()):
 		return StatusNotFound, nil
 	case errors.Is(err, shard.ErrNotLeader):
 		var nle *shard.NotLeaderError

--- a/server/handlers.go
+++ b/server/handlers.go
@@ -201,6 +201,11 @@ func clientFacingErr(err error) bool {
 		// caller unredacted.
 		errors.Is(err, vector.ErrRecordTooLarge),
 		vector.IsRecordTooLargeMessage(err.Error()),
+		// vector.ErrRecordMalformed: a payload carrying record bytes no operate
+		// engine can open. Same bucket and same reasoning as the cap above — the
+		// caller sent those bytes, the remedy is to send a well-formed record,
+		// and the message names only the payload key the caller chose.
+		errors.Is(err, vector.ErrRecordMalformed),
 		errors.Is(err, vector.ErrEmptyFilter),
 		errors.Is(err, vector.ErrEmptyGroupBy),
 		errors.Is(err, vector.ErrSparseMismatch),

--- a/server/handlers.go
+++ b/server/handlers.go
@@ -262,10 +262,11 @@ func clientFacingErr(err error) bool {
 		// fault. The message names no key, no path and no size — only that the
 		// arguments are invalid — so it is safe verbatim.
 		//
-		// Sentinel only, no message-shape arm: this error is raised by the
-		// decoder the handler itself calls, so it reaches the classifier with its
-		// identity intact.
-		// The clustered path stringifies the sentinel across the Raft boundary:
+		// Sentinel AND exact message shape, both arms load-bearing. The sentinel
+		// arm covers the direct path, where the decoder the handler itself calls
+		// hands the error back with its identity intact.
+		// The message-shape arm covers the clustered path, which stringifies the
+		// sentinel across the Raft boundary:
 		// an operate handler decodes its frame INSIDE the FSM apply, so
 		// shard.decodePBResult rebuilds the error with errors.New and errors.Is
 		// stops matching — which left a malformed frame from a clustered caller
@@ -273,8 +274,17 @@ func clientFacingErr(err error) bool {
 		// reach. wire.IsOperateArgsMessage, not strings.Contains: a bare
 		// substring check would also match an unrelated internal error that
 		// merely wraps the sentinel, leaking it unredacted.
+		//
+		// wire.ErrVectorArgsTruncated rides in the same bucket, by both arms, for
+		// the same reasons: DecodeVectorOperateArgs raises it for a frame shorter
+		// than the fields it declares, right beside the ErrOperateArgs it raises
+		// for a complete-but-invalid one. Both are the caller's framing mistake
+		// and both name nothing but "the arguments do not decode"; left
+		// unclassified, a truncated frame read as a server fault.
 		wire.IsOperateArgsMessage(err.Error()),
-		errors.Is(err, wire.ErrOperateArgs):
+		errors.Is(err, wire.ErrOperateArgs),
+		wire.IsVectorArgsTruncatedMessage(err.Error()),
+		errors.Is(err, wire.ErrVectorArgsTruncated):
 		return true
 	case errors.Is(err, ops.ErrOperateDuringReshard),
 		// ops.ErrOperateDuringReshard: a vector_operate against a collection a

--- a/server/handlers.go
+++ b/server/handlers.go
@@ -265,6 +265,15 @@ func clientFacingErr(err error) bool {
 		// Sentinel only, no message-shape arm: this error is raised by the
 		// decoder the handler itself calls, so it reaches the classifier with its
 		// identity intact.
+		// The clustered path stringifies the sentinel across the Raft boundary:
+		// an operate handler decodes its frame INSIDE the FSM apply, so
+		// shard.decodePBResult rebuilds the error with errors.New and errors.Is
+		// stops matching — which left a malformed frame from a clustered caller
+		// redacted as a server fault, the one case the sentinel arm above cannot
+		// reach. wire.IsOperateArgsMessage, not strings.Contains: a bare
+		// substring check would also match an unrelated internal error that
+		// merely wraps the sentinel, leaking it unredacted.
+		wire.IsOperateArgsMessage(err.Error()),
 		errors.Is(err, wire.ErrOperateArgs):
 		return true
 	case errors.Is(err, ops.ErrOperateDuringReshard),

--- a/server/handlers.go
+++ b/server/handlers.go
@@ -13,6 +13,7 @@ import (
 	"github.com/rostamlabs/rostam/cache"
 	"github.com/rostamlabs/rostam/ops"
 	"github.com/rostamlabs/rostam/rlog"
+	"github.com/rostamlabs/rostam/sdk/wire"
 	"github.com/rostamlabs/rostam/shard"
 	"github.com/rostamlabs/rostam/vector"
 )
@@ -252,7 +253,19 @@ func clientFacingErr(err error) bool {
 		// correctly but is not a metadata object. Kept in sync with httpapi's
 		// statusForError, which answers 400 for it — a caller mistake, not a server
 		// fault, whichever transport carried it.
-		errors.Is(err, ops.ErrMalformedPayloadJSON):
+		errors.Is(err, ops.ErrMalformedPayloadJSON),
+		// wire.ErrOperateArgs: a malformed operate frame — a vector_operate or a KV
+		// operate whose args do not decode, or which names a second target or a
+		// TTL the op does not carry (DecodeVectorOperateArgs /
+		// ops.checkVectorOperateArgs / DecodeOperateArgs). The caller built the
+		// frame, so it is their mistake to fix; unclassified it read as a server
+		// fault. The message names no key, no path and no size — only that the
+		// arguments are invalid — so it is safe verbatim.
+		//
+		// Sentinel only, no message-shape arm: this error is raised by the
+		// decoder the handler itself calls, so it reaches the classifier with its
+		// identity intact.
+		errors.Is(err, wire.ErrOperateArgs):
 		return true
 	case errors.Is(err, ops.ErrOperateDuringReshard),
 		// ops.ErrOperateDuringReshard: a vector_operate against a collection a

--- a/server/handlers.go
+++ b/server/handlers.go
@@ -206,6 +206,12 @@ func clientFacingErr(err error) bool {
 		// caller sent those bytes, the remedy is to send a well-formed record,
 		// and the message names only the payload key the caller chose.
 		errors.Is(err, vector.ErrRecordMalformed),
+		// vector.ErrPayloadKeyNotRecord: a vector_operate aimed at a payload key
+		// that holds a plain value (or the reserved content key) rather than a
+		// record. Same bucket and same reasoning as the two above — the caller
+		// chose the key, the remedy is to name a record key, and the message
+		// discloses only that key and the kind stored under it.
+		errors.Is(err, vector.ErrPayloadKeyNotRecord),
 		errors.Is(err, vector.ErrEmptyFilter),
 		errors.Is(err, vector.ErrEmptyGroupBy),
 		errors.Is(err, vector.ErrSparseMismatch),

--- a/server/handlers.go
+++ b/server/handlers.go
@@ -254,6 +254,22 @@ func clientFacingErr(err error) bool {
 		// fault, whichever transport carried it.
 		errors.Is(err, ops.ErrMalformedPayloadJSON):
 		return true
+	case errors.Is(err, ops.ErrOperateDuringReshard),
+		// ops.ErrOperateDuringReshard: a vector_operate against a collection a
+		// reshard is dual-writing. operate is not idempotent, so the store
+		// REFUSES rather than sending the op-list to both generations — and the
+		// whole design rests on the caller being told to retry after cutover.
+		// Unclassified it fell to the redacted internal-error bucket, so the
+		// retryability never reached the client and a transient read as a server
+		// fault. Same bucket as the leadership/ownership transients below (this
+		// transport carries no separate retryable status: StatusNotLeader is
+		// specifically a leader hint, and this is not a leadership condition).
+		//
+		// Sentinel AND exact message shape, for the usual clustered-apply reason;
+		// ops.IsOperateDuringReshardMessage, not strings.Contains, so an internal
+		// fault that merely mentions the refusal is not leaked.
+		ops.IsOperateDuringReshardMessage(err.Error()):
+		return true
 	case errors.Is(err, vector.ErrInvalidDim),
 		errors.Is(err, vector.ErrInvalidMetric),
 		errors.Is(err, vector.ErrInvalidM),

--- a/server/redaction_test.go
+++ b/server/redaction_test.go
@@ -452,6 +452,10 @@ func TestMapResultMalformedOperateFrameIsClientFacing(t *testing.T) {
 		{"sentinel", wire.ErrOperateArgs},
 		{"wrapped (%w, exercises errors.Is identity)", fmt.Errorf("vector_operate: %w", wire.ErrOperateArgs)},
 		{"as the decoder actually returns it", decErr},
+		// The clustered shape, and the one the sentinel arm cannot reach: an
+		// operate handler decodes inside the FSM apply, so shard.decodePBResult
+		// hands the error back rebuilt with errors.New and identity is gone.
+		{"stringified across Raft, real bare shape", errors.New(wire.ErrOperateArgs.Error())},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			status, payload := mapResult(disp, nil, tc.err, "")
@@ -467,4 +471,17 @@ func TestMapResultMalformedOperateFrameIsClientFacing(t *testing.T) {
 			}
 		})
 	}
+	// Negative control: an unrelated internal fault that merely mentions the
+	// sentinel text must STAY redacted. This is what an exact-equality matcher
+	// buys over a strings.Contains arm.
+	t.Run("negative/unrelated fault wrapping the sentinel with a foreign prefix", func(t *testing.T) {
+		err := errors.New("apply: " + wire.ErrOperateArgs.Error())
+		status, payload := mapResult(disp, nil, err, "")
+		if status != StatusError {
+			t.Fatalf("status = %d, want StatusError (%d)", status, StatusError)
+		}
+		if msg, _ := DecodeErrorPayload(payload); msg != "internal error" {
+			t.Fatalf("payload = %q, want the redacted message", msg)
+		}
+	})
 }

--- a/server/redaction_test.go
+++ b/server/redaction_test.go
@@ -207,3 +207,19 @@ func TestMapResultKeepsRecordTooLargeVisible(t *testing.T) {
 		})
 	}
 }
+
+// TestClientFacingErrMalformedRecord pins the TCP transport's half of the same
+// classification the HTTP edge makes (httpapi.TestStatusForErrorMalformedRecord).
+// vector.ErrRecordMalformed is a caller mistake — bytes the caller sent that no
+// operate engine can open — so its message must reach the client verbatim rather
+// than being redacted to "internal error", which would leave a client unable to
+// tell a bad payload from a server fault.
+func TestClientFacingErrMalformedRecord(t *testing.T) {
+	err := fmt.Errorf("%w: payload key %q: bad", vector.ErrRecordMalformed, "session")
+	if !clientFacingErr(err) {
+		t.Error("clientFacingErr(ErrRecordMalformed) = false, want true")
+	}
+	if !clientFacingErr(vector.ErrRecordTooLarge) {
+		t.Error("clientFacingErr(ErrRecordTooLarge) = false, want true (the sibling bound)")
+	}
+}

--- a/server/redaction_test.go
+++ b/server/redaction_test.go
@@ -236,3 +236,37 @@ func TestClientFacingErrPayloadKeyNotRecord(t *testing.T) {
 		t.Error("clientFacingErr(ErrPayloadKeyNotRecord) = false, want true")
 	}
 }
+
+// TestMapResultVectorRecordAbsentIsNotFound pins vector_operate's create=NONE
+// refusal as the SAME wire status KV operate answers with. handleOperate maps
+// its create=NONE-against-an-absent-key case to cache.ErrNotFound, which
+// mapResult already answers StatusNotFound for (TestOperateCreateNoneOnAbsent
+// pins the KV half); ops.ErrVectorRecordAbsent is that signal for a record held
+// in a point's payload, so the two transports must not disagree about it. Left
+// unclassified it fell through to the redacted StatusError bucket, telling a
+// caller "internal error" for a record that simply is not there.
+//
+// The substring arm covers the clustered path, where the sentinel is stringified
+// across the Raft boundary and errors.Is stops matching — the same reason
+// clientFacingErr carries string fallbacks.
+func TestMapResultVectorRecordAbsentIsNotFound(t *testing.T) {
+	disp := &fakeDispatcher{}
+	for _, tc := range []struct {
+		name string
+		err  error
+	}{
+		{"sentinel", ops.ErrVectorRecordAbsent},
+		{"wrapped", fmt.Errorf("shard 3: %w", ops.ErrVectorRecordAbsent)},
+		{"stringified across Raft", errors.New("apply: " + ops.ErrVectorRecordAbsent.Error())},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			status, payload := mapResult(disp, nil, tc.err, "")
+			if status != StatusNotFound {
+				t.Fatalf("status = %d, want StatusNotFound (%d)", status, StatusNotFound)
+			}
+			if payload != nil {
+				t.Fatalf("payload = %q, want nil (the not-found status carries no body, as for cache.ErrNotFound)", payload)
+			}
+		})
+	}
+}

--- a/server/redaction_test.go
+++ b/server/redaction_test.go
@@ -214,13 +214,44 @@ func TestMapResultKeepsRecordTooLargeVisible(t *testing.T) {
 // operate engine can open — so its message must reach the client verbatim rather
 // than being redacted to "internal error", which would leave a client unable to
 // tell a bad payload from a server fault.
+//
+// Three arms, like TestMapResultVectorRecordAbsentIsNotFound: sentinel, wrapped,
+// and stringified across the Raft boundary (a clustered apply loses errors.Is
+// identity, which is exactly why clientFacingErr also matches by substring).
 func TestClientFacingErrMalformedRecord(t *testing.T) {
-	err := fmt.Errorf("%w: payload key %q: bad", vector.ErrRecordMalformed, "session")
-	if !clientFacingErr(err) {
-		t.Error("clientFacingErr(ErrRecordMalformed) = false, want true")
+	for _, tc := range []struct {
+		name string
+		err  error
+	}{
+		{"sentinel", vector.ErrRecordMalformed},
+		{"wrapped", fmt.Errorf("%w: payload key %q: bad", vector.ErrRecordMalformed, "session")},
+		{"stringified across Raft", errors.New("apply: " + vector.ErrRecordMalformed.Error())},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if !clientFacingErr(tc.err) {
+				t.Error("clientFacingErr(ErrRecordMalformed) = false, want true")
+			}
+		})
 	}
-	if !clientFacingErr(vector.ErrRecordTooLarge) {
-		t.Error("clientFacingErr(ErrRecordTooLarge) = false, want true (the sibling bound)")
+}
+
+// TestClientFacingErrRecordTooLarge is ErrRecordMalformed's sibling bound: a
+// record value above the storage cap is the same caller-fixable-mistake bucket,
+// with the same three-arm (sentinel / wrapped / stringified) coverage.
+func TestClientFacingErrRecordTooLarge(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		err  error
+	}{
+		{"sentinel", vector.ErrRecordTooLarge},
+		{"wrapped", fmt.Errorf("%w: payload key %q: 17000000 > 16777216", vector.ErrRecordTooLarge, "session")},
+		{"stringified across Raft", errors.New("apply: " + vector.ErrRecordTooLarge.Error())},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if !clientFacingErr(tc.err) {
+				t.Error("clientFacingErr(ErrRecordTooLarge) = false, want true")
+			}
+		})
 	}
 }
 
@@ -230,10 +261,23 @@ func TestClientFacingErrMalformedRecord(t *testing.T) {
 // destroy data the caller can still read — and that refusal names the caller's
 // own key, so it must reach the client verbatim instead of being redacted to
 // "internal error", which would read as a server fault for a caller mistake.
+//
+// Three arms, like TestMapResultVectorRecordAbsentIsNotFound: sentinel, wrapped,
+// and stringified across the Raft boundary.
 func TestClientFacingErrPayloadKeyNotRecord(t *testing.T) {
-	err := fmt.Errorf("%w: payload key %q holds a value of kind %d", vector.ErrPayloadKeyNotRecord, "country", 2)
-	if !clientFacingErr(err) {
-		t.Error("clientFacingErr(ErrPayloadKeyNotRecord) = false, want true")
+	for _, tc := range []struct {
+		name string
+		err  error
+	}{
+		{"sentinel", vector.ErrPayloadKeyNotRecord},
+		{"wrapped", fmt.Errorf("%w: payload key %q holds a value of kind %d", vector.ErrPayloadKeyNotRecord, "country", 2)},
+		{"stringified across Raft", errors.New("apply: " + vector.ErrPayloadKeyNotRecord.Error())},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if !clientFacingErr(tc.err) {
+				t.Error("clientFacingErr(ErrPayloadKeyNotRecord) = false, want true")
+			}
+		})
 	}
 }
 

--- a/server/redaction_test.go
+++ b/server/redaction_test.go
@@ -485,3 +485,56 @@ func TestMapResultMalformedOperateFrameIsClientFacing(t *testing.T) {
 		}
 	})
 }
+
+// TestMapResultTruncatedOperateFrameIsClientFacing is the parity guard for
+// wire.ErrVectorArgsTruncated, the sentinel DecodeVectorOperateArgs raises for a
+// frame SHORTER than the fields it declares — right beside the ErrOperateArgs it
+// raises for a complete-but-invalid one.
+//
+// Both are the caller's framing mistake and both say nothing but "the arguments
+// do not decode", so both belong in the same bucket. Left unclassified, a
+// truncated frame was redacted to "internal error" and the caller was told a
+// server fault had happened.
+func TestMapResultTruncatedOperateFrameIsClientFacing(t *testing.T) {
+	disp := &fakeDispatcher{}
+	// A real production shape: a frame that declares a 4-byte collection name
+	// and then simply stops.
+	frame := []byte{4, 'd', 'o'}
+	_, _, _, _, _, _, decErr := wire.DecodeVectorOperateArgs(frame)
+	if !errors.Is(decErr, wire.ErrVectorArgsTruncated) {
+		t.Fatalf("decoder fixture drifted: err = %v, want wire.ErrVectorArgsTruncated", decErr)
+	}
+	for _, tc := range []struct {
+		name string
+		err  error
+	}{
+		{"sentinel", wire.ErrVectorArgsTruncated},
+		{"wrapped (%w, exercises errors.Is identity)", fmt.Errorf("vector_operate: %w", wire.ErrVectorArgsTruncated)},
+		{"as the decoder actually returns it", decErr},
+		{"stringified across Raft, real bare shape", errors.New(wire.ErrVectorArgsTruncated.Error())},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			status, payload := mapResult(disp, nil, tc.err, "")
+			if status != StatusError {
+				t.Fatalf("status = %d, want StatusError (%d)", status, StatusError)
+			}
+			msg, _ := DecodeErrorPayload(payload)
+			if msg == "internal error" {
+				t.Fatalf("a truncated frame was redacted to %q — a client protocol mistake reads as a server fault", msg)
+			}
+			if msg != tc.err.Error() {
+				t.Fatalf("payload = %q, want the verbatim message %q", msg, tc.err.Error())
+			}
+		})
+	}
+	t.Run("negative/unrelated fault wrapping the sentinel with a foreign prefix", func(t *testing.T) {
+		err := errors.New("apply: " + wire.ErrVectorArgsTruncated.Error())
+		status, payload := mapResult(disp, nil, err, "")
+		if status != StatusError {
+			t.Fatalf("status = %d, want StatusError (%d)", status, StatusError)
+		}
+		if msg, _ := DecodeErrorPayload(payload); msg != "internal error" {
+			t.Fatalf("payload = %q, want the redacted message", msg)
+		}
+	})
+}

--- a/server/redaction_test.go
+++ b/server/redaction_test.go
@@ -223,3 +223,16 @@ func TestClientFacingErrMalformedRecord(t *testing.T) {
 		t.Error("clientFacingErr(ErrRecordTooLarge) = false, want true (the sibling bound)")
 	}
 }
+
+// TestClientFacingErrPayloadKeyNotRecord pins the TCP transport's half of
+// httpapi.TestStatusForErrorPayloadKeyNotRecord. vector_operate refuses a
+// payload key that holds a plain value rather than a record — replacing it would
+// destroy data the caller can still read — and that refusal names the caller's
+// own key, so it must reach the client verbatim instead of being redacted to
+// "internal error", which would read as a server fault for a caller mistake.
+func TestClientFacingErrPayloadKeyNotRecord(t *testing.T) {
+	err := fmt.Errorf("%w: payload key %q holds a value of kind %d", vector.ErrPayloadKeyNotRecord, "country", 2)
+	if !clientFacingErr(err) {
+		t.Error("clientFacingErr(ErrPayloadKeyNotRecord) = false, want true")
+	}
+}

--- a/server/redaction_test.go
+++ b/server/redaction_test.go
@@ -208,6 +208,20 @@ func TestMapResultKeepsRecordTooLargeVisible(t *testing.T) {
 	}
 }
 
+// errRealMalformedSingle, errRealMalformedBulk and errRealNotRecordDetailed reproduce
+// the EXACT shapes checkRecordValues / checkRecordValuesAll (ErrRecordMalformed)
+// and currentRecordValue (ErrPayloadKeyNotRecord) actually produce in
+// production — see vector.IsRecordMalformedMessage / IsPayloadKeyNotRecordMessage
+// for the format strings these mirror. server cannot call those unexported
+// vector-package producers directly, so the shapes are reproduced by hand;
+// vector's own TestIsRecordMalformedMessage / TestIsPayloadKeyNotRecordMessage
+// pin them against the real producers.
+var (
+	errRealMalformedSingle   = fmt.Errorf("%w: payload key %q: %s", vector.ErrRecordMalformed, "session", "record: malformed record: wire: args too short")
+	errRealMalformedBulk     = fmt.Errorf("payload %d: %w", 7, errRealMalformedSingle)
+	errRealNotRecordDetailed = fmt.Errorf("%w: payload key %q holds a value of kind %d", vector.ErrPayloadKeyNotRecord, "country", 2)
+)
+
 // TestClientFacingErrMalformedRecord pins the TCP transport's half of the same
 // classification the HTTP edge makes (httpapi.TestStatusForErrorMalformedRecord).
 // vector.ErrRecordMalformed is a caller mistake — bytes the caller sent that no
@@ -215,17 +229,23 @@ func TestMapResultKeepsRecordTooLargeVisible(t *testing.T) {
 // than being redacted to "internal error", which would leave a client unable to
 // tell a bad payload from a server fault.
 //
-// Three arms, like TestMapResultVectorRecordAbsentIsNotFound: sentinel, wrapped,
-// and stringified across the Raft boundary (a clustered apply loses errors.Is
-// identity, which is exactly why clientFacingErr also matches by substring).
+// Per shape: the bare sentinel, the real %w-wrapped single/bulk shapes (matched
+// by errors.Is regardless of exact text), and those shapes stringified across
+// the Raft boundary (matched only by vector.IsRecordMalformedMessage — a
+// clustered apply loses errors.Is identity, which is why clientFacingErr also
+// carries a message-shape fallback). A negative control asserts an unrelated
+// error that merely wraps the sentinel with a foreign prefix stays redacted —
+// the exact bug a bare strings.Contains classifier would reintroduce.
 func TestClientFacingErrMalformedRecord(t *testing.T) {
 	for _, tc := range []struct {
 		name string
 		err  error
 	}{
 		{"sentinel", vector.ErrRecordMalformed},
-		{"wrapped", fmt.Errorf("%w: payload key %q: bad", vector.ErrRecordMalformed, "session")},
-		{"stringified across Raft", errors.New("apply: " + vector.ErrRecordMalformed.Error())},
+		{"wrapped, real single-payload shape", errRealMalformedSingle},
+		{"wrapped, real bulk shape", errRealMalformedBulk},
+		{"stringified across Raft, real single-payload shape", errors.New(errRealMalformedSingle.Error())},
+		{"stringified across Raft, real bulk shape", errors.New(errRealMalformedBulk.Error())},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			if !clientFacingErr(tc.err) {
@@ -233,19 +253,26 @@ func TestClientFacingErrMalformedRecord(t *testing.T) {
 			}
 		})
 	}
+	t.Run("negative/unrelated fault wrapping the sentinel with a foreign prefix (%v, no %w identity)", func(t *testing.T) {
+		if clientFacingErr(fmt.Errorf("wal append failed at /var/lib/rostam/x: %v", vector.ErrRecordMalformed)) {
+			t.Error("clientFacingErr(wrapped ErrRecordMalformed) = true, want false (redacted)")
+		}
+	})
 }
 
 // TestClientFacingErrRecordTooLarge is ErrRecordMalformed's sibling bound: a
-// record value above the storage cap is the same caller-fixable-mistake bucket,
-// with the same three-arm (sentinel / wrapped / stringified) coverage.
+// record value above the storage cap is the same caller-fixable-mistake bucket.
+// Per shape: bare sentinel, real %w-wrapped shape, and that shape stringified
+// across the Raft boundary, plus a negative control for an unrelated wrap.
 func TestClientFacingErrRecordTooLarge(t *testing.T) {
+	wrapped := fmt.Errorf("%w: payload key %q holds a 17000000-byte record, the cap is 16777216 bytes", vector.ErrRecordTooLarge, "session")
 	for _, tc := range []struct {
 		name string
 		err  error
 	}{
 		{"sentinel", vector.ErrRecordTooLarge},
-		{"wrapped", fmt.Errorf("%w: payload key %q: 17000000 > 16777216", vector.ErrRecordTooLarge, "session")},
-		{"stringified across Raft", errors.New("apply: " + vector.ErrRecordTooLarge.Error())},
+		{"wrapped, real shape", wrapped},
+		{"stringified across Raft, real shape", errors.New(wrapped.Error())},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			if !clientFacingErr(tc.err) {
@@ -253,6 +280,11 @@ func TestClientFacingErrRecordTooLarge(t *testing.T) {
 			}
 		})
 	}
+	t.Run("negative/unrelated fault wrapping the sentinel with a foreign prefix (%v, no %w identity)", func(t *testing.T) {
+		if clientFacingErr(fmt.Errorf("wal append failed at /var/lib/rostam/x: %v", vector.ErrRecordTooLarge)) {
+			t.Error("clientFacingErr(wrapped ErrRecordTooLarge) = true, want false (redacted)")
+		}
+	})
 }
 
 // TestClientFacingErrPayloadKeyNotRecord pins the TCP transport's half of
@@ -262,16 +294,18 @@ func TestClientFacingErrRecordTooLarge(t *testing.T) {
 // own key, so it must reach the client verbatim instead of being redacted to
 // "internal error", which would read as a server fault for a caller mistake.
 //
-// Three arms, like TestMapResultVectorRecordAbsentIsNotFound: sentinel, wrapped,
-// and stringified across the Raft boundary.
+// Per shape: bare sentinel, real %w-wrapped detailed shape, and that shape
+// stringified across the Raft boundary, plus a negative control for an
+// unrelated wrap.
 func TestClientFacingErrPayloadKeyNotRecord(t *testing.T) {
 	for _, tc := range []struct {
 		name string
 		err  error
 	}{
 		{"sentinel", vector.ErrPayloadKeyNotRecord},
-		{"wrapped", fmt.Errorf("%w: payload key %q holds a value of kind %d", vector.ErrPayloadKeyNotRecord, "country", 2)},
-		{"stringified across Raft", errors.New("apply: " + vector.ErrPayloadKeyNotRecord.Error())},
+		{"wrapped, real detailed shape", errRealNotRecordDetailed},
+		{"stringified across Raft, real detailed shape", errors.New(errRealNotRecordDetailed.Error())},
+		{"stringified across Raft, bare shape", errors.New(vector.ErrPayloadKeyNotRecord.Error())},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			if !clientFacingErr(tc.err) {
@@ -279,6 +313,11 @@ func TestClientFacingErrPayloadKeyNotRecord(t *testing.T) {
 			}
 		})
 	}
+	t.Run("negative/unrelated fault wrapping the sentinel with a foreign prefix (%v, no %w identity)", func(t *testing.T) {
+		if clientFacingErr(fmt.Errorf("wal append failed at /var/lib/rostam/x: %v", vector.ErrPayloadKeyNotRecord)) {
+			t.Error("clientFacingErr(wrapped ErrPayloadKeyNotRecord) = true, want false (redacted)")
+		}
+	})
 }
 
 // TestMapResultVectorRecordAbsentIsNotFound pins vector_operate's create=NONE
@@ -290,9 +329,14 @@ func TestClientFacingErrPayloadKeyNotRecord(t *testing.T) {
 // unclassified it fell through to the redacted StatusError bucket, telling a
 // caller "internal error" for a record that simply is not there.
 //
-// The substring arm covers the clustered path, where the sentinel is stringified
-// across the Raft boundary and errors.Is stops matching — the same reason
-// clientFacingErr carries string fallbacks.
+// ErrVectorRecordAbsent has exactly ONE production shape — bare, never wrapped
+// (see ops.IsVectorRecordAbsentMessage's doc). "wrapped" here is a synthetic
+// %w wrap exercising errors.Is identity, not a real production shape;
+// "stringified" is the bare form re-created with errors.New, the real
+// clustered-apply shape. A negative control asserts an unrelated error that
+// wraps the sentinel with a foreign prefix (the message-shape matcher's whole
+// reason to exist — a bare strings.Contains classifier used to accept this)
+// stays redacted.
 func TestMapResultVectorRecordAbsentIsNotFound(t *testing.T) {
 	disp := &fakeDispatcher{}
 	for _, tc := range []struct {
@@ -300,8 +344,9 @@ func TestMapResultVectorRecordAbsentIsNotFound(t *testing.T) {
 		err  error
 	}{
 		{"sentinel", ops.ErrVectorRecordAbsent},
-		{"wrapped", fmt.Errorf("shard 3: %w", ops.ErrVectorRecordAbsent)},
-		{"stringified across Raft", errors.New("apply: " + ops.ErrVectorRecordAbsent.Error())},
+		{"wrapped (synthetic %w, exercises errors.Is identity — production never wraps this sentinel)",
+			fmt.Errorf("shard 3: %w", ops.ErrVectorRecordAbsent)},
+		{"stringified across Raft, real bare shape", errors.New(ops.ErrVectorRecordAbsent.Error())},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			status, payload := mapResult(disp, nil, tc.err, "")
@@ -313,4 +358,13 @@ func TestMapResultVectorRecordAbsentIsNotFound(t *testing.T) {
 			}
 		})
 	}
+	t.Run("negative/unrelated fault wrapping the sentinel with a foreign prefix", func(t *testing.T) {
+		status, payload := mapResult(disp, nil, errors.New("apply: "+ops.ErrVectorRecordAbsent.Error()), "")
+		if status != StatusError {
+			t.Fatalf("status = %d, want StatusError (%d), i.e. redacted, not StatusNotFound", status, StatusError)
+		}
+		if msg, _ := DecodeErrorPayload(payload); msg != "internal error" {
+			t.Fatalf("payload = %q, want the redacted message", msg)
+		}
+	})
 }

--- a/server/redaction_test.go
+++ b/server/redaction_test.go
@@ -368,3 +368,57 @@ func TestMapResultVectorRecordAbsentIsNotFound(t *testing.T) {
 		}
 	})
 }
+
+// TestMapResultOperateDuringReshardIsClientFacing pins the reshard refusal as a
+// client-facing signal on the binary transport. A vector_operate against a
+// collection a reshard is dual-writing is REFUSED — the op-list is not
+// idempotent, so applying it to both generations would double-count — and the
+// whole design rests on the caller learning it should retry after cutover.
+// Unclassified, the refusal fell to the redacted internal-error bucket and a
+// retryable transient read as a server fault.
+//
+// StatusError with the verbatim message is the same answer this transport gives
+// the other retryable conditions ("no reachable owner" and friends); StatusNotLeader
+// is specifically a leader hint and this is not a leadership condition.
+//
+// A negative control asserts an unrelated fault that merely wraps the refusal
+// text with a foreign prefix stays redacted — the exact class a bare
+// strings.Contains arm would leak.
+func TestMapResultOperateDuringReshardIsClientFacing(t *testing.T) {
+	disp := &fakeDispatcher{}
+	detailed := ops.OperateDuringReshardErr("docs")
+	for _, tc := range []struct {
+		name string
+		err  error
+	}{
+		{"sentinel", ops.ErrOperateDuringReshard},
+		{"production detailed form (names the collection)", detailed},
+		{"wrapped (%w, exercises errors.Is identity)", fmt.Errorf("shard 3: %w", ops.ErrOperateDuringReshard)},
+		{"stringified across Raft, bare shape", errors.New(ops.ErrOperateDuringReshard.Error())},
+		{"stringified across Raft, detailed shape", errors.New(detailed.Error())},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			status, payload := mapResult(disp, nil, tc.err, "")
+			if status != StatusError {
+				t.Fatalf("status = %d, want StatusError (%d)", status, StatusError)
+			}
+			msg, _ := DecodeErrorPayload(payload)
+			if msg == "internal error" {
+				t.Fatalf("the refusal was redacted to %q — the caller is never told to retry", msg)
+			}
+			if msg != tc.err.Error() {
+				t.Fatalf("payload = %q, want the verbatim refusal %q", msg, tc.err.Error())
+			}
+		})
+	}
+	t.Run("negative/unrelated fault wrapping the refusal with a foreign prefix", func(t *testing.T) {
+		err := errors.New("apply: " + detailed.Error())
+		status, payload := mapResult(disp, nil, err, "")
+		if status != StatusError {
+			t.Fatalf("status = %d, want StatusError (%d)", status, StatusError)
+		}
+		if msg, _ := DecodeErrorPayload(payload); msg != "internal error" {
+			t.Fatalf("payload = %q, want the redacted message", msg)
+		}
+	})
+}

--- a/server/redaction_test.go
+++ b/server/redaction_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/rostamlabs/rostam/cache"
 	"github.com/rostamlabs/rostam/ops"
+	"github.com/rostamlabs/rostam/sdk/wire"
 	"github.com/rostamlabs/rostam/shard"
 	"github.com/rostamlabs/rostam/vector"
 )
@@ -421,4 +422,49 @@ func TestMapResultOperateDuringReshardIsClientFacing(t *testing.T) {
 			t.Fatalf("payload = %q, want the redacted message", msg)
 		}
 	})
+}
+
+// TestMapResultMalformedOperateFrameIsClientFacing pins a malformed operate
+// frame as the caller's mistake on the binary transport. wire.ErrOperateArgs is
+// what DecodeVectorOperateArgs, ops.checkVectorOperateArgs and the KV
+// DecodeOperateArgs raise for args that do not decode, that name a second target,
+// or that carry a TTL the op does not own. Unclassified, a client protocol
+// mistake read as a server fault and the message was redacted, leaving the caller
+// nothing to act on.
+//
+// KV operate raises the same sentinel from the same decoder, so this one arm
+// covers both ops.
+func TestMapResultMalformedOperateFrameIsClientFacing(t *testing.T) {
+	disp := &fakeDispatcher{}
+	// A real production shape, not a hand-written sentinel: a structurally
+	// complete frame declaring an EMPTY payload key, which
+	// DecodeVectorOperateArgs rejects with ErrOperateArgs.
+	frame := append([]byte{4, 'd', 'o', 'c', 's'}, make([]byte, 8)...) // colLen, "docs", id=0
+	frame = append(frame, 0, 0)                                       // pkLen = 0
+	_, _, _, _, _, _, decErr := wire.DecodeVectorOperateArgs(frame)
+	if !errors.Is(decErr, wire.ErrOperateArgs) {
+		t.Fatalf("decoder fixture drifted: err = %v, want wire.ErrOperateArgs", decErr)
+	}
+	for _, tc := range []struct {
+		name string
+		err  error
+	}{
+		{"sentinel", wire.ErrOperateArgs},
+		{"wrapped (%w, exercises errors.Is identity)", fmt.Errorf("vector_operate: %w", wire.ErrOperateArgs)},
+		{"as the decoder actually returns it", decErr},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			status, payload := mapResult(disp, nil, tc.err, "")
+			if status != StatusError {
+				t.Fatalf("status = %d, want StatusError (%d)", status, StatusError)
+			}
+			msg, _ := DecodeErrorPayload(payload)
+			if msg == "internal error" {
+				t.Fatalf("a malformed frame was redacted to %q — a client protocol mistake reads as a server fault", msg)
+			}
+			if msg != tc.err.Error() {
+				t.Fatalf("payload = %q, want the verbatim message %q", msg, tc.err.Error())
+			}
+		})
+	}
 }

--- a/server/redaction_test.go
+++ b/server/redaction_test.go
@@ -440,7 +440,7 @@ func TestMapResultMalformedOperateFrameIsClientFacing(t *testing.T) {
 	// complete frame declaring an EMPTY payload key, which
 	// DecodeVectorOperateArgs rejects with ErrOperateArgs.
 	frame := append([]byte{4, 'd', 'o', 'c', 's'}, make([]byte, 8)...) // colLen, "docs", id=0
-	frame = append(frame, 0, 0)                                       // pkLen = 0
+	frame = append(frame, 0, 0)                                        // pkLen = 0
 	_, _, _, _, _, _, decErr := wire.DecodeVectorOperateArgs(frame)
 	if !errors.Is(decErr, wire.ErrOperateArgs) {
 		t.Fatalf("decoder fixture drifted: err = %v, want wire.ErrOperateArgs", decErr)

--- a/shard/store.go
+++ b/shard/store.go
@@ -394,6 +394,21 @@ func (s *Store) Close() error {
 	return errors.Join(errs...)
 }
 
+// VectorStore returns the shard's vector collection store, or nil when this
+// shard was built without one (a KV-only store). It is the shard-level twin of
+// Server.VectorStore(): a handle for out-of-band drivers that must reach the
+// collections directly rather than through an op — the per-node backup/restore
+// driver, the cold-tier mover, and the replica-determinism tests, which pin each
+// replica's TTL wall clock through CollectionStore.SetNowFunc.
+//
+// It hands out the LIVE store. A caller that mutates collections through it
+// bypasses Raft entirely and will diverge this replica from its peers; the only
+// supported writes through this handle are the ones the replicated apply path
+// itself makes.
+func (s *Store) VectorStore() *vector.CollectionStore {
+	return s.vectors
+}
+
 // Get reads directly from the local cache (no Raft). Returns cache.ErrNotFound if absent.
 func (s *Store) Get(key []byte) ([]byte, error) {
 	return s.cache.Get(key)

--- a/store.go
+++ b/store.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/rostamlabs/rostam/ops"
+	"github.com/rostamlabs/rostam/sdk/wire"
 	"github.com/rostamlabs/rostam/vector"
 )
 
@@ -590,6 +591,29 @@ type Store interface {
 	// an error) for an absent point.
 	VectorClearPayload(ctx context.Context, collection string, id uint64, opts ...WriteOpts) (applied bool, err error)
 
+	// VectorOperate applies one operate op-list to the RECORD stored in the
+	// point's payload under payloadKey — the same op-list a KV operate runs,
+	// against a record held inside a point instead of under a KV key. The whole
+	// read-modify-write happens inside the collection's write lock, so it is
+	// atomic: one WAL record, one version bump, and a failed CHECK leaves the
+	// point byte-identical AND unbumped.
+	//
+	// found is false (NOT an error) for an absent/tombstoned/expired point,
+	// exactly like VectorSetPayload's applied flag. A point that exists but whose
+	// payload key holds no record, when a.Create is OperateCreateNone, is
+	// ops.ErrVectorRecordAbsent — a real error, not a silent no-op. A payload key
+	// holding a non-record value is vector.ErrPayloadKeyNotRecord.
+	//
+	// opts[0].ExpectedVersion is honored on EVERY backend: it rides in the ARGS
+	// (wire.EncodeVectorOperateArgs), not in the write-consistency envelope, so a
+	// mismatch returns vector.ErrVersionConflict with no mutation whether the call
+	// went out embedded, networked or direct.
+	//
+	// The op is REFUSED with ErrOperateDuringReshard while the collection is
+	// mid-reshard: it is non-idempotent, so the dual-write VectorSetPayload uses
+	// would double-count every ADD across the two generations. Retry after cutover.
+	VectorOperate(ctx context.Context, collection string, id uint64, payloadKey string, a *wire.OperateArgs, opts ...WriteOpts) (found bool, res *wire.OperateResult, err error)
+
 	// VectorNamedGet retrieves a named-vector point by id: its per-space vectors
 	// (map[name][]float32; omitted spaces absent), shared payload, and remaining
 	// TTL. found is false (not an error) for an absent/expired point. See VectorGet.
@@ -634,6 +658,10 @@ type Store interface {
 	// VectorNamedClearPayload removes id's entire shared payload. applied false (not
 	// an error) for absent.
 	VectorNamedClearPayload(ctx context.Context, name string, id uint64, opts ...WriteOpts) (applied bool, err error)
+
+	// VectorNamedOperate is VectorOperate against a named-vector point's SHARED
+	// payload. Same contract in every respect — see VectorOperate.
+	VectorNamedOperate(ctx context.Context, name string, id uint64, payloadKey string, a *wire.OperateArgs, opts ...WriteOpts) (found bool, res *wire.OperateResult, err error)
 
 	// VectorMVGet retrieves a multi-vector document by id: its token matrix
 	// ([][]float32) and payload. found is false (not an error) for an absent
@@ -697,6 +725,10 @@ type Store interface {
 	// VectorMVClearPayload removes docID's entire payload. applied false (not an
 	// error) for an absent document.
 	VectorMVClearPayload(ctx context.Context, name string, docID uint64, opts ...WriteOpts) (applied bool, err error)
+
+	// VectorMVOperate is VectorOperate against a multi-vector document's payload.
+	// Same contract in every respect — see VectorOperate.
+	VectorMVOperate(ctx context.Context, name string, docID uint64, payloadKey string, a *wire.OperateArgs, opts ...WriteOpts) (found bool, res *wire.OperateResult, err error)
 }
 
 // getFlags builds the get-op projection flags byte from the with_vector /

--- a/store.go
+++ b/store.go
@@ -612,7 +612,13 @@ type Store interface {
 	// The op is REFUSED with ErrOperateDuringReshard while the collection is
 	// mid-reshard: it is non-idempotent, so the dual-write VectorSetPayload uses
 	// would double-count every ADD across the two generations. Retry after cutover.
-	VectorOperate(ctx context.Context, collection string, id uint64, payloadKey string, a *wire.OperateArgs, opts ...WriteOpts) (found bool, res *wire.OperateResult, err error)
+	// version is the point's version AFTER the call: bumped when the op-list
+	// applied, and the CURRENT unbumped one when it was a deliberate no-op (a
+	// failed CHECK). It is 0 when found is false. Feed it to the next call's
+	// opts[0].ExpectedVersion to run a CAS loop without re-reading the point —
+	// the re-read is both a round trip and a race, since another writer can land
+	// between it and the retry.
+	VectorOperate(ctx context.Context, collection string, id uint64, payloadKey string, a *wire.OperateArgs, opts ...WriteOpts) (found bool, res *wire.OperateResult, version uint64, err error)
 
 	// VectorNamedGet retrieves a named-vector point by id: its per-space vectors
 	// (map[name][]float32; omitted spaces absent), shared payload, and remaining
@@ -661,7 +667,7 @@ type Store interface {
 
 	// VectorNamedOperate is VectorOperate against a named-vector point's SHARED
 	// payload. Same contract in every respect — see VectorOperate.
-	VectorNamedOperate(ctx context.Context, name string, id uint64, payloadKey string, a *wire.OperateArgs, opts ...WriteOpts) (found bool, res *wire.OperateResult, err error)
+	VectorNamedOperate(ctx context.Context, name string, id uint64, payloadKey string, a *wire.OperateArgs, opts ...WriteOpts) (found bool, res *wire.OperateResult, version uint64, err error)
 
 	// VectorMVGet retrieves a multi-vector document by id: its token matrix
 	// ([][]float32) and payload. found is false (not an error) for an absent
@@ -728,7 +734,7 @@ type Store interface {
 
 	// VectorMVOperate is VectorOperate against a multi-vector document's payload.
 	// Same contract in every respect — see VectorOperate.
-	VectorMVOperate(ctx context.Context, name string, docID uint64, payloadKey string, a *wire.OperateArgs, opts ...WriteOpts) (found bool, res *wire.OperateResult, err error)
+	VectorMVOperate(ctx context.Context, name string, docID uint64, payloadKey string, a *wire.OperateArgs, opts ...WriteOpts) (found bool, res *wire.OperateResult, version uint64, err error)
 }
 
 // getFlags builds the get-op projection flags byte from the with_vector /

--- a/vector/collection.go
+++ b/vector/collection.go
@@ -1232,6 +1232,32 @@ func (c *Collection) ClearPayloadCASAt(id uint64, cas CASCond, nowMs int64) (uin
 	}, id)
 }
 
+// MutatePayloadRecordCAS applies fn to the operate record stored under key in
+// id's payload, atomically with the CAS check and the version bump, and WAL-logs
+// the RESULTING payload (a replace, not a merge) exactly as every other payload
+// mutation does. A deliberate no-op — fn reporting RecordUnchanged (a failed
+// CHECK), or a delete of an already-absent key — writes no WAL record and
+// returns the current, unbumped version. Returns ErrIDNotFound for a dead point,
+// ErrVersionConflict on a CAS mismatch, ErrPayloadKeyNotRecord when the key
+// holds a non-record value, ErrRecordTooLarge when the resulting record exceeds
+// the storage cap, and fn's own error verbatim — in every case with the point
+// left exactly as it was.
+func (c *Collection) MutatePayloadRecordCAS(id uint64, key string, fn RecordMutator, cas CASCond) (uint64, error) {
+	return c.payloadOpCASChanged(cas, func(cc CASCond) (Metadata, map[string]uint64, uint64, bool, error) {
+		return c.idx.MutatePayloadRecord(id, key, fn, cc)
+	}, id)
+}
+
+// MutatePayloadRecordCASAt is MutatePayloadRecordCAS under a leader apply stamp:
+// the engine judges the dead-point liveness gate, the per-key deadline check and
+// the stale-deadline drop against nowMs, so every replica reads the same record
+// and stores the same bytes (#4 vector TTL determinism).
+func (c *Collection) MutatePayloadRecordCASAt(id uint64, key string, fn RecordMutator, cas CASCond, nowMs int64) (uint64, error) {
+	return c.payloadOpCASChanged(cas, func(cc CASCond) (Metadata, map[string]uint64, uint64, bool, error) {
+		return c.idx.MutatePayloadRecordAt(id, key, fn, cc, nowMs)
+	}, id)
+}
+
 // DeleteCASAt is DeleteCAS judging the dead-slot liveness gate against the leader
 // apply stamp nowMs, so replicas agree on already-dead vs live and keep identical
 // tombstone sets (#4 vector TTL determinism).
@@ -1379,40 +1405,64 @@ func (c *Collection) UpsertCASKeyTTLAt(id uint64, vec []float32, content string,
 	return version, nil
 }
 
-// payloadOpCAS is the shared CAS-aware payload-mutation core: it runs the engine
-// op (which enforces the CAS precondition + bumps the version) and, on a WAL-mode
-// collection, logs the resulting payload + per-key deadlines + version under opMu.
-// Returns the resulting version; ErrVersionConflict (or ErrIDNotFound) propagate
-// from the engine with no WAL append.
-func (c *Collection) payloadOpCAS(cas CASCond, op func(CASCond) (Metadata, map[string]uint64, uint64, error), id uint64) (uint64, error) {
+// payloadOpCASChanged is payloadOpCAS for an op that may legitimately apply
+// NOTHING (a record mutation whose CHECK failed): when op reports changed=false
+// the version it returns is the current, unbumped one, and no WAL record is
+// staged — a no-op must not cost a log entry or move a version a CAS loop is
+// watching.
+//
+// opMu is held across {apply + WAL WRITE} only, scoped to a closure (see
+// InsertCASKeyTTL) so a panic inside op or the WAL append still unlocks opMu via
+// the deferred Unlock instead of leaking it forever. The durability wait runs
+// outside opMu so concurrent payload writers group-commit instead of each paying
+// a serialized fsync under the collection's op lock.
+func (c *Collection) payloadOpCASChanged(cas CASCond, op func(CASCond) (Metadata, map[string]uint64, uint64, bool, error), id uint64) (uint64, error) {
 	if c.wal == nil {
-		_, _, version, err := op(cas)
+		_, _, version, _, err := op(cas)
 		return version, err
 	}
-	// opMu is held across {apply + WAL WRITE} only, scoped to a closure (see
-	// InsertCASKeyTTL) so a panic inside op or the WAL append still unlocks opMu
-	// via the deferred Unlock instead of leaking it forever. The durability wait
-	// runs outside opMu so concurrent payload writers group-commit instead of
-	// each paying a serialized fsync under the collection's op lock.
 	var seq, version uint64
+	var changed bool
 	err := func() error {
 		c.opMu.Lock()
 		defer c.opMu.Unlock()
-		resulting, ke, v, err := op(cas)
+		resulting, ke, v, ch, err := op(cas)
 		if err != nil {
 			return err
 		}
-		version = v
+		version, changed = v, ch
+		if !ch {
+			return nil
+		}
 		seq, err = c.wal.appendSetPayloadStaged(id, resulting, ke, v)
 		return err
 	}()
 	if err != nil {
 		return 0, err
 	}
+	if !changed {
+		return version, nil
+	}
 	if err := c.wal.commitWaitStaged(seq); err != nil {
 		return 0, err
 	}
 	return version, nil
+}
+
+// payloadOpCAS is the shared CAS-aware payload-mutation core: it runs the engine
+// op (which enforces the CAS precondition + bumps the version) and, on a WAL-mode
+// collection, logs the resulting payload + per-key deadlines + version under opMu.
+// Returns the resulting version; ErrVersionConflict (or ErrIDNotFound) propagate
+// from the engine with no WAL append.
+//
+// It is the always-changed form every payload mutation other than the record
+// mutator takes. Behaviour-preserving: payloadOpCASChanged tests err before it
+// reads changed, so the hard-coded true is never consulted on an error path.
+func (c *Collection) payloadOpCAS(cas CASCond, op func(CASCond) (Metadata, map[string]uint64, uint64, error), id uint64) (uint64, error) {
+	return c.payloadOpCASChanged(cas, func(cc CASCond) (Metadata, map[string]uint64, uint64, bool, error) {
+		m, ke, v, err := op(cc)
+		return m, ke, v, true, err
+	}, id)
 }
 
 // replayWAL re-applies a WAL's records onto the (just-restored) index. Apply

--- a/vector/collection.go
+++ b/vector/collection.go
@@ -746,6 +746,13 @@ func (c *Collection) StageBulk(ids []uint64, vecs [][]float32) error {
 // point. Everything StageBulk documents about dimension checking applies here
 // unchanged.
 func (c *Collection) StageBulkPayloads(ids []uint64, vecs [][]float32, metas []Metadata) error {
+	// THE FULL GATE, HERE, EVEN THOUGH BuildConcurrentMeta RUNS IT AGAIN.
+	// BuildStaged takes the staged slices and CLEARS the buffer before it calls
+	// the engine, so a record that got past staging is discovered with the
+	// caller's whole staged batch already gone. Rejecting at stage time keeps the
+	// buffer intact and names the offending row while the caller can still fix it
+	// — the same reason the dimension check is here rather than only in the
+	// builder. See TestStagedBatchSurvivesARejectedRecord.
 	if err := checkRecordValuesAll(metas); err != nil {
 		return err
 	}
@@ -838,6 +845,13 @@ func (c *Collection) UpsertCAS(id uint64, vec []float32, content string, ttl tim
 // deadlines; the WAL logs them so replay restores them verbatim. Empty/nil
 // keyTTLMs is the zero-overhead path.
 func (c *Collection) UpsertCASKeyTTL(id uint64, vec []float32, content string, ttl time.Duration, meta Metadata, sparse *SparseVector, keyTTLMs map[string]int64, cas CASCond) (uint64, error) {
+	// THE FULL GATE, HERE, EVEN THOUGH insertBody RUNS IT AGAIN. Upsert is
+	// delete-then-insert, and the delete below is irreversible: downgrade this to
+	// checkRecordValuesSize and a malformed record deletes the existing point and
+	// only THEN fails inside c.idx.Insert, so a REFUSED write destroys the data it
+	// was replacing. That is the one shape of this bug that is worse than the
+	// poison the gate prevents, so this path decodes the record twice on purpose.
+	// See checkRecordValues' doc and TestRecordValidationCountPerWrite.
 	if err := checkRecordValues(meta); err != nil {
 		return 0, err
 	}
@@ -1338,6 +1352,9 @@ func (c *Collection) DeleteByFilterAt(filter Filter, nowMs int64) (int, error) {
 // precheck + unconditional delete), then re-inserts via InsertAt so the point/per-key
 // deadlines are stamped identically on every replica (#4 vector TTL determinism).
 func (c *Collection) UpsertCASKeyTTLAt(id uint64, vec []float32, content string, ttl time.Duration, meta Metadata, sparse *SparseVector, keyTTLMs map[string]int64, cas CASCond, nowMs int64) (uint64, error) {
+	// The full gate before the tombstone, for the reason UpsertCASKeyTTL states:
+	// this path deletes before it inserts, so a size-only check here would let a
+	// malformed record destroy the point it was refused from replacing.
 	if err := checkRecordValues(meta); err != nil {
 		return 0, err
 	}

--- a/vector/collection.go
+++ b/vector/collection.go
@@ -1256,6 +1256,13 @@ func (c *Collection) ClearPayloadCASAt(id uint64, cas CASCond, nowMs int64) (uin
 // holds a non-record value, ErrRecordTooLarge when the resulting record exceeds
 // the storage cap, and fn's own error verbatim — in every case with the point
 // left exactly as it was.
+//
+// THE KEY'S DEADLINE IS NOT CONSULTED HERE. Unstamped, `now` is this process's
+// own wall clock, and letting it decide whether the record EXISTS would let two
+// replicas store different bytes. So an unstamped mutation treats a
+// deadline-passed record as PRESENT and passes its deadline through untouched;
+// only the *At variant expires the key. See recordKeyPastDeadline
+// (vector/record_mutate.go).
 func (c *Collection) MutatePayloadRecordCAS(id uint64, key string, fn RecordMutator, cas CASCond) (uint64, error) {
 	return c.payloadOpCASChanged(cas, func(cc CASCond) (Metadata, map[string]uint64, uint64, bool, error) {
 		return c.idx.MutatePayloadRecord(id, key, fn, cc)
@@ -1266,6 +1273,10 @@ func (c *Collection) MutatePayloadRecordCAS(id uint64, key string, fn RecordMuta
 // the engine judges the dead-point liveness gate, the per-key deadline check and
 // the stale-deadline drop against nowMs, so every replica reads the same record
 // and stores the same bytes (#4 vector TTL determinism).
+//
+// This is the ONLY variant that may expire the payload key: its clock is the
+// leader's stamp, identical on every replica. See recordKeyPastDeadline
+// (vector/record_mutate.go) for why the unstamped twin must not.
 func (c *Collection) MutatePayloadRecordCASAt(id uint64, key string, fn RecordMutator, cas CASCond, nowMs int64) (uint64, error) {
 	return c.payloadOpCASChanged(cas, func(cc CASCond) (Metadata, map[string]uint64, uint64, bool, error) {
 		return c.idx.MutatePayloadRecordAt(id, key, fn, cc, nowMs)

--- a/vector/collections.go
+++ b/vector/collections.go
@@ -1136,6 +1136,30 @@ func (s *CollectionStore) ClearPayloadCASAt(name string, id uint64, cas CASCond,
 	return payloadAppliedV(c.ClearPayloadCASAt(id, cas, nowMs))
 }
 
+// MutatePayloadRecordCAS applies fn to the operate record under key in the named
+// collection's point id. See Collection.MutatePayloadRecordCAS. An absent point
+// is the not-found FLAG (applied=false, err=nil), like every other payload
+// dispatcher here.
+func (s *CollectionStore) MutatePayloadRecordCAS(name string, id uint64, key string, fn RecordMutator, cas CASCond) (applied bool, version uint64, err error) {
+	c, ok := s.Acquire(name)
+	if !ok {
+		return false, 0, fmt.Errorf("vector: no collection %q", name)
+	}
+	defer c.Release()
+	return payloadAppliedV(c.MutatePayloadRecordCAS(id, key, fn, cas))
+}
+
+// MutatePayloadRecordCASAt is MutatePayloadRecordCAS under the leader apply
+// stamp nowMs. See Collection.MutatePayloadRecordCASAt.
+func (s *CollectionStore) MutatePayloadRecordCASAt(name string, id uint64, key string, fn RecordMutator, cas CASCond, nowMs int64) (applied bool, version uint64, err error) {
+	c, ok := s.Acquire(name)
+	if !ok {
+		return false, 0, fmt.Errorf("vector: no collection %q", name)
+	}
+	defer c.Release()
+	return payloadAppliedV(c.MutatePayloadRecordCASAt(id, key, fn, cas, nowMs))
+}
+
 // payloadAppliedV is payloadApplied for the CAS variants that also return the
 // resulting version: ErrIDNotFound → (false, 0, nil) (absent point is a FLAG);
 // any other error (incl. ErrVersionConflict) → (false, 0, err); nil → (true,

--- a/vector/collections_multi.go
+++ b/vector/collections_multi.go
@@ -479,6 +479,30 @@ func (s *CollectionStore) MVSetPayloadCASAt(name string, docID uint64, patch Met
 	return payloadAppliedV(idx.SetPayloadCASAt(docID, patch, keyTTLMs, cas, nowMs))
 }
 
+// MVMutatePayloadRecordCAS applies fn to the operate record under key in the
+// multi-vector collection's document docID. See
+// MultiVectorIndex.MutatePayloadRecordCAS. An absent document is the not-found
+// FLAG (applied=false, err=nil), like every other payload dispatcher here.
+func (s *CollectionStore) MVMutatePayloadRecordCAS(name string, docID uint64, key string, fn RecordMutator, cas CASCond) (applied bool, version uint64, err error) {
+	idx, ok := s.AcquireMulti(name)
+	if !ok {
+		return false, 0, fmt.Errorf("vector: no multi-vector collection %q", name)
+	}
+	defer idx.Release()
+	return payloadAppliedV(idx.MutatePayloadRecordCAS(docID, key, fn, cas))
+}
+
+// MVMutatePayloadRecordCASAt is MVMutatePayloadRecordCAS under the leader apply
+// stamp nowMs. See MultiVectorIndex.MutatePayloadRecordCASAt.
+func (s *CollectionStore) MVMutatePayloadRecordCASAt(name string, docID uint64, key string, fn RecordMutator, cas CASCond, nowMs int64) (applied bool, version uint64, err error) {
+	idx, ok := s.AcquireMulti(name)
+	if !ok {
+		return false, 0, fmt.Errorf("vector: no multi-vector collection %q", name)
+	}
+	defer idx.Release()
+	return payloadAppliedV(idx.MutatePayloadRecordCASAt(docID, key, fn, cas, nowMs))
+}
+
 // MVOverwritePayload replaces docID's entire payload with meta. keyTTLMs sets the
 // per-key relative TTLs on the new payload. applied=false for an absent document
 // (not an error). See MultiVectorIndex.OverwritePayload.

--- a/vector/collections_named.go
+++ b/vector/collections_named.go
@@ -401,6 +401,30 @@ func (s *CollectionStore) NamedSetPayloadCASAt(name string, id uint64, patch Met
 	return payloadAppliedV(nc.SetPayloadCASAt(id, patch, keyTTLMs, cas, nowMs))
 }
 
+// NamedMutatePayloadRecordCAS applies fn to the operate record under key in the
+// named collection's point id. See NamedCollection.MutatePayloadRecordCAS. An
+// absent point is the not-found FLAG (applied=false, err=nil), like every other
+// payload dispatcher here.
+func (s *CollectionStore) NamedMutatePayloadRecordCAS(name string, id uint64, key string, fn RecordMutator, cas CASCond) (applied bool, version uint64, err error) {
+	nc, ok := s.AcquireNamed(name)
+	if !ok {
+		return false, 0, fmt.Errorf("%w %q", ErrNoNamed, name)
+	}
+	defer nc.Release()
+	return payloadAppliedV(nc.MutatePayloadRecordCAS(id, key, fn, cas))
+}
+
+// NamedMutatePayloadRecordCASAt is NamedMutatePayloadRecordCAS under the leader
+// apply stamp nowMs. See NamedCollection.MutatePayloadRecordCASAt.
+func (s *CollectionStore) NamedMutatePayloadRecordCASAt(name string, id uint64, key string, fn RecordMutator, cas CASCond, nowMs int64) (applied bool, version uint64, err error) {
+	nc, ok := s.AcquireNamed(name)
+	if !ok {
+		return false, 0, fmt.Errorf("%w %q", ErrNoNamed, name)
+	}
+	defer nc.Release()
+	return payloadAppliedV(nc.MutatePayloadRecordCASAt(id, key, fn, cas, nowMs))
+}
+
 // NamedOverwritePayload replaces id's entire shared payload with meta. keyTTLMs sets
 // the per-key relative TTLs on the new payload. applied=false for an absent/expired
 // point (not an error). See NamedCollection.OverwritePayload.

--- a/vector/hnsw.go
+++ b/vector/hnsw.go
@@ -3011,6 +3011,13 @@ func (h *hnsw) overwritePayloadBody(id uint64, meta Metadata, keyTTLMs map[strin
 // means the call was a deliberate no-op (a failed CHECK, or a delete of an
 // absent key): nothing was stored, nothing was logged, the version is the
 // CURRENT one and was not bumped.
+//
+// THE KEY'S DEADLINE IS NOT CONSULTED HERE. Unstamped, `now` is this process's
+// own wall clock, and letting it decide whether the record EXISTS would let two
+// replicas store different bytes. So an unstamped mutation treats a
+// deadline-passed record as PRESENT and passes its deadline through untouched;
+// only the *At variant expires the key. See recordKeyPastDeadline
+// (vector/record_mutate.go).
 func (h *hnsw) MutatePayloadRecord(id uint64, key string, fn RecordMutator, cas CASCond) (Metadata, map[string]uint64, uint64, bool, error) {
 	return h.mutatePayloadRecordBody(id, key, fn, cas, false, 0)
 }
@@ -3020,6 +3027,10 @@ func (h *hnsw) MutatePayloadRecord(id uint64, key string, fn RecordMutator, cas 
 // clock nowMs, so a replicated record mutation sees the same record and produces
 // the same bytes on every replica (#4 vector TTL determinism, mirroring
 // SetPayloadAt).
+//
+// This is the ONLY variant that may expire the payload key: its clock is the
+// leader's stamp, identical on every replica. See recordKeyPastDeadline
+// (vector/record_mutate.go) for why the unstamped twin must not.
 func (h *hnsw) MutatePayloadRecordAt(id uint64, key string, fn RecordMutator, cas CASCond, nowMs int64) (Metadata, map[string]uint64, uint64, bool, error) {
 	return h.mutatePayloadRecordBody(id, key, fn, cas, true, uint64(nowMs)) //nolint:gosec // stamped unix-millis is non-negative
 }
@@ -3043,7 +3054,15 @@ func (h *hnsw) mutatePayloadRecordBody(id uint64, key string, fn RecordMutator, 
 	}
 	oldMeta := h.arena.Metadata(slot)
 	oldKE := h.arena.KeyExpires(slot)
-	old, exists, err := currentRecordValue(oldMeta, key, keyExpired(oldKE[key], now))
+	// Only a STAMPED apply may judge the key's deadline; an unstamped one treats
+	// the record as PRESENT and leaves the deadline alone. recordKeyPastDeadline
+	// (vector/record_mutate.go) carries the reasoning — the short version is that
+	// a per-replica wall clock deciding whether a record EXISTS makes replicas
+	// store different bytes, which is not the bounded-deadline-skew class
+	// setPayloadBody lives with. LOCKSTEP: the same two lines exist in
+	// vector/hnsw.go, vector/ivf.go, vector/named.go and vector/multivector.go.
+	keyPastDeadline := recordKeyPastDeadline(stamped, oldKE[key], now)
+	old, exists, err := currentRecordValue(oldMeta, key, keyPastDeadline)
 	if err != nil {
 		return nil, nil, 0, false, err
 	}
@@ -3094,10 +3113,14 @@ func (h *hnsw) mutatePayloadRecordBody(id uint64, key string, fn RecordMutator, 
 		merged[key] = Value{Kind: ValueRecord, Rec: rec} // ownership hand-off; see RecordMutator
 	}
 	ke := cloneKeyExpires(oldKE)
-	// A logically expired key read as ABSENT above: its stale deadline must go,
-	// or the record this call just created would be invisible the instant it is
-	// written. pruneKeyExpires only drops deadlines for keys no longer present.
-	if ke != nil && keyExpired(ke[key], now) {
+	// A key read as ABSENT above because its deadline had passed — STAMPED
+	// applies only: its stale deadline must go, or the record this call just
+	// created would be invisible the instant it is written. pruneKeyExpires only
+	// drops deadlines for keys no longer present. On an unstamped apply
+	// keyPastDeadline is false by construction, so an expired key's deadline is
+	// passed through UNTOUCHED, exactly as setPayloadBody passes an expired key
+	// through unchanged.
+	if ke != nil && keyPastDeadline {
 		delete(ke, key)
 	}
 	ke = pruneKeyExpires(ke, merged)

--- a/vector/hnsw.go
+++ b/vector/hnsw.go
@@ -3099,18 +3099,30 @@ func (h *hnsw) mutatePayloadRecordBody(id uint64, key string, fn RecordMutator, 
 		// it cannot reach bytes the operate engine just produced, which is what
 		// this site exists for. Keep the two in step.
 		//
-		// SIZE ONLY, DELIBERATELY: no record.Validate here. These bytes come from
-		// applyRecordBytes, which phase 1 held to the tree oracle, so they are
-		// well-formed by construction; re-decoding the whole record on every
-		// counter increment would double the op's cost for a case that cannot
-		// arise. The shape check belongs where bytes arrive from a CALLER, which
-		// is checkRecordValues.
+		// SIZE FIRST, THEN SHAPE — the same order and the same two gates
+		// checkRecordValues applies to a caller's patch, so an oversize value is
+		// refused without ever being decoded.
 		//
-		// The MESSAGE comes from recordTooLargeErr (vector/metadata.go), the one
-		// producer of this error's detailed form: one canonical shape for the
-		// matcher to anchor on across replication, with the caller's key bounded.
+		// The shape check is here because MutatePayloadRecordCAS is EXPORTED. The
+		// mutator ops supplies returns applyRecordBytes' output, which phase 1
+		// held to the tree oracle and which cannot be malformed — but a direct Go
+		// caller of this API supplies its own mutator, and whatever bytes it
+		// returns were being stored on the size cap alone. That poisons the
+		// payload key for the whole collection: every path under it declines to
+		// accelerate, and a later vector_operate on the same key fails with
+		// wire.ErrOperateRecord. The cost is one decode of the bytes the engine
+		// just produced, on a write that already decoded and re-encoded the
+		// record.
+		//
+		// Both MESSAGES come from the one producer of their detailed form
+		// (recordTooLargeErr / recordMalformedErr, vector/metadata.go): one
+		// canonical shape for the transport matchers to anchor on across
+		// replication, with the caller's key bounded.
 		if len(rec) > maxRecordValueBytes {
 			return nil, nil, 0, false, recordTooLargeErr(key, len(rec))
+		}
+		if verr := validateRecord(rec); verr != nil {
+			return nil, nil, 0, false, recordMalformedErr(key, verr)
 		}
 	default:
 		return nil, nil, 0, false, ErrRecordMutation

--- a/vector/hnsw.go
+++ b/vector/hnsw.go
@@ -2014,7 +2014,11 @@ func (h *hnsw) RestoreInsertAt(id uint64, vec []float32, ttl time.Duration, meta
 }
 
 func (h *hnsw) restoreInsertBody(id uint64, vec []float32, ttl time.Duration, meta Metadata, sparse *SparseVector, keyExpires map[string]uint64, version uint64, stamped bool, nowMs uint64) error {
-	if err := checkRecordValues(meta); err != nil {
+	// REPLAY body: size only. Its callers are Collection.RestoreInsert[At] —
+	// which already ran the full checkRecordValues on the caller's metadata —
+	// and WAL replay, which must never refuse an acked record. See
+	// checkRecordValuesSize.
+	if err := checkRecordValuesSize(meta); err != nil {
 		return err
 	}
 	if len(vec) != h.cfg.Dim {
@@ -3059,6 +3063,13 @@ func (h *hnsw) mutatePayloadRecordBody(id uint64, key string, fn RecordMutator, 
 		// same cap on the ingest side, but it only ever sees a caller's patch —
 		// it cannot reach bytes the operate engine just produced, which is what
 		// this site exists for. Keep the two in step.
+		//
+		// SIZE ONLY, DELIBERATELY: no record.Validate here. These bytes come from
+		// applyRecordBytes, which phase 1 held to the tree oracle, so they are
+		// well-formed by construction; re-decoding the whole record on every
+		// counter increment would double the op's cost for a case that cannot
+		// arise. The shape check belongs where bytes arrive from a CALLER, which
+		// is checkRecordValues.
 		if len(rec) > maxRecordValueBytes {
 			return nil, nil, 0, false, fmt.Errorf("%w: payload key %q would hold a %d-byte record, the cap is %d bytes",
 				ErrRecordTooLarge, key, len(rec), maxRecordValueBytes)
@@ -3194,7 +3205,10 @@ func (h *hnsw) clearPayloadBody(id uint64, cas CASCond, stamped bool, nowMs uint
 // section. Returns ErrIDNotFound for a dead/absent point. Both maps are stored by
 // reference (caller hands off ownership); nil clears the respective state.
 func (h *hnsw) RestorePayload(id uint64, meta Metadata, keyExpires map[string]uint64, version uint64) error {
-	if err := checkRecordValues(meta); err != nil {
+	// REPLAY body: size only. Its only caller is the WAL replay of a set_payload
+	// record (vector/collection.go replayRecord); a shape check here would refuse
+	// to rebuild an acked write. See checkRecordValuesSize.
+	if err := checkRecordValuesSize(meta); err != nil {
 		return err
 	}
 	h.mu.Lock()

--- a/vector/hnsw.go
+++ b/vector/hnsw.go
@@ -3089,9 +3089,12 @@ func (h *hnsw) mutatePayloadRecordBody(id uint64, key string, fn RecordMutator, 
 		// counter increment would double the op's cost for a case that cannot
 		// arise. The shape check belongs where bytes arrive from a CALLER, which
 		// is checkRecordValues.
+		//
+		// The MESSAGE comes from recordTooLargeErr (vector/metadata.go), the one
+		// producer of this error's detailed form: one canonical shape for the
+		// matcher to anchor on across replication, with the caller's key bounded.
 		if len(rec) > maxRecordValueBytes {
-			return nil, nil, 0, false, fmt.Errorf("%w: payload key %q would hold a %d-byte record, the cap is %d bytes",
-				ErrRecordTooLarge, key, len(rec), maxRecordValueBytes)
+			return nil, nil, 0, false, recordTooLargeErr(key, len(rec))
 		}
 	default:
 		return nil, nil, 0, false, ErrRecordMutation

--- a/vector/hnsw.go
+++ b/vector/hnsw.go
@@ -3035,6 +3035,22 @@ func (h *hnsw) MutatePayloadRecordAt(id uint64, key string, fn RecordMutator, ca
 	return h.mutatePayloadRecordBody(id, key, fn, cas, true, uint64(nowMs)) //nolint:gosec // stamped unix-millis is non-negative
 }
 
+// LOCKSTEP with vector/ivf.go mutatePayloadRecordBody and the named/multi-vector
+// mutatePayloadRecordLockedAt in vector/named.go and vector/multivector.go.
+// These four bodies are ~110 near-identical lines each and are deliberately NOT
+// factored into one: that matches the house style of their set_payload /
+// overwrite_payload siblings, whose engine differences (slot- vs id-keyed
+// indexes, uint64 vs int64 deadlines, BM25 on dense only) are real and are what
+// a shared body would have to branch on.
+//
+// The cost is real too, and it has already been paid once: a single formatting
+// difference in the size-bound message landed as a defect in all four at the
+// same time, and the deadline rule below had to be corrected in all four at the
+// same time. So both of those now live in SHARED helpers — recordTooLargeErr
+// (vector/metadata.go) and recordKeyPastDeadline[Abs] (vector/record_mutate.go)
+// — and any further change to the RULES, as opposed to the plumbing, belongs in
+// a helper rather than in a fifth copy. A change here that is not mirrored in
+// the other three is a bug, not a variation.
 func (h *hnsw) mutatePayloadRecordBody(id uint64, key string, fn RecordMutator, cas CASCond, stamped bool, nowMs uint64) (Metadata, map[string]uint64, uint64, bool, error) {
 	if fn == nil || key == "" || key == contentField {
 		return nil, nil, 0, false, ErrPayloadKeyNotRecord

--- a/vector/hnsw.go
+++ b/vector/hnsw.go
@@ -2995,6 +2995,109 @@ func (h *hnsw) overwritePayloadBody(id uint64, meta Metadata, keyTTLMs map[strin
 	return newMeta, ke, h.arena.BumpVersion(slot), nil
 }
 
+// MutatePayloadRecord applies fn to the operate record stored under key in id's
+// payload and stores what fn returns, all inside ONE write-lock critical
+// section: read the current bytes, transform, bound, store/delete, prune the
+// key's deadline, reindex, bump. It is the store-agnostic seam ops.handleVector-
+// Operate drives with applyRecordBytes — vector never imports ops, so the
+// transform arrives as a function.
+//
+// Returns the RESULTING payload and per-key deadlines (so Collection WAL-logs
+// exactly what was applied), the resulting version, and changed. changed=false
+// means the call was a deliberate no-op (a failed CHECK, or a delete of an
+// absent key): nothing was stored, nothing was logged, the version is the
+// CURRENT one and was not bumped.
+func (h *hnsw) MutatePayloadRecord(id uint64, key string, fn RecordMutator, cas CASCond) (Metadata, map[string]uint64, uint64, bool, error) {
+	return h.mutatePayloadRecordBody(id, key, fn, cas, false, 0)
+}
+
+// MutatePayloadRecordAt judges the dead-point liveness gate, the per-key
+// deadline check and the stale-deadline drop against the EXPLICIT leader-stamped
+// clock nowMs, so a replicated record mutation sees the same record and produces
+// the same bytes on every replica (#4 vector TTL determinism, mirroring
+// SetPayloadAt).
+func (h *hnsw) MutatePayloadRecordAt(id uint64, key string, fn RecordMutator, cas CASCond, nowMs int64) (Metadata, map[string]uint64, uint64, bool, error) {
+	return h.mutatePayloadRecordBody(id, key, fn, cas, true, uint64(nowMs)) //nolint:gosec // stamped unix-millis is non-negative
+}
+
+func (h *hnsw) mutatePayloadRecordBody(id uint64, key string, fn RecordMutator, cas CASCond, stamped bool, nowMs uint64) (Metadata, map[string]uint64, uint64, bool, error) {
+	if fn == nil || key == "" || key == contentField {
+		return nil, nil, 0, false, ErrPayloadKeyNotRecord
+	}
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	now := nowMs
+	if !stamped {
+		now = uint64(h.now())
+	}
+	slot, ok := h.arena.Slot(id)
+	if !ok || h.tombstoned[slot] || h.isExpiredAt(slot, now) {
+		return nil, nil, 0, false, ErrIDNotFound
+	}
+	if err := cas.check(h.arena.Version(slot)); err != nil {
+		return nil, nil, 0, false, err // CAS mismatch: no mutation, no bump
+	}
+	oldMeta := h.arena.Metadata(slot)
+	oldKE := h.arena.KeyExpires(slot)
+	old, exists, err := currentRecordValue(oldMeta, key, keyExpired(oldKE[key], now))
+	if err != nil {
+		return nil, nil, 0, false, err
+	}
+	rec, act, err := fn(old, exists)
+	if err != nil {
+		return nil, nil, 0, false, err
+	}
+	switch act {
+	case RecordUnchanged:
+		return nil, nil, h.arena.Version(slot), false, nil
+	case RecordDelete:
+		if !exists {
+			return nil, nil, h.arena.Version(slot), false, nil
+		}
+	case RecordStore:
+		// The POST-mutation bound. checkRecordValues (vector/metadata.go) is the
+		// same cap on the ingest side, but it only ever sees a caller's patch —
+		// it cannot reach bytes the operate engine just produced, which is what
+		// this site exists for. Keep the two in step.
+		if len(rec) > maxRecordValueBytes {
+			return nil, nil, 0, false, fmt.Errorf("%w: payload key %q would hold a %d-byte record, the cap is %d bytes",
+				ErrRecordTooLarge, key, len(rec), maxRecordValueBytes)
+		}
+	default:
+		return nil, nil, 0, false, ErrRecordMutation
+	}
+	merged := cloneMeta(oldMeta)
+	if act == RecordDelete {
+		delete(merged, key)
+		if len(merged) == 0 {
+			// An emptied payload stores nil, exactly as deletePayloadKeysBody
+			// normalizes it. Storing an empty non-nil map instead would make the
+			// live state differ from the same state after a WAL replay (the log
+			// encodes an empty payload as absent and restores nil), for no gain.
+			merged = nil
+		}
+	} else {
+		if merged == nil {
+			merged = make(Metadata, 1)
+		}
+		merged[key] = Value{Kind: ValueRecord, Rec: rec} // ownership hand-off; see RecordMutator
+	}
+	ke := cloneKeyExpires(oldKE)
+	// A logically expired key read as ABSENT above: its stale deadline must go,
+	// or the record this call just created would be invisible the instant it is
+	// written. pruneKeyExpires only drops deadlines for keys no longer present.
+	if ke != nil && keyExpired(ke[key], now) {
+		delete(ke, key)
+	}
+	ke = pruneKeyExpires(ke, merged)
+	h.maintainBM25OnPayloadChange(slot, oldMeta, merged)
+	h.arena.SetMetadata(slot, merged)
+	h.arena.SetKeyExpires(slot, ke)
+	h.payloadIdx.reindex(slot, merged)
+	h.bumpData() // payload-value change: invalidate the order_by snapshot (NOT idSetVersion)
+	return merged, ke, h.arena.BumpVersion(slot), true, nil
+}
+
 // DeletePayloadKeys removes the listed keys from id's payload (absent keys are a
 // no-op) AND drops their per-key deadlines. Read-compute-set-reindex run in one
 // write-lock critical section. Returns the resulting payload AND the resulting

--- a/vector/index.go
+++ b/vector/index.go
@@ -616,6 +616,25 @@ type VectorIndex interface {
 	OverwritePayloadAt(id uint64, meta Metadata, keyTTLMs map[string]int64, cas CASCond, nowMs int64) (Metadata, map[string]uint64, uint64, error)
 	DeletePayloadKeysAt(id uint64, keys []string, cas CASCond, nowMs int64) (Metadata, map[string]uint64, uint64, error)
 	ClearPayloadAt(id uint64, cas CASCond, nowMs int64) (Metadata, map[string]uint64, uint64, error)
+	// MutatePayloadRecord applies fn to the operate record stored under key in
+	// id's payload and stores what fn returns, in ONE write-lock critical
+	// section (read, transform, bound, store/delete, reindex, bump). It is the
+	// store-agnostic seam the ops vector_operate handler drives: vector never
+	// imports ops, so the transform arrives as a function.
+	//
+	// Returns the resulting payload, the resulting absolute per-key deadlines,
+	// the resulting version, changed, and an error. changed=false means the
+	// call was a deliberate no-op (a failed CHECK, or a delete of an absent
+	// key): nothing was written and the returned version is the CURRENT,
+	// UNBUMPED one, so a no-op costs neither a WAL record nor a version move a
+	// CAS loop is watching.
+	MutatePayloadRecord(id uint64, key string, fn RecordMutator, cas CASCond) (Metadata, map[string]uint64, uint64, bool, error)
+	// MutatePayloadRecordAt judges the dead-point liveness gate, the per-key
+	// deadline check and the stale-deadline drop against the EXPLICIT
+	// leader-stamped clock nowMs, so a replicated record mutation reads the
+	// same record and produces the same bytes on every replica (#4 vector TTL
+	// determinism, mirroring SetPayloadAt).
+	MutatePayloadRecordAt(id uint64, key string, fn RecordMutator, cas CASCond, nowMs int64) (Metadata, map[string]uint64, uint64, bool, error)
 	// RestorePayload restores a logged payload + per-key deadlines AND the exact
 	// version verbatim (NOT bumped) — the WAL-replay primitive.
 	RestorePayload(id uint64, meta Metadata, keyExpires map[string]uint64, version uint64) error

--- a/vector/ivf.go
+++ b/vector/ivf.go
@@ -3696,6 +3696,22 @@ func (ix *ivf) MutatePayloadRecordAt(id uint64, key string, fn RecordMutator, ca
 	return ix.mutatePayloadRecordBody(id, key, fn, cas, true, uint64(nowMs)) //nolint:gosec // stamped unix-millis is non-negative
 }
 
+// LOCKSTEP with vector/hnsw.go mutatePayloadRecordBody and the named/multi-vector
+// mutatePayloadRecordLockedAt in vector/named.go and vector/multivector.go.
+// These four bodies are ~110 near-identical lines each and are deliberately NOT
+// factored into one: that matches the house style of their set_payload /
+// overwrite_payload siblings, whose engine differences (slot- vs id-keyed
+// indexes, uint64 vs int64 deadlines, BM25 on dense only) are real and are what
+// a shared body would have to branch on.
+//
+// The cost is real too, and it has already been paid once: a single formatting
+// difference in the size-bound message landed as a defect in all four at the
+// same time, and the deadline rule below had to be corrected in all four at the
+// same time. So both of those now live in SHARED helpers — recordTooLargeErr
+// (vector/metadata.go) and recordKeyPastDeadline[Abs] (vector/record_mutate.go)
+// — and any further change to the RULES, as opposed to the plumbing, belongs in
+// a helper rather than in a fifth copy. A change here that is not mirrored in
+// the other three is a bug, not a variation.
 func (ix *ivf) mutatePayloadRecordBody(id uint64, key string, fn RecordMutator, cas CASCond, stamped bool, nowMs uint64) (Metadata, map[string]uint64, uint64, bool, error) {
 	if fn == nil || key == "" || key == contentField {
 		return nil, nil, 0, false, ErrPayloadKeyNotRecord

--- a/vector/ivf.go
+++ b/vector/ivf.go
@@ -4,6 +4,7 @@ package vector
 
 import (
 	"bufio"
+	"fmt"
 	"io"
 	"math"
 	"runtime"
@@ -3656,6 +3657,108 @@ func (ix *ivf) overwritePayloadBody(id uint64, meta Metadata, keyTTLMs map[strin
 	ix.payloadIdx.reindex(slot, newMeta)
 	ix.bumpData() // payload-value change: invalidate the order_by snapshot (NOT idSetVersion)
 	return newMeta, ke, ix.arena.BumpVersion(slot), nil
+}
+
+// MutatePayloadRecord applies fn to the operate record stored under key in id's
+// payload and stores what fn returns, all inside ONE write-lock critical
+// section: read the current bytes, transform, bound, store/delete, prune the
+// key's deadline, reindex, bump. It is the store-agnostic seam ops.handleVector-
+// Operate drives with applyRecordBytes — vector never imports ops, so the
+// transform arrives as a function.
+//
+// Returns the RESULTING payload and per-key deadlines (so Collection WAL-logs
+// exactly what was applied), the resulting version, and changed. changed=false
+// means the call was a deliberate no-op (a failed CHECK, or a delete of an
+// absent key): nothing was stored, nothing was logged, the version is the
+// CURRENT one and was not bumped.
+func (ix *ivf) MutatePayloadRecord(id uint64, key string, fn RecordMutator, cas CASCond) (Metadata, map[string]uint64, uint64, bool, error) {
+	return ix.mutatePayloadRecordBody(id, key, fn, cas, false, 0)
+}
+
+// MutatePayloadRecordAt judges the dead-point liveness gate, the per-key
+// deadline check and the stale-deadline drop against the EXPLICIT leader-stamped
+// clock nowMs, so a replicated record mutation sees the same record and produces
+// the same bytes on every replica (#4 vector TTL determinism, mirroring
+// SetPayloadAt).
+func (ix *ivf) MutatePayloadRecordAt(id uint64, key string, fn RecordMutator, cas CASCond, nowMs int64) (Metadata, map[string]uint64, uint64, bool, error) {
+	return ix.mutatePayloadRecordBody(id, key, fn, cas, true, uint64(nowMs)) //nolint:gosec // stamped unix-millis is non-negative
+}
+
+func (ix *ivf) mutatePayloadRecordBody(id uint64, key string, fn RecordMutator, cas CASCond, stamped bool, nowMs uint64) (Metadata, map[string]uint64, uint64, bool, error) {
+	if fn == nil || key == "" || key == contentField {
+		return nil, nil, 0, false, ErrPayloadKeyNotRecord
+	}
+	ix.mu.Lock()
+	defer ix.mu.Unlock()
+	now := nowMs
+	if !stamped {
+		now = uint64(ix.now())
+	}
+	slot, ok := ix.arena.Slot(id)
+	if !ok || ix.tombstoned[slot] || ix.isExpiredAt(slot, now) {
+		return nil, nil, 0, false, ErrIDNotFound
+	}
+	if err := cas.check(ix.arena.Version(slot)); err != nil {
+		return nil, nil, 0, false, err // CAS mismatch: no mutation, no bump
+	}
+	oldMeta := ix.arena.Metadata(slot)
+	oldKE := ix.arena.KeyExpires(slot)
+	old, exists, err := currentRecordValue(oldMeta, key, keyExpired(oldKE[key], now))
+	if err != nil {
+		return nil, nil, 0, false, err
+	}
+	rec, act, err := fn(old, exists)
+	if err != nil {
+		return nil, nil, 0, false, err
+	}
+	switch act {
+	case RecordUnchanged:
+		return nil, nil, ix.arena.Version(slot), false, nil
+	case RecordDelete:
+		if !exists {
+			return nil, nil, ix.arena.Version(slot), false, nil
+		}
+	case RecordStore:
+		// The POST-mutation bound. checkRecordValues (vector/metadata.go) is the
+		// same cap on the ingest side, but it only ever sees a caller's patch —
+		// it cannot reach bytes the operate engine just produced, which is what
+		// this site exists for. Keep the two in step.
+		if len(rec) > maxRecordValueBytes {
+			return nil, nil, 0, false, fmt.Errorf("%w: payload key %q would hold a %d-byte record, the cap is %d bytes",
+				ErrRecordTooLarge, key, len(rec), maxRecordValueBytes)
+		}
+	default:
+		return nil, nil, 0, false, ErrRecordMutation
+	}
+	merged := cloneMeta(oldMeta)
+	if act == RecordDelete {
+		delete(merged, key)
+		if len(merged) == 0 {
+			// An emptied payload stores nil, exactly as deletePayloadKeysBody
+			// normalizes it. Storing an empty non-nil map instead would make the
+			// live state differ from the same state after a WAL replay (the log
+			// encodes an empty payload as absent and restores nil), for no gain.
+			merged = nil
+		}
+	} else {
+		if merged == nil {
+			merged = make(Metadata, 1)
+		}
+		merged[key] = Value{Kind: ValueRecord, Rec: rec} // ownership hand-off; see RecordMutator
+	}
+	ke := cloneKeyExpires(oldKE)
+	// A logically expired key read as ABSENT above: its stale deadline must go,
+	// or the record this call just created would be invisible the instant it is
+	// written. pruneKeyExpires only drops deadlines for keys no longer present.
+	if ke != nil && keyExpired(ke[key], now) {
+		delete(ke, key)
+	}
+	ke = pruneKeyExpires(ke, merged)
+	ix.arena.SetMetadata(slot, merged)
+	ix.arena.SetKeyExpires(slot, ke)
+	ix.payloadIdx.reindex(slot, merged)
+	ix.bumpData() // payload-value change: invalidate the order_by snapshot (NOT idSetVersion)
+	return merged, ke, ix.arena.BumpVersion(slot), true, nil
 }
 
 func (ix *ivf) DeletePayloadKeys(id uint64, keys []string, cas CASCond) (Metadata, map[string]uint64, uint64, error) {

--- a/vector/ivf.go
+++ b/vector/ivf.go
@@ -3673,6 +3673,13 @@ func (ix *ivf) overwritePayloadBody(id uint64, meta Metadata, keyTTLMs map[strin
 // means the call was a deliberate no-op (a failed CHECK, or a delete of an
 // absent key): nothing was stored, nothing was logged, the version is the
 // CURRENT one and was not bumped.
+//
+// THE KEY'S DEADLINE IS NOT CONSULTED HERE. Unstamped, `now` is this process's
+// own wall clock, and letting it decide whether the record EXISTS would let two
+// replicas store different bytes. So an unstamped mutation treats a
+// deadline-passed record as PRESENT and passes its deadline through untouched;
+// only the *At variant expires the key. See recordKeyPastDeadline
+// (vector/record_mutate.go).
 func (ix *ivf) MutatePayloadRecord(id uint64, key string, fn RecordMutator, cas CASCond) (Metadata, map[string]uint64, uint64, bool, error) {
 	return ix.mutatePayloadRecordBody(id, key, fn, cas, false, 0)
 }
@@ -3682,6 +3689,10 @@ func (ix *ivf) MutatePayloadRecord(id uint64, key string, fn RecordMutator, cas 
 // clock nowMs, so a replicated record mutation sees the same record and produces
 // the same bytes on every replica (#4 vector TTL determinism, mirroring
 // SetPayloadAt).
+//
+// This is the ONLY variant that may expire the payload key: its clock is the
+// leader's stamp, identical on every replica. See recordKeyPastDeadline
+// (vector/record_mutate.go) for why the unstamped twin must not.
 func (ix *ivf) MutatePayloadRecordAt(id uint64, key string, fn RecordMutator, cas CASCond, nowMs int64) (Metadata, map[string]uint64, uint64, bool, error) {
 	return ix.mutatePayloadRecordBody(id, key, fn, cas, true, uint64(nowMs)) //nolint:gosec // stamped unix-millis is non-negative
 }
@@ -3705,7 +3716,15 @@ func (ix *ivf) mutatePayloadRecordBody(id uint64, key string, fn RecordMutator, 
 	}
 	oldMeta := ix.arena.Metadata(slot)
 	oldKE := ix.arena.KeyExpires(slot)
-	old, exists, err := currentRecordValue(oldMeta, key, keyExpired(oldKE[key], now))
+	// Only a STAMPED apply may judge the key's deadline; an unstamped one treats
+	// the record as PRESENT and leaves the deadline alone. recordKeyPastDeadline
+	// (vector/record_mutate.go) carries the reasoning — the short version is that
+	// a per-replica wall clock deciding whether a record EXISTS makes replicas
+	// store different bytes, which is not the bounded-deadline-skew class
+	// setPayloadBody lives with. LOCKSTEP: the same two lines exist in
+	// vector/hnsw.go, vector/ivf.go, vector/named.go and vector/multivector.go.
+	keyPastDeadline := recordKeyPastDeadline(stamped, oldKE[key], now)
+	old, exists, err := currentRecordValue(oldMeta, key, keyPastDeadline)
 	if err != nil {
 		return nil, nil, 0, false, err
 	}
@@ -3756,10 +3775,14 @@ func (ix *ivf) mutatePayloadRecordBody(id uint64, key string, fn RecordMutator, 
 		merged[key] = Value{Kind: ValueRecord, Rec: rec} // ownership hand-off; see RecordMutator
 	}
 	ke := cloneKeyExpires(oldKE)
-	// A logically expired key read as ABSENT above: its stale deadline must go,
-	// or the record this call just created would be invisible the instant it is
-	// written. pruneKeyExpires only drops deadlines for keys no longer present.
-	if ke != nil && keyExpired(ke[key], now) {
+	// A key read as ABSENT above because its deadline had passed — STAMPED
+	// applies only: its stale deadline must go, or the record this call just
+	// created would be invisible the instant it is written. pruneKeyExpires only
+	// drops deadlines for keys no longer present. On an unstamped apply
+	// keyPastDeadline is false by construction, so an expired key's deadline is
+	// passed through UNTOUCHED, exactly as setPayloadBody passes an expired key
+	// through unchanged.
+	if ke != nil && keyPastDeadline {
 		delete(ke, key)
 	}
 	ke = pruneKeyExpires(ke, merged)

--- a/vector/ivf.go
+++ b/vector/ivf.go
@@ -3760,18 +3760,30 @@ func (ix *ivf) mutatePayloadRecordBody(id uint64, key string, fn RecordMutator, 
 		// it cannot reach bytes the operate engine just produced, which is what
 		// this site exists for. Keep the two in step.
 		//
-		// SIZE ONLY, DELIBERATELY: no record.Validate here. These bytes come from
-		// applyRecordBytes, which phase 1 held to the tree oracle, so they are
-		// well-formed by construction; re-decoding the whole record on every
-		// counter increment would double the op's cost for a case that cannot
-		// arise. The shape check belongs where bytes arrive from a CALLER, which
-		// is checkRecordValues.
+		// SIZE FIRST, THEN SHAPE — the same order and the same two gates
+		// checkRecordValues applies to a caller's patch, so an oversize value is
+		// refused without ever being decoded.
 		//
-		// The MESSAGE comes from recordTooLargeErr (vector/metadata.go), the one
-		// producer of this error's detailed form: one canonical shape for the
-		// matcher to anchor on across replication, with the caller's key bounded.
+		// The shape check is here because MutatePayloadRecordCAS is EXPORTED. The
+		// mutator ops supplies returns applyRecordBytes' output, which phase 1
+		// held to the tree oracle and which cannot be malformed — but a direct Go
+		// caller of this API supplies its own mutator, and whatever bytes it
+		// returns were being stored on the size cap alone. That poisons the
+		// payload key for the whole collection: every path under it declines to
+		// accelerate, and a later vector_operate on the same key fails with
+		// wire.ErrOperateRecord. The cost is one decode of the bytes the engine
+		// just produced, on a write that already decoded and re-encoded the
+		// record.
+		//
+		// Both MESSAGES come from the one producer of their detailed form
+		// (recordTooLargeErr / recordMalformedErr, vector/metadata.go): one
+		// canonical shape for the transport matchers to anchor on across
+		// replication, with the caller's key bounded.
 		if len(rec) > maxRecordValueBytes {
 			return nil, nil, 0, false, recordTooLargeErr(key, len(rec))
+		}
+		if verr := validateRecord(rec); verr != nil {
+			return nil, nil, 0, false, recordMalformedErr(key, verr)
 		}
 	default:
 		return nil, nil, 0, false, ErrRecordMutation

--- a/vector/ivf.go
+++ b/vector/ivf.go
@@ -548,7 +548,9 @@ func (ix *ivf) RestoreInsertAt(id uint64, vec []float32, ttl time.Duration, meta
 }
 
 func (ix *ivf) restoreInsertBody(id uint64, vec []float32, ttl time.Duration, meta Metadata, sparse *SparseVector, keyExpires map[string]uint64, version uint64, stamped bool, nowMs uint64) error {
-	if err := checkRecordValues(meta); err != nil {
+	// REPLAY body: size only — the IVF twin of hnsw.restoreInsertBody. See
+	// checkRecordValuesSize.
+	if err := checkRecordValuesSize(meta); err != nil {
 		return err
 	}
 	if len(vec) != ix.cfg.Dim {
@@ -3723,6 +3725,13 @@ func (ix *ivf) mutatePayloadRecordBody(id uint64, key string, fn RecordMutator, 
 		// same cap on the ingest side, but it only ever sees a caller's patch —
 		// it cannot reach bytes the operate engine just produced, which is what
 		// this site exists for. Keep the two in step.
+		//
+		// SIZE ONLY, DELIBERATELY: no record.Validate here. These bytes come from
+		// applyRecordBytes, which phase 1 held to the tree oracle, so they are
+		// well-formed by construction; re-decoding the whole record on every
+		// counter increment would double the op's cost for a case that cannot
+		// arise. The shape check belongs where bytes arrive from a CALLER, which
+		// is checkRecordValues.
 		if len(rec) > maxRecordValueBytes {
 			return nil, nil, 0, false, fmt.Errorf("%w: payload key %q would hold a %d-byte record, the cap is %d bytes",
 				ErrRecordTooLarge, key, len(rec), maxRecordValueBytes)
@@ -3836,7 +3845,9 @@ func (ix *ivf) clearPayloadBody(id uint64, cas CASCond, stamped bool, nowMs uint
 }
 
 func (ix *ivf) RestorePayload(id uint64, meta Metadata, keyExpires map[string]uint64, version uint64) error {
-	if err := checkRecordValues(meta); err != nil {
+	// REPLAY body: size only — the IVF twin of hnsw.RestorePayload. See
+	// checkRecordValuesSize.
+	if err := checkRecordValuesSize(meta); err != nil {
 		return err
 	}
 	ix.mu.Lock()

--- a/vector/ivf.go
+++ b/vector/ivf.go
@@ -4,7 +4,6 @@ package vector
 
 import (
 	"bufio"
-	"fmt"
 	"io"
 	"math"
 	"runtime"
@@ -3751,9 +3750,12 @@ func (ix *ivf) mutatePayloadRecordBody(id uint64, key string, fn RecordMutator, 
 		// counter increment would double the op's cost for a case that cannot
 		// arise. The shape check belongs where bytes arrive from a CALLER, which
 		// is checkRecordValues.
+		//
+		// The MESSAGE comes from recordTooLargeErr (vector/metadata.go), the one
+		// producer of this error's detailed form: one canonical shape for the
+		// matcher to anchor on across replication, with the caller's key bounded.
 		if len(rec) > maxRecordValueBytes {
-			return nil, nil, 0, false, fmt.Errorf("%w: payload key %q would hold a %d-byte record, the cap is %d bytes",
-				ErrRecordTooLarge, key, len(rec), maxRecordValueBytes)
+			return nil, nil, 0, false, recordTooLargeErr(key, len(rec))
 		}
 	default:
 		return nil, nil, 0, false, ErrRecordMutation

--- a/vector/metadata.go
+++ b/vector/metadata.go
@@ -338,8 +338,10 @@ func checkRecordValuesAll(metas []Metadata) error {
 // Error())) is not silently redacted; the equality check cannot mis-fire on
 // anything else, so it costs nothing to include.
 //
-// Phase 2 adds the same treatment for ErrRecordMalformed, ErrPayloadKeyNotRecord,
-// and ErrVectorRecordAbsent; this helper does not attempt those.
+// IsRecordMalformedMessage, in this file, gives ErrRecordMalformed the same
+// treatment. ErrPayloadKeyNotRecord (vector.IsPayloadKeyNotRecordMessage, in
+// record_mutate.go) and ErrVectorRecordAbsent (ops.IsVectorRecordAbsentMessage,
+// in ops/vector_operate.go) get their own matchers next to their sentinels.
 func IsRecordTooLargeMessage(s string) bool {
 	if len(s) == 0 || len(s) > maxRecordTooLargeMessageLen {
 		return false
@@ -416,6 +418,105 @@ func hasRecordTooLargeSuffix(s string) bool {
 		return false
 	}
 	return strings.HasSuffix(rest[:i], recordTooLargeSuffixMid)
+}
+
+// IsRecordMalformedMessage reports whether s is the EXACT serialised form of
+// an ErrRecordMalformed error produced by checkRecordValues (single-payload)
+// or checkRecordValuesAll (bulk) — anchored on the fixed prefix/marker text
+// those two produce, exactly as IsRecordTooLargeMessage is for its sentinel,
+// and for the same reason: shard.decodePBResult rebuilds a replicated op
+// error with errors.New, losing errors.Is identity, and a bare
+// strings.Contains fallback would make any error whose message happens to
+// mention the sentinel text client-facing — including an internal error that
+// merely wraps it.
+//
+// The three recognized shapes (<key> is clipField's bounded rendering of the
+// caller's payload key; <detail> is validateRecord's — i.e. record.Validate's
+// — own message for what DecodeRecord rejected, e.g. "unexpected EOF"):
+//
+//	vector: record payload value is not a decodable operate record
+//	vector: record payload value is not a decodable operate record: payload key <key>: record: malformed record: <detail>
+//	payload I: vector: record payload value is not a decodable operate record: payload key <key>: record: malformed record: <detail>
+//
+// UNLIKE IsRecordTooLargeMessage, the tail after the fixed "record: malformed
+// record: " marker has no fixed closing suffix to anchor on — record.Validate
+// wraps whatever wire.DecodeRecord's own error says, which is not one fixed
+// shape. This matcher therefore requires only that the marker appear
+// somewhere after the fixed prefix and that SOME non-empty text follow it; it
+// does not attempt to bound or validate the detail itself. That is still safe
+// against the redaction-bypass this exists to close: an unrelated error (a
+// WAL/path/IO failure, say) would have to independently reproduce the exact,
+// highly specific opening text before falling through to an arbitrary tail,
+// which an accidental wrap around the sentinel cannot do — a wrap always adds
+// its OWN text as a prefix, which fails the exact-prefix check below.
+func IsRecordMalformedMessage(s string) bool {
+	if len(s) == 0 || len(s) > maxRecordMalformedMessageLen {
+		return false
+	}
+	if s == ErrRecordMalformed.Error() {
+		return true
+	}
+	rest, ok := cutRecordMalformedPrefix(s)
+	if !ok {
+		return false
+	}
+	return hasRecordMalformedSuffix(rest)
+}
+
+// maxRecordMalformedMessageLen bounds the input IsRecordMalformedMessage
+// scans, so classification cost cannot scale with an attacker-chosen string's
+// length. Mirrors maxRecordTooLargeMessageLen's reasoning; sized a little
+// larger to leave headroom for record.Validate's detail text.
+const maxRecordMalformedMessageLen = 2048
+
+// recordMalformedPrefix is the fixed text that opens the single-payload form,
+// ending right before the caller-controlled clipField(k) rendering.
+var recordMalformedPrefix = ErrRecordMalformed.Error() + ": payload key "
+
+// recordMalformedMidMarker is the fixed text that separates the
+// caller-controlled key rendering from record.Validate's own detail: the
+// wrapped record.ErrRecord sentinel, colon-space delimited on both sides.
+var recordMalformedMidMarker = ": " + record.ErrRecord.Error() + ": "
+
+// cutRecordMalformedPrefix strips either the single-payload prefix or the
+// bulk "payload <digits>: " wrapper followed by the single-payload prefix,
+// and returns what follows (the clipField rendering, the mid marker, and
+// record.Validate's detail). Structurally identical to
+// cutRecordTooLargePrefix, duplicated rather than shared because the two
+// prefixes differ.
+func cutRecordMalformedPrefix(s string) (string, bool) {
+	if rest, ok := strings.CutPrefix(s, recordMalformedPrefix); ok {
+		return rest, true
+	}
+	rest, ok := strings.CutPrefix(s, "payload ")
+	if !ok {
+		return "", false
+	}
+	i := 0
+	for i < len(rest) && rest[i] >= '0' && rest[i] <= '9' {
+		i++
+	}
+	if i == 0 {
+		return "", false
+	}
+	rest, ok = strings.CutPrefix(rest[i:], ": ")
+	if !ok {
+		return "", false
+	}
+	return strings.CutPrefix(rest, recordMalformedPrefix)
+}
+
+// hasRecordMalformedSuffix reports whether s contains the fixed mid marker
+// somewhere after the caller-controlled key rendering, followed by at least
+// one byte of record.Validate's detail. Unlike hasRecordTooLargeSuffix there
+// is no fixed tail to anchor the far end on (see IsRecordMalformedMessage's
+// doc for why that is still safe).
+func hasRecordMalformedSuffix(s string) bool {
+	i := strings.Index(s, recordMalformedMidMarker)
+	if i < 0 {
+		return false
+	}
+	return i+len(recordMalformedMidMarker) < len(s)
 }
 
 // recordPoison is the READ side of the payload index's per-payload-key

--- a/vector/metadata.go
+++ b/vector/metadata.go
@@ -172,6 +172,35 @@ func (fl fieldLookup) get(m Metadata) (Value, bool) {
 // transports like ErrDimMismatch.
 var ErrRecordTooLarge = errors.New("vector: record payload value exceeds the storage cap")
 
+// recordTooLargeErr is the ONE producer of ErrRecordTooLarge's detailed form.
+// Every site that reports the record cap — the ingest gates checkRecordValues /
+// checkRecordValuesSize and the post-mutation bound in the four
+// mutatePayloadRecord bodies (vector/hnsw.go, vector/ivf.go, vector/named.go,
+// vector/multivector.go) — goes through it, so there is exactly one message
+// shape for IsRecordTooLargeMessage to anchor on.
+//
+// IT EXISTS BECAUSE THE COPIES DRIFTED. The four mutate bodies formatted their
+// own variant ("payload key %q would hold a %d-byte record"), and the two
+// differences were each a real defect: "would hold a" is not the " holds a "
+// the matcher anchors on, so a clustered apply — where shard.decodePBResult
+// rebuilds the error with errors.New and errors.Is identity is gone — declined
+// to classify it and redacted a fixable client mistake to "internal error";
+// and %q quoted an unbounded caller-supplied key, echoing up to ~65 KB of it
+// (DecodeVectorOperateArgs' payloadKey cap) straight back in the message.
+//
+// clipField (vector/filter.go) bounds the key at 64 source bytes for the second
+// reason, exactly as currentRecordValue and the two check helpers do: the key is
+// caller-supplied, and this message is returned VERBATIM to the caller on every
+// transport (a client error, classified 400 / InvalidArgument) and carried
+// across replication as a string.
+//
+// n is the size that was refused. Callers keep their own tense in surrounding
+// prose; the MESSAGE is fixed here and must not be re-phrased per site.
+func recordTooLargeErr(key string, n int) error {
+	return fmt.Errorf("%w: payload key %s holds a %d-byte record, the cap is %d bytes",
+		ErrRecordTooLarge, clipField(key), n, maxRecordValueBytes)
+}
+
 // checkRecordValues is the INGEST gate for every payload a caller supplies. It
 // rejects a ValueRecord that is oversize (ErrRecordTooLarge) or that no operate
 // engine could open (ErrRecordMalformed). Every wire-reachable mutation entry
@@ -232,8 +261,7 @@ func checkRecordValues(m Metadata) error {
 		// string. A short key renders exactly as %q did. Keep in step with
 		// checkRecordValuesSize.
 		if len(v.Rec) > maxRecordValueBytes {
-			return fmt.Errorf("%w: payload key %s holds a %d-byte record, the cap is %d bytes",
-				ErrRecordTooLarge, clipField(k), len(v.Rec), maxRecordValueBytes)
+			return recordTooLargeErr(k, len(v.Rec))
 		}
 		if err := validateRecord(v.Rec); err != nil {
 			return fmt.Errorf("%w: payload key %s: %w", ErrRecordMalformed, clipField(k), err)
@@ -287,8 +315,7 @@ func checkRecordValuesSize(m Metadata) error {
 			// returned VERBATIM to the caller on every transport (it is a
 			// client error, classified 400 / InvalidArgument) and carried across
 			// replication as a string. A short key renders exactly as %q did.
-			return fmt.Errorf("%w: payload key %s holds a %d-byte record, the cap is %d bytes",
-				ErrRecordTooLarge, clipField(k), len(v.Rec), maxRecordValueBytes)
+			return recordTooLargeErr(k, len(v.Rec))
 		}
 	}
 	return nil

--- a/vector/metadata.go
+++ b/vector/metadata.go
@@ -176,8 +176,29 @@ var ErrRecordTooLarge = errors.New("vector: record payload value exceeds the sto
 // rejects a ValueRecord that is oversize (ErrRecordTooLarge) or that no operate
 // engine could open (ErrRecordMalformed). Every wire-reachable mutation entry
 // calls it BEFORE it touches any state or stages a WAL write; the inner helpers
-// those entries share deliberately do NOT repeat it, so each op pays exactly one
-// pass over its own payload.
+// those entries share deliberately do NOT repeat it, so almost every op pays
+// exactly one pass over its own payload.
+//
+// TWO OPS PAY TWO PASSES, AND BOTH ARE LOAD-BEARING — see
+// TestRecordValidationCountPerWrite, which pins the count for every path.
+// UpsertCASKeyTTL[At] and StageBulkPayloads each do something IRREVERSIBLE
+// before the engine body they delegate to runs its own gate, so their pass
+// cannot be dropped or downgraded to size-only:
+//
+//   - Upsert is delete-then-insert. Its wrapper pass runs before
+//     idxDeleteLogged; without it a malformed record deletes the existing point
+//     and only then fails in insertBody, so a REJECTED write destroys the data it
+//     was replacing. TestMalformedRecordRejectedAtIngestDense fails exactly that
+//     way if the wrapper is downgraded.
+//   - BuildStaged hands the staged slices to the engine and CLEARS the stage
+//     buffer before BuildConcurrentMeta's gate runs, so a record that got past
+//     staging takes the caller's whole staged batch down with it.
+//     TestStagedBatchSurvivesARejectedRecord pins this.
+//
+// The duplicate pass costs one extra decode of the same bytes on those two paths
+// (BenchmarkCheckRecordValues sizes it). That is the price of failing before an
+// irreversible step, and it is the right trade: the alternative is losing a
+// point, or a batch, on a request that was refused.
 //
 // TWO CHECKS, TWO REACHES.
 //
@@ -214,12 +235,23 @@ func checkRecordValues(m Metadata) error {
 			return fmt.Errorf("%w: payload key %s holds a %d-byte record, the cap is %d bytes",
 				ErrRecordTooLarge, clipField(k), len(v.Rec), maxRecordValueBytes)
 		}
-		if err := record.Validate(v.Rec); err != nil {
+		if err := validateRecord(v.Rec); err != nil {
 			return fmt.Errorf("%w: payload key %s: %w", ErrRecordMalformed, clipField(k), err)
 		}
 	}
 	return nil
 }
+
+// validateRecord is record.Validate behind a package-level indirection, so a test
+// can COUNT how many times one write decodes the same record bytes. The count is
+// a real invariant, not a curiosity: the shape check is O(record) with
+// allocations (see BenchmarkCheckRecordValues), so a path that silently grew a
+// third pass would multiply the write cost of every record-bearing payload with
+// nothing to show for it. TestRecordValidationCountPerWrite pins the number for
+// every ingest path and documents the two that are legitimately two.
+//
+// Swapped only by tests, never concurrently with a live write.
+var validateRecord = record.Validate
 
 // checkRecordValuesSize is checkRecordValues WITHOUT the shape check: the size
 // bound only. It is what the REPLAY bodies call — the ones whose metadata comes

--- a/vector/metadata.go
+++ b/vector/metadata.go
@@ -201,6 +201,20 @@ func recordTooLargeErr(key string, n int) error {
 		ErrRecordTooLarge, clipField(key), n, maxRecordValueBytes)
 }
 
+// recordMalformedErr is the ONE producer of ErrRecordMalformed's detailed form,
+// the twin of recordTooLargeErr and for the same two reasons: the message is
+// carried across replication as a string, so IsRecordMalformedMessage has to
+// anchor on ONE shape; and the key is caller-supplied, so it goes through
+// clipField rather than %q.
+//
+// err is what validateRecord (record.Validate) said about the bytes; it is
+// wrapped, not summarised, so the caller learns which part of the record could
+// not be opened. Both the ingest gate (checkRecordValues) and the four
+// post-mutation gates in the engine bodies raise it from here.
+func recordMalformedErr(key string, err error) error {
+	return fmt.Errorf("%w: payload key %s: %w", ErrRecordMalformed, clipField(key), err)
+}
+
 // checkRecordValues is the INGEST gate for every payload a caller supplies. It
 // rejects a ValueRecord that is oversize (ErrRecordTooLarge) or that no operate
 // engine could open (ErrRecordMalformed). Every wire-reachable mutation entry
@@ -264,7 +278,7 @@ func checkRecordValues(m Metadata) error {
 			return recordTooLargeErr(k, len(v.Rec))
 		}
 		if err := validateRecord(v.Rec); err != nil {
-			return fmt.Errorf("%w: payload key %s: %w", ErrRecordMalformed, clipField(k), err)
+			return recordMalformedErr(k, err)
 		}
 	}
 	return nil

--- a/vector/metadata.go
+++ b/vector/metadata.go
@@ -172,17 +172,82 @@ func (fl fieldLookup) get(m Metadata) (Value, bool) {
 // transports like ErrDimMismatch.
 var ErrRecordTooLarge = errors.New("vector: record payload value exceeds the storage cap")
 
-// checkRecordValues rejects a payload carrying an oversize ValueRecord. Every
-// mutation entry calls it BEFORE it touches any state or stages a WAL write;
-// the inner helpers those entries share deliberately do NOT repeat it, so each
-// op pays exactly one pass over its own payload.
+// checkRecordValues is the INGEST gate for every payload a caller supplies. It
+// rejects a ValueRecord that is oversize (ErrRecordTooLarge) or that no operate
+// engine could open (ErrRecordMalformed). Every wire-reachable mutation entry
+// calls it BEFORE it touches any state or stages a WAL write; the inner helpers
+// those entries share deliberately do NOT repeat it, so each op pays exactly one
+// pass over its own payload.
 //
-// It is one of TWO sites for this bound, and the divergence is deliberate: this
-// one sees a CALLER's patch, while mutatePayloadRecordBody (vector/hnsw.go, with
-// twins in vector/ivf.go and in the named/MV mutatePayloadRecordLockedAt) bounds
-// the POST-mutation bytes the operate engine just produced, which no patch check
-// can reach. Keep the two in step.
+// TWO CHECKS, TWO REACHES.
+//
+//   - The SIZE bound is one of two sites, and the divergence is deliberate: this
+//     one sees a CALLER's patch, while mutatePayloadRecordBody (vector/hnsw.go,
+//     with twins in vector/ivf.go and in the named/MV mutatePayloadRecordLockedAt)
+//     bounds the POST-mutation bytes the operate engine just produced, which no
+//     patch check can reach. Keep the two in step.
+//   - The SHAPE check (record.Validate) closes the poison hole phase 1 could only
+//     fail closed around: a record IndexEntries cannot enumerate but Resolve still
+//     answers from makes every path under that payload key decline to accelerate,
+//     for every point in the collection, and a later vector_operate on the same
+//     key fails with wire.ErrOperateRecord. Refusing it at the door costs the
+//     caller one error; accepting it costs the collection a payload key.
+//
+// WHY THE ORDER MATTERS: size first. An oversize value is refused without ever
+// being decoded, so a 16 MiB+1 payload cannot be used to make the gate itself
+// expensive.
+//
+// The replay bodies call checkRecordValuesSize instead — see its doc for which
+// ones and why.
 func checkRecordValues(m Metadata) error {
+	for k, v := range m {
+		if v.Kind != ValueRecord {
+			continue
+		}
+		// Both messages put the key through clipField, not %q: it is
+		// caller-supplied and bounded only by the route body cap, and both are
+		// returned VERBATIM to the caller on every transport (client errors,
+		// classified 400 / InvalidArgument) and carried across replication as a
+		// string. A short key renders exactly as %q did. Keep in step with
+		// checkRecordValuesSize.
+		if len(v.Rec) > maxRecordValueBytes {
+			return fmt.Errorf("%w: payload key %s holds a %d-byte record, the cap is %d bytes",
+				ErrRecordTooLarge, clipField(k), len(v.Rec), maxRecordValueBytes)
+		}
+		if err := record.Validate(v.Rec); err != nil {
+			return fmt.Errorf("%w: payload key %s: %w", ErrRecordMalformed, clipField(k), err)
+		}
+	}
+	return nil
+}
+
+// checkRecordValuesSize is checkRecordValues WITHOUT the shape check: the size
+// bound only. It is what the REPLAY bodies call — the ones whose metadata comes
+// from a WAL record or a snapshot this store already acked, never from a live
+// caller:
+//
+//	hnsw.restoreInsertBody / hnsw.RestorePayload
+//	ivf.restoreInsertBody  / ivf.RestorePayload
+//	NamedCollection.RestoreInsert (its only caller is named_wal.go replay)
+//	MultiVectorIndex.restoreAdd   (mv_wal.go replay; the WIRE entry above it,
+//	                               MultiRestoreAddSparse, does the full check)
+//
+// WHY REPLAY MUST NOT VALIDATE SHAPE. Replay's job is to rebuild state that was
+// already ACKNOWLEDGED. A shape check there could refuse a record written before
+// this gate existed and silently drop the write (named_wal.go and mv_wal.go
+// discard the restore error), turning a lost acceleration into lost data — a
+// strictly worse failure than the poison the gate prevents. The size bound is
+// safe to keep here because nothing the WAL or a snapshot can hold can fail it
+// (writeOptMeta refuses to encode an oversize record and readValue caps at
+// maxRecordValueBytes), so on these paths it can only ever fire for a caller
+// that reached the engine body directly.
+//
+// The WIRE-reachable members of the restore family are NOT in this list:
+// Collection.RestoreInsert/RestoreInsertAt (ops/builtin.go routes a wire insert
+// carrying a non-zero version to them) and MultiVectorIndex.MultiRestoreAddSparse
+// (ops/multivector.go, ops/mv_batch.go) carry the caller's own metadata, so they
+// run the full checkRecordValues like any other ingest entry.
+func checkRecordValuesSize(m Metadata) error {
 	for k, v := range m {
 		if v.Kind == ValueRecord && len(v.Rec) > maxRecordValueBytes {
 			// The key goes through clipField, not %q: it is caller-supplied and

--- a/vector/metadata.go
+++ b/vector/metadata.go
@@ -176,6 +176,12 @@ var ErrRecordTooLarge = errors.New("vector: record payload value exceeds the sto
 // mutation entry calls it BEFORE it touches any state or stages a WAL write;
 // the inner helpers those entries share deliberately do NOT repeat it, so each
 // op pays exactly one pass over its own payload.
+//
+// It is one of TWO sites for this bound, and the divergence is deliberate: this
+// one sees a CALLER's patch, while mutatePayloadRecordBody (vector/hnsw.go, with
+// twins in vector/ivf.go and in the named/MV mutatePayloadRecordLockedAt) bounds
+// the POST-mutation bytes the operate engine just produced, which no patch check
+// can reach. Keep the two in step.
 func checkRecordValues(m Metadata) error {
 	for k, v := range m {
 		if v.Kind == ValueRecord && len(v.Rec) > maxRecordValueBytes {

--- a/vector/multivector.go
+++ b/vector/multivector.go
@@ -1036,7 +1036,7 @@ func (m *MultiVectorIndex) MultiBulkBuild(recs []MultiScanRecord, workers int) (
 			}
 		}
 		// THIS ENTRY IS WIRE-REACHABLE and it is NOT a replay body, so it runs the
-		// record ingest gate. ops/mv_batch.go decodes a batch straight off the wire
+		// full ingest gate. ops/mv_batch.go decodes a batch straight off the wire
 		// and calls it as the FAST PATH whenever the target index is empty,
 		// falling through to the gated MultiRestoreAddSparse only once documents
 		// exist — so without this the same op is gated or ungated depending on the

--- a/vector/multivector.go
+++ b/vector/multivector.go
@@ -1591,9 +1591,12 @@ func (m *MultiVectorIndex) mutatePayloadRecordLockedAt(docID uint64, key string,
 		// counter increment would double the op's cost for a case that cannot
 		// arise. The shape check belongs where bytes arrive from a CALLER, which
 		// is checkRecordValues.
+		//
+		// The MESSAGE comes from recordTooLargeErr (vector/metadata.go), the one
+		// producer of this error's detailed form: one canonical shape for the
+		// matcher to anchor on across replication, with the caller's key bounded.
 		if len(rec) > maxRecordValueBytes {
-			return nil, nil, 0, false, fmt.Errorf("%w: payload key %q would hold a %d-byte record, the cap is %d bytes",
-				ErrRecordTooLarge, key, len(rec), maxRecordValueBytes)
+			return nil, nil, 0, false, recordTooLargeErr(key, len(rec))
 		}
 	default:
 		return nil, nil, 0, false, ErrRecordMutation

--- a/vector/multivector.go
+++ b/vector/multivector.go
@@ -1542,6 +1542,23 @@ func (m *MultiVectorIndex) MutatePayloadRecordCASAt(docID uint64, key string, fn
 // WAL-logs exactly what was applied), the resulting version, and changed.
 // changed=false means the call was a deliberate no-op: nothing was stored,
 // nothing will be logged, and the version is the CURRENT one, unbumped.
+//
+// LOCKSTEP with the dense mutatePayloadRecordBody in vector/hnsw.go and vector/ivf.go,
+// and vector/named.go mutatePayloadRecordLockedAt.
+// These four bodies are ~110 near-identical lines each and are deliberately NOT
+// factored into one: that matches the house style of their set_payload /
+// overwrite_payload siblings, whose engine differences (slot- vs id-keyed
+// indexes, uint64 vs int64 deadlines, BM25 on dense only) are real and are what
+// a shared body would have to branch on.
+//
+// The cost is real too, and it has already been paid once: a single formatting
+// difference in the size-bound message landed as a defect in all four at the
+// same time, and the deadline rule below had to be corrected in all four at the
+// same time. So both of those now live in SHARED helpers — recordTooLargeErr
+// (vector/metadata.go) and recordKeyPastDeadline[Abs] (vector/record_mutate.go)
+// — and any further change to the RULES, as opposed to the plumbing, belongs in
+// a helper rather than in a fifth copy. A change here that is not mirrored in
+// the other three is a bug, not a variation.
 func (m *MultiVectorIndex) mutatePayloadRecordLockedAt(docID uint64, key string, fn RecordMutator, cas CASCond, now int64, stamped bool) (Metadata, map[string]int64, uint64, bool, error) {
 	if fn == nil || key == "" || key == contentField {
 		return nil, nil, 0, false, ErrPayloadKeyNotRecord

--- a/vector/multivector.go
+++ b/vector/multivector.go
@@ -677,7 +677,10 @@ func (m *MultiVectorIndex) addLockedAt(docID uint64, tokens [][]float32, meta Me
 // does NOT WAL-log. A version of 0 falls back to the normal bump (an old record
 // predating the version block defaults a fresh add to 1).
 func (m *MultiVectorIndex) restoreAdd(docID uint64, tokens [][]float32, meta Metadata, keyExpires map[string]uint64, version uint64, sparse *SparseVector) error {
-	if err := checkRecordValues(meta); err != nil {
+	// REPLAY body: size only. mv_wal.go replays through here directly, so a
+	// shape check would refuse an acked doc; the WIRE entry above it,
+	// MultiRestoreAddSparse, runs the full check. See checkRecordValuesSize.
+	if err := checkRecordValuesSize(meta); err != nil {
 		return err
 	}
 	if len(tokens) == 0 {
@@ -962,6 +965,16 @@ func (m *MultiVectorIndex) MultiRestoreAddSparse(docID uint64, tokens [][]float3
 		if err := sparse.Validate(); err != nil {
 			return err
 		}
+	}
+	// THIS ENTRY IS WIRE-REACHABLE, its inner restoreAdd is not: ops/multivector.go
+	// (handleMVRestoreAdd) and ops/mv_batch.go route a client's own metadata here,
+	// while mv_wal.go replays straight into restoreAdd. So the full ingest gate runs
+	// HERE — restoreAdd keeps the size-only check for the replay path. The size half
+	// is therefore walked twice on this path; that is one pass over a map on an
+	// offline backfill, and the alternative is a shape check on replay, which could
+	// discard an acked document.
+	if err := checkRecordValues(meta); err != nil {
+		return err
 	}
 	// keyExpires carries the doc's ABSOLUTE per-key payload deadlines (from the scan
 	// trailer); restoreAdd sets them VERBATIM (NOT recomputed). nil ⇒ the no-key-TTL
@@ -1553,6 +1566,13 @@ func (m *MultiVectorIndex) mutatePayloadRecordLockedAt(docID uint64, key string,
 		// same cap on the ingest side, but it only ever sees a caller's patch —
 		// it cannot reach bytes the operate engine just produced, which is what
 		// this site exists for. Keep the two in step.
+		//
+		// SIZE ONLY, DELIBERATELY: no record.Validate here. These bytes come from
+		// applyRecordBytes, which phase 1 held to the tree oracle, so they are
+		// well-formed by construction; re-decoding the whole record on every
+		// counter increment would double the op's cost for a case that cannot
+		// arise. The shape check belongs where bytes arrive from a CALLER, which
+		// is checkRecordValues.
 		if len(rec) > maxRecordValueBytes {
 			return nil, nil, 0, false, fmt.Errorf("%w: payload key %q would hold a %d-byte record, the cap is %d bytes",
 				ErrRecordTooLarge, key, len(rec), maxRecordValueBytes)

--- a/vector/multivector.go
+++ b/vector/multivector.go
@@ -1501,9 +1501,16 @@ func (m *MultiVectorIndex) setPayloadLockedAt(docID uint64, patch Metadata, keyT
 // key holds a non-record value, ErrRecordTooLarge when the resulting record
 // exceeds the storage cap, and fn's own error verbatim — in every case with the
 // document left exactly as it was.
+//
+// THE KEY'S DEADLINE IS NOT CONSULTED HERE. Unstamped, `now` is this process's
+// own wall clock, and letting it decide whether the record EXISTS would let two
+// replicas store different bytes. So an unstamped mutation treats a
+// deadline-passed record as PRESENT and passes its deadline through untouched;
+// only the *At variant expires the key. See recordKeyPastDeadline
+// (vector/record_mutate.go).
 func (m *MultiVectorIndex) MutatePayloadRecordCAS(docID uint64, key string, fn RecordMutator, cas CASCond) (uint64, error) {
 	return m.logPayloadOpChanged(func() (Metadata, map[string]int64, uint64, bool, error) {
-		return m.mutatePayloadRecordLockedAt(docID, key, fn, cas, m.nowMs())
+		return m.mutatePayloadRecordLockedAt(docID, key, fn, cas, m.nowMs(), false)
 	}, docID)
 }
 
@@ -1511,9 +1518,13 @@ func (m *MultiVectorIndex) MutatePayloadRecordCAS(docID uint64, key string, fn R
 // the per-key deadline check and the stale-deadline drop are judged against
 // nowMs, so every replica reads the same record and stores the same bytes (#4
 // vector TTL determinism, mirroring SetPayloadCASAt).
+//
+// This is the ONLY variant that may expire the payload key: its clock is the
+// leader's stamp, identical on every replica. See recordKeyPastDeadline
+// (vector/record_mutate.go) for why the unstamped twin must not.
 func (m *MultiVectorIndex) MutatePayloadRecordCASAt(docID uint64, key string, fn RecordMutator, cas CASCond, nowMs int64) (uint64, error) {
 	return m.logPayloadOpChanged(func() (Metadata, map[string]int64, uint64, bool, error) {
-		return m.mutatePayloadRecordLockedAt(docID, key, fn, cas, nowMs)
+		return m.mutatePayloadRecordLockedAt(docID, key, fn, cas, nowMs, true)
 	}, docID)
 }
 
@@ -1531,7 +1542,7 @@ func (m *MultiVectorIndex) MutatePayloadRecordCASAt(docID uint64, key string, fn
 // WAL-logs exactly what was applied), the resulting version, and changed.
 // changed=false means the call was a deliberate no-op: nothing was stored,
 // nothing will be logged, and the version is the CURRENT one, unbumped.
-func (m *MultiVectorIndex) mutatePayloadRecordLockedAt(docID uint64, key string, fn RecordMutator, cas CASCond, now int64) (Metadata, map[string]int64, uint64, bool, error) {
+func (m *MultiVectorIndex) mutatePayloadRecordLockedAt(docID uint64, key string, fn RecordMutator, cas CASCond, now int64, stamped bool) (Metadata, map[string]int64, uint64, bool, error) {
 	if fn == nil || key == "" || key == contentField {
 		return nil, nil, 0, false, ErrPayloadKeyNotRecord
 	}
@@ -1544,9 +1555,16 @@ func (m *MultiVectorIndex) mutatePayloadRecordLockedAt(docID uint64, key string,
 		return nil, nil, 0, false, err // CAS mismatch: no mutation, no bump
 	}
 	oldMeta, oldKE := m.docMeta[docID], m.keyTTL[docID]
-	// named/MV have no keyExpired twin: liveMetaMap's rule, inlined.
-	dl := oldKE[key]
-	old, exists, err := currentRecordValue(oldMeta, key, dl != 0 && dl <= now)
+	// Only a STAMPED apply may judge the key's deadline; an unstamped one treats
+	// the record as PRESENT and leaves the deadline alone. recordKeyPastDeadline
+	// (vector/record_mutate.go) carries the reasoning — the short version is that
+	// a per-replica wall clock deciding whether a record EXISTS makes replicas
+	// store different bytes, which is not the bounded-deadline-skew class
+	// setPayloadBody lives with. named/MV have no keyExpired twin, so the Abs
+	// twin inlines liveMetaMap's rule. LOCKSTEP: the same two lines exist in
+	// vector/hnsw.go, vector/ivf.go, vector/named.go and vector/multivector.go.
+	keyPastDeadline := recordKeyPastDeadlineAbs(stamped, oldKE[key], now)
+	old, exists, err := currentRecordValue(oldMeta, key, keyPastDeadline)
 	if err != nil {
 		return nil, nil, 0, false, err
 	}
@@ -1597,10 +1615,14 @@ func (m *MultiVectorIndex) mutatePayloadRecordLockedAt(docID uint64, key string,
 		merged[key] = Value{Kind: ValueRecord, Rec: rec} // ownership hand-off; see RecordMutator
 	}
 	ke := cloneKeyTTL(oldKE)
-	// A logically expired key read as ABSENT above: its stale deadline must go,
-	// or the record this call just created would be invisible the instant it is
-	// written. pruneKeyTTL only drops deadlines for keys no longer present.
-	if d, present := ke[key]; present && d != 0 && d <= now {
+	// A key read as ABSENT above because its deadline had passed — STAMPED
+	// applies only: its stale deadline must go, or the record this call just
+	// created would be invisible the instant it is written. pruneKeyTTL only
+	// drops deadlines for keys no longer present. On an unstamped apply
+	// keyPastDeadline is false by construction, so an expired key's deadline is
+	// passed through UNTOUCHED, exactly as setPayloadBody passes an expired key
+	// through unchanged.
+	if keyPastDeadline {
 		delete(ke, key)
 	}
 	ke = pruneKeyTTL(ke, merged)

--- a/vector/multivector.go
+++ b/vector/multivector.go
@@ -1602,18 +1602,30 @@ func (m *MultiVectorIndex) mutatePayloadRecordLockedAt(docID uint64, key string,
 		// it cannot reach bytes the operate engine just produced, which is what
 		// this site exists for. Keep the two in step.
 		//
-		// SIZE ONLY, DELIBERATELY: no record.Validate here. These bytes come from
-		// applyRecordBytes, which phase 1 held to the tree oracle, so they are
-		// well-formed by construction; re-decoding the whole record on every
-		// counter increment would double the op's cost for a case that cannot
-		// arise. The shape check belongs where bytes arrive from a CALLER, which
-		// is checkRecordValues.
+		// SIZE FIRST, THEN SHAPE — the same order and the same two gates
+		// checkRecordValues applies to a caller's patch, so an oversize value is
+		// refused without ever being decoded.
 		//
-		// The MESSAGE comes from recordTooLargeErr (vector/metadata.go), the one
-		// producer of this error's detailed form: one canonical shape for the
-		// matcher to anchor on across replication, with the caller's key bounded.
+		// The shape check is here because MutatePayloadRecordCAS is EXPORTED. The
+		// mutator ops supplies returns applyRecordBytes' output, which phase 1
+		// held to the tree oracle and which cannot be malformed — but a direct Go
+		// caller of this API supplies its own mutator, and whatever bytes it
+		// returns were being stored on the size cap alone. That poisons the
+		// payload key for the whole collection: every path under it declines to
+		// accelerate, and a later vector_operate on the same key fails with
+		// wire.ErrOperateRecord. The cost is one decode of the bytes the engine
+		// just produced, on a write that already decoded and re-encoded the
+		// record.
+		//
+		// Both MESSAGES come from the one producer of their detailed form
+		// (recordTooLargeErr / recordMalformedErr, vector/metadata.go): one
+		// canonical shape for the transport matchers to anchor on across
+		// replication, with the caller's key bounded.
 		if len(rec) > maxRecordValueBytes {
 			return nil, nil, 0, false, recordTooLargeErr(key, len(rec))
+		}
+		if verr := validateRecord(rec); verr != nil {
+			return nil, nil, 0, false, recordMalformedErr(key, verr)
 		}
 	default:
 		return nil, nil, 0, false, ErrRecordMutation

--- a/vector/multivector.go
+++ b/vector/multivector.go
@@ -1478,30 +1478,163 @@ func (m *MultiVectorIndex) setPayloadLockedAt(docID uint64, patch Metadata, keyT
 	return merged, ke, v, nil
 }
 
-// logPayloadOp runs a payload mutator (apply, which captures the RESULTING full
-// payload + absolute per-key deadlines under m.mu) and, on a WAL-mode index,
+// MutatePayloadRecordCAS applies fn to the operate record stored under key in
+// docID's payload, atomically with the CAS check and the version bump, and
+// WAL-logs the RESULTING payload (a replace, not a merge) exactly as every other
+// MV payload mutation does. A deliberate no-op — fn reporting RecordUnchanged (a
+// failed CHECK), or a delete of an already-absent key — writes no WAL record and
+// returns the current, unbumped version. Returns ErrIDNotFound for an absent
+// document, ErrVersionConflict on a CAS mismatch, ErrPayloadKeyNotRecord when the
+// key holds a non-record value, ErrRecordTooLarge when the resulting record
+// exceeds the storage cap, and fn's own error verbatim — in every case with the
+// document left exactly as it was.
+func (m *MultiVectorIndex) MutatePayloadRecordCAS(docID uint64, key string, fn RecordMutator, cas CASCond) (uint64, error) {
+	return m.logPayloadOpChanged(func() (Metadata, map[string]int64, uint64, bool, error) {
+		return m.mutatePayloadRecordLockedAt(docID, key, fn, cas, m.nowMs())
+	}, docID)
+}
+
+// MutatePayloadRecordCASAt is MutatePayloadRecordCAS under a leader apply stamp:
+// the per-key deadline check and the stale-deadline drop are judged against
+// nowMs, so every replica reads the same record and stores the same bytes (#4
+// vector TTL determinism, mirroring SetPayloadCASAt).
+func (m *MultiVectorIndex) MutatePayloadRecordCASAt(docID uint64, key string, fn RecordMutator, cas CASCond, nowMs int64) (uint64, error) {
+	return m.logPayloadOpChanged(func() (Metadata, map[string]int64, uint64, bool, error) {
+		return m.mutatePayloadRecordLockedAt(docID, key, fn, cas, nowMs)
+	}, docID)
+}
+
+// mutatePayloadRecordLockedAt is the MV twin of the dense
+// mutatePayloadRecordBody: read the current record bytes, transform, bound,
+// store/delete, prune the key's deadline, reindex, bump — all inside ONE write-
+// lock critical section. It differs from dense in exactly three ways, and in
+// nothing else: deadlines are absolute unix-ms int64 (so the expiry rule is
+// liveMetaMap's, inlined — MV has no keyExpired twin), the payload index is keyed
+// by DOC ID not by slot, and there is no BM25 maintenance. The document liveness
+// gate is docTokens membership: the MV family has no per-document point TTL, so
+// `now` reaches only the per-key deadlines.
+//
+// Returns the RESULTING payload and per-key deadlines (so logPayloadOpChanged
+// WAL-logs exactly what was applied), the resulting version, and changed.
+// changed=false means the call was a deliberate no-op: nothing was stored,
+// nothing will be logged, and the version is the CURRENT one, unbumped.
+func (m *MultiVectorIndex) mutatePayloadRecordLockedAt(docID uint64, key string, fn RecordMutator, cas CASCond, now int64) (Metadata, map[string]int64, uint64, bool, error) {
+	if fn == nil || key == "" || key == contentField {
+		return nil, nil, 0, false, ErrPayloadKeyNotRecord
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if _, exists := m.docTokens[docID]; !exists {
+		return nil, nil, 0, false, ErrIDNotFound
+	}
+	if err := cas.check(m.version[docID]); err != nil {
+		return nil, nil, 0, false, err // CAS mismatch: no mutation, no bump
+	}
+	oldMeta, oldKE := m.docMeta[docID], m.keyTTL[docID]
+	// named/MV have no keyExpired twin: liveMetaMap's rule, inlined.
+	dl := oldKE[key]
+	old, exists, err := currentRecordValue(oldMeta, key, dl != 0 && dl <= now)
+	if err != nil {
+		return nil, nil, 0, false, err
+	}
+	rec, act, err := fn(old, exists)
+	if err != nil {
+		return nil, nil, 0, false, err
+	}
+	switch act {
+	case RecordUnchanged:
+		return nil, nil, m.version[docID], false, nil
+	case RecordDelete:
+		if !exists {
+			return nil, nil, m.version[docID], false, nil
+		}
+	case RecordStore:
+		// The POST-mutation bound. checkRecordValues (vector/metadata.go) is the
+		// same cap on the ingest side, but it only ever sees a caller's patch —
+		// it cannot reach bytes the operate engine just produced, which is what
+		// this site exists for. Keep the two in step.
+		if len(rec) > maxRecordValueBytes {
+			return nil, nil, 0, false, fmt.Errorf("%w: payload key %q would hold a %d-byte record, the cap is %d bytes",
+				ErrRecordTooLarge, key, len(rec), maxRecordValueBytes)
+		}
+	default:
+		return nil, nil, 0, false, ErrRecordMutation
+	}
+	merged := cloneMeta(oldMeta)
+	if act == RecordDelete {
+		delete(merged, key)
+		if len(merged) == 0 {
+			// An emptied payload stores nil, exactly as deletePayloadKeysLocked
+			// normalizes it. Storing an empty non-nil map instead would make the
+			// live state differ from the same state after a WAL replay (the log
+			// encodes an empty payload as absent and restores nil), for no gain.
+			merged = nil
+		}
+	} else {
+		if merged == nil {
+			merged = make(Metadata, 1)
+		}
+		merged[key] = Value{Kind: ValueRecord, Rec: rec} // ownership hand-off; see RecordMutator
+	}
+	ke := cloneKeyTTL(oldKE)
+	// A logically expired key read as ABSENT above: its stale deadline must go,
+	// or the record this call just created would be invisible the instant it is
+	// written. pruneKeyTTL only drops deadlines for keys no longer present.
+	if d, present := ke[key]; present && d != 0 && d <= now {
+		delete(ke, key)
+	}
+	ke = pruneKeyTTL(ke, merged)
+	m.docMeta[docID] = merged
+	m.payloadIdx.reindex(docID, merged) // resulting payload may add/remove indexed fields
+	if ke == nil {
+		delete(m.keyTTL, docID)
+	} else {
+		m.keyTTL[docID] = ke
+	}
+	v := m.version[docID] + 1
+	m.version[docID] = v
+	m.bumpData() // payload-value change: invalidate the order_by snapshot
+	return merged, ke, v, true, nil
+}
+
+// logPayloadOpChanged runs a payload mutator (apply, which captures the RESULTING
+// full payload + absolute per-key deadlines under m.mu) and, on a WAL-mode index,
 // appends ONE op-agnostic mvSetPayload record with that resulting state — the
 // dense/named resulting-payload collapse (set/overwrite/delete-keys/clear all
 // reduce to "this is the new payload"). The whole apply+append runs under opMu so
 // a concurrent FlushMVWAL can't interleave. The deadlines are logged VERBATIM
 // (absolute unix-ms) so replay is time-stable.
-func (m *MultiVectorIndex) logPayloadOp(apply func() (Metadata, map[string]int64, uint64, error), docID uint64) (uint64, error) {
+//
+// It is logPayloadOp generalized to an apply that may legitimately do NOTHING (a
+// record mutation whose CHECK failed): changed=false stages no WAL record and
+// returns the current, unbumped version — a no-op must not cost a log entry or
+// move a version a CAS loop is watching.
+//
+// The two error returns below are MV's, not the dense payloadOpCASChanged's, and
+// must stay that way: the applied version rides along even when only the WAL
+// write failed, and a commitWaitStaged failure returns that version too rather
+// than 0. Pinned by TestMVSetPayloadReturnsVersionOnWALAppendError.
+func (m *MultiVectorIndex) logPayloadOpChanged(apply func() (Metadata, map[string]int64, uint64, bool, error), docID uint64) (uint64, error) {
 	if m.wal == nil {
-		_, _, version, err := apply()
+		_, _, version, _, err := apply()
 		return version, err
 	}
 	// {apply + WAL WRITE} under opMu in a panic-safe closure; the durability wait
 	// runs outside so concurrent payload writers group-commit instead of each
 	// paying a serialized fsync under the index's op lock.
 	var seq, version uint64
+	var changed bool
 	err := func() error {
 		m.opMu.Lock()
 		defer m.opMu.Unlock()
-		meta, ke, v, err := apply()
+		meta, ke, v, ch, err := apply()
 		if err != nil {
 			return err
 		}
-		version = v
+		version, changed = v, ch
+		if !ch {
+			return nil // a no-op stages nothing
+		}
 		seq, err = m.wal.appendMVSetPayloadStaged(docID, meta, keyTTLToU64(ke), v)
 		return err
 	}()
@@ -1510,7 +1643,21 @@ func (m *MultiVectorIndex) logPayloadOp(apply func() (Metadata, map[string]int64
 		// only the WAL write failed.
 		return version, err
 	}
+	if !changed {
+		return version, nil
+	}
 	return version, m.wal.commitWaitStaged(seq)
+}
+
+// logPayloadOp is the always-changed form the four existing payload mutations
+// (set/overwrite/delete-keys/clear) take. Behaviour-preserving:
+// logPayloadOpChanged tests apply's error before it reads changed, so the
+// hard-coded true is never consulted on an error path.
+func (m *MultiVectorIndex) logPayloadOp(apply func() (Metadata, map[string]int64, uint64, error), docID uint64) (uint64, error) {
+	return m.logPayloadOpChanged(func() (Metadata, map[string]int64, uint64, bool, error) {
+		meta, ke, v, err := apply()
+		return meta, ke, v, true, err
+	}, docID)
 }
 
 // rebuildPayloadIdx discards and reconstructs the filter-first index from the

--- a/vector/named.go
+++ b/vector/named.go
@@ -1396,9 +1396,12 @@ func (nc *NamedCollection) mutatePayloadRecordLockedAt(id uint64, key string, fn
 		// counter increment would double the op's cost for a case that cannot
 		// arise. The shape check belongs where bytes arrive from a CALLER, which
 		// is checkRecordValues.
+		//
+		// The MESSAGE comes from recordTooLargeErr (vector/metadata.go), the one
+		// producer of this error's detailed form: one canonical shape for the
+		// matcher to anchor on across replication, with the caller's key bounded.
 		if len(rec) > maxRecordValueBytes {
-			return nil, nil, 0, false, fmt.Errorf("%w: payload key %q would hold a %d-byte record, the cap is %d bytes",
-				ErrRecordTooLarge, key, len(rec), maxRecordValueBytes)
+			return nil, nil, 0, false, recordTooLargeErr(key, len(rec))
 		}
 	default:
 		return nil, nil, 0, false, ErrRecordMutation

--- a/vector/named.go
+++ b/vector/named.go
@@ -1307,9 +1307,16 @@ func (nc *NamedCollection) setPayloadLockedAt(id uint64, patch Metadata, keyTTLM
 // ErrPayloadKeyNotRecord when the key holds a non-record value,
 // ErrRecordTooLarge when the resulting record exceeds the storage cap, and fn's
 // own error verbatim — in every case with the point left exactly as it was.
+//
+// THE KEY'S DEADLINE IS NOT CONSULTED HERE. Unstamped, `now` is this process's
+// own wall clock, and letting it decide whether the record EXISTS would let two
+// replicas store different bytes. So an unstamped mutation treats a
+// deadline-passed record as PRESENT and passes its deadline through untouched;
+// only the *At variant expires the key. See recordKeyPastDeadline
+// (vector/record_mutate.go).
 func (nc *NamedCollection) MutatePayloadRecordCAS(id uint64, key string, fn RecordMutator, cas CASCond) (uint64, error) {
 	return nc.logPayloadOpChanged(func() (Metadata, map[string]int64, uint64, bool, error) {
-		return nc.mutatePayloadRecordLockedAt(id, key, fn, cas, nc.nowMs())
+		return nc.mutatePayloadRecordLockedAt(id, key, fn, cas, nc.nowMs(), false)
 	}, id)
 }
 
@@ -1317,9 +1324,13 @@ func (nc *NamedCollection) MutatePayloadRecordCAS(id uint64, key string, fn Reco
 // the dead-point liveness gate, the per-key deadline check and the stale-deadline
 // drop are all judged against nowMs, so every replica reads the same record and
 // stores the same bytes (#4 vector TTL determinism, mirroring SetPayloadCASAt).
+//
+// This is the ONLY variant that may expire the payload key: its clock is the
+// leader's stamp, identical on every replica. See recordKeyPastDeadline
+// (vector/record_mutate.go) for why the unstamped twin must not.
 func (nc *NamedCollection) MutatePayloadRecordCASAt(id uint64, key string, fn RecordMutator, cas CASCond, nowMs int64) (uint64, error) {
 	return nc.logPayloadOpChanged(func() (Metadata, map[string]int64, uint64, bool, error) {
-		return nc.mutatePayloadRecordLockedAt(id, key, fn, cas, nowMs)
+		return nc.mutatePayloadRecordLockedAt(id, key, fn, cas, nowMs, true)
 	}, id)
 }
 
@@ -1336,7 +1347,7 @@ func (nc *NamedCollection) MutatePayloadRecordCASAt(id uint64, key string, fn Re
 // WAL-logs exactly what was applied), the resulting version, and changed.
 // changed=false means the call was a deliberate no-op: nothing was stored,
 // nothing will be logged, and the version is the CURRENT one, unbumped.
-func (nc *NamedCollection) mutatePayloadRecordLockedAt(id uint64, key string, fn RecordMutator, cas CASCond, now int64) (Metadata, map[string]int64, uint64, bool, error) {
+func (nc *NamedCollection) mutatePayloadRecordLockedAt(id uint64, key string, fn RecordMutator, cas CASCond, now int64, stamped bool) (Metadata, map[string]int64, uint64, bool, error) {
 	if fn == nil || key == "" || key == contentField {
 		return nil, nil, 0, false, ErrPayloadKeyNotRecord
 	}
@@ -1349,9 +1360,16 @@ func (nc *NamedCollection) mutatePayloadRecordLockedAt(id uint64, key string, fn
 		return nil, nil, 0, false, err // CAS mismatch: no mutation, no bump
 	}
 	oldMeta, oldKE := nc.meta[id], nc.keyTTL[id]
-	// named/MV have no keyExpired twin: liveMetaMap's rule, inlined.
-	dl := oldKE[key]
-	old, exists, err := currentRecordValue(oldMeta, key, dl != 0 && dl <= now)
+	// Only a STAMPED apply may judge the key's deadline; an unstamped one treats
+	// the record as PRESENT and leaves the deadline alone. recordKeyPastDeadline
+	// (vector/record_mutate.go) carries the reasoning — the short version is that
+	// a per-replica wall clock deciding whether a record EXISTS makes replicas
+	// store different bytes, which is not the bounded-deadline-skew class
+	// setPayloadBody lives with. named/MV have no keyExpired twin, so the Abs
+	// twin inlines liveMetaMap's rule. LOCKSTEP: the same two lines exist in
+	// vector/hnsw.go, vector/ivf.go, vector/named.go and vector/multivector.go.
+	keyPastDeadline := recordKeyPastDeadlineAbs(stamped, oldKE[key], now)
+	old, exists, err := currentRecordValue(oldMeta, key, keyPastDeadline)
 	if err != nil {
 		return nil, nil, 0, false, err
 	}
@@ -1402,10 +1420,14 @@ func (nc *NamedCollection) mutatePayloadRecordLockedAt(id uint64, key string, fn
 		merged[key] = Value{Kind: ValueRecord, Rec: rec} // ownership hand-off; see RecordMutator
 	}
 	ke := cloneKeyTTL(oldKE)
-	// A logically expired key read as ABSENT above: its stale deadline must go,
-	// or the record this call just created would be invisible the instant it is
-	// written. pruneKeyTTL only drops deadlines for keys no longer present.
-	if d, present := ke[key]; present && d != 0 && d <= now {
+	// A key read as ABSENT above because its deadline had passed — STAMPED
+	// applies only: its stale deadline must go, or the record this call just
+	// created would be invisible the instant it is written. pruneKeyTTL only
+	// drops deadlines for keys no longer present. On an unstamped apply
+	// keyPastDeadline is false by construction, so an expired key's deadline is
+	// passed through UNTOUCHED, exactly as setPayloadBody passes an expired key
+	// through unchanged.
+	if keyPastDeadline {
 		delete(ke, key)
 	}
 	ke = pruneKeyTTL(ke, merged)

--- a/vector/named.go
+++ b/vector/named.go
@@ -1347,6 +1347,23 @@ func (nc *NamedCollection) MutatePayloadRecordCASAt(id uint64, key string, fn Re
 // WAL-logs exactly what was applied), the resulting version, and changed.
 // changed=false means the call was a deliberate no-op: nothing was stored,
 // nothing will be logged, and the version is the CURRENT one, unbumped.
+//
+// LOCKSTEP with the dense mutatePayloadRecordBody in vector/hnsw.go and vector/ivf.go,
+// and vector/multivector.go mutatePayloadRecordLockedAt.
+// These four bodies are ~110 near-identical lines each and are deliberately NOT
+// factored into one: that matches the house style of their set_payload /
+// overwrite_payload siblings, whose engine differences (slot- vs id-keyed
+// indexes, uint64 vs int64 deadlines, BM25 on dense only) are real and are what
+// a shared body would have to branch on.
+//
+// The cost is real too, and it has already been paid once: a single formatting
+// difference in the size-bound message landed as a defect in all four at the
+// same time, and the deadline rule below had to be corrected in all four at the
+// same time. So both of those now live in SHARED helpers — recordTooLargeErr
+// (vector/metadata.go) and recordKeyPastDeadline[Abs] (vector/record_mutate.go)
+// — and any further change to the RULES, as opposed to the plumbing, belongs in
+// a helper rather than in a fifth copy. A change here that is not mirrored in
+// the other three is a bug, not a variation.
 func (nc *NamedCollection) mutatePayloadRecordLockedAt(id uint64, key string, fn RecordMutator, cas CASCond, now int64, stamped bool) (Metadata, map[string]int64, uint64, bool, error) {
 	if fn == nil || key == "" || key == contentField {
 		return nil, nil, 0, false, ErrPayloadKeyNotRecord

--- a/vector/named.go
+++ b/vector/named.go
@@ -670,7 +670,10 @@ func (nc *NamedCollection) insertLockedAt(id uint64, vectors map[string][]float3
 // normal bump (an old record predating the version block defaults a fresh insert
 // to 1).
 func (nc *NamedCollection) RestoreInsert(id uint64, vectors map[string][]float32, sparseVectors map[string]*SparseVector, payload Metadata, ttl time.Duration, keyExpires map[string]uint64, version uint64) error {
-	if err := checkRecordValues(payload); err != nil {
+	// REPLAY body: size only. Its only caller is named_wal.go's replay, which
+	// discards the error — a shape check here would silently drop an acked
+	// write. No ops handler reaches it. See checkRecordValuesSize.
+	if err := checkRecordValuesSize(payload); err != nil {
 		return err
 	}
 	if err := nc.validateInsertSpaces(vectors, sparseVectors); err != nil {
@@ -1368,6 +1371,13 @@ func (nc *NamedCollection) mutatePayloadRecordLockedAt(id uint64, key string, fn
 		// same cap on the ingest side, but it only ever sees a caller's patch —
 		// it cannot reach bytes the operate engine just produced, which is what
 		// this site exists for. Keep the two in step.
+		//
+		// SIZE ONLY, DELIBERATELY: no record.Validate here. These bytes come from
+		// applyRecordBytes, which phase 1 held to the tree oracle, so they are
+		// well-formed by construction; re-decoding the whole record on every
+		// counter increment would double the op's cost for a case that cannot
+		// arise. The shape check belongs where bytes arrive from a CALLER, which
+		// is checkRecordValues.
 		if len(rec) > maxRecordValueBytes {
 			return nil, nil, 0, false, fmt.Errorf("%w: payload key %q would hold a %d-byte record, the cap is %d bytes",
 				ErrRecordTooLarge, key, len(rec), maxRecordValueBytes)

--- a/vector/named.go
+++ b/vector/named.go
@@ -1294,30 +1294,163 @@ func (nc *NamedCollection) setPayloadLockedAt(id uint64, patch Metadata, keyTTLM
 	return merged, ke, v, nil
 }
 
-// logPayloadOp runs a payload mutator (apply, which captures the RESULTING full
-// payload + absolute per-key deadlines under nc.mu) and, on a WAL-mode
+// MutatePayloadRecordCAS applies fn to the operate record stored under key in
+// id's shared payload, atomically with the CAS check and the version bump, and
+// WAL-logs the RESULTING payload (a replace, not a merge) exactly as every other
+// named payload mutation does. A deliberate no-op — fn reporting RecordUnchanged
+// (a failed CHECK), or a delete of an already-absent key — writes no WAL record
+// and returns the current, unbumped version. Returns ErrIDNotFound for a
+// dead/expired point, ErrVersionConflict on a CAS mismatch,
+// ErrPayloadKeyNotRecord when the key holds a non-record value,
+// ErrRecordTooLarge when the resulting record exceeds the storage cap, and fn's
+// own error verbatim — in every case with the point left exactly as it was.
+func (nc *NamedCollection) MutatePayloadRecordCAS(id uint64, key string, fn RecordMutator, cas CASCond) (uint64, error) {
+	return nc.logPayloadOpChanged(func() (Metadata, map[string]int64, uint64, bool, error) {
+		return nc.mutatePayloadRecordLockedAt(id, key, fn, cas, nc.nowMs())
+	}, id)
+}
+
+// MutatePayloadRecordCASAt is MutatePayloadRecordCAS under a leader apply stamp:
+// the dead-point liveness gate, the per-key deadline check and the stale-deadline
+// drop are all judged against nowMs, so every replica reads the same record and
+// stores the same bytes (#4 vector TTL determinism, mirroring SetPayloadCASAt).
+func (nc *NamedCollection) MutatePayloadRecordCASAt(id uint64, key string, fn RecordMutator, cas CASCond, nowMs int64) (uint64, error) {
+	return nc.logPayloadOpChanged(func() (Metadata, map[string]int64, uint64, bool, error) {
+		return nc.mutatePayloadRecordLockedAt(id, key, fn, cas, nowMs)
+	}, id)
+}
+
+// mutatePayloadRecordLockedAt is the named twin of the dense
+// mutatePayloadRecordBody: read the current record bytes, transform, bound,
+// store/delete, prune the key's deadline, reindex, bump — all inside ONE write-
+// lock critical section. It differs from dense in exactly three ways, and in
+// nothing else: deadlines are absolute unix-ms int64 (so the expiry rule is
+// liveMetaMap's, inlined — named has no keyExpired twin), the payload index is
+// keyed by ID not by slot, and there is no BM25 maintenance (the named family
+// carries no dense text index).
+//
+// Returns the RESULTING payload and per-key deadlines (so logPayloadOpChanged
+// WAL-logs exactly what was applied), the resulting version, and changed.
+// changed=false means the call was a deliberate no-op: nothing was stored,
+// nothing will be logged, and the version is the CURRENT one, unbumped.
+func (nc *NamedCollection) mutatePayloadRecordLockedAt(id uint64, key string, fn RecordMutator, cas CASCond, now int64) (Metadata, map[string]int64, uint64, bool, error) {
+	if fn == nil || key == "" || key == contentField {
+		return nil, nil, 0, false, ErrPayloadKeyNotRecord
+	}
+	nc.mu.Lock()
+	defer nc.mu.Unlock()
+	if !nc.liveLockedAt(id, now) {
+		return nil, nil, 0, false, ErrIDNotFound
+	}
+	if err := cas.check(nc.version[id]); err != nil {
+		return nil, nil, 0, false, err // CAS mismatch: no mutation, no bump
+	}
+	oldMeta, oldKE := nc.meta[id], nc.keyTTL[id]
+	// named/MV have no keyExpired twin: liveMetaMap's rule, inlined.
+	dl := oldKE[key]
+	old, exists, err := currentRecordValue(oldMeta, key, dl != 0 && dl <= now)
+	if err != nil {
+		return nil, nil, 0, false, err
+	}
+	rec, act, err := fn(old, exists)
+	if err != nil {
+		return nil, nil, 0, false, err
+	}
+	switch act {
+	case RecordUnchanged:
+		return nil, nil, nc.version[id], false, nil
+	case RecordDelete:
+		if !exists {
+			return nil, nil, nc.version[id], false, nil
+		}
+	case RecordStore:
+		// The POST-mutation bound. checkRecordValues (vector/metadata.go) is the
+		// same cap on the ingest side, but it only ever sees a caller's patch —
+		// it cannot reach bytes the operate engine just produced, which is what
+		// this site exists for. Keep the two in step.
+		if len(rec) > maxRecordValueBytes {
+			return nil, nil, 0, false, fmt.Errorf("%w: payload key %q would hold a %d-byte record, the cap is %d bytes",
+				ErrRecordTooLarge, key, len(rec), maxRecordValueBytes)
+		}
+	default:
+		return nil, nil, 0, false, ErrRecordMutation
+	}
+	merged := cloneMeta(oldMeta)
+	if act == RecordDelete {
+		delete(merged, key)
+		if len(merged) == 0 {
+			// An emptied payload stores nil, exactly as deletePayloadKeysLockedAt
+			// normalizes it. Storing an empty non-nil map instead would make the
+			// live state differ from the same state after a WAL replay (the log
+			// encodes an empty payload as absent and restores nil), for no gain.
+			merged = nil
+		}
+	} else {
+		if merged == nil {
+			merged = make(Metadata, 1)
+		}
+		merged[key] = Value{Kind: ValueRecord, Rec: rec} // ownership hand-off; see RecordMutator
+	}
+	ke := cloneKeyTTL(oldKE)
+	// A logically expired key read as ABSENT above: its stale deadline must go,
+	// or the record this call just created would be invisible the instant it is
+	// written. pruneKeyTTL only drops deadlines for keys no longer present.
+	if d, present := ke[key]; present && d != 0 && d <= now {
+		delete(ke, key)
+	}
+	ke = pruneKeyTTL(ke, merged)
+	nc.meta[id] = merged
+	nc.payloadIdx.reindex(id, merged) // resulting payload may add/remove indexed fields
+	if ke == nil {
+		delete(nc.keyTTL, id)
+	} else {
+		nc.keyTTL[id] = ke
+	}
+	v := nc.version[id] + 1
+	nc.version[id] = v
+	nc.bumpData() // payload-value change: invalidate the order_by snapshot
+	return merged, ke, v, true, nil
+}
+
+// logPayloadOpChanged runs a payload mutator (apply, which captures the RESULTING
+// full payload + absolute per-key deadlines under nc.mu) and, on a WAL-mode
 // collection, appends ONE op-agnostic namedSetPayload record with that resulting
 // state — the dense resulting-payload collapse (set/overwrite/delete-keys/clear
 // all reduce to "this is the new payload"). The whole apply+append runs under
 // opMu so a concurrent Flush can't interleave. The deadlines are logged VERBATIM
 // (absolute unix-ms) so replay is time-stable.
-func (nc *NamedCollection) logPayloadOp(apply func() (Metadata, map[string]int64, uint64, error), id uint64) (uint64, error) {
+//
+// It is logPayloadOp generalized to an apply that may legitimately do NOTHING (a
+// record mutation whose CHECK failed): changed=false stages no WAL record and
+// returns the current, unbumped version — a no-op must not cost a log entry or
+// move a version a CAS loop is watching.
+//
+// The two error returns below are NAMED's, not the dense payloadOpCASChanged's,
+// and must stay that way: the applied version rides along even when only the WAL
+// write failed (the pre-split contract), and a commitWaitStaged failure returns
+// that version too rather than 0. Pinned by
+// TestNamedSetPayloadReturnsVersionOnWALAppendError.
+func (nc *NamedCollection) logPayloadOpChanged(apply func() (Metadata, map[string]int64, uint64, bool, error), id uint64) (uint64, error) {
 	if nc.wal == nil {
-		_, _, version, err := apply()
+		_, _, version, _, err := apply()
 		return version, err
 	}
 	// {apply + WAL WRITE} under opMu in a panic-safe closure; the durability wait
 	// runs outside so concurrent payload writers group-commit instead of each
 	// paying a serialized fsync under the collection's op lock.
 	var seq, version uint64
+	var changed bool
 	err := func() error {
 		nc.opMu.Lock()
 		defer nc.opMu.Unlock()
-		meta, ke, v, err := apply()
+		meta, ke, v, ch, err := apply()
 		if err != nil {
 			return err
 		}
-		version = v
+		version, changed = v, ch
+		if !ch {
+			return nil // a no-op stages nothing
+		}
 		seq, err = nc.wal.appendNamedSetPayloadStaged(id, meta, keyTTLToU64(ke), v)
 		return err
 	}()
@@ -1327,7 +1460,21 @@ func (nc *NamedCollection) logPayloadOp(apply func() (Metadata, map[string]int64
 		// the append error, so keep returning it.
 		return version, err
 	}
+	if !changed {
+		return version, nil
+	}
 	return version, nc.wal.commitWaitStaged(seq)
+}
+
+// logPayloadOp is the always-changed form the four existing payload mutations
+// (set/overwrite/delete-keys/clear) take. Behaviour-preserving:
+// logPayloadOpChanged tests apply's error before it reads changed, so the
+// hard-coded true is never consulted on an error path.
+func (nc *NamedCollection) logPayloadOp(apply func() (Metadata, map[string]int64, uint64, error), id uint64) (uint64, error) {
+	return nc.logPayloadOpChanged(func() (Metadata, map[string]int64, uint64, bool, error) {
+		m, ke, v, err := apply()
+		return m, ke, v, true, err
+	}, id)
 }
 
 // keyTTLToU64 converts named's absolute int64 unix-ms deadlines to the uint64

--- a/vector/named.go
+++ b/vector/named.go
@@ -1407,18 +1407,30 @@ func (nc *NamedCollection) mutatePayloadRecordLockedAt(id uint64, key string, fn
 		// it cannot reach bytes the operate engine just produced, which is what
 		// this site exists for. Keep the two in step.
 		//
-		// SIZE ONLY, DELIBERATELY: no record.Validate here. These bytes come from
-		// applyRecordBytes, which phase 1 held to the tree oracle, so they are
-		// well-formed by construction; re-decoding the whole record on every
-		// counter increment would double the op's cost for a case that cannot
-		// arise. The shape check belongs where bytes arrive from a CALLER, which
-		// is checkRecordValues.
+		// SIZE FIRST, THEN SHAPE — the same order and the same two gates
+		// checkRecordValues applies to a caller's patch, so an oversize value is
+		// refused without ever being decoded.
 		//
-		// The MESSAGE comes from recordTooLargeErr (vector/metadata.go), the one
-		// producer of this error's detailed form: one canonical shape for the
-		// matcher to anchor on across replication, with the caller's key bounded.
+		// The shape check is here because MutatePayloadRecordCAS is EXPORTED. The
+		// mutator ops supplies returns applyRecordBytes' output, which phase 1
+		// held to the tree oracle and which cannot be malformed — but a direct Go
+		// caller of this API supplies its own mutator, and whatever bytes it
+		// returns were being stored on the size cap alone. That poisons the
+		// payload key for the whole collection: every path under it declines to
+		// accelerate, and a later vector_operate on the same key fails with
+		// wire.ErrOperateRecord. The cost is one decode of the bytes the engine
+		// just produced, on a write that already decoded and re-encoded the
+		// record.
+		//
+		// Both MESSAGES come from the one producer of their detailed form
+		// (recordTooLargeErr / recordMalformedErr, vector/metadata.go): one
+		// canonical shape for the transport matchers to anchor on across
+		// replication, with the caller's key bounded.
 		if len(rec) > maxRecordValueBytes {
 			return nil, nil, 0, false, recordTooLargeErr(key, len(rec))
+		}
+		if verr := validateRecord(rec); verr != nil {
+			return nil, nil, 0, false, recordMalformedErr(key, verr)
 		}
 	default:
 		return nil, nil, 0, false, ErrRecordMutation

--- a/vector/payload_index_record_poison_test.go
+++ b/vector/payload_index_record_poison_test.go
@@ -86,6 +86,28 @@ func namelessSchemaRecord(t *testing.T, a int64) []byte {
 	return enc
 }
 
+// insertViaReplay places a point through the engine's REPLAY entry, which checks
+// a record value's SIZE but not its SHAPE (see checkRecordValuesSize).
+//
+// WHY THE CORPORA BELOW NO LONGER USE Insert. The public ingest entries now run
+// record.Validate on every ValueRecord and refuse a malformed one with
+// ErrRecordMalformed, so no client can put a torn record under a payload key any
+// more — which is exactly what that gate is for. The fail-closed machinery this
+// file tests must still hold for records stored BEFORE the gate existed, so the
+// fixtures reach that state the only way it is still reachable: the replay path,
+// which must never refuse an acked write.
+//
+// It is otherwise the same insert. RestoreInsert runs the identical
+// placeLockedAt (arena insert, payload-index update, version, level draw) and the
+// identical runLink, and version 0 bumps a fresh point to 1 exactly as Insert
+// does — so the corpus is byte-identical to the one Insert used to build.
+func insertViaReplay(t *testing.T, h *hnsw, id uint64, vec []float32, m Metadata) {
+	t.Helper()
+	if err := h.RestoreInsert(id, vec, 0, m, nil, nil, 0); err != nil {
+		t.Fatalf("RestoreInsert(%d): %v", id, err)
+	}
+}
+
 // TestRecordTornFixturesReproduceTheAsymmetry pins the PRECONDITION of every
 // test below: these bytes really do fail IndexEntries while still resolving a
 // field. If a future change to sdk/record makes IndexEntries partial (or makes
@@ -132,9 +154,7 @@ func poisonCorpus(t *testing.T, n int, badID uint64, bad []byte) (*hnsw, map[uin
 		}
 		corpus[id] = v
 		metas[id] = m
-		if _, _, err := h.Insert(id, v, 0, m, nil, nil, CASCond{}); err != nil {
-			t.Fatal(err)
-		}
+		insertViaReplay(t, h, id, v, m)
 	}
 	return h, corpus, metas
 }

--- a/vector/payload_index_record_test.go
+++ b/vector/payload_index_record_test.go
@@ -205,9 +205,9 @@ func recordCorpus(t *testing.T, n, dim int) (*hnsw, map[uint64][]float32, map[ui
 		}
 		corpus[id] = v
 		metas[id] = m
-		if _, _, err := h.Insert(id, v, 0, m, nil, nil, CASCond{}); err != nil {
-			t.Fatal(err)
-		}
+		// A few of these points carry a DAMAGED record under "torn", which the
+		// public entries now refuse (ErrRecordMalformed) — see insertViaReplay.
+		insertViaReplay(t, h, id, v, m)
 	}
 	return h, corpus, metas
 }

--- a/vector/payload_key_not_record_message_test.go
+++ b/vector/payload_key_not_record_message_test.go
@@ -29,6 +29,16 @@ func TestIsPayloadKeyNotRecordMessage(t *testing.T) {
 	_, _, detailedFloat := currentRecordValue(Metadata{"widerKind": {Kind: ValueFloat, Flt: 1.5}}, "widerKind", false)
 	detailedFloatMsg := detailedFloat.Error()
 
+	// A caller-chosen key of arbitrary length must not blow up the message: the
+	// producer clips it with clipField, exactly like ErrRecordMalformed /
+	// ErrRecordTooLarge, so even a 1 MiB key yields a short, bounded message.
+	bigKey := strings.Repeat("k", 1<<20)
+	_, _, detailedBig := currentRecordValue(Metadata{bigKey: {Kind: ValueInt, Int: 5}}, bigKey, false)
+	detailedBigMsg := detailedBig.Error()
+	if len(detailedBigMsg) >= 256 {
+		t.Fatalf("clipField did not bound a 1 MiB key: message length %d (%q)", len(detailedBigMsg), detailedBigMsg)
+	}
+
 	accept := []struct {
 		name string
 		msg  string
@@ -36,6 +46,7 @@ func TestIsPayloadKeyNotRecordMessage(t *testing.T) {
 		{"bare sentinel text (guard-clause form)", ErrPayloadKeyNotRecord.Error()},
 		{"detailed form, short key", detailedMsg},
 		{"detailed form, different kind digit", detailedFloatMsg},
+		{"detailed form, 1 MiB key clipped to a short message", detailedBigMsg},
 		{"bare form re-stringified (simulates decodePBResult)", errors.New(ErrPayloadKeyNotRecord.Error()).Error()},
 		{"detailed form re-stringified (simulates decodePBResult)", errors.New(detailedMsg).Error()},
 	}
@@ -66,8 +77,8 @@ func TestIsPayloadKeyNotRecordMessage(t *testing.T) {
 			ErrPayloadKeyNotRecord.Error() + `: payload key "k" holds a value of kind `},
 		{"looks like the marker but missing a space",
 			ErrPayloadKeyNotRecord.Error() + `: payload key "k" holds a value of kind5`},
-		{"oversize input beyond the length bound",
-			ErrPayloadKeyNotRecord.Error() + `: payload key "` + strings.Repeat("k", 5000) + `" holds a value of kind 2`},
+		{"oversize input beyond the length bound (structurally well-formed but longer than any real clipField output)",
+			payloadKeyNotRecordPrefix + strings.Repeat("k", 600) + payloadKeyNotRecordSuffixMid + "2"},
 	}
 	for _, tc := range reject {
 		t.Run("reject/"+tc.name, func(t *testing.T) {

--- a/vector/payload_key_not_record_message_test.go
+++ b/vector/payload_key_not_record_message_test.go
@@ -1,0 +1,79 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package vector
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+)
+
+// TestIsPayloadKeyNotRecordMessage pins IsPayloadKeyNotRecordMessage against the
+// exact shapes production code produces for ErrPayloadKeyNotRecord (the bare
+// guard-clause form and currentRecordValue's detailed form), and against the
+// class of input it exists to REJECT: an unrelated error whose message merely
+// contains the sentinel text. A bare strings.Contains would pass every case in
+// the reject table below, which is exactly the bug this replaces.
+func TestIsPayloadKeyNotRecordMessage(t *testing.T) {
+	_, _, detailed := currentRecordValue(Metadata{"k": {Kind: ValueInt, Int: 5}}, "k", false)
+	if detailed == nil {
+		t.Fatal("currentRecordValue fixture returned a nil error")
+	}
+	detailedMsg := detailed.Error()
+	wantPrefix := ErrPayloadKeyNotRecord.Error() + `: payload key "k" holds a value of kind `
+	if !strings.HasPrefix(detailedMsg, wantPrefix) {
+		t.Fatalf("detailed-form fixture drifted from currentRecordValue: %q", detailedMsg)
+	}
+
+	_, _, detailedFloat := currentRecordValue(Metadata{"widerKind": {Kind: ValueFloat, Flt: 1.5}}, "widerKind", false)
+	detailedFloatMsg := detailedFloat.Error()
+
+	accept := []struct {
+		name string
+		msg  string
+	}{
+		{"bare sentinel text (guard-clause form)", ErrPayloadKeyNotRecord.Error()},
+		{"detailed form, short key", detailedMsg},
+		{"detailed form, different kind digit", detailedFloatMsg},
+		{"bare form re-stringified (simulates decodePBResult)", errors.New(ErrPayloadKeyNotRecord.Error()).Error()},
+		{"detailed form re-stringified (simulates decodePBResult)", errors.New(detailedMsg).Error()},
+	}
+	for _, tc := range accept {
+		t.Run("accept/"+tc.name, func(t *testing.T) {
+			if !IsPayloadKeyNotRecordMessage(tc.msg) {
+				t.Errorf("IsPayloadKeyNotRecordMessage(%q) = false, want true", tc.msg)
+			}
+		})
+	}
+
+	reject := []struct {
+		name string
+		msg  string
+	}{
+		{"empty string", ""},
+		{"unrelated error containing the sentinel text (%v wrap)",
+			fmt.Errorf("wal append failed at /var/lib/rostam/x: %v", ErrPayloadKeyNotRecord).Error()},
+		{"unrelated error containing the sentinel text (%w wrap, op-name prefixed)",
+			fmt.Errorf("vector_operate: %w", ErrPayloadKeyNotRecord).Error()},
+		{"sentinel text embedded mid-message with unrelated trailing content",
+			"apply failed: " + ErrPayloadKeyNotRecord.Error() + " (retrying on shard 3)"},
+		{"detailed form with a byte cut off the front",
+			strings.TrimPrefix(detailedMsg, "v")},
+		{"detailed form with trailing garbage appended after the digits",
+			detailedMsg + " extra"},
+		{"detailed form with no digits after the marker",
+			ErrPayloadKeyNotRecord.Error() + `: payload key "k" holds a value of kind `},
+		{"looks like the marker but missing a space",
+			ErrPayloadKeyNotRecord.Error() + `: payload key "k" holds a value of kind5`},
+		{"oversize input beyond the length bound",
+			ErrPayloadKeyNotRecord.Error() + `: payload key "` + strings.Repeat("k", 5000) + `" holds a value of kind 2`},
+	}
+	for _, tc := range reject {
+		t.Run("reject/"+tc.name, func(t *testing.T) {
+			if IsPayloadKeyNotRecordMessage(tc.msg) {
+				t.Errorf("IsPayloadKeyNotRecordMessage(%q) = true, want false", tc.msg)
+			}
+		})
+	}
+}

--- a/vector/record_malformed_message_test.go
+++ b/vector/record_malformed_message_test.go
@@ -1,0 +1,85 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package vector
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+)
+
+// TestIsRecordMalformedMessage pins IsRecordMalformedMessage against the exact
+// shapes checkRecordValues / checkRecordValuesAll produce for ErrRecordMalformed,
+// and against the class of input it exists to REJECT: an unrelated error whose
+// message merely contains the sentinel text. A bare strings.Contains would pass
+// every case in the reject table below, which is exactly the bug (a WAL/path/IO
+// error that wraps ErrRecordMalformed becoming client-facing verbatim,
+// unredacted).
+func TestIsRecordMalformedMessage(t *testing.T) {
+	single := checkRecordValues(malformedRecord()).Error()
+	if !strings.HasPrefix(single, ErrRecordMalformed.Error()+": payload key \"session\": record: malformed record: ") {
+		t.Fatalf("single-form fixture drifted from checkRecordValues: %q", single)
+	}
+
+	bulkRow0 := checkRecordValuesAll([]Metadata{malformedRecord()}).Error()
+	bulkRow12 := checkRecordValuesAll([]Metadata{
+		{}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {},
+		malformedRecord(),
+	}).Error()
+
+	longKey := strings.Repeat("k", 200)
+	singleLongKey := checkRecordValues(Metadata{longKey: NewRecord([]byte{0x01, 0xFF})}).Error()
+
+	accept := []struct {
+		name string
+		msg  string
+	}{
+		{"bare sentinel text", ErrRecordMalformed.Error()},
+		{"single-payload form", single},
+		{"single-payload form, long/clipped key", singleLongKey},
+		{"bulk form, row 0", bulkRow0},
+		{"bulk form, row 12 (multi-digit index)", bulkRow12},
+		{"single form re-stringified (simulates decodePBResult)", errors.New(single).Error()},
+		{"bulk form re-stringified (simulates decodePBResult)", errors.New(bulkRow12).Error()},
+		{"trailing content appended after the detail (record.Validate's own detail has no closing anchor, so this is a real accepted shape, not a near-miss)",
+			single + ": extra wrapped context"},
+	}
+	for _, tc := range accept {
+		t.Run("accept/"+tc.name, func(t *testing.T) {
+			if !IsRecordMalformedMessage(tc.msg) {
+				t.Errorf("IsRecordMalformedMessage(%q) = false, want true", tc.msg)
+			}
+		})
+	}
+
+	reject := []struct {
+		name string
+		msg  string
+	}{
+		{"empty string", ""},
+		{"unrelated error containing the sentinel text (%v wrap)",
+			fmt.Errorf("wal append failed at /var/lib/rostam/x: %v", ErrRecordMalformed).Error()},
+		{"unrelated error containing the sentinel text (%w wrap, op-name prefixed)",
+			fmt.Errorf("vector_insert: %w", ErrRecordMalformed).Error()},
+		{"sentinel text embedded mid-message with unrelated trailing content",
+			"apply failed: " + ErrRecordMalformed.Error() + " (retrying on shard 3)"},
+		{"single-payload form with a byte cut off the front",
+			strings.TrimPrefix(single, "v")},
+		{"bulk form with the row index missing",
+			"payload : " + single},
+		{"looks like the sentinel but missing the record.ErrRecord marker entirely",
+			ErrRecordMalformed.Error() + ": payload key \"session\": wire: args too short"},
+		{"marker present but nothing follows it (empty detail)",
+			ErrRecordMalformed.Error() + ": payload key \"session\": record: malformed record: "},
+		{"oversize input beyond the length bound",
+			single + strings.Repeat(" more detail", 300)},
+	}
+	for _, tc := range reject {
+		t.Run("reject/"+tc.name, func(t *testing.T) {
+			if IsRecordMalformedMessage(tc.msg) {
+				t.Errorf("IsRecordMalformedMessage(%q) = true, want false", tc.msg)
+			}
+		})
+	}
+}

--- a/vector/record_mutate.go
+++ b/vector/record_mutate.go
@@ -69,7 +69,13 @@ func currentRecordValue(meta Metadata, key string, expired bool) (rec []byte, ex
 		return nil, false, nil
 	}
 	if v.Kind != ValueRecord {
-		return nil, false, fmt.Errorf("%w: payload key %q holds a value of kind %d", ErrPayloadKeyNotRecord, key, v.Kind)
+		// The key goes through clipField, not %q: it is caller-supplied and
+		// unbounded, and this message is returned VERBATIM to the caller on
+		// every transport (a client error, classified 400 / InvalidArgument)
+		// and carried across replication as a string. Keep in step with
+		// checkRecordValues / checkRecordValuesAll (vector/metadata.go), which
+		// clip the key for the same reason.
+		return nil, false, fmt.Errorf("%w: payload key %s holds a value of kind %d", ErrPayloadKeyNotRecord, clipField(key), v.Kind)
 	}
 	return v.Rec, true, nil
 }
@@ -81,9 +87,8 @@ func currentRecordValue(meta Metadata, key string, expired bool) (rec []byte, ex
 // errors.New, losing errors.Is identity, and a bare strings.Contains fallback
 // would make any error that merely mentions the sentinel text client-facing.
 //
-// The two recognized shapes (<key> is the RAW payload key rendered by %q —
-// unlike ErrRecordMalformed/ErrRecordTooLarge this producer does not run it
-// through clipField, so a caller-chosen key of any length can appear here;
+// The two recognized shapes (<key> is clipField's bounded rendering of the
+// caller's payload key, exactly as for ErrRecordMalformed/ErrRecordTooLarge;
 // <N> is the decimal vtypes.ValueKind of whatever the key actually holds):
 //
 //	vector: payload key does not hold a record
@@ -117,13 +122,14 @@ func IsPayloadKeyNotRecordMessage(s string) bool {
 
 // maxPayloadKeyNotRecordMessageLen bounds the input IsPayloadKeyNotRecordMessage
 // scans, so classification cost cannot scale with an attacker-chosen key's
-// length (the key here is unbounded — see IsPayloadKeyNotRecordMessage's doc).
-// A key longer than this cap simply fails to match and falls through to the
-// redacted internal-error bucket, which is the safe direction to fail in.
-const maxPayloadKeyNotRecordMessageLen = 4096
+// length. clipField already bounds the key to ~64 source bytes (worst-case
+// quoted/escaped well under 300), so — unlike before clipField was used here —
+// even a caller-chosen key of arbitrary length (a 1 MiB key, say) produces a
+// message well under this cap; mirrors maxRecordTooLargeMessageLen's reasoning.
+const maxPayloadKeyNotRecordMessageLen = 512
 
 // payloadKeyNotRecordPrefix is the fixed text that opens the detailed form,
-// ending right before the caller-controlled %q(key) rendering.
+// ending right before the caller-controlled clipField(key) rendering.
 var payloadKeyNotRecordPrefix = ErrPayloadKeyNotRecord.Error() + ": payload key "
 
 // payloadKeyNotRecordSuffixMid is the fixed text between the caller-controlled

--- a/vector/record_mutate.go
+++ b/vector/record_mutate.go
@@ -5,6 +5,7 @@ package vector
 import (
 	"errors"
 	"fmt"
+	"strings"
 )
 
 // RecordMutation is what a RecordMutator asks the engine to do with the record
@@ -71,4 +72,74 @@ func currentRecordValue(meta Metadata, key string, expired bool) (rec []byte, ex
 		return nil, false, fmt.Errorf("%w: payload key %q holds a value of kind %d", ErrPayloadKeyNotRecord, key, v.Kind)
 	}
 	return v.Rec, true, nil
+}
+
+// IsPayloadKeyNotRecordMessage reports whether s is the EXACT serialised form
+// of an ErrPayloadKeyNotRecord error — anchored the same way
+// IsRecordTooLargeMessage (vector/metadata.go) is for its sentinel, and for
+// the same reason: shard.decodePBResult rebuilds a replicated op error with
+// errors.New, losing errors.Is identity, and a bare strings.Contains fallback
+// would make any error that merely mentions the sentinel text client-facing.
+//
+// The two recognized shapes (<key> is the RAW payload key rendered by %q —
+// unlike ErrRecordMalformed/ErrRecordTooLarge this producer does not run it
+// through clipField, so a caller-chosen key of any length can appear here;
+// <N> is the decimal vtypes.ValueKind of whatever the key actually holds):
+//
+//	vector: payload key does not hold a record
+//	vector: payload key does not hold a record: payload key <key> holds a value of kind <N>
+//
+// The bare form comes from mutatePayloadRecordLockedAt / mutatePayloadRecordBody's
+// own guard clause (fn == nil, key == "", or key == contentField); the detailed
+// form comes from currentRecordValue, for a key that resolves to a non-record
+// value. Neither ever passes through a bulk "payload N: " wrapper — a
+// vector_operate always targets exactly one payload key on exactly one point,
+// unlike the ingest paths ErrRecordMalformed/ErrRecordTooLarge share.
+//
+// Like IsRecordTooLargeMessage's numeric tail, the kind digits sit at the very
+// end of the string with nothing after them, so — unlike
+// IsRecordMalformedMessage — the far end IS fully anchored: this reports false
+// for anything that does not end in "... holds a value of kind " followed by
+// one or more digits and nothing else.
+func IsPayloadKeyNotRecordMessage(s string) bool {
+	if len(s) == 0 || len(s) > maxPayloadKeyNotRecordMessageLen {
+		return false
+	}
+	if s == ErrPayloadKeyNotRecord.Error() {
+		return true
+	}
+	rest, ok := strings.CutPrefix(s, payloadKeyNotRecordPrefix)
+	if !ok {
+		return false
+	}
+	return hasPayloadKeyNotRecordSuffix(rest)
+}
+
+// maxPayloadKeyNotRecordMessageLen bounds the input IsPayloadKeyNotRecordMessage
+// scans, so classification cost cannot scale with an attacker-chosen key's
+// length (the key here is unbounded — see IsPayloadKeyNotRecordMessage's doc).
+// A key longer than this cap simply fails to match and falls through to the
+// redacted internal-error bucket, which is the safe direction to fail in.
+const maxPayloadKeyNotRecordMessageLen = 4096
+
+// payloadKeyNotRecordPrefix is the fixed text that opens the detailed form,
+// ending right before the caller-controlled %q(key) rendering.
+var payloadKeyNotRecordPrefix = ErrPayloadKeyNotRecord.Error() + ": payload key "
+
+// payloadKeyNotRecordSuffixMid is the fixed text between the caller-controlled
+// key rendering and the trailing kind digits.
+const payloadKeyNotRecordSuffixMid = " holds a value of kind "
+
+// hasPayloadKeyNotRecordSuffix reports whether s ends with the fixed marker
+// text followed by one or more decimal digits and nothing else — the same
+// digit-stripping-then-anchor approach hasRecordTooLargeSuffix uses.
+func hasPayloadKeyNotRecordSuffix(s string) bool {
+	i := len(s)
+	for i > 0 && s[i-1] >= '0' && s[i-1] <= '9' {
+		i--
+	}
+	if i == len(s) {
+		return false
+	}
+	return strings.HasSuffix(s[:i], payloadKeyNotRecordSuffixMid)
 }

--- a/vector/record_mutate.go
+++ b/vector/record_mutate.go
@@ -53,11 +53,67 @@ var ErrRecordMutation = errors.New("vector: record mutator returned an unknown m
 // record is told so at ingest instead of poisoning the payload index.
 var ErrRecordMalformed = errors.New("vector: record payload value is not a decodable operate record")
 
+// recordKeyPastDeadline reports whether the record under a mutated payload key
+// must be treated as ABSENT because its per-key deadline has passed — and it
+// answers false, always, on an UNSTAMPED apply.
+//
+// THE ASYMMETRY IS THE WHOLE POINT, AND IT IS NOT THE SAME AS set_payload's.
+// A replicated apply runs the op-list inside every replica's own FSM. With the
+// leader apply stamp off (its rollout flag is off cluster-wide today) each
+// replica computes `now` from its OWN wall clock. If the mutator were allowed to
+// judge the key's deadline against that clock, a replica whose clock is past the
+// deadline would read the record as absent and CREATE A FRESH ONE, while a
+// replica whose clock is not yet past it would increment the existing one. Both
+// commit, both bump the version, neither errors, and the two replicas hold
+// permanently different record BYTES.
+//
+// setPayloadBody (vector/hnsw.go) has no such class: it copies an expired key
+// through unchanged and only ever moves a DEADLINE value, so its wall-clock read
+// costs a bounded millisecond skew in a deadline, never divergent stored bytes.
+// A record mutation reads the stored bytes and writes a function of them, so the
+// same wall-clock read converts that bounded skew into unbounded content
+// divergence. Hence: only the STAMPED branch — whose clock is the leader's
+// stamp, identical on every replica and therefore deterministic — may expire the
+// key. The unstamped branch treats the record as PRESENT and passes its deadline
+// through untouched, which is exactly what setPayloadBody does with an expired
+// key it is not asked to re-deadline.
+//
+// The consequence, stated plainly so it is not rediscovered as a bug: an
+// unstamped vector_operate against a key whose deadline has passed mutates the
+// record in place and keeps the stale deadline, rather than starting a new
+// record. The key is still invisible to every READ path (which judges liveness
+// at read time), so the only observable difference is what the next read sees
+// after the deadline is refreshed. Determinism is worth that.
+//
+// The POINT-level liveness gate is deliberately NOT covered by this rule: it is
+// judged against the wall clock on the unstamped branch exactly as
+// setPayloadBody's is, because that is a pre-existing, phase-wide property of
+// every unstamped write and changing it here would make record mutation
+// disagree with its siblings about whether a point exists.
+func recordKeyPastDeadline(stamped bool, deadline, now uint64) bool {
+	return stamped && keyExpired(deadline, now)
+}
+
+// recordKeyPastDeadlineAbs is recordKeyPastDeadline for the named/multi-vector
+// families, whose per-key deadlines are ABSOLUTE unix-millis int64 and which
+// have no keyExpired twin (liveMetaMap's rule, inlined). Same stamped-only
+// contract, same reasons — see recordKeyPastDeadline.
+func recordKeyPastDeadlineAbs(stamped bool, deadline, now int64) bool {
+	return stamped && deadline != 0 && deadline <= now
+}
+
 // currentRecordValue reads the record bytes stored under key in meta, treating a
 // key whose per-key deadline has passed as ABSENT (a logically expired key is
 // invisible to every read path, so it must be invisible here too). It never
 // copies: the returned slice aliases arena storage and is valid only under the
 // engine lock.
+//
+// WHO DECIDES `expired`: the four mutate bodies, through
+// recordKeyPastDeadline[Abs], which answer false on an UNSTAMPED apply so a
+// replica's wall clock can never decide whether a record exists. Read that
+// helper's doc before changing anything here — this function's "expired means
+// absent" rule is only safe because the caller refuses to evaluate it against a
+// per-replica clock.
 //
 // A key holding a non-record value is an ERROR, not an implicit overwrite. The
 // caller can still read that value through get/search; silently replacing it

--- a/vector/record_mutate.go
+++ b/vector/record_mutate.go
@@ -1,0 +1,74 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package vector
+
+import (
+	"errors"
+	"fmt"
+)
+
+// RecordMutation is what a RecordMutator asks the engine to do with the record
+// under the payload key. Three outcomes, not two: a failed CHECK must leave the
+// point byte-identical AND unbumped, which "store these bytes" cannot express.
+type RecordMutation uint8
+
+const (
+	RecordStore     RecordMutation = iota // store rec under the payload key
+	RecordDelete                          // remove the payload key entirely
+	RecordUnchanged                       // leave the point exactly as it was
+)
+
+// RecordMutator transforms the record bytes stored under one payload key.
+//
+// old aliases engine-owned memory and is valid ONLY for the duration of the
+// call: a mutator must never retain it, never write through it, and never call
+// back into the collection (it runs under the engine write lock). exists is
+// false when the key is absent OR logically expired.
+//
+// OWNERSHIP HAND-OFF: rec goes the other way. The engine stores it BY REFERENCE
+// (arena.SetMetadata: "The map is stored by reference; the caller must not
+// mutate it after the hand-off"), so the mutator must return bytes it will never
+// reuse, pool, or write through again. ops satisfies this because copyRecord
+// allocates a fresh buffer per call and createRecord allocates fresh — NOT
+// because the pooled operate engines promise it (schemaEngine.clear() nils
+// e.buf rather than reusing it). A future pooled-buffer optimisation in ops
+// would silently corrupt vector payloads; copyRecord carries a comment saying a
+// caller now depends on its freshness.
+type RecordMutator func(old []byte, exists bool) (rec []byte, act RecordMutation, err error)
+
+// ErrPayloadKeyNotRecord is returned when the targeted payload key names
+// something a record mutation cannot address: a key holding a non-record value,
+// the empty key, or the reserved document-content key.
+var ErrPayloadKeyNotRecord = errors.New("vector: payload key does not hold a record")
+
+// ErrRecordMutation is returned when a RecordMutator reports an action outside
+// the closed RecordMutation enumeration — a programming error in the caller,
+// caught before any state change rather than defaulted to "store".
+var ErrRecordMutation = errors.New("vector: record mutator returned an unknown mutation")
+
+// ErrRecordMalformed is the ingest-side rejection for record bytes no operate
+// engine can open. It is the shape half of the bound checkRecordValues already
+// enforces on size, and it exists so a caller that hands the engine a torn
+// record is told so at ingest instead of poisoning the payload index.
+var ErrRecordMalformed = errors.New("vector: record payload value is not a decodable operate record")
+
+// currentRecordValue reads the record bytes stored under key in meta, treating a
+// key whose per-key deadline has passed as ABSENT (a logically expired key is
+// invisible to every read path, so it must be invisible here too). It never
+// copies: the returned slice aliases arena storage and is valid only under the
+// engine lock.
+//
+// A key holding a non-record value is an ERROR, not an implicit overwrite. The
+// caller can still read that value through get/search; silently replacing it
+// with a record would destroy it on a call the caller believes only touches a
+// record.
+func currentRecordValue(meta Metadata, key string, expired bool) (rec []byte, exists bool, err error) {
+	v, present := meta[key]
+	if !present || expired {
+		return nil, false, nil
+	}
+	if v.Kind != ValueRecord {
+		return nil, false, fmt.Errorf("%w: payload key %q holds a value of kind %d", ErrPayloadKeyNotRecord, key, v.Kind)
+	}
+	return v.Rec, true, nil
+}

--- a/vector/record_mutate_named_test.go
+++ b/vector/record_mutate_named_test.go
@@ -988,3 +988,108 @@ func TestMutateRecordNamedWALNoOp(t *testing.T) {
 		})
 	}
 }
+
+// TestMutateRejectsMalformedMutatorBytes drives every engine's post-mutation
+// SHAPE gate, the twin of the size cap beside it.
+//
+// MutatePayloadRecordCAS is exported. The mutator ops supplies cannot produce
+// malformed bytes — it returns applyRecordBytes' output — but a direct Go caller
+// brings its own, and bytes that no operate engine can open used to be stored on
+// the size cap alone. That poisons the payload key for the whole collection: no
+// path under it accelerates, and the next vector_operate on the same key fails.
+//
+// The refusal must leave the point byte-identical AND unbumped, exactly like a
+// failed CHECK — the record the caller already had is not collateral for a bad
+// mutator.
+func TestMutateRejectsMalformedMutatorBytes(t *testing.T) {
+	garbage := []byte{0xff, 0x00, 0x13, 0x37}
+	if err := validateRecord(garbage); err == nil {
+		t.Fatal("fixture is not malformed: validateRecord accepted it")
+	}
+	for _, newH := range allMutateHarnesses(t) {
+		h := newH(t)
+		t.Run(h.name, func(t *testing.T) {
+			before, ok := h.record(t, 1, "session")
+			if !ok {
+				t.Fatal("harness seed is missing the session record")
+			}
+			beforeVersion := h.version(1)
+
+			_, changed, err := h.mutate(1, "session", func(_ []byte, _ bool) ([]byte, RecordMutation, error) {
+				return garbage, RecordStore, nil
+			}, CASCond{})
+			if !errors.Is(err, ErrRecordMalformed) {
+				t.Fatalf("a mutator returning malformed bytes = %v, want ErrRecordMalformed", err)
+			}
+			if changed {
+				t.Fatal("the refused mutation reported changed=true")
+			}
+			if !IsRecordMalformedMessage(err.Error()) {
+				t.Fatalf("message %q is not the shape the transport classifiers match; "+
+					"a clustered caller would see it redacted to an internal error", err)
+			}
+
+			after, ok := h.record(t, 1, "session")
+			if !ok {
+				t.Fatal("the refused mutation removed the record")
+			}
+			if !bytes.Equal(before, after) {
+				t.Fatal("the refused mutation changed the stored record")
+			}
+			if got := h.version(1); got != beforeVersion {
+				t.Fatalf("version = %d after a refused mutation, want %d (unbumped)", got, beforeVersion)
+			}
+		})
+	}
+}
+
+// TestMutateValidatesRecordExactlyOnce pins the cost of the gate above: one
+// decode of the bytes the engine just produced, never two. The shape check is
+// O(record) with allocations, so a path that grew a second pass would multiply
+// the cost of every operate — the same invariant
+// TestRecordValidationCountPerWrite holds for the ingest paths.
+func TestMutateValidatesRecordExactlyOnce(t *testing.T) {
+	want := sessionRecordBytesRC(t, 9)
+	for _, newH := range allMutateHarnesses(t) {
+		h := newH(t)
+		t.Run(h.name, func(t *testing.T) {
+			n := countValidates(t, func() {
+				if _, _, err := h.mutate(1, "session", func(_ []byte, _ bool) ([]byte, RecordMutation, error) {
+					return want, RecordStore, nil
+				}, CASCond{}); err != nil {
+					t.Fatalf("mutate: %v", err)
+				}
+			})
+			if n != 1 {
+				t.Fatalf("a record mutation decoded its result %d times, want exactly 1", n)
+			}
+		})
+	}
+}
+
+// TestMutateSkipsValidationWhenNothingIsStored is the other half of the cost
+// invariant: a mutation that stores nothing must not decode anything.
+func TestMutateSkipsValidationWhenNothingIsStored(t *testing.T) {
+	for _, newH := range allMutateHarnesses(t) {
+		h := newH(t)
+		t.Run(h.name, func(t *testing.T) {
+			for _, act := range []struct {
+				name string
+				act  RecordMutation
+			}{{"unchanged", RecordUnchanged}, {"delete", RecordDelete}} {
+				t.Run(act.name, func(t *testing.T) {
+					n := countValidates(t, func() {
+						if _, _, err := h.mutate(1, "session", func(_ []byte, _ bool) ([]byte, RecordMutation, error) {
+							return nil, act.act, nil
+						}, CASCond{}); err != nil {
+							t.Fatalf("mutate: %v", err)
+						}
+					})
+					if n != 0 {
+						t.Fatalf("a %s mutation decoded a record %d times, want 0", act.name, n)
+					}
+				})
+			}
+		})
+	}
+}

--- a/vector/record_mutate_named_test.go
+++ b/vector/record_mutate_named_test.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"os"
 	"testing"
+	"time"
 )
 
 // ---------------------------------------------------------------------------
@@ -30,6 +31,14 @@ func walAppendFails(w *wal) { w.poisoned.Store(true) }
 // still writes, but f.Sync() on a pipe fails with EINVAL, so the append succeeds
 // and commitWaitStaged fails — the tail error return. The pipe's read end is
 // held open for the test's lifetime so the write never draws EPIPE.
+//
+// CLEANUP ORDERING. t.Cleanup runs LIFO, and the store's own `_ = cs.Close()`
+// cleanup is registered FIRST (by seedB2Named/seedB2MV), so this one runs
+// BEFORE it: by the time Close reaches the WAL, w.f is a closed pipe and its
+// final Sync fails. That is harmless here and deliberate — those callers discard
+// Close's error, and the swapped-away real log file is closed by this cleanup
+// rather than leaked. A future caller that ASSERTS on Close's error must swap
+// w.f back instead of relying on this ordering.
 func walSyncFails(t *testing.T, w *wal) {
 	t.Helper()
 	pr, pw, err := os.Pipe()
@@ -205,6 +214,10 @@ func namedMutateHarness(t *testing.T) mutateHarness {
 			_, _, v, changed, err := nc.mutatePayloadRecordLockedAt(id, key, fn, cas, nowMs)
 			return v, changed, err
 		},
+		mutateAtKE: func(id uint64, key string, fn RecordMutator, cas CASCond, nowMs int64) (map[string]int64, uint64, bool, error) {
+			_, ke, v, changed, err := nc.mutatePayloadRecordLockedAt(id, key, fn, cas, nowMs)
+			return ke, v, changed, err
+		},
 		payload: func(id uint64) (Metadata, bool) {
 			_, meta, _, _, ok := nc.Get(id)
 			return meta, ok
@@ -254,6 +267,10 @@ func mvMutateHarness(t *testing.T) mutateHarness {
 		mutateAt: func(id uint64, key string, fn RecordMutator, cas CASCond, nowMs int64) (uint64, bool, error) {
 			_, _, v, changed, err := m.mutatePayloadRecordLockedAt(id, key, fn, cas, nowMs)
 			return v, changed, err
+		},
+		mutateAtKE: func(id uint64, key string, fn RecordMutator, cas CASCond, nowMs int64) (map[string]int64, uint64, bool, error) {
+			_, ke, v, changed, err := m.mutatePayloadRecordLockedAt(id, key, fn, cas, nowMs)
+			return ke, v, changed, err
 		},
 		payload: func(id uint64) (Metadata, bool) {
 			_, meta, _, ok := m.Get(id)
@@ -439,6 +456,103 @@ func TestMutateRecordNamedAndMVMatchDense(t *testing.T) {
 			})
 		}
 	})
+
+	// A mutation touches ONE key. The engines rebuild the whole per-key deadline
+	// map when they write, so the hazard is not that the other key's VALUE
+	// changes — the "creates under an absent key" case already covers that — but
+	// that its DEADLINE is dropped or recomputed on the way through, silently
+	// making a key with hours left expire now or never.
+	t.Run("a mutation preserves the other keys' deadlines", func(t *testing.T) {
+		for _, newH := range allMutateHarnesses(t) {
+			h := newH(t)
+			t.Run(h.name, func(t *testing.T) {
+				// At now=4000: "session" gets deadline 5000, "other" gets 9000.
+				h.setNow(4000)
+				h.setPayload(t, 1, Metadata{
+					"session": NewRecord(sessionRecordBytes(t)),
+					"other":   NewString("keep me"),
+				}, map[string]int64{"session": 1000, "other": 5000})
+
+				ke, _, changed, err := h.mutateAtKE(1, "session",
+					storeFn(sessionRecordBytesRC(t, 8)), CASCond{}, 4500)
+				if err != nil {
+					t.Fatalf("mutateAtKE(4500): %v", err)
+				}
+				if !changed {
+					t.Fatal("changed=false storing under a live key")
+				}
+				if got := ke["other"]; got != 9000 {
+					t.Errorf("the untouched key's deadline = %d, want 9000 (deadlines: %v)", got, ke)
+				}
+
+				// And it is a real deadline, not just a number in the returned
+				// map: the key is live before 9000 and gone after it.
+				h.setNow(8999)
+				if meta, ok := h.payload(1); !ok || !meta["other"].Equal(NewString("keep me")) {
+					t.Errorf("the untouched key is not live at now=8999: %v", meta)
+				}
+				h.setNow(9000)
+				if meta, ok := h.payload(1); ok {
+					if _, present := meta["other"]; present {
+						t.Errorf("the untouched key outlived its deadline at now=9000: %v", meta)
+					}
+				}
+			})
+		}
+	})
+}
+
+// TestMutateRecordNamedPointTTLExpiryGate is the named family's POINT-ttl gate,
+// the twin of the dense TestMutateRecordDeadPointNotFound. A point whose own TTL
+// has passed is gone: the mutation must report ErrIDNotFound against the STAMPED
+// clock, and — because a mutator is caller code that may have side effects — it
+// must never run at all.
+func TestMutateRecordNamedPointTTLExpiryGate(t *testing.T) {
+	nc := newTestNamed(t)
+	nc.now = func() int64 { return mutateHarnessBase }
+	// A 1s point TTL: the deadline is mutateHarnessBase+1000.
+	if _, err := nc.InsertCAS(1, namedVecs(),
+		Metadata{"session": NewRecord(sessionRecordBytes(t))}, time.Second, CASCond{}); err != nil {
+		t.Fatalf("InsertCAS: %v", err)
+	}
+	// The wall clock is moved far past the deadline, so any judgement below that
+	// comes out "live" proves the stamp — not the clock — decided it.
+	nc.now = func() int64 { return mutateHarnessBase + 9_000_000 }
+
+	// One millisecond before the deadline the point is still there.
+	var called bool
+	if _, _, _, changed, err := nc.mutatePayloadRecordLockedAt(1, "session",
+		func(_ []byte, _ bool) ([]byte, RecordMutation, error) {
+			called = true
+			return nil, RecordUnchanged, nil
+		}, CASCond{}, mutateHarnessBase+999); err != nil {
+		t.Fatalf("mutate at stamp base+999: %v, want nil", err)
+	} else if changed {
+		t.Error("changed=true for RecordUnchanged")
+	}
+	if !called {
+		t.Fatal("the mutator never ran against a live point — the wall clock was consulted")
+	}
+
+	// At the deadline it is gone.
+	called = false
+	version, changed, err := func() (uint64, bool, error) {
+		_, _, v, ch, e := nc.mutatePayloadRecordLockedAt(1, "session",
+			func(_ []byte, _ bool) ([]byte, RecordMutation, error) {
+				called = true
+				return sessionRecordBytesRC(t, 8), RecordStore, nil
+			}, CASCond{}, mutateHarnessBase+1000)
+		return v, ch, e
+	}()
+	if !errors.Is(err, ErrIDNotFound) {
+		t.Fatalf("err = %v, want ErrIDNotFound", err)
+	}
+	if called {
+		t.Error("the mutator ran against a point past its TTL")
+	}
+	if changed || version != 0 {
+		t.Errorf("changed=%v version=%d against an expired point, want false/0", changed, version)
+	}
 }
 
 // ---------------------------------------------------------------------------
@@ -535,8 +649,15 @@ func TestMutateRecordNamedSharedPayloadReindex(t *testing.T) {
 		// A mode byte followed by a torn schema blob: IndexEntries cannot
 		// enumerate it, so the payload key is poisoned and nothing under it
 		// accelerates. The accounting is per-ID here, not per-slot.
-		if _, err := nc.InsertCAS(1, namedVecs(), Metadata{"session": NewRecord([]byte{0x01, 0xFF})}, 0, CASCond{}); err != nil {
-			t.Fatalf("InsertCAS: %v", err)
+		//
+		// Seeded through NamedCollection.RestoreInsert, the named family's REPLAY
+		// entry (size-checked, not shape-checked — see checkRecordValuesSize):
+		// InsertCAS now refuses a malformed record with ErrRecordMalformed, so
+		// this state is only reachable the way it originally arose, from bytes
+		// stored before the gate existed. version 0 bumps a fresh point to 1
+		// exactly as InsertCAS did.
+		if err := nc.RestoreInsert(1, namedVecs(), nil, Metadata{"session": NewRecord([]byte{0x01, 0xFF})}, 0, nil, 0); err != nil {
+			t.Fatalf("RestoreInsert: %v", err)
 		}
 		if !nc.payloadIdx.badRecords.poisoned("session") {
 			t.Fatal("the malformed record did not poison the payload key — the fixture is wrong")

--- a/vector/record_mutate_named_test.go
+++ b/vector/record_mutate_named_test.go
@@ -207,15 +207,15 @@ func namedMutateHarness(t *testing.T) mutateHarness {
 			}
 		},
 		mutate: func(id uint64, key string, fn RecordMutator, cas CASCond) (uint64, bool, error) {
-			_, _, v, changed, err := nc.mutatePayloadRecordLockedAt(id, key, fn, cas, nc.nowMs())
+			_, _, v, changed, err := nc.mutatePayloadRecordLockedAt(id, key, fn, cas, nc.nowMs(), false)
 			return v, changed, err
 		},
 		mutateAt: func(id uint64, key string, fn RecordMutator, cas CASCond, nowMs int64) (uint64, bool, error) {
-			_, _, v, changed, err := nc.mutatePayloadRecordLockedAt(id, key, fn, cas, nowMs)
+			_, _, v, changed, err := nc.mutatePayloadRecordLockedAt(id, key, fn, cas, nowMs, true)
 			return v, changed, err
 		},
 		mutateAtKE: func(id uint64, key string, fn RecordMutator, cas CASCond, nowMs int64) (map[string]int64, uint64, bool, error) {
-			_, ke, v, changed, err := nc.mutatePayloadRecordLockedAt(id, key, fn, cas, nowMs)
+			_, ke, v, changed, err := nc.mutatePayloadRecordLockedAt(id, key, fn, cas, nowMs, true)
 			return ke, v, changed, err
 		},
 		payload: func(id uint64) (Metadata, bool) {
@@ -261,15 +261,15 @@ func mvMutateHarness(t *testing.T) mutateHarness {
 			}
 		},
 		mutate: func(id uint64, key string, fn RecordMutator, cas CASCond) (uint64, bool, error) {
-			_, _, v, changed, err := m.mutatePayloadRecordLockedAt(id, key, fn, cas, m.nowMs())
+			_, _, v, changed, err := m.mutatePayloadRecordLockedAt(id, key, fn, cas, m.nowMs(), false)
 			return v, changed, err
 		},
 		mutateAt: func(id uint64, key string, fn RecordMutator, cas CASCond, nowMs int64) (uint64, bool, error) {
-			_, _, v, changed, err := m.mutatePayloadRecordLockedAt(id, key, fn, cas, nowMs)
+			_, _, v, changed, err := m.mutatePayloadRecordLockedAt(id, key, fn, cas, nowMs, true)
 			return v, changed, err
 		},
 		mutateAtKE: func(id uint64, key string, fn RecordMutator, cas CASCond, nowMs int64) (map[string]int64, uint64, bool, error) {
-			_, ke, v, changed, err := m.mutatePayloadRecordLockedAt(id, key, fn, cas, nowMs)
+			_, ke, v, changed, err := m.mutatePayloadRecordLockedAt(id, key, fn, cas, nowMs, true)
 			return ke, v, changed, err
 		},
 		payload: func(id uint64) (Metadata, bool) {
@@ -525,7 +525,7 @@ func TestMutateRecordNamedPointTTLExpiryGate(t *testing.T) {
 		func(_ []byte, _ bool) ([]byte, RecordMutation, error) {
 			called = true
 			return nil, RecordUnchanged, nil
-		}, CASCond{}, mutateHarnessBase+999); err != nil {
+		}, CASCond{}, mutateHarnessBase+999, true); err != nil {
 		t.Fatalf("mutate at stamp base+999: %v, want nil", err)
 	} else if changed {
 		t.Error("changed=true for RecordUnchanged")
@@ -541,7 +541,7 @@ func TestMutateRecordNamedPointTTLExpiryGate(t *testing.T) {
 			func(_ []byte, _ bool) ([]byte, RecordMutation, error) {
 				called = true
 				return sessionRecordBytesRC(t, 8), RecordStore, nil
-			}, CASCond{}, mutateHarnessBase+1000)
+			}, CASCond{}, mutateHarnessBase+1000, true)
 		return v, ch, e
 	}()
 	if !errors.Is(err, ErrIDNotFound) {

--- a/vector/record_mutate_named_test.go
+++ b/vector/record_mutate_named_test.go
@@ -1,0 +1,869 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package vector
+
+import (
+	"bytes"
+	"errors"
+	"os"
+	"testing"
+)
+
+// ---------------------------------------------------------------------------
+// B2 regression: the named/MV WAL wrapper's error returns
+// ---------------------------------------------------------------------------
+//
+// logPayloadOp on the named and MV families returns (version, err) — the APPLIED
+// version rides along even when only the WAL write failed — where the dense
+// payloadOpCASChanged returns (0, err). That divergence is deliberate and
+// pre-dates the record mutator (vector/named.go, vector/multivector.go: "the
+// pre-split code returned the applied version alongside the append error").
+// Splitting logPayloadOp into a changed-aware core must not quietly adopt the
+// dense contract, so these two tests characterise the existing behaviour at BOTH
+// error returns and are run before and after the refactor.
+
+// walAppendFails poisons w so the next appendFramedStaged fails immediately with
+// ErrWALPoisoned, without touching the file — the append-side error return.
+func walAppendFails(w *wal) { w.poisoned.Store(true) }
+
+// walSyncFails swaps w's file for the write end of a pipe: a small framed record
+// still writes, but f.Sync() on a pipe fails with EINVAL, so the append succeeds
+// and commitWaitStaged fails — the tail error return. The pipe's read end is
+// held open for the test's lifetime so the write never draws EPIPE.
+func walSyncFails(t *testing.T, w *wal) {
+	t.Helper()
+	pr, pw, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("os.Pipe: %v", err)
+	}
+	w.mu.Lock()
+	old := w.f
+	w.f = pw
+	w.mu.Unlock()
+	t.Cleanup(func() {
+		_ = pw.Close()
+		_ = pr.Close()
+		_ = old.Close() // the real log file the store's Close will no longer reach
+	})
+}
+
+// seedB2Named opens a WAL-mode named collection in the store holding point 1 at
+// version 1, and returns it with the store closed on cleanup.
+func seedB2Named(t *testing.T) *NamedCollection {
+	t.Helper()
+	cs, err := OpenCollectionStore(t.TempDir())
+	if err != nil {
+		t.Fatalf("OpenCollectionStore: %v", err)
+	}
+	t.Cleanup(func() { _ = cs.Close() })
+	if err := cs.CreateCollection("named", namedWALConfig()); err != nil {
+		t.Fatalf("CreateCollection: %v", err)
+	}
+	nc, ok := cs.GetNamed("named")
+	if !ok {
+		t.Fatal("named collection missing after create")
+	}
+	if nc.wal == nil {
+		t.Fatal("WAL-mode named collection has nil wal")
+	}
+	v, err := nc.InsertCAS(1, map[string][]float32{"title": {1, 0, 0, 0}}, Metadata{"k": NewInt(1)}, 0, CASCond{})
+	if err != nil || v != 1 {
+		t.Fatalf("seed insert: v=%d err=%v (want 1, nil)", v, err)
+	}
+	return nc
+}
+
+// seedB2MV is seedB2Named for the multi-vector family.
+func seedB2MV(t *testing.T) *MultiVectorIndex {
+	t.Helper()
+	cs, err := OpenCollectionStore(t.TempDir())
+	if err != nil {
+		t.Fatalf("OpenCollectionStore: %v", err)
+	}
+	t.Cleanup(func() { _ = cs.Close() })
+	if err := cs.CreateMultiVector("mv", mvWALConfig()); err != nil {
+		t.Fatalf("CreateMultiVector: %v", err)
+	}
+	idx, ok := cs.GetMultiVector("mv")
+	if !ok {
+		t.Fatal("MV collection missing after create")
+	}
+	if idx.wal == nil {
+		t.Fatal("WAL-mode MV collection has nil wal")
+	}
+	v, err := idx.AddCAS(1, [][]float32{{1, 0, 0, 0}}, Metadata{"k": NewInt(1)}, CASCond{})
+	if err != nil || v != 1 {
+		t.Fatalf("seed add: v=%d err=%v (want 1, nil)", v, err)
+	}
+	return idx
+}
+
+func TestNamedSetPayloadReturnsVersionOnWALAppendError(t *testing.T) {
+	t.Run("append fails", func(t *testing.T) {
+		nc := seedB2Named(t)
+		walAppendFails(nc.wal)
+		version, err := nc.SetPayloadCAS(1, Metadata{"k": NewInt(9)}, nil, CASCond{})
+		if err == nil {
+			t.Fatal("SetPayloadCAS succeeded on a poisoned WAL")
+		}
+		if version != 2 {
+			t.Fatalf("version = %d alongside the append error, want the APPLIED 2 (named returns the applied version, not 0)", version)
+		}
+	})
+
+	t.Run("commit wait fails", func(t *testing.T) {
+		nc := seedB2Named(t)
+		walSyncFails(t, nc.wal)
+		version, err := nc.SetPayloadCAS(1, Metadata{"k": NewInt(9)}, nil, CASCond{})
+		if err == nil {
+			t.Fatal("SetPayloadCAS succeeded with a failing fsync")
+		}
+		if version != 2 {
+			t.Fatalf("version = %d alongside the commit-wait error, want the APPLIED 2", version)
+		}
+	})
+
+	t.Run("engine error still returns 0", func(t *testing.T) {
+		nc := seedB2Named(t)
+		version, err := nc.SetPayloadCAS(404, Metadata{"k": NewInt(9)}, nil, CASCond{})
+		if !errors.Is(err, ErrIDNotFound) {
+			t.Fatalf("err = %v, want ErrIDNotFound", err)
+		}
+		if version != 0 {
+			t.Fatalf("version = %d for an apply that never ran, want 0", version)
+		}
+	})
+}
+
+func TestMVSetPayloadReturnsVersionOnWALAppendError(t *testing.T) {
+	t.Run("append fails", func(t *testing.T) {
+		idx := seedB2MV(t)
+		walAppendFails(idx.wal)
+		version, err := idx.SetPayloadCAS(1, Metadata{"k": NewInt(9)}, nil, CASCond{})
+		if err == nil {
+			t.Fatal("SetPayloadCAS succeeded on a poisoned WAL")
+		}
+		if version != 2 {
+			t.Fatalf("version = %d alongside the append error, want the APPLIED 2 (MV returns the applied version, not 0)", version)
+		}
+	})
+
+	t.Run("commit wait fails", func(t *testing.T) {
+		idx := seedB2MV(t)
+		walSyncFails(t, idx.wal)
+		version, err := idx.SetPayloadCAS(1, Metadata{"k": NewInt(9)}, nil, CASCond{})
+		if err == nil {
+			t.Fatal("SetPayloadCAS succeeded with a failing fsync")
+		}
+		if version != 2 {
+			t.Fatalf("version = %d alongside the commit-wait error, want the APPLIED 2", version)
+		}
+	})
+
+	t.Run("engine error still returns 0", func(t *testing.T) {
+		idx := seedB2MV(t)
+		version, err := idx.SetPayloadCAS(404, Metadata{"k": NewInt(9)}, nil, CASCond{})
+		if !errors.Is(err, ErrIDNotFound) {
+			t.Fatalf("err = %v, want ErrIDNotFound", err)
+		}
+		if version != 0 {
+			t.Fatalf("version = %d for an apply that never ran, want 0", version)
+		}
+	})
+}
+
+// ---------------------------------------------------------------------------
+// the shared table, on the named and multi-vector engines
+// ---------------------------------------------------------------------------
+
+// namedMutateHarness seeds a heap-only named collection holding point 1 with an
+// rc=7 "session" record — the same state every other harness starts from.
+func namedMutateHarness(t *testing.T) mutateHarness {
+	t.Helper()
+	nc := newTestNamed(t)
+	nc.now = func() int64 { return mutateHarnessBase }
+	h := mutateHarness{
+		name:   "named",
+		setNow: func(ms int64) { nc.now = func() int64 { return ms } },
+		insert: func(t *testing.T, id uint64, meta Metadata) {
+			t.Helper()
+			if _, err := nc.InsertCAS(id, namedVecs(), meta, 0, CASCond{}); err != nil {
+				t.Fatalf("named: InsertCAS(%d): %v", id, err)
+			}
+		},
+		setPayload: func(t *testing.T, id uint64, meta Metadata, keyTTLMs map[string]int64) {
+			t.Helper()
+			if err := nc.SetPayload(id, meta, keyTTLMs); err != nil {
+				t.Fatalf("named: SetPayload(%d): %v", id, err)
+			}
+		},
+		mutate: func(id uint64, key string, fn RecordMutator, cas CASCond) (uint64, bool, error) {
+			_, _, v, changed, err := nc.mutatePayloadRecordLockedAt(id, key, fn, cas, nc.nowMs())
+			return v, changed, err
+		},
+		mutateAt: func(id uint64, key string, fn RecordMutator, cas CASCond, nowMs int64) (uint64, bool, error) {
+			_, _, v, changed, err := nc.mutatePayloadRecordLockedAt(id, key, fn, cas, nowMs)
+			return v, changed, err
+		},
+		payload: func(id uint64) (Metadata, bool) {
+			_, meta, _, _, ok := nc.Get(id)
+			return meta, ok
+		},
+		version: func(id uint64) uint64 {
+			_, _, _, v, ok := nc.Get(id)
+			if !ok {
+				return 0
+			}
+			return v
+		},
+		stored: func(t *testing.T, id uint64) Metadata {
+			t.Helper()
+			nc.mu.RLock()
+			defer nc.mu.RUnlock()
+			return nc.meta[id]
+		},
+	}
+	h.insert(t, 1, Metadata{"session": NewRecord(sessionRecordBytes(t))})
+	return h
+}
+
+// mvMutateHarness is namedMutateHarness for the multi-vector family.
+func mvMutateHarness(t *testing.T) mutateHarness {
+	t.Helper()
+	m := newTestMV(t)
+	m.now = func() int64 { return mutateHarnessBase }
+	h := mutateHarness{
+		name:   "mv",
+		setNow: func(ms int64) { m.now = func() int64 { return ms } },
+		insert: func(t *testing.T, id uint64, meta Metadata) {
+			t.Helper()
+			if _, err := m.AddCAS(id, mvTokensV(), meta, CASCond{}); err != nil {
+				t.Fatalf("mv: AddCAS(%d): %v", id, err)
+			}
+		},
+		setPayload: func(t *testing.T, id uint64, meta Metadata, keyTTLMs map[string]int64) {
+			t.Helper()
+			if err := m.SetPayload(id, meta, keyTTLMs); err != nil {
+				t.Fatalf("mv: SetPayload(%d): %v", id, err)
+			}
+		},
+		mutate: func(id uint64, key string, fn RecordMutator, cas CASCond) (uint64, bool, error) {
+			_, _, v, changed, err := m.mutatePayloadRecordLockedAt(id, key, fn, cas, m.nowMs())
+			return v, changed, err
+		},
+		mutateAt: func(id uint64, key string, fn RecordMutator, cas CASCond, nowMs int64) (uint64, bool, error) {
+			_, _, v, changed, err := m.mutatePayloadRecordLockedAt(id, key, fn, cas, nowMs)
+			return v, changed, err
+		},
+		payload: func(id uint64) (Metadata, bool) {
+			_, meta, _, ok := m.Get(id)
+			return meta, ok
+		},
+		version: func(id uint64) uint64 {
+			_, _, v, ok := m.Get(id)
+			if !ok {
+				return 0
+			}
+			return v
+		},
+		stored: func(t *testing.T, id uint64) Metadata {
+			t.Helper()
+			m.mu.RLock()
+			defer m.mu.RUnlock()
+			return m.docMeta[id]
+		},
+	}
+	h.insert(t, 1, Metadata{"session": NewRecord(sessionRecordBytes(t))})
+	return h
+}
+
+// allMutateHarnesses builds one harness per engine. Every engine carries its own
+// copy of the record-mutation body, so they are all driven from the SAME table:
+// a divergence in any one of the four fails here.
+func allMutateHarnesses(t *testing.T) []func(*testing.T) mutateHarness {
+	t.Helper()
+	return []func(*testing.T) mutateHarness{
+		denseMutateHarness, ivfMutateHarness, namedMutateHarness, mvMutateHarness,
+	}
+}
+
+func TestMutateRecordNamedAndMVMatchDense(t *testing.T) {
+	t.Run("shared table", func(t *testing.T) {
+		for _, tc := range mutateCases(t) {
+			t.Run(tc.name, func(t *testing.T) {
+				for _, newH := range allMutateHarnesses(t) {
+					h := newH(t)
+					t.Run(h.name, func(t *testing.T) { runMutateCase(t, h, tc) })
+				}
+			})
+		}
+	})
+
+	t.Run("creates under an absent key", func(t *testing.T) {
+		for _, newH := range allMutateHarnesses(t) {
+			h := newH(t)
+			t.Run(h.name, func(t *testing.T) {
+				want := sessionRecordBytesRC(t, 8)
+				var sawOld []byte
+				var sawExists, called bool
+				version, changed, err := h.mutate(1, "fresh", func(old []byte, exists bool) ([]byte, RecordMutation, error) {
+					called, sawOld, sawExists = true, old, exists
+					return want, RecordStore, nil
+				}, CASCond{})
+				if err != nil {
+					t.Fatalf("mutate: %v", err)
+				}
+				if !called {
+					t.Fatal("the mutator was never called for an absent key")
+				}
+				if sawOld != nil || sawExists {
+					t.Errorf("the mutator saw (%v, %v) for an absent key, want (nil, false)", sawOld, sawExists)
+				}
+				if !changed || version != 2 {
+					t.Fatalf("changed=%v version=%d, want true/2", changed, version)
+				}
+				if got, ok := h.record(t, 1, "fresh"); !ok || !bytes.Equal(got, want) {
+					t.Fatal("the new key does not hold the stored record")
+				}
+				if got, ok := h.record(t, 1, "session"); !ok || !bytes.Equal(got, sessionRecordBytes(t)) {
+					t.Fatal("the untouched key changed — a mutation must only touch its own key")
+				}
+			})
+		}
+	})
+
+	t.Run("non-record value is an error", func(t *testing.T) {
+		for _, newH := range allMutateHarnesses(t) {
+			h := newH(t)
+			t.Run(h.name, func(t *testing.T) {
+				h.insert(t, 2, Metadata{"session": NewRecord(sessionRecordBytes(t)), "country": NewString("DE")})
+				before := h.version(2)
+				var called bool
+				_, changed, err := h.mutate(2, "country", func(_ []byte, _ bool) ([]byte, RecordMutation, error) {
+					called = true
+					return sessionRecordBytes(t), RecordStore, nil
+				}, CASCond{})
+				if !errors.Is(err, ErrPayloadKeyNotRecord) {
+					t.Fatalf("err = %v, want ErrPayloadKeyNotRecord", err)
+				}
+				if called {
+					t.Error("the mutator ran against a non-record value")
+				}
+				if changed {
+					t.Error("changed=true on a rejected call")
+				}
+				meta, ok := h.payload(2)
+				if !ok {
+					t.Fatal("point 2 is not live")
+				}
+				if got := meta["country"]; !got.Equal(NewString("DE")) {
+					t.Errorf("the non-record value changed: %+v", got)
+				}
+				if v := h.version(2); v != before {
+					t.Errorf("version = %d after a rejected call, want %d", v, before)
+				}
+			})
+		}
+	})
+
+	t.Run("absent id is not found", func(t *testing.T) {
+		for _, newH := range allMutateHarnesses(t) {
+			h := newH(t)
+			t.Run(h.name, func(t *testing.T) {
+				var called bool
+				version, changed, err := h.mutate(404, "session", func(_ []byte, _ bool) ([]byte, RecordMutation, error) {
+					called = true
+					return sessionRecordBytesRC(t, 8), RecordStore, nil
+				}, CASCond{})
+				if !errors.Is(err, ErrIDNotFound) {
+					t.Fatalf("err = %v, want ErrIDNotFound", err)
+				}
+				if called {
+					t.Error("the mutator ran against an absent point")
+				}
+				if changed || version != 0 {
+					t.Errorf("changed=%v version=%d against an absent point, want false/0", changed, version)
+				}
+			})
+		}
+	})
+
+	// The stamped clock: the per-key deadline check AND the stale-deadline drop
+	// must come from the explicit stamp, never from the engine's wall clock, or
+	// two replicas applying the same op would store different bytes.
+	t.Run("stamped clock decides expiry and drops the stale deadline", func(t *testing.T) {
+		for _, newH := range allMutateHarnesses(t) {
+			h := newH(t)
+			t.Run(h.name, func(t *testing.T) {
+				// Pin the wall clock at 4000 so the seeding set_payload gives
+				// "session" an ABSOLUTE deadline of 5000, then move it far away.
+				h.setNow(4000)
+				h.setPayload(t, 1, Metadata{"session": NewRecord(sessionRecordBytes(t))},
+					map[string]int64{"session": 1000})
+				h.setNow(9_000_000) // far past every stamp used below
+
+				// One millisecond before the deadline the key is still live.
+				var sawExists bool
+				if _, _, err := h.mutateAt(1, "session", func(_ []byte, exists bool) ([]byte, RecordMutation, error) {
+					sawExists = exists
+					return nil, RecordUnchanged, nil
+				}, CASCond{}, 4999); err != nil {
+					t.Fatalf("mutateAt(4999): %v", err)
+				}
+				if !sawExists {
+					t.Fatal("at stamp 4999 the mutator saw the key as absent — the wall clock was consulted")
+				}
+
+				// At the deadline the key reads as ABSENT, and storing under it
+				// must drop the stale deadline, or the record just written would
+				// be invisible the instant it lands.
+				want := sessionRecordBytesRC(t, 8)
+				_, changed, err := h.mutateAt(1, "session", func(_ []byte, exists bool) ([]byte, RecordMutation, error) {
+					sawExists = exists
+					return want, RecordStore, nil
+				}, CASCond{}, 5000)
+				if err != nil {
+					t.Fatalf("mutateAt(5000): %v", err)
+				}
+				if sawExists {
+					t.Fatal("at stamp 5000 the mutator saw the expired key as present")
+				}
+				if !changed {
+					t.Fatal("changed=false storing under an expired key")
+				}
+				h.setNow(6000)
+				got, ok := h.record(t, 1, "session")
+				if !ok || !bytes.Equal(got, want) {
+					t.Fatal("the freshly stored record is invisible at now=6000 — the stale deadline was not dropped")
+				}
+			})
+		}
+	})
+}
+
+// ---------------------------------------------------------------------------
+// named: the shared payload's id-keyed index after a mutation
+// ---------------------------------------------------------------------------
+
+// recordIDIn reports whether the id-keyed index posts id under field=key.
+func recordIDIn(p *payloadIndexID, field string, key scalarKey, id uint64) bool {
+	vals := p.fields[field]
+	if vals == nil {
+		return false
+	}
+	set := vals[key]
+	if set == nil {
+		return false
+	}
+	_, ok := set[id]
+	return ok
+}
+
+// assertRecordPostingsExactID is assertRecordPostingsExact for the id-keyed
+// mirror: for the synthetic field, the index's postings agree EXACTLY with what
+// lookupPath resolves from each id's stored payload (the map reindex was last
+// handed).
+func assertRecordPostingsExactID(t *testing.T, p *payloadIndexID, meta map[uint64]Metadata, ids []uint64, field string) {
+	t.Helper()
+	posted := make(map[uint64]scalarKey)
+	for key, set := range p.fields[field] {
+		for id := range set {
+			if prev, dup := posted[id]; dup {
+				t.Errorf("id %d is posted under two keys for %q: %+v and %+v", id, field, prev, key)
+			}
+			posted[id] = key
+		}
+	}
+	for _, id := range ids {
+		v, resolved := lookupPath(meta[id], field)
+		key, scalar := scalarKeyOf(v)
+		gotKey, gotPosted := posted[id]
+		delete(posted, id)
+		if resolved && scalar {
+			if !gotPosted {
+				t.Errorf("id %d resolves %q = %+v but has no posting", id, field, key)
+			} else if gotKey != key {
+				t.Errorf("id %d resolves %q = %+v but is posted under %+v", id, field, key, gotKey)
+			}
+			continue
+		}
+		if gotPosted {
+			t.Errorf("id %d does not resolve %q but is posted under %+v", id, field, gotKey)
+		}
+	}
+	for id, key := range posted {
+		t.Errorf("%q has a posting for id %d under %+v that no live id explains", field, id, key)
+	}
+}
+
+func TestMutateRecordNamedSharedPayloadReindex(t *testing.T) {
+	t.Run("postings stay exact", func(t *testing.T) {
+		nc := newTestNamed(t)
+		ids := make([]uint64, 0, 12)
+		for i := 1; i <= 12; i++ {
+			id := uint64(i)
+			meta := Metadata{"session": NewRecord(sessionRecordBytesRC(t, uint8(i%5)))} //nolint:gosec // bounded
+			if _, err := nc.InsertCAS(id, namedVecs(), meta, 0, CASCond{}); err != nil {
+				t.Fatalf("InsertCAS(%d): %v", id, err)
+			}
+			ids = append(ids, id)
+		}
+		// Point 1 goes to rc=7 and then to rc=8, so the mutation must move it.
+		if _, err := nc.MutatePayloadRecordCAS(1, "session", storeFn(sessionRecordBytesRC(t, 7)), CASCond{}); err != nil {
+			t.Fatalf("MutatePayloadRecordCAS: %v", err)
+		}
+		nc.mu.RLock()
+		assertRecordPostingsExactID(t, nc.payloadIdx, nc.meta, ids, "session/rc")
+		nc.mu.RUnlock()
+
+		if _, err := nc.MutatePayloadRecordCAS(1, "session", storeFn(sessionRecordBytesRC(t, 8)), CASCond{}); err != nil {
+			t.Fatalf("MutatePayloadRecordCAS: %v", err)
+		}
+		nc.mu.RLock()
+		defer nc.mu.RUnlock()
+		if recordIDIn(nc.payloadIdx, "session/rc", intKey(7), 1) {
+			t.Error("fields[session/rc][7] still holds the mutated id — stale posting after a record mutation")
+		}
+		if !recordIDIn(nc.payloadIdx, "session/rc", intKey(8), 1) {
+			t.Error("fields[session/rc][8] is missing the mutated id")
+		}
+		assertRecordPostingsExactID(t, nc.payloadIdx, nc.meta, ids, "session/rc")
+	})
+
+	t.Run("bad-record poison clears", func(t *testing.T) {
+		nc := newTestNamed(t)
+		// A mode byte followed by a torn schema blob: IndexEntries cannot
+		// enumerate it, so the payload key is poisoned and nothing under it
+		// accelerates. The accounting is per-ID here, not per-slot.
+		if _, err := nc.InsertCAS(1, namedVecs(), Metadata{"session": NewRecord([]byte{0x01, 0xFF})}, 0, CASCond{}); err != nil {
+			t.Fatalf("InsertCAS: %v", err)
+		}
+		if !nc.payloadIdx.badRecords.poisoned("session") {
+			t.Fatal("the malformed record did not poison the payload key — the fixture is wrong")
+		}
+		want := sessionRecordBytes(t)
+		if _, err := nc.MutatePayloadRecordCAS(1, "session", storeFn(want), CASCond{}); err != nil {
+			t.Fatalf("MutatePayloadRecordCAS over a malformed record: %v", err)
+		}
+		nc.mu.RLock()
+		defer nc.mu.RUnlock()
+		if nc.payloadIdx.badRecords.poisoned("session") {
+			t.Fatal("the payload key stayed poisoned after the malformed record was replaced")
+		}
+		if !recordIDIn(nc.payloadIdx, "session/rc", intKey(7), 1) {
+			t.Error("the repaired record did not regain acceleration (no session/rc posting)")
+		}
+	})
+}
+
+// ---------------------------------------------------------------------------
+// named/MV WAL: one record per applied mutation, replayed verbatim
+// ---------------------------------------------------------------------------
+
+// walMutateEngine is one WAL-mode family behind the reopen table.
+type walMutateEngine struct {
+	mutate   func(key string, fn RecordMutator, cas CASCond) (uint64, error)
+	mutateAt func(key string, fn RecordMutator, cas CASCond, nowMs int64) (uint64, error)
+	payload  func() (Metadata, bool)
+	version  func() uint64
+	stored   func(t *testing.T) Metadata
+	postings func() map[scalarKey]map[uint64]struct{} // session/rc postings
+	wal      *wal
+}
+
+func namedWALEngine(nc *NamedCollection) walMutateEngine {
+	return walMutateEngine{
+		mutate: func(key string, fn RecordMutator, cas CASCond) (uint64, error) {
+			return nc.MutatePayloadRecordCAS(1, key, fn, cas)
+		},
+		mutateAt: func(key string, fn RecordMutator, cas CASCond, nowMs int64) (uint64, error) {
+			return nc.MutatePayloadRecordCASAt(1, key, fn, cas, nowMs)
+		},
+		payload: func() (Metadata, bool) {
+			_, meta, _, _, ok := nc.Get(1)
+			return meta, ok
+		},
+		version: func() uint64 {
+			_, _, _, v, ok := nc.Get(1)
+			if !ok {
+				return 0
+			}
+			return v
+		},
+		stored: func(t *testing.T) Metadata {
+			t.Helper()
+			nc.mu.RLock()
+			defer nc.mu.RUnlock()
+			return nc.meta[1]
+		},
+		postings: func() map[scalarKey]map[uint64]struct{} {
+			nc.mu.RLock()
+			defer nc.mu.RUnlock()
+			return nc.payloadIdx.fields["session/rc"]
+		},
+		wal: nc.wal,
+	}
+}
+
+func mvWALEngine(m *MultiVectorIndex) walMutateEngine {
+	return walMutateEngine{
+		mutate: func(key string, fn RecordMutator, cas CASCond) (uint64, error) {
+			return m.MutatePayloadRecordCAS(1, key, fn, cas)
+		},
+		mutateAt: func(key string, fn RecordMutator, cas CASCond, nowMs int64) (uint64, error) {
+			return m.MutatePayloadRecordCASAt(1, key, fn, cas, nowMs)
+		},
+		payload: func() (Metadata, bool) {
+			_, meta, _, ok := m.Get(1)
+			return meta, ok
+		},
+		version: func() uint64 {
+			_, _, v, ok := m.Get(1)
+			if !ok {
+				return 0
+			}
+			return v
+		},
+		stored: func(t *testing.T) Metadata {
+			t.Helper()
+			m.mu.RLock()
+			defer m.mu.RUnlock()
+			return m.docMeta[1]
+		},
+		postings: func() map[scalarKey]map[uint64]struct{} {
+			m.mu.RLock()
+			defer m.mu.RUnlock()
+			return m.payloadIdx.fields["session/rc"]
+		},
+		wal: m.wal,
+	}
+}
+
+// walMutateFamily opens (or reopens) a WAL-mode collection of one family in dir,
+// holding point/doc 1 with an rc=7 "session" record. The caller owns Close — the
+// reopen cases close deliberately, without a Flush.
+type walMutateFamily struct {
+	name string
+	open func(t *testing.T, dir string) (*CollectionStore, walMutateEngine)
+}
+
+func walMutateFamilies() []walMutateFamily {
+	return []walMutateFamily{
+		{
+			name: "named",
+			open: func(t *testing.T, dir string) (*CollectionStore, walMutateEngine) {
+				t.Helper()
+				cs, err := OpenCollectionStore(dir)
+				if err != nil {
+					t.Fatalf("OpenCollectionStore: %v", err)
+				}
+				nc, ok := cs.GetNamed("named")
+				if !ok {
+					if err := cs.CreateCollection("named", namedWALConfig()); err != nil {
+						t.Fatalf("CreateCollection: %v", err)
+					}
+					if nc, ok = cs.GetNamed("named"); !ok {
+						t.Fatal("named collection missing after create")
+					}
+					if _, err := nc.InsertCAS(1, map[string][]float32{"title": {1, 0, 0, 0}},
+						Metadata{"session": NewRecord(sessionRecordBytes(t))}, 0, CASCond{}); err != nil {
+						t.Fatalf("seed insert: %v", err)
+					}
+				}
+				if nc.wal == nil {
+					t.Fatal("WAL-mode named collection has nil wal")
+				}
+				return cs, namedWALEngine(nc)
+			},
+		},
+		{
+			name: "mv",
+			open: func(t *testing.T, dir string) (*CollectionStore, walMutateEngine) {
+				t.Helper()
+				cs, err := OpenCollectionStore(dir)
+				if err != nil {
+					t.Fatalf("OpenCollectionStore: %v", err)
+				}
+				idx, ok := cs.GetMultiVector("mv")
+				if !ok {
+					if err := cs.CreateMultiVector("mv", mvWALConfig()); err != nil {
+						t.Fatalf("CreateMultiVector: %v", err)
+					}
+					if idx, ok = cs.GetMultiVector("mv"); !ok {
+						t.Fatal("MV collection missing after create")
+					}
+					if _, err := idx.AddCAS(1, [][]float32{{1, 0, 0, 0}, {0, 1, 0, 0}},
+						Metadata{"session": NewRecord(sessionRecordBytes(t))}, CASCond{}); err != nil {
+						t.Fatalf("seed add: %v", err)
+					}
+				}
+				if idx.wal == nil {
+					t.Fatal("WAL-mode MV collection has nil wal")
+				}
+				return cs, mvWALEngine(idx)
+			},
+		},
+	}
+}
+
+func TestMutateRecordNamedAndMVSurviveReopen(t *testing.T) {
+	const stamp int64 = 1_700_000_000_000
+	cases := []struct {
+		name   string
+		mutate func(t *testing.T, e walMutateEngine) (version uint64)
+		verify func(t *testing.T, e walMutateEngine, version uint64)
+	}{
+		{
+			name: "store",
+			mutate: func(t *testing.T, e walMutateEngine) uint64 {
+				v, err := e.mutate("session", storeFn(sessionRecordBytesRC(t, 8)), CASCond{})
+				if err != nil {
+					t.Fatalf("MutatePayloadRecordCAS: %v", err)
+				}
+				return v
+			},
+			verify: func(t *testing.T, e walMutateEngine, version uint64) {
+				meta, ok := e.payload()
+				if !ok {
+					t.Fatal("point 1 lost across reopen")
+				}
+				if v := e.version(); v != version {
+					t.Fatalf("version = %d after replay, want the acked %d", v, version)
+				}
+				if got := meta["session"]; got.Kind != ValueRecord || !bytes.Equal(got.Rec, sessionRecordBytesRC(t, 8)) {
+					t.Fatal("the mutated record did not replay byte-identically")
+				}
+			},
+		},
+		{
+			name: "delete",
+			mutate: func(t *testing.T, e walMutateEngine) uint64 {
+				v, err := e.mutate("session",
+					func(_ []byte, _ bool) ([]byte, RecordMutation, error) { return nil, RecordDelete, nil }, CASCond{})
+				if err != nil {
+					t.Fatalf("MutatePayloadRecordCAS (delete): %v", err)
+				}
+				return v
+			},
+			verify: func(t *testing.T, e walMutateEngine, version uint64) {
+				meta, ok := e.payload()
+				if !ok {
+					t.Fatal("point 1 lost across reopen")
+				}
+				if v := e.version(); v != version {
+					t.Fatalf("version = %d after replay, want the acked %d", v, version)
+				}
+				if _, present := meta["session"]; present {
+					t.Fatal("the deleted key came back on replay — the WAL record is a REPLACE, not a merge")
+				}
+				if got := e.stored(t); got != nil {
+					t.Errorf("replayed stored payload = %v, want nil (the pre-restart state)", got)
+				}
+				if p := e.postings(); len(p) != 0 {
+					t.Fatalf("the rebuilt index still posts session/rc: %v", p)
+				}
+			},
+		},
+		{
+			name: "stamped op-list",
+			mutate: func(t *testing.T, e walMutateEngine) uint64 {
+				v, err := e.mutateAt("session", storeFn(stampedRecordBytes(t, stamp)), CASCond{}, stamp)
+				if err != nil {
+					t.Fatalf("MutatePayloadRecordCASAt: %v", err)
+				}
+				return v
+			},
+			verify: func(t *testing.T, e walMutateEngine, version uint64) {
+				meta, ok := e.payload()
+				if !ok {
+					t.Fatal("point 1 lost across reopen")
+				}
+				if v := e.version(); v != version {
+					t.Fatalf("version = %d after replay, want the acked %d", v, version)
+				}
+				if got := meta["session"]; !bytes.Equal(got.Rec, stampedRecordBytes(t, stamp)) {
+					t.Fatal("the stamped record changed on replay — the op-list must never be re-run")
+				}
+			},
+		},
+	}
+
+	for _, fam := range walMutateFamilies() {
+		t.Run(fam.name, func(t *testing.T) {
+			for _, tc := range cases {
+				t.Run(tc.name, func(t *testing.T) {
+					dir := t.TempDir()
+					cs, e := fam.open(t, dir)
+					version := tc.mutate(t, e)
+					// NO Flush: the WAL alone must carry the mutation.
+					if err := cs.Close(); err != nil {
+						t.Fatalf("Close: %v", err)
+					}
+					reopened, e2 := fam.open(t, dir)
+					t.Cleanup(func() { _ = reopened.Close() })
+					tc.verify(t, e2, version)
+				})
+			}
+		})
+	}
+}
+
+// walSeqOf reads a WAL's monotonic record counter under its own lock.
+func walSeqOf(w *wal) uint64 {
+	w.syncMu.Lock()
+	defer w.syncMu.Unlock()
+	return w.writeSeq
+}
+
+// walSizeOf reads the WAL file's on-disk size.
+func walSizeOf(t *testing.T, w *wal) int64 {
+	t.Helper()
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	fi, err := w.f.Stat()
+	if err != nil {
+		t.Fatalf("stat wal: %v", err)
+	}
+	return fi.Size()
+}
+
+// TestMutateRecordNamedWALNoOp pins the whole point of the changed flag on the
+// named and MV wrappers: a mutation that reports RecordUnchanged (a failed CHECK)
+// stages NOTHING — neither a log record nor a byte on disk — while a RecordStore
+// stages exactly one.
+func TestMutateRecordNamedWALNoOp(t *testing.T) {
+	for _, fam := range walMutateFamilies() {
+		t.Run(fam.name, func(t *testing.T) {
+			cs, e := fam.open(t, t.TempDir())
+			t.Cleanup(func() { _ = cs.Close() })
+
+			before := e.version()
+			seqBefore, sizeBefore := walSeqOf(e.wal), walSizeOf(t, e.wal)
+			version, err := e.mutate("session",
+				func(_ []byte, _ bool) ([]byte, RecordMutation, error) { return nil, RecordUnchanged, nil }, CASCond{})
+			if err != nil {
+				t.Fatalf("MutatePayloadRecordCAS: %v", err)
+			}
+			if version != before {
+				t.Fatalf("version = %d after a no-op, want the unbumped %d", version, before)
+			}
+			if got := walSeqOf(e.wal); got != seqBefore {
+				t.Fatalf("the WAL advanced %d -> %d on a no-op — a failed CHECK must not cost a log record", seqBefore, got)
+			}
+			if got := walSizeOf(t, e.wal); got != sizeBefore {
+				t.Fatalf("the WAL file grew %d -> %d bytes on a no-op", sizeBefore, got)
+			}
+
+			// A real store stages exactly one record.
+			if _, err := e.mutate("session", storeFn(sessionRecordBytesRC(t, 8)), CASCond{}); err != nil {
+				t.Fatalf("MutatePayloadRecordCAS (store): %v", err)
+			}
+			if got := walSeqOf(e.wal); got != seqBefore+1 {
+				t.Fatalf("the WAL advanced %d -> %d on a store, want exactly one record", seqBefore, got)
+			}
+			if e.version() != before+1 {
+				t.Fatalf("version = %d after a store, want %d", e.version(), before+1)
+			}
+		})
+	}
+}

--- a/vector/record_mutate_test.go
+++ b/vector/record_mutate_test.go
@@ -577,11 +577,9 @@ func TestMutateRecordReindexesBadRecordPoison(t *testing.T) {
 	}
 	// A mode byte followed by a torn schema blob: IndexEntries cannot
 	// enumerate it, so the payload key is poisoned and nothing under it
-	// accelerates.
-	if _, _, err := h.Insert(1, []float32{1, 0, 0, 0},
-		0, Metadata{"session": NewRecord([]byte{0x01, 0xFF})}, nil, nil, CASCond{}); err != nil {
-		t.Fatal(err)
-	}
+	// accelerates. Seeded through the REPLAY entry because the public ones now
+	// refuse a malformed record (ErrRecordMalformed) — see insertViaReplay.
+	insertViaReplay(t, h, 1, []float32{1, 0, 0, 0}, Metadata{"session": NewRecord([]byte{0x01, 0xFF})})
 	if !h.payloadIdx.badRecords.poisoned("session") {
 		t.Fatal("the malformed record did not poison the payload key — the fixture is wrong")
 	}
@@ -780,6 +778,11 @@ type mutateHarness struct {
 	setPayload func(t *testing.T, id uint64, meta Metadata, keyTTLMs map[string]int64)
 	mutate     func(id uint64, key string, fn RecordMutator, cas CASCond) (version uint64, changed bool, err error)
 	mutateAt   func(id uint64, key string, fn RecordMutator, cas CASCond, nowMs int64) (version uint64, changed bool, err error)
+	// mutateAtKE is mutateAt keeping the RESULTING per-key deadline map, which
+	// mutateAt drops. It is normalised to int64 unix-millis (the slot-keyed
+	// engines report uint64, the id-keyed ones int64) so one table can assert on
+	// all four engines.
+	mutateAtKE func(id uint64, key string, fn RecordMutator, cas CASCond, nowMs int64) (map[string]int64, uint64, bool, error)
 	// payload is the live payload as a reader sees it at the pinned clock
 	// (per-key-expired keys already dropped); ok=false for a dead/absent point.
 	payload func(id uint64) (Metadata, bool)
@@ -861,6 +864,10 @@ func vectorIndexHarness(name string, ix VectorIndex, setNow func(int64)) mutateH
 			_, _, version, changed, err := ix.MutatePayloadRecordAt(id, key, fn, cas, nowMs)
 			return version, changed, err
 		},
+		mutateAtKE: func(id uint64, key string, fn RecordMutator, cas CASCond, nowMs int64) (map[string]int64, uint64, bool, error) {
+			_, ke, version, changed, err := ix.MutatePayloadRecordAt(id, key, fn, cas, nowMs)
+			return deadlinesInt64(ke), version, changed, err
+		},
 		payload: func(id uint64) (Metadata, bool) {
 			_, meta, _, _, _, ok := ix.Get(id)
 			return meta, ok
@@ -877,6 +884,20 @@ func vectorIndexHarness(name string, ix VectorIndex, setNow func(int64)) mutateH
 			return storedMeta(t, ix, id)
 		},
 	}
+}
+
+// deadlinesInt64 converts a slot-keyed engine's absolute per-key deadline map to
+// the int64 unix-millis the id-keyed engines already report, so the shared table
+// compares like with like.
+func deadlinesInt64(ke map[string]uint64) map[string]int64 {
+	if ke == nil {
+		return nil
+	}
+	out := make(map[string]int64, len(ke))
+	for k, v := range ke {
+		out[k] = int64(v) //nolint:gosec // absolute unix-millis deadlines fit int64
+	}
+	return out
 }
 
 // mutateCase is one engine-level scenario, run against every engine so no copy

--- a/vector/record_mutate_test.go
+++ b/vector/record_mutate_test.go
@@ -1042,3 +1042,116 @@ func TestMutateRecordIVFMatchesHNSW(t *testing.T) {
 		})
 	}
 }
+
+// ---------------------------------------------------------------------------
+// the stamped/unstamped asymmetry on a key that carries a deadline
+// ---------------------------------------------------------------------------
+
+// TestMutateRecordUnstampedKeepsTheKeyDeadline pins the rule that makes an
+// unstamped replicated apply deterministic: on the UNSTAMPED path the mutator
+// must not consult the clock for the payload key's deadline at all.
+//
+// Without it, two replicas applying the same entry with wall clocks either side
+// of the deadline disagree about whether the record EXISTS — one creates a fresh
+// record, the other increments the stored one — and they hold different bytes
+// forever. So the unstamped path treats a deadline-passed record as present,
+// mutates it in place, and passes the deadline through untouched; only the
+// stamped path (whose clock is the leader's, identical everywhere) may expire
+// the key. See recordKeyPastDeadline (vector/record_mutate.go).
+//
+// Runs on all four engines, because the rule lives in four bodies.
+func TestMutateRecordUnstampedKeepsTheKeyDeadline(t *testing.T) {
+	const deadline = mutateHarnessBase + 1000
+
+	t.Run("unstamped mutates in place and keeps the deadline", func(t *testing.T) {
+		for _, newH := range allMutateHarnesses(t) {
+			h := newH(t)
+			t.Run(h.name, func(t *testing.T) {
+				// Seed an absolute deadline of base+1000 on the record key.
+				h.setNow(mutateHarnessBase)
+				h.setPayload(t, 1, Metadata{"session": NewRecord(sessionRecordBytes(t))},
+					map[string]int64{"session": 1000})
+
+				// Move this "replica's" wall clock well past the deadline.
+				h.setNow(deadline + 4000)
+
+				want := sessionRecordBytesRC(t, 8)
+				var sawOld []byte
+				var sawExists bool
+				version, changed, err := h.mutate(1, "session", func(old []byte, exists bool) ([]byte, RecordMutation, error) {
+					sawOld, sawExists = append([]byte(nil), old...), exists
+					return want, RecordStore, nil
+				}, CASCond{})
+				if err != nil {
+					t.Fatalf("%s: unstamped mutate past the deadline: %v", h.name, err)
+				}
+				if !sawExists {
+					t.Fatalf("%s: the unstamped mutator saw the record as ABSENT — a wall clock decided whether it exists, "+
+						"which is exactly what makes two replicas store different bytes", h.name)
+				}
+				if !bytes.Equal(sawOld, sessionRecordBytes(t)) {
+					t.Fatalf("%s: the unstamped mutator got old=%x, want the stored record %x",
+						h.name, sawOld, sessionRecordBytes(t))
+				}
+				if !changed || version == 0 {
+					t.Fatalf("%s: changed=%v version=%d, want a real applied mutation", h.name, changed, version)
+				}
+
+				// The deadline survived: BEFORE it the freshly written record is
+				// visible, AFTER it the key is gone again. A dropped deadline would
+				// leave the key visible at both clocks.
+				h.setNow(deadline - 1)
+				if rec, ok := h.record(t, 1, "session"); !ok || !bytes.Equal(rec, want) {
+					t.Fatalf("%s: before the deadline the mutated record is not readable (ok=%v)", h.name, ok)
+				}
+				h.setNow(deadline)
+				if _, ok := h.record(t, 1, "session"); ok {
+					t.Fatalf("%s: the key is still live at its deadline — the unstamped mutation DROPPED the deadline "+
+						"instead of passing it through", h.name)
+				}
+			})
+		}
+	})
+
+	// The control: the stamped path is the one that may expire the key, and it
+	// still does. A stamp past the deadline reads the record as absent and drops
+	// the stale deadline, so the record it writes is immediately visible.
+	t.Run("stamped past the deadline still reads absent", func(t *testing.T) {
+		for _, newH := range allMutateHarnesses(t) {
+			h := newH(t)
+			t.Run(h.name, func(t *testing.T) {
+				h.setNow(mutateHarnessBase)
+				h.setPayload(t, 1, Metadata{"session": NewRecord(sessionRecordBytes(t))},
+					map[string]int64{"session": 1000})
+				// The wall clock stays BEFORE the deadline: anything that comes out
+				// "expired" below was decided by the stamp, not by the clock.
+				h.setNow(mutateHarnessBase)
+
+				want := sessionRecordBytesRC(t, 9)
+				var sawExists bool
+				ke, version, changed, err := h.mutateAtKE(1, "session", func(_ []byte, exists bool) ([]byte, RecordMutation, error) {
+					sawExists = exists
+					return want, RecordStore, nil
+				}, CASCond{}, deadline)
+				if err != nil {
+					t.Fatalf("%s: stamped mutate at the deadline: %v", h.name, err)
+				}
+				if sawExists {
+					t.Fatalf("%s: the stamped mutator saw the deadline-passed record as PRESENT — the stamp was ignored", h.name)
+				}
+				if !changed || version == 0 {
+					t.Fatalf("%s: changed=%v version=%d, want a real applied mutation", h.name, changed, version)
+				}
+				if _, present := ke["session"]; present {
+					t.Fatalf("%s: the stale deadline survived a stamped mutation: %v", h.name, ke)
+				}
+				// The record just written is visible at a clock past the old deadline.
+				h.setNow(deadline + 4000)
+				if rec, ok := h.record(t, 1, "session"); !ok || !bytes.Equal(rec, want) {
+					t.Fatalf("%s: the record stored by the stamped mutation is invisible (ok=%v) — the stale deadline was not dropped",
+						h.name, ok)
+				}
+			})
+		}
+	})
+}

--- a/vector/record_mutate_test.go
+++ b/vector/record_mutate_test.go
@@ -1,0 +1,870 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package vector
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"testing"
+	"time"
+
+	"github.com/rostamlabs/rostam/sdk/wire"
+)
+
+// ---------------------------------------------------------------------------
+// fixtures
+// ---------------------------------------------------------------------------
+
+// mutateRecordCfg is the dense config every engine-level test in this file
+// uses (the brief's fixture: dim 4, L2, seeded so the graph is deterministic).
+func mutateRecordCfg() Config {
+	return Config{Dim: 4, Metric: L2, M: 16, EfConstruction: 200, EfSearch: 128, Seed: 1}
+}
+
+// seedMutateHNSW returns a dense engine holding point 1 with a "session"
+// record (rc=7) — the single point almost every case below mutates.
+func seedMutateHNSW(t *testing.T) *hnsw {
+	t.Helper()
+	h, err := newHNSW(mutateRecordCfg())
+	if err != nil {
+		t.Fatalf("newHNSW: %v", err)
+	}
+	seedMutatePoint(t, h, 1)
+	return h
+}
+
+// seedMutatePoint inserts id carrying a "session" record with rc=7 into any
+// engine, so the dense and IVF tables run against identical state.
+func seedMutatePoint(t *testing.T, ix VectorIndex, id uint64) {
+	t.Helper()
+	vec := make([]float32, ix.Dim())
+	vec[0] = float32(id)
+	if _, _, err := ix.Insert(id, vec, 0, Metadata{"session": NewRecord(sessionRecordBytes(t))}, nil, nil, CASCond{}); err != nil {
+		t.Fatalf("Insert(%d): %v", id, err)
+	}
+}
+
+// storeFn is a mutator that unconditionally stores rec.
+func storeFn(rec []byte) RecordMutator {
+	return func(_ []byte, _ bool) ([]byte, RecordMutation, error) { return rec, RecordStore, nil }
+}
+
+// stampedRecordBytes is a dynamic-mode record {at: I64 = stamp}. It stands in
+// for an op-list containing STAMP: the value is baked in by the CALLER's
+// pinned clock, so a replay that re-ran the op-list under a different clock
+// would produce different bytes.
+func stampedRecordBytes(t *testing.T, stamp int64) []byte {
+	t.Helper()
+	enc := (&wire.Record{Mode: wire.OperateModeDynamic, Fields: []wire.Field{
+		{Name: "at", Cell: wire.Cell{Type: wire.OperateTypeI64, U: su64(stamp)}},
+	}}).Encode()
+	if enc == nil {
+		t.Fatal("stamped record failed to encode")
+	}
+	return enc
+}
+
+// storedMeta returns the metadata the arena actually holds for id — the state
+// Get normalizes away (it reports nil for any empty payload) and the state a WAL
+// replay has to reproduce.
+func storedMeta(t *testing.T, h *hnsw, id uint64) Metadata {
+	t.Helper()
+	h.mu.RLock()
+	defer h.mu.RUnlock()
+	slot, ok := h.arena.Slot(id)
+	if !ok {
+		t.Fatalf("id %d has no slot", id)
+	}
+	return h.arena.Metadata(slot)
+}
+
+// pointVersion reads id's current version through the public read path.
+func pointVersion(t *testing.T, ix VectorIndex, id uint64) uint64 {
+	t.Helper()
+	_, _, _, _, v, ok := ix.Get(id)
+	if !ok {
+		t.Fatalf("Get(%d): point is not live", id)
+	}
+	return v
+}
+
+// recordUnder returns the record bytes stored under key in id's payload.
+func recordUnder(t *testing.T, ix VectorIndex, id uint64, key string) ([]byte, bool) {
+	t.Helper()
+	_, meta, _, _, _, ok := ix.Get(id)
+	if !ok {
+		t.Fatalf("Get(%d): point is not live", id)
+	}
+	v, present := meta[key]
+	if !present {
+		return nil, false
+	}
+	if v.Kind != ValueRecord {
+		t.Fatalf("payload key %q holds kind %d, want a record", key, v.Kind)
+	}
+	return v.Rec, true
+}
+
+// ---------------------------------------------------------------------------
+// engine-level behaviour (dense)
+// ---------------------------------------------------------------------------
+
+func TestMutateRecordStoresAndBumps(t *testing.T) {
+	h := seedMutateHNSW(t)
+	before := pointVersion(t, h, 1)
+	want := sessionRecordBytesRC(t, 8)
+
+	var sawOld []byte
+	var sawExists bool
+	meta, ke, version, changed, err := h.MutatePayloadRecord(1, "session", func(old []byte, exists bool) ([]byte, RecordMutation, error) {
+		sawOld = append([]byte(nil), old...)
+		sawExists = exists
+		return want, RecordStore, nil
+	}, CASCond{})
+	if err != nil {
+		t.Fatalf("MutatePayloadRecord: %v", err)
+	}
+	if !changed {
+		t.Fatal("changed=false for a RecordStore — a stored record is a change")
+	}
+	if version != before+1 {
+		t.Fatalf("version = %d, want %d (exactly one bump)", version, before+1)
+	}
+	if !sawExists {
+		t.Error("the mutator saw exists=false for a key that holds a record")
+	}
+	if !bytes.Equal(sawOld, sessionRecordBytesRC(t, 7)) {
+		t.Errorf("the mutator saw %d old bytes, want the stored rc=7 record", len(sawOld))
+	}
+	if got := meta["session"]; got.Kind != ValueRecord || !bytes.Equal(got.Rec, want) {
+		t.Error("the returned payload does not carry the new record bytes")
+	}
+	if len(ke) != 0 {
+		t.Errorf("resulting per-key deadlines = %v, want none", ke)
+	}
+	got, present := recordUnder(t, h, 1, "session")
+	if !present || !bytes.Equal(got, want) {
+		t.Fatal("Get(1) does not show the new record bytes")
+	}
+	if v := pointVersion(t, h, 1); v != version {
+		t.Fatalf("Get(1) version = %d, want the returned %d", v, version)
+	}
+}
+
+func TestMutateRecordCreatesUnderAbsentKey(t *testing.T) {
+	h := seedMutateHNSW(t)
+	want := sessionRecordBytesRC(t, 8)
+
+	var sawOld []byte
+	var sawExists, called bool
+	_, _, _, changed, err := h.MutatePayloadRecord(1, "fresh", func(old []byte, exists bool) ([]byte, RecordMutation, error) {
+		called, sawOld, sawExists = true, old, exists
+		return want, RecordStore, nil
+	}, CASCond{})
+	if err != nil {
+		t.Fatalf("MutatePayloadRecord: %v", err)
+	}
+	if !called {
+		t.Fatal("the mutator was never called for an absent key")
+	}
+	if sawOld != nil || sawExists {
+		t.Errorf("the mutator saw (%v, %v) for an absent key, want (nil, false)", sawOld, sawExists)
+	}
+	if !changed {
+		t.Fatal("changed=false after creating a record under an absent key")
+	}
+	fresh, ok := recordUnder(t, h, 1, "fresh")
+	if !ok || !bytes.Equal(fresh, want) {
+		t.Fatal("the new key does not hold the stored record")
+	}
+	session, ok := recordUnder(t, h, 1, "session")
+	if !ok || !bytes.Equal(session, sessionRecordBytes(t)) {
+		t.Fatal("the untouched key changed — a mutation must only touch its own key")
+	}
+}
+
+func TestMutateRecordUnchangedIsANoOp(t *testing.T) {
+	t.Run("engine", func(t *testing.T) {
+		h := seedMutateHNSW(t)
+		before := pointVersion(t, h, 1)
+		meta, ke, version, changed, err := h.MutatePayloadRecord(1, "session",
+			func(_ []byte, _ bool) ([]byte, RecordMutation, error) { return nil, RecordUnchanged, nil }, CASCond{})
+		if err != nil {
+			t.Fatalf("MutatePayloadRecord: %v", err)
+		}
+		if changed {
+			t.Fatal("changed=true for RecordUnchanged")
+		}
+		if version != before {
+			t.Fatalf("version = %d after a no-op, want the unbumped %d", version, before)
+		}
+		if meta != nil || ke != nil {
+			t.Errorf("a no-op returned a payload/deadline map (%v, %v) — nothing was applied", meta, ke)
+		}
+		got, ok := recordUnder(t, h, 1, "session")
+		if !ok || !bytes.Equal(got, sessionRecordBytes(t)) {
+			t.Fatal("a no-op changed the stored bytes")
+		}
+	})
+
+	t.Run("wal", func(t *testing.T) {
+		_, c := seedMutateWALCollection(t)
+		before := pointVersion(t, c.idx, 1)
+		seqBefore := walWriteSeq(c)
+		version, err := c.MutatePayloadRecordCAS(1, "session",
+			func(_ []byte, _ bool) ([]byte, RecordMutation, error) { return nil, RecordUnchanged, nil }, CASCond{})
+		if err != nil {
+			t.Fatalf("MutatePayloadRecordCAS: %v", err)
+		}
+		if version != before {
+			t.Fatalf("version = %d after a no-op, want the unbumped %d", version, before)
+		}
+		if got := walWriteSeq(c); got != seqBefore {
+			t.Fatalf("the WAL advanced %d -> %d on a no-op — a failed CHECK must not cost a log record", seqBefore, got)
+		}
+	})
+}
+
+func TestMutateRecordDelete(t *testing.T) {
+	h := seedMutateHNSW(t)
+	before := pointVersion(t, h, 1)
+
+	meta, _, version, changed, err := h.MutatePayloadRecord(1, "session",
+		func(_ []byte, _ bool) ([]byte, RecordMutation, error) { return nil, RecordDelete, nil }, CASCond{})
+	if err != nil {
+		t.Fatalf("MutatePayloadRecord (delete): %v", err)
+	}
+	if !changed || version != before+1 {
+		t.Fatalf("delete of a present key: changed=%v version=%d, want true/%d", changed, version, before+1)
+	}
+	if _, present := meta["session"]; present {
+		t.Error("the returned payload still holds the deleted key")
+	}
+	if _, ok := recordUnder(t, h, 1, "session"); ok {
+		t.Fatal("the payload key survived a RecordDelete")
+	}
+	// Deleting the only key empties the payload, and an empty payload is STORED
+	// as nil — the same normalization DeletePayloadKeys applies. Get cannot see
+	// the difference (it returns nil for any empty payload), so this asserts on
+	// the arena: an empty non-nil map there would differ from the state the same
+	// WAL record rebuilds on replay, which decodes an absent payload as nil.
+	if got := storedMeta(t, h, 1); got != nil {
+		t.Errorf("stored payload = %v after deleting the only key, want nil", got)
+	}
+
+	// A second delete of the now-absent key is a deliberate no-op.
+	_, _, version2, changed2, err := h.MutatePayloadRecord(1, "session",
+		func(_ []byte, _ bool) ([]byte, RecordMutation, error) { return nil, RecordDelete, nil }, CASCond{})
+	if err != nil {
+		t.Fatalf("MutatePayloadRecord (second delete): %v", err)
+	}
+	if changed2 {
+		t.Error("changed=true deleting an already-absent key")
+	}
+	if version2 != version {
+		t.Fatalf("version = %d after deleting an absent key, want the unbumped %d", version2, version)
+	}
+}
+
+func TestMutateRecordNonRecordValueIsAnError(t *testing.T) {
+	h, err := newHNSW(mutateRecordCfg())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := h.Insert(1, []float32{1, 0, 0, 0},
+		0, Metadata{"session": NewRecord(sessionRecordBytes(t)), "country": NewString("DE")}, nil, nil, CASCond{}); err != nil {
+		t.Fatal(err)
+	}
+	before := pointVersion(t, h, 1)
+
+	var called bool
+	_, _, _, changed, err := h.MutatePayloadRecord(1, "country", func(_ []byte, _ bool) ([]byte, RecordMutation, error) {
+		called = true
+		return sessionRecordBytes(t), RecordStore, nil
+	}, CASCond{})
+	if !errors.Is(err, ErrPayloadKeyNotRecord) {
+		t.Fatalf("err = %v, want ErrPayloadKeyNotRecord", err)
+	}
+	if called {
+		t.Error("the mutator ran against a non-record value — the key must be rejected before fn")
+	}
+	if changed {
+		t.Error("changed=true on a rejected call")
+	}
+	_, meta, _, _, version, _ := h.Get(1)
+	if got := meta["country"]; !got.Equal(NewString("DE")) {
+		t.Errorf("the non-record value changed: %+v", got)
+	}
+	if version != before {
+		t.Fatalf("version = %d after a rejected call, want %d", version, before)
+	}
+}
+
+func TestMutateRecordOversizeRejected(t *testing.T) {
+	h := seedMutateHNSW(t)
+	before := pointVersion(t, h, 1)
+
+	_, _, _, changed, err := h.MutatePayloadRecord(1, "session", storeFn(make([]byte, maxRecordValueBytes+1)), CASCond{})
+	if !errors.Is(err, ErrRecordTooLarge) {
+		t.Fatalf("err = %v, want ErrRecordTooLarge", err)
+	}
+	if changed {
+		t.Error("changed=true on a rejected oversize store")
+	}
+	got, ok := recordUnder(t, h, 1, "session")
+	if !ok || !bytes.Equal(got, sessionRecordBytes(t)) {
+		t.Fatal("the point changed despite the oversize rejection")
+	}
+	if v := pointVersion(t, h, 1); v != before {
+		t.Fatalf("version = %d after a rejected store, want %d", v, before)
+	}
+	// The invariant the cap exists for: the snapshot writer must still be able
+	// to encode every stored value.
+	if err := h.Snapshot(io.Discard); err != nil {
+		t.Fatalf("Snapshot after a rejected oversize store: %v", err)
+	}
+}
+
+func TestMutateRecordMutatorErrorLeavesPointUnchanged(t *testing.T) {
+	h := seedMutateHNSW(t)
+	before := pointVersion(t, h, 1)
+
+	_, _, _, changed, err := h.MutatePayloadRecord(1, "session",
+		func(_ []byte, _ bool) ([]byte, RecordMutation, error) { return nil, RecordStore, wire.ErrOperateRecord }, CASCond{})
+	if !errors.Is(err, wire.ErrOperateRecord) {
+		t.Fatalf("err = %v, want the mutator's error verbatim", err)
+	}
+	if changed {
+		t.Error("changed=true after a mutator error")
+	}
+	got, ok := recordUnder(t, h, 1, "session")
+	if !ok || !bytes.Equal(got, sessionRecordBytes(t)) {
+		t.Fatal("the payload changed after a mutator error")
+	}
+	if v := pointVersion(t, h, 1); v != before {
+		t.Fatalf("version = %d after a mutator error, want %d", v, before)
+	}
+}
+
+func TestMutateRecordCASConflict(t *testing.T) {
+	h := seedMutateHNSW(t)
+	before := pointVersion(t, h, 1)
+
+	var called bool
+	_, _, _, changed, err := h.MutatePayloadRecord(1, "session", func(_ []byte, _ bool) ([]byte, RecordMutation, error) {
+		called = true
+		return sessionRecordBytesRC(t, 8), RecordStore, nil
+	}, CASCond{Expected: 99, Has: true})
+	if !errors.Is(err, ErrVersionConflict) {
+		t.Fatalf("err = %v, want ErrVersionConflict", err)
+	}
+	if called {
+		t.Error("the mutator ran under a failed CAS")
+	}
+	if changed {
+		t.Error("changed=true under a failed CAS")
+	}
+	if v := pointVersion(t, h, 1); v != before {
+		t.Fatalf("version = %d after a CAS conflict, want %d", v, before)
+	}
+}
+
+func TestMutateRecordDeadPointNotFound(t *testing.T) {
+	h, err := newHNSW(mutateRecordCfg())
+	if err != nil {
+		t.Fatal(err)
+	}
+	var fakeNow int64 = 1_000_000
+	h.now = func() int64 { return fakeNow }
+	seedMutatePoint(t, h, 1)
+	// Point 2 carries a 1s point TTL, so it expires by the wall clock the
+	// non-At form reads.
+	if _, _, err := h.Insert(2, []float32{0, 1, 0, 0}, time.Second,
+		Metadata{"session": NewRecord(sessionRecordBytes(t))}, nil, nil, CASCond{}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := h.Delete(1, CASCond{}); err != nil {
+		t.Fatal(err)
+	}
+	fakeNow += 5000
+
+	for _, id := range []uint64{1, 2, 404} {
+		var called bool
+		_, _, _, changed, err := h.MutatePayloadRecord(id, "session", func(_ []byte, _ bool) ([]byte, RecordMutation, error) {
+			called = true
+			return sessionRecordBytesRC(t, 8), RecordStore, nil
+		}, CASCond{})
+		if !errors.Is(err, ErrIDNotFound) {
+			t.Errorf("id %d: err = %v, want ErrIDNotFound", id, err)
+		}
+		if called {
+			t.Errorf("id %d: the mutator ran against a dead point", id)
+		}
+		if changed {
+			t.Errorf("id %d: changed=true against a dead point", id)
+		}
+	}
+}
+
+func TestMutateRecordAtUsesTheStampedClock(t *testing.T) {
+	h, err := newHNSW(mutateRecordCfg())
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Pin the wall clock at 4000 for the seeding SetPayload so the "session"
+	// key gets an ABSOLUTE deadline of 5000, then move it far away: every
+	// judgement below must come from the explicit stamp, not from here.
+	var fakeNow int64 = 4000
+	h.now = func() int64 { return fakeNow }
+	seedMutatePoint(t, h, 1)
+	if _, ke, _, err := h.SetPayload(1, Metadata{"session": NewRecord(sessionRecordBytes(t))},
+		map[string]int64{"session": 1000}, CASCond{}); err != nil {
+		t.Fatalf("SetPayload: %v", err)
+	} else if ke["session"] != 5000 {
+		t.Fatalf("seeded deadline = %d, want 5000", ke["session"])
+	}
+	fakeNow = 9_000_000 // far past every stamp used below
+
+	// One millisecond before the deadline the key is still live.
+	var sawExists bool
+	if _, _, _, _, err := h.MutatePayloadRecordAt(1, "session", func(_ []byte, exists bool) ([]byte, RecordMutation, error) {
+		sawExists = exists
+		return nil, RecordUnchanged, nil
+	}, CASCond{}, 4999); err != nil {
+		t.Fatalf("MutatePayloadRecordAt(4999): %v", err)
+	}
+	if !sawExists {
+		t.Fatal("at stamp 4999 the mutator saw the key as absent — the wall clock was consulted")
+	}
+
+	// At the deadline the key reads as ABSENT, and storing under it must drop
+	// the stale deadline, or the record just written would be invisible.
+	want := sessionRecordBytesRC(t, 8)
+	_, ke, _, changed, err := h.MutatePayloadRecordAt(1, "session", func(_ []byte, exists bool) ([]byte, RecordMutation, error) {
+		sawExists = exists
+		return want, RecordStore, nil
+	}, CASCond{}, 5000)
+	if err != nil {
+		t.Fatalf("MutatePayloadRecordAt(5000): %v", err)
+	}
+	if sawExists {
+		t.Fatal("at stamp 5000 the mutator saw the expired key as present")
+	}
+	if !changed {
+		t.Fatal("changed=false storing under an expired key")
+	}
+	if _, present := ke["session"]; present {
+		t.Fatalf("the stale deadline survived: %v", ke)
+	}
+	fakeNow = 6000
+	_, meta, _, _, _, ok := h.GetProjected(1, false, true)
+	if !ok {
+		t.Fatal("GetProjected(1): point not live")
+	}
+	got, present := meta["session"]
+	if !present || !bytes.Equal(got.Rec, want) {
+		t.Fatal("the freshly stored record is invisible at now=6000 — the stale deadline was not dropped")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// auto-index exactness (phase-1 invariant, restated after a mutation)
+// ---------------------------------------------------------------------------
+
+// assertRecordPostingsExact re-proves the phase-1 exactness invariant over the
+// given ids: for the synthetic field, the index's postings agree EXACTLY with
+// what lookupPath resolves from each live slot's live metadata.
+func assertRecordPostingsExact(t *testing.T, h *hnsw, ids []uint64, field string) {
+	t.Helper()
+	h.mu.RLock()
+	defer h.mu.RUnlock()
+	now := uint64(h.now()) //nolint:gosec // test clock is non-negative
+	posted := make(map[uint32]scalarKey)
+	for key, slots := range h.payloadIdx.fields[field] {
+		for slot := range slots {
+			if prev, dup := posted[slot]; dup {
+				t.Errorf("slot %d is posted under two keys for %q: %+v and %+v", slot, field, prev, key)
+			}
+			posted[slot] = key
+		}
+	}
+	for _, id := range ids {
+		slot, ok := h.arena.Slot(id)
+		if !ok || h.tombstoned[slot] || h.isExpiredAt(slot, now) {
+			continue
+		}
+		v, resolved := lookupPath(h.liveMeta(slot, now), field)
+		key, scalar := scalarKeyOf(v)
+		gotKey, gotPosted := posted[slot]
+		delete(posted, slot)
+		if resolved && scalar {
+			if !gotPosted {
+				t.Errorf("id %d resolves %q = %+v but has no posting", id, field, key)
+			} else if gotKey != key {
+				t.Errorf("id %d resolves %q = %+v but is posted under %+v", id, field, key, gotKey)
+			}
+			continue
+		}
+		if gotPosted {
+			t.Errorf("id %d does not resolve %q but is posted under %+v", id, field, gotKey)
+		}
+	}
+	for slot, key := range posted {
+		t.Errorf("%q has a posting for slot %d under %+v that no live id explains", field, slot, key)
+	}
+}
+
+func TestMutateRecordIndexExactAfterMutation(t *testing.T) {
+	h, err := newHNSW(mutateRecordCfg())
+	if err != nil {
+		t.Fatal(err)
+	}
+	ids := make([]uint64, 0, 12)
+	for i := 1; i <= 12; i++ {
+		id := uint64(i)
+		vec := []float32{float32(i), float32(i % 5), 0, 1}
+		if _, _, err := h.Insert(id, vec, 0,
+			Metadata{"session": NewRecord(sessionRecordBytesRC(t, uint8(i%5)))}, nil, nil, CASCond{}); err != nil { //nolint:gosec // bounded
+			t.Fatal(err)
+		}
+		ids = append(ids, id)
+	}
+	// Point 1 goes to rc=7 and then to rc=8, so the mutation must move it.
+	if _, _, _, _, err := h.MutatePayloadRecord(1, "session", storeFn(sessionRecordBytesRC(t, 7)), CASCond{}); err != nil {
+		t.Fatal(err)
+	}
+	assertRecordPostingsExact(t, h, ids, "session/rc")
+	if _, _, _, _, err := h.MutatePayloadRecord(1, "session", storeFn(sessionRecordBytesRC(t, 8)), CASCond{}); err != nil {
+		t.Fatal(err)
+	}
+
+	slot, ok := h.arena.Slot(1)
+	if !ok {
+		t.Fatal("point 1 has no slot")
+	}
+	if recordSlotIn(h.payloadIdx, "session/rc", intKey(7), slot) {
+		t.Error("fields[session/rc][7] still holds the mutated slot — stale posting after a record mutation")
+	}
+	if !recordSlotIn(h.payloadIdx, "session/rc", intKey(8), slot) {
+		t.Error("fields[session/rc][8] is missing the mutated slot")
+	}
+	assertRecordPostingsExact(t, h, ids, "session/rc")
+}
+
+func TestMutateRecordReindexesBadRecordPoison(t *testing.T) {
+	h, err := newHNSW(mutateRecordCfg())
+	if err != nil {
+		t.Fatal(err)
+	}
+	// A mode byte followed by a torn schema blob: IndexEntries cannot
+	// enumerate it, so the payload key is poisoned and nothing under it
+	// accelerates.
+	if _, _, err := h.Insert(1, []float32{1, 0, 0, 0},
+		0, Metadata{"session": NewRecord([]byte{0x01, 0xFF})}, nil, nil, CASCond{}); err != nil {
+		t.Fatal(err)
+	}
+	if !h.payloadIdx.badRecords.poisoned("session") {
+		t.Fatal("the malformed record did not poison the payload key — the fixture is wrong")
+	}
+
+	want := sessionRecordBytes(t)
+	if _, _, _, changed, err := h.MutatePayloadRecord(1, "session", storeFn(want), CASCond{}); err != nil {
+		t.Fatalf("MutatePayloadRecord over a malformed record: %v", err)
+	} else if !changed {
+		t.Fatal("changed=false replacing a malformed record")
+	}
+	if h.payloadIdx.badRecords.poisoned("session") {
+		t.Fatal("the payload key stayed poisoned after the malformed record was replaced")
+	}
+	slot, _ := h.arena.Slot(1)
+	if !recordSlotIn(h.payloadIdx, "session/rc", intKey(7), slot) {
+		t.Error("the repaired record did not regain acceleration (no session/rc posting)")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// WAL: one record per applied mutation, replayed verbatim
+// ---------------------------------------------------------------------------
+
+// walWriteSeq reads the WAL's monotonic record counter under its own lock.
+func walWriteSeq(c *Collection) uint64 {
+	c.wal.syncMu.Lock()
+	defer c.wal.syncMu.Unlock()
+	return c.wal.writeSeq
+}
+
+// seedMutateWALCollection opens a WAL-mode store holding point 1 with a
+// "session" record and returns both, with the store closed on cleanup.
+func seedMutateWALCollection(t *testing.T) (*CollectionStore, *Collection) {
+	t.Helper()
+	cs, c := openMutateWALCollection(t, t.TempDir())
+	t.Cleanup(func() { _ = cs.Close() })
+	return cs, c
+}
+
+// openMutateWALCollection opens (or creates) the WAL collection in dir. The
+// caller owns Close — the reopen test closes it deliberately, without a Flush.
+func openMutateWALCollection(t *testing.T, dir string) (*CollectionStore, *Collection) {
+	t.Helper()
+	cs, err := OpenCollectionStore(dir)
+	if err != nil {
+		t.Fatalf("OpenCollectionStore: %v", err)
+	}
+	if err := cs.CreateCollection("docs", walCfg()); err != nil {
+		t.Fatalf("CreateCollection: %v", err)
+	}
+	c, ok := cs.Get("docs")
+	if !ok {
+		t.Fatal("collection missing")
+	}
+	vec := make([]float32, 16)
+	vec[0] = 1
+	if err := c.Insert(1, vec, 0, Metadata{"session": NewRecord(sessionRecordBytes(t))}, nil); err != nil {
+		t.Fatalf("Insert: %v", err)
+	}
+	return cs, c
+}
+
+func TestMutateRecordSurvivesReopen(t *testing.T) {
+	cases := []struct {
+		name   string
+		mutate func(t *testing.T, c *Collection) (version uint64)
+		verify func(t *testing.T, c2 *Collection, version uint64)
+	}{
+		{
+			name: "store",
+			mutate: func(t *testing.T, c *Collection) uint64 {
+				v, err := c.MutatePayloadRecordCAS(1, "session", storeFn(sessionRecordBytesRC(t, 8)), CASCond{})
+				if err != nil {
+					t.Fatalf("MutatePayloadRecordCAS: %v", err)
+				}
+				return v
+			},
+			verify: func(t *testing.T, c2 *Collection, version uint64) {
+				_, meta, _, _, v, ok := c2.Get(1)
+				if !ok {
+					t.Fatal("point 1 lost across reopen")
+				}
+				if v != version {
+					t.Fatalf("version = %d after replay, want the acked %d", v, version)
+				}
+				if got := meta["session"]; got.Kind != ValueRecord || !bytes.Equal(got.Rec, sessionRecordBytesRC(t, 8)) {
+					t.Fatal("the mutated record did not replay byte-identically")
+				}
+			},
+		},
+		{
+			name: "delete",
+			mutate: func(t *testing.T, c *Collection) uint64 {
+				v, err := c.MutatePayloadRecordCAS(1, "session",
+					func(_ []byte, _ bool) ([]byte, RecordMutation, error) { return nil, RecordDelete, nil }, CASCond{})
+				if err != nil {
+					t.Fatalf("MutatePayloadRecordCAS (delete): %v", err)
+				}
+				return v
+			},
+			verify: func(t *testing.T, c2 *Collection, version uint64) {
+				_, meta, _, _, v, ok := c2.Get(1)
+				if !ok {
+					t.Fatal("point 1 lost across reopen")
+				}
+				if v != version {
+					t.Fatalf("version = %d after replay, want the acked %d", v, version)
+				}
+				if _, present := meta["session"]; present {
+					t.Fatal("the deleted key came back on replay — the WAL record is a REPLACE, not a merge")
+				}
+				h, ok := c2.idx.(*hnsw)
+				if !ok {
+					t.Fatal("the reopened collection is not dense")
+				}
+				if got := storedMeta(t, h, 1); got != nil {
+					t.Errorf("replayed stored payload = %v, want nil (the pre-restart state)", got)
+				}
+				h.mu.RLock()
+				defer h.mu.RUnlock()
+				if len(h.payloadIdx.fields["session/rc"]) != 0 {
+					t.Fatalf("the rebuilt index still posts session/rc: %v", h.payloadIdx.fields["session/rc"])
+				}
+			},
+		},
+		{
+			name: "stamped op-list",
+			mutate: func(t *testing.T, c *Collection) uint64 {
+				const stamp int64 = 1_700_000_000_000
+				v, err := c.MutatePayloadRecordCASAt(1, "session", storeFn(stampedRecordBytes(t, stamp)), CASCond{}, stamp)
+				if err != nil {
+					t.Fatalf("MutatePayloadRecordCASAt: %v", err)
+				}
+				return v
+			},
+			verify: func(t *testing.T, c2 *Collection, version uint64) {
+				const stamp int64 = 1_700_000_000_000
+				_, meta, _, _, v, ok := c2.Get(1)
+				if !ok {
+					t.Fatal("point 1 lost across reopen")
+				}
+				if v != version {
+					t.Fatalf("version = %d after replay, want the acked %d", v, version)
+				}
+				if got := meta["session"]; !bytes.Equal(got.Rec, stampedRecordBytes(t, stamp)) {
+					t.Fatal("the stamped record changed on replay — the op-list must never be re-run")
+				}
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			cs, c := openMutateWALCollection(t, dir)
+			version := tc.mutate(t, c)
+			// NO Flush: the WAL alone must carry the mutation.
+			if err := cs.Close(); err != nil {
+				t.Fatalf("Close: %v", err)
+			}
+			reopened, err := OpenCollectionStore(dir)
+			if err != nil {
+				t.Fatalf("reopen: %v", err)
+			}
+			t.Cleanup(func() { _ = reopened.Close() })
+			c2, ok := reopened.Get("docs")
+			if !ok {
+				t.Fatal("collection missing after reopen")
+			}
+			tc.verify(t, c2, version)
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// IVF parity
+// ---------------------------------------------------------------------------
+
+// mutateCase is one engine-level scenario, run against both engines so the IVF
+// copy cannot drift from the dense one.
+type mutateCase struct {
+	name        string
+	key         string
+	fn          RecordMutator
+	cas         CASCond
+	wantErr     error
+	wantChanged bool
+	wantBump    bool
+	wantRec     func(t *testing.T) ([]byte, bool) // resulting bytes under "session"
+}
+
+func mutateCases(t *testing.T) []mutateCase {
+	t.Helper()
+	return []mutateCase{
+		{
+			name: "store", key: "session", fn: storeFn(sessionRecordBytesRC(t, 8)),
+			wantChanged: true, wantBump: true,
+			wantRec: func(t *testing.T) ([]byte, bool) { return sessionRecordBytesRC(t, 8), true },
+		},
+		{
+			name: "unchanged", key: "session",
+			fn:      func(_ []byte, _ bool) ([]byte, RecordMutation, error) { return nil, RecordUnchanged, nil },
+			wantRec: func(t *testing.T) ([]byte, bool) { return sessionRecordBytes(t), true },
+		},
+		{
+			name: "delete", key: "session",
+			fn:          func(_ []byte, _ bool) ([]byte, RecordMutation, error) { return nil, RecordDelete, nil },
+			wantChanged: true, wantBump: true,
+			wantRec: func(*testing.T) ([]byte, bool) { return nil, false },
+		},
+		{
+			name: "cas conflict", key: "session", fn: storeFn(sessionRecordBytesRC(t, 8)),
+			cas: CASCond{Expected: 99, Has: true}, wantErr: ErrVersionConflict,
+			wantRec: func(t *testing.T) ([]byte, bool) { return sessionRecordBytes(t), true },
+		},
+		{
+			name: "mutator error", key: "session",
+			fn: func(_ []byte, _ bool) ([]byte, RecordMutation, error) {
+				return nil, RecordStore, wire.ErrOperateRecord
+			},
+			wantErr: wire.ErrOperateRecord,
+			wantRec: func(t *testing.T) ([]byte, bool) { return sessionRecordBytes(t), true },
+		},
+		{
+			name: "oversize", key: "session", fn: storeFn(make([]byte, maxRecordValueBytes+1)),
+			wantErr: ErrRecordTooLarge,
+			wantRec: func(t *testing.T) ([]byte, bool) { return sessionRecordBytes(t), true },
+		},
+		{
+			name: "unknown mutation", key: "session",
+			fn:      func(_ []byte, _ bool) ([]byte, RecordMutation, error) { return nil, RecordMutation(9), nil },
+			wantErr: ErrRecordMutation,
+			wantRec: func(t *testing.T) ([]byte, bool) { return sessionRecordBytes(t), true },
+		},
+		{
+			name: "empty key", key: "", fn: storeFn(sessionRecordBytesRC(t, 8)),
+			wantErr: ErrPayloadKeyNotRecord,
+			wantRec: func(t *testing.T) ([]byte, bool) { return sessionRecordBytes(t), true },
+		},
+	}
+}
+
+// runMutateCase applies one case to a freshly seeded engine and asserts the
+// outcome, so the two engines are held to the same table.
+func runMutateCase(t *testing.T, ix VectorIndex, tc mutateCase) {
+	t.Helper()
+	before := pointVersion(t, ix, 1)
+	_, _, version, changed, err := ix.MutatePayloadRecord(1, tc.key, tc.fn, tc.cas)
+	if tc.wantErr != nil {
+		if !errors.Is(err, tc.wantErr) {
+			t.Fatalf("%s: err = %v, want %v", tc.name, err, tc.wantErr)
+		}
+	} else if err != nil {
+		t.Fatalf("%s: unexpected err %v", tc.name, err)
+	}
+	if changed != tc.wantChanged {
+		t.Errorf("%s: changed = %v, want %v", tc.name, changed, tc.wantChanged)
+	}
+	if tc.wantErr == nil {
+		want := before
+		if tc.wantBump {
+			want = before + 1
+		}
+		if version != want {
+			t.Errorf("%s: returned version = %d, want %d", tc.name, version, want)
+		}
+	}
+	wantBytes, wantPresent := tc.wantRec(t)
+	got, present := recordUnder(t, ix, 1, "session")
+	if present != wantPresent {
+		t.Fatalf("%s: session present = %v, want %v", tc.name, present, wantPresent)
+	}
+	if present && !bytes.Equal(got, wantBytes) {
+		t.Errorf("%s: stored bytes differ from the expected result", tc.name)
+	}
+	live := pointVersion(t, ix, 1)
+	wantLive := before
+	if tc.wantBump {
+		wantLive = before + 1
+	}
+	if live != wantLive {
+		t.Errorf("%s: point version = %d, want %d", tc.name, live, wantLive)
+	}
+}
+
+func TestMutateRecordIVFMatchesHNSW(t *testing.T) {
+	for _, tc := range mutateCases(t) {
+		t.Run(tc.name, func(t *testing.T) {
+			h, err := newHNSW(mutateRecordCfg())
+			if err != nil {
+				t.Fatal(err)
+			}
+			seedMutatePoint(t, h, 1)
+			cfg := ivfTestConfig(4)
+			ix, err := newIVF(cfg)
+			if err != nil {
+				t.Fatal(err)
+			}
+			seedMutatePoint(t, ix, 1)
+			t.Run("hnsw", func(t *testing.T) { runMutateCase(t, h, tc) })
+			t.Run("ivf", func(t *testing.T) { runMutateCase(t, ix, tc) })
+		})
+	}
+}

--- a/vector/record_mutate_test.go
+++ b/vector/record_mutate_test.go
@@ -68,15 +68,33 @@ func stampedRecordBytes(t *testing.T, stamp int64) []byte {
 // storedMeta returns the metadata the arena actually holds for id — the state
 // Get normalizes away (it reports nil for any empty payload) and the state a WAL
 // replay has to reproduce.
-func storedMeta(t *testing.T, h *hnsw, id uint64) Metadata {
+//
+// It takes the INTERFACE and switches on the concrete engine so the shared table
+// can assert the empty-payload-stores-nil normalisation on the IVF copy too, not
+// only on the dense one it was first written against.
+func storedMeta(t *testing.T, ix VectorIndex, id uint64) Metadata {
 	t.Helper()
-	h.mu.RLock()
-	defer h.mu.RUnlock()
-	slot, ok := h.arena.Slot(id)
-	if !ok {
-		t.Fatalf("id %d has no slot", id)
+	switch e := ix.(type) {
+	case *hnsw:
+		e.mu.RLock()
+		defer e.mu.RUnlock()
+		slot, ok := e.arena.Slot(id)
+		if !ok {
+			t.Fatalf("id %d has no slot", id)
+		}
+		return e.arena.Metadata(slot)
+	case *ivf:
+		e.mu.RLock()
+		defer e.mu.RUnlock()
+		slot, ok := e.arena.Slot(id)
+		if !ok {
+			t.Fatalf("id %d has no slot", id)
+		}
+		return e.arena.Metadata(slot)
+	default:
+		t.Fatalf("storedMeta: unhandled engine %T — add it, or the nil normalisation goes unchecked", ix)
+		return nil
 	}
-	return h.arena.Metadata(slot)
 }
 
 // pointVersion reads id's current version through the public read path.
@@ -739,11 +757,130 @@ func TestMutateRecordSurvivesReopen(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// IVF parity
+// cross-engine parity (dense, IVF, named, multi-vector)
 // ---------------------------------------------------------------------------
 
-// mutateCase is one engine-level scenario, run against both engines so the IVF
-// copy cannot drift from the dense one.
+// mutateHarness is ONE engine behind the shared record-mutation table: a seeded
+// point 1 holding a "session" record, plus the four accessors every case needs.
+// The dense, IVF, named and multi-vector implementations are four copies of the
+// same body, so they are held to ONE table (TestMutateRecordNamedAndMVMatchDense
+// runs all four) and a divergence in any of them fails loudly.
+//
+// mutate targets the ENGINE-level entry (which reports changed), not the
+// collection wrapper, so the table sees the no-op flag directly on every family.
+type mutateHarness struct {
+	name string
+	// insert seeds an ADDITIONAL point carrying meta (point 1 is already seeded
+	// with an rc=7 "session" record when the harness is built).
+	insert func(t *testing.T, id uint64, meta Metadata)
+	// setNow pins the engine's wall clock, so the non-At entries and every read
+	// below are judged against an explicit, deterministic time.
+	setNow func(ms int64)
+	// setPayload is the family's set_payload, used only to seed a per-key TTL.
+	setPayload func(t *testing.T, id uint64, meta Metadata, keyTTLMs map[string]int64)
+	mutate     func(id uint64, key string, fn RecordMutator, cas CASCond) (version uint64, changed bool, err error)
+	mutateAt   func(id uint64, key string, fn RecordMutator, cas CASCond, nowMs int64) (version uint64, changed bool, err error)
+	// payload is the live payload as a reader sees it at the pinned clock
+	// (per-key-expired keys already dropped); ok=false for a dead/absent point.
+	payload func(id uint64) (Metadata, bool)
+	// version is the point's current version, 0 for a dead/absent point.
+	version func(id uint64) uint64
+	// stored is the RAW stored payload, before the nil normalisation Get hides.
+	stored func(t *testing.T, id uint64) Metadata
+}
+
+// record reads the record bytes under key from the harness's live payload.
+func (h mutateHarness) record(t *testing.T, id uint64, key string) ([]byte, bool) {
+	t.Helper()
+	meta, ok := h.payload(id)
+	if !ok {
+		t.Fatalf("%s: point %d is not live", h.name, id)
+	}
+	v, present := meta[key]
+	if !present {
+		return nil, false
+	}
+	if v.Kind != ValueRecord {
+		t.Fatalf("%s: payload key %q holds kind %d, want a record", h.name, key, v.Kind)
+	}
+	return v.Rec, true
+}
+
+// mutateHarnessBase is the clock every harness is pinned to before a case runs,
+// so "now" is explicit rather than whatever time.Now happened to return.
+const mutateHarnessBase int64 = 1_000_000_000_000
+
+// denseMutateHarness seeds a dense engine holding point 1 with an rc=7 record.
+func denseMutateHarness(t *testing.T) mutateHarness {
+	t.Helper()
+	h, err := newHNSW(mutateRecordCfg())
+	if err != nil {
+		t.Fatalf("newHNSW: %v", err)
+	}
+	h.now = func() int64 { return mutateHarnessBase }
+	seedMutatePoint(t, h, 1)
+	return vectorIndexHarness("hnsw", h, func(ms int64) { h.now = func() int64 { return ms } })
+}
+
+// ivfMutateHarness seeds an IVF engine with the identical point.
+func ivfMutateHarness(t *testing.T) mutateHarness {
+	t.Helper()
+	ix, err := newIVF(ivfTestConfig(4))
+	if err != nil {
+		t.Fatalf("newIVF: %v", err)
+	}
+	ix.now = func() int64 { return mutateHarnessBase }
+	seedMutatePoint(t, ix, 1)
+	return vectorIndexHarness("ivf", ix, func(ms int64) { ix.now = func() int64 { return ms } })
+}
+
+// vectorIndexHarness adapts either slot-keyed engine to the shared table.
+func vectorIndexHarness(name string, ix VectorIndex, setNow func(int64)) mutateHarness {
+	return mutateHarness{
+		name:   name,
+		setNow: setNow,
+		insert: func(t *testing.T, id uint64, meta Metadata) {
+			t.Helper()
+			vec := make([]float32, ix.Dim())
+			vec[0] = float32(id)
+			if _, _, err := ix.Insert(id, vec, 0, meta, nil, nil, CASCond{}); err != nil {
+				t.Fatalf("%s: Insert(%d): %v", name, id, err)
+			}
+		},
+		setPayload: func(t *testing.T, id uint64, meta Metadata, keyTTLMs map[string]int64) {
+			t.Helper()
+			if _, _, _, err := ix.SetPayload(id, meta, keyTTLMs, CASCond{}); err != nil {
+				t.Fatalf("%s: SetPayload(%d): %v", name, id, err)
+			}
+		},
+		mutate: func(id uint64, key string, fn RecordMutator, cas CASCond) (uint64, bool, error) {
+			_, _, version, changed, err := ix.MutatePayloadRecord(id, key, fn, cas)
+			return version, changed, err
+		},
+		mutateAt: func(id uint64, key string, fn RecordMutator, cas CASCond, nowMs int64) (uint64, bool, error) {
+			_, _, version, changed, err := ix.MutatePayloadRecordAt(id, key, fn, cas, nowMs)
+			return version, changed, err
+		},
+		payload: func(id uint64) (Metadata, bool) {
+			_, meta, _, _, _, ok := ix.Get(id)
+			return meta, ok
+		},
+		version: func(id uint64) uint64 {
+			_, _, _, _, v, ok := ix.Get(id)
+			if !ok {
+				return 0
+			}
+			return v
+		},
+		stored: func(t *testing.T, id uint64) Metadata {
+			t.Helper()
+			return storedMeta(t, ix, id)
+		},
+	}
+}
+
+// mutateCase is one engine-level scenario, run against every engine so no copy
+// of the body can drift from the others.
 type mutateCase struct {
 	name        string
 	key         string
@@ -753,6 +890,10 @@ type mutateCase struct {
 	wantChanged bool
 	wantBump    bool
 	wantRec     func(t *testing.T) ([]byte, bool) // resulting bytes under "session"
+	// wantStoredNil asserts the RAW stored payload is nil afterwards — the
+	// empty-payload normalisation Get hides (it reports nil for any empty
+	// payload) and a WAL replay has to reproduce.
+	wantStoredNil bool
 }
 
 func mutateCases(t *testing.T) []mutateCase {
@@ -773,6 +914,10 @@ func mutateCases(t *testing.T) []mutateCase {
 			fn:          func(_ []byte, _ bool) ([]byte, RecordMutation, error) { return nil, RecordDelete, nil },
 			wantChanged: true, wantBump: true,
 			wantRec: func(*testing.T) ([]byte, bool) { return nil, false },
+			// "session" is the point's ONLY key, so deleting it empties the payload
+			// — which every engine must store as nil, or the live state differs
+			// from the state the same WAL record rebuilds on replay.
+			wantStoredNil: true,
 		},
 		{
 			name: "cas conflict", key: "session", fn: storeFn(sessionRecordBytesRC(t, 8)),
@@ -803,15 +948,29 @@ func mutateCases(t *testing.T) []mutateCase {
 			wantErr: ErrPayloadKeyNotRecord,
 			wantRec: func(t *testing.T) ([]byte, bool) { return sessionRecordBytes(t), true },
 		},
+		{
+			// The reserved document-content key never holds a record: rejected on
+			// the same guard as the empty key, before the point is even read.
+			name: "content field", key: contentField, fn: storeFn(sessionRecordBytesRC(t, 8)),
+			wantErr: ErrPayloadKeyNotRecord,
+			wantRec: func(t *testing.T) ([]byte, bool) { return sessionRecordBytes(t), true },
+		},
+		{
+			// A nil mutator is a caller bug, caught by the same guard rather than
+			// panicking inside the write-lock critical section.
+			name: "nil mutator", key: "session", fn: nil,
+			wantErr: ErrPayloadKeyNotRecord,
+			wantRec: func(t *testing.T) ([]byte, bool) { return sessionRecordBytes(t), true },
+		},
 	}
 }
 
 // runMutateCase applies one case to a freshly seeded engine and asserts the
-// outcome, so the two engines are held to the same table.
-func runMutateCase(t *testing.T, ix VectorIndex, tc mutateCase) {
+// outcome, so every engine is held to the same table.
+func runMutateCase(t *testing.T, h mutateHarness, tc mutateCase) {
 	t.Helper()
-	before := pointVersion(t, ix, 1)
-	_, _, version, changed, err := ix.MutatePayloadRecord(1, tc.key, tc.fn, tc.cas)
+	before := h.version(1)
+	version, changed, err := h.mutate(1, tc.key, tc.fn, tc.cas)
 	if tc.wantErr != nil {
 		if !errors.Is(err, tc.wantErr) {
 			t.Fatalf("%s: err = %v, want %v", tc.name, err, tc.wantErr)
@@ -832,14 +991,19 @@ func runMutateCase(t *testing.T, ix VectorIndex, tc mutateCase) {
 		}
 	}
 	wantBytes, wantPresent := tc.wantRec(t)
-	got, present := recordUnder(t, ix, 1, "session")
+	got, present := h.record(t, 1, "session")
 	if present != wantPresent {
 		t.Fatalf("%s: session present = %v, want %v", tc.name, present, wantPresent)
 	}
 	if present && !bytes.Equal(got, wantBytes) {
 		t.Errorf("%s: stored bytes differ from the expected result", tc.name)
 	}
-	live := pointVersion(t, ix, 1)
+	if tc.wantStoredNil {
+		if stored := h.stored(t, 1); stored != nil {
+			t.Errorf("%s: raw stored payload = %v, want nil (an emptied payload stores nil)", tc.name, stored)
+		}
+	}
+	live := h.version(1)
 	wantLive := before
 	if tc.wantBump {
 		wantLive = before + 1
@@ -852,19 +1016,8 @@ func runMutateCase(t *testing.T, ix VectorIndex, tc mutateCase) {
 func TestMutateRecordIVFMatchesHNSW(t *testing.T) {
 	for _, tc := range mutateCases(t) {
 		t.Run(tc.name, func(t *testing.T) {
-			h, err := newHNSW(mutateRecordCfg())
-			if err != nil {
-				t.Fatal(err)
-			}
-			seedMutatePoint(t, h, 1)
-			cfg := ivfTestConfig(4)
-			ix, err := newIVF(cfg)
-			if err != nil {
-				t.Fatal(err)
-			}
-			seedMutatePoint(t, ix, 1)
-			t.Run("hnsw", func(t *testing.T) { runMutateCase(t, h, tc) })
-			t.Run("ivf", func(t *testing.T) { runMutateCase(t, ix, tc) })
+			t.Run("hnsw", func(t *testing.T) { runMutateCase(t, denseMutateHarness(t), tc) })
+			t.Run("ivf", func(t *testing.T) { runMutateCase(t, ivfMutateHarness(t), tc) })
 		})
 	}
 }

--- a/vector/record_oversize_test.go
+++ b/vector/record_oversize_test.go
@@ -5,9 +5,13 @@ package vector
 import (
 	"bytes"
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/rostamlabs/rostam/sdk/record"
+	"github.com/rostamlabs/rostam/sdk/wire"
 )
 
 // A ValueRecord above maxRecordValueBytes is the one payload value the
@@ -27,15 +31,85 @@ import (
 
 // oversizeRecord builds a payload whose record value is one byte past the cap.
 // It is not a valid record — it never needs to be, because the size check runs
-// before anything looks inside it.
+// BEFORE the shape check (checkRecordValues), which is what keeps an oversize
+// payload from being an expensive way to make the gate decode 16 MiB.
 func oversizeRecord() Metadata {
 	return Metadata{"session": NewRecord(make([]byte, maxRecordValueBytes+1))}
 }
 
 // atCapRecord is the largest record the codec accepts: the boundary must be
 // inclusive, or the check would move the limit rather than enforce it.
-func atCapRecord() Metadata {
-	return Metadata{"session": NewRecord(make([]byte, maxRecordValueBytes))}
+func atCapRecord(t *testing.T) Metadata {
+	t.Helper()
+	return Metadata{"session": NewRecord(atCapRecordBytes(t))}
+}
+
+// atCapRecordBytes builds a WELL-FORMED record of EXACTLY maxRecordValueBytes.
+//
+// It used to be maxRecordValueBytes zero bytes, which was enough while the gate
+// only bounded a record's SIZE. Now that checkRecordValues also validates its
+// SHAPE, a run of zeroes is rejected as malformed and the boundary test would
+// pass for the wrong reason — it would stop saying anything about the cap. So
+// the fixture has to be legal in both senses.
+//
+// Shape: a dynamic-mode record of BYTES fields. One BYTES value is capped at
+// wire.OperateMaxBytesLen (64 KiB), so reaching 16 MiB takes ~256 of them, and
+// two trailing fields (always present, so the field count never changes) carry
+// the padding that lands the encoding exactly on the cap. The length is TUNED by
+// measurement rather than computed, because a length prefix is a uvarint whose
+// own width changes with the value it holds.
+func atCapRecordBytes(t *testing.T) []byte {
+	t.Helper()
+	const full = wire.OperateMaxBytesLen
+
+	build := func(n, tailTotal int) []byte {
+		a := tailTotal
+		if a > full {
+			a = full
+		}
+		fields := make([]wire.Field, 0, n+2)
+		for i := 0; i < n; i++ {
+			fields = append(fields, wire.Field{
+				Name: fmt.Sprintf("f%04d", i),
+				Cell: wire.Cell{Type: wire.OperateTypeBytes, B: make([]byte, full)},
+			})
+		}
+		fields = append(fields,
+			wire.Field{Name: "g0", Cell: wire.Cell{Type: wire.OperateTypeBytes, B: make([]byte, a)}},
+			wire.Field{Name: "g1", Cell: wire.Cell{Type: wire.OperateTypeBytes, B: make([]byte, tailTotal-a)}},
+		)
+		return (&wire.Record{Mode: wire.OperateModeDynamic, Fields: fields}).Encode()
+	}
+
+	// Two small encodes give the per-field cost and the fixed overhead, so the
+	// full-field count is chosen in one step instead of by growing the record.
+	l1, l2 := len(build(1, 0)), len(build(2, 0))
+	per := l2 - l1
+	if per <= 0 {
+		t.Fatalf("per-field size = %d, want > 0", per)
+	}
+	n := (maxRecordValueBytes - (l1 - per) - full) / per // aim the tail at ~half its range
+
+	tail := full
+	for range 8 {
+		enc := build(n, tail)
+		if enc == nil {
+			t.Fatal("at-cap record failed to encode")
+		}
+		delta := maxRecordValueBytes - len(enc)
+		if delta == 0 {
+			if err := record.Validate(enc); err != nil {
+				t.Fatalf("the at-cap fixture is not a decodable record: %v", err)
+			}
+			return enc
+		}
+		if tail+delta < 0 || tail+delta > 2*full {
+			t.Fatalf("cannot tune the padding to the cap: n=%d tail=%d delta=%d", n, tail, delta)
+		}
+		tail += delta
+	}
+	t.Fatal("the at-cap record length did not converge")
+	return nil
 }
 
 func wantTooLarge(t *testing.T, what string, err error) {
@@ -204,7 +278,7 @@ func TestRecordAtCapAccepted(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewCollection: %v", err)
 	}
-	if err := c.Insert(1, []float32{1, 0, 0, 0}, 0, atCapRecord(), nil); err != nil {
+	if err := c.Insert(1, []float32{1, 0, 0, 0}, 0, atCapRecord(t), nil); err != nil {
 		t.Fatalf("Insert at exactly the cap: %v, want nil", err)
 	}
 }
@@ -417,7 +491,7 @@ func TestRestoreAtCapAccepted(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewCollection: %v", err)
 	}
-	if err := c.RestoreInsert(1, []float32{1, 0, 0, 0}, 0, atCapRecord(), nil, nil, 5); err != nil {
+	if err := c.RestoreInsert(1, []float32{1, 0, 0, 0}, 0, atCapRecord(t), nil, nil, 5); err != nil {
 		t.Fatalf("RestoreInsert at exactly the cap: %v, want nil", err)
 	}
 	if _, _, _, _, version, ok := c.Get(1); !ok || version != 5 {

--- a/vector/record_too_large_message_test.go
+++ b/vector/record_too_large_message_test.go
@@ -37,11 +37,39 @@ func TestIsRecordTooLargeMessage(t *testing.T) {
 		{"session": NewRecord(make([]byte, maxRecordValueBytes+1))},
 	}).Error()
 
+	// The POST-MUTATION form: not an ingest gate at all, but the bound the four
+	// mutatePayloadRecord bodies apply to the bytes the operate engine just
+	// produced. It used to be a SECOND shape ("payload key %q would hold a ...")
+	// that this matcher declined, which redacted a fixable client mistake to
+	// "internal error" on every clustered apply — see recordTooLargeErr. Built by
+	// driving a real mutation so a re-divergence fails here rather than in
+	// production.
+	mutated := func(key string) string {
+		t.Helper()
+		h, err := newHNSW(mutateRecordCfg())
+		if err != nil {
+			t.Fatalf("newHNSW: %v", err)
+		}
+		seedMutatePoint(t, h, 1)
+		_, _, _, _, merr := h.MutatePayloadRecord(1, key, func(_ []byte, _ bool) ([]byte, RecordMutation, error) {
+			return make([]byte, maxRecordValueBytes+1), RecordStore, nil
+		}, CASCond{})
+		if !errors.Is(merr, ErrRecordTooLarge) {
+			t.Fatalf("post-mutation fixture: err = %v, want ErrRecordTooLarge", merr)
+		}
+		return merr.Error()
+	}
+	postMutation := mutated("session")
+	postMutationLongKey := mutated(longKey)
+
 	accept := []struct {
 		name string
 		msg  string
 	}{
 		{"bare sentinel text", ErrRecordTooLarge.Error()},
+		{"post-mutation form, short key", postMutation},
+		{"post-mutation form, long/clipped key", postMutationLongKey},
+		{"post-mutation form re-stringified (simulates decodePBResult)", errors.New(postMutation).Error()},
 		{"single-payload form, short key", single},
 		{"single-payload form, long/clipped key", singleLongKey},
 		{"bulk form, row 0", bulkRow0},

--- a/vector/record_validate_test.go
+++ b/vector/record_validate_test.go
@@ -540,3 +540,269 @@ func benchVectorTableRecord(b *testing.B, size int) []byte {
 	}
 	return enc
 }
+
+// TestRecordValuesGatedAtMVBulkBuild covers the entry the first round missed.
+//
+// MultiBulkBuild is the MV analogue of the dense bulk stage+build, and it is
+// WIRE-REACHABLE: ops/mv_batch.go (handleMVAddBatch) decodes the batch straight
+// off the wire and calls it as the FAST PATH whenever the target index is empty,
+// falling through to the gated MultiRestoreAddSparse only once documents exist.
+// So the same op was gated or ungated depending on the target's emptiness, and
+// the ungated case — a fresh partition — is exactly the one an offline MV resplit
+// drives. It stored the caller's metadata into docMeta and reindexed it with no
+// check at all: a malformed record poisoned badRecords for that key across the
+// whole collection, and an oversize one made the collection unsnapshottable.
+//
+// The gate runs over the WHOLE batch before m.mu is taken, so one bad record
+// refuses every record in the batch rather than leaving a half-built index.
+func TestRecordValuesGatedAtMVBulkBuild(t *testing.T) {
+	tokens := [][]float32{{1, 0, 0, 0}}
+	for _, tc := range []struct {
+		name string
+		meta Metadata
+		want error
+	}{
+		{"malformed", malformedRecord(), ErrRecordMalformed},
+		{"oversize", oversizeRecord(), ErrRecordTooLarge},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			m, err := NewMultiVectorIndex(MultiVectorConfig{Dim: 4, M: 16, EfConstruction: 200, EfSearch: 64, Seed: 1})
+			if err != nil {
+				t.Fatalf("NewMultiVectorIndex: %v", err)
+			}
+			// The GOOD record comes first, so a gate that only checked the
+			// offending row would already have written doc 1.
+			recs := []MultiScanRecord{
+				{ID: 1, Tokens: tokens, Metadata: Metadata{"session": NewRecord(sessionRecordBytes(t))}},
+				{ID: 2, Tokens: tokens, Metadata: tc.meta},
+			}
+			built, err := m.MultiBulkBuild(recs, 1)
+			if built {
+				t.Fatal("MultiBulkBuild reported a build for a batch it must refuse")
+			}
+			if !errors.Is(err, tc.want) {
+				t.Fatalf("err = %v, want %v", err, tc.want)
+			}
+			for _, id := range []uint64{1, 2} {
+				if _, _, _, ok := m.Get(id); ok {
+					t.Errorf("refused batch still stored doc %d", id)
+				}
+			}
+			m.mu.RLock()
+			poisoned := m.payloadIdx.badRecords.poisoned("session")
+			m.mu.RUnlock()
+			if poisoned {
+				t.Error("refused batch still poisoned the payload key")
+			}
+			// The index was never mutated, so it is still EMPTY and the fast path
+			// is still available to a corrected batch — a gate that half-built
+			// would have forced the caller onto the per-record path forever.
+			built, err = m.MultiBulkBuild([]MultiScanRecord{
+				{ID: 1, Tokens: tokens, Metadata: Metadata{"session": NewRecord(sessionRecordBytes(t))}},
+			}, 1)
+			if err != nil || !built {
+				t.Fatalf("corrected batch: built=%v err=%v, want true/nil", built, err)
+			}
+			if _, _, _, ok := m.Get(1); !ok {
+				t.Fatal("the corrected batch did not land")
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// how many times one write decodes the same record
+// ---------------------------------------------------------------------------
+
+// countValidates runs fn with the package's record-validation seam swapped for a
+// counting wrapper, and reports how many times a record was decoded. The seam is
+// restored on cleanup, and no test that uses it runs in parallel.
+func countValidates(t *testing.T, fn func()) int {
+	t.Helper()
+	n := 0
+	orig := validateRecord
+	validateRecord = func(rec []byte) error {
+		n++
+		return orig(rec)
+	}
+	t.Cleanup(func() { validateRecord = orig })
+	fn()
+	return n
+}
+
+// TestRecordValidationCountPerWrite pins how many times each ingest path decodes
+// a record value. The shape check is O(record) with allocations
+// (BenchmarkCheckRecordValues), so an unnoticed extra pass multiplies the write
+// cost of every record-bearing payload; this test is what makes that visible.
+//
+// Every path is ONE except the two that do something irreversible before the
+// engine body they delegate to runs its own gate. Those are 2 on purpose, and
+// TestMalformedRecordRejectedAtIngestDense (upsert) and
+// TestStagedBatchSurvivesARejectedRecord (bulk) are the tests that fail if the
+// duplicate is "optimised" away:
+//
+//   - Upsert deletes before it inserts, so its wrapper pass must reject BEFORE
+//     the delete or a refused write destroys the point it was replacing.
+//   - BuildStaged clears the stage buffer before the engine's gate runs, so
+//     StageBulkPayloads must reject while the caller's batch still exists.
+func TestRecordValidationCountPerWrite(t *testing.T) {
+	rec := func() Metadata { return Metadata{"session": NewRecord(sessionRecordBytes(t))} }
+	vec := []float32{1, 0, 0, 0}
+	newDense := func(name string) *Collection {
+		t.Helper()
+		c, err := NewCollection(name, oversizeDenseConfig())
+		if err != nil {
+			t.Fatalf("NewCollection: %v", err)
+		}
+		return c
+	}
+
+	c := newDense("default/count")
+	nc, err := NewNamedCollection("default/count-named", namedTestConfig())
+	if err != nil {
+		t.Fatalf("NewNamedCollection: %v", err)
+	}
+	namedVecs := map[string][]float32{"title": {1, 0, 0, 0}, "image": {1, 0, 0}}
+	m, err := NewMultiVectorIndex(MultiVectorConfig{Dim: 4, M: 16, EfConstruction: 200, EfSearch: 64, Seed: 1})
+	if err != nil {
+		t.Fatalf("NewMultiVectorIndex: %v", err)
+	}
+	tokens := [][]float32{{1, 0, 0, 0}}
+
+	cases := []struct {
+		name string
+		want int
+		why  string
+		run  func()
+	}{
+		{"Insert", 1, "", func() {
+			if err := c.Insert(1, vec, 0, rec(), nil); err != nil {
+				t.Fatalf("Insert: %v", err)
+			}
+		}},
+		{"InsertIfAbsent", 1, "", func() {
+			if _, err := c.InsertIfAbsent(2, vec, 0, rec(), nil); err != nil {
+				t.Fatalf("InsertIfAbsent: %v", err)
+			}
+		}},
+		{"SetPayload", 1, "", func() {
+			if err := c.SetPayload(1, rec(), nil); err != nil {
+				t.Fatalf("SetPayload: %v", err)
+			}
+		}},
+		{"OverwritePayload", 1, "", func() {
+			if err := c.OverwritePayload(1, rec(), nil); err != nil {
+				t.Fatalf("OverwritePayload: %v", err)
+			}
+		}},
+		{"RestoreInsert", 1, "", func() {
+			if err := c.RestoreInsert(3, vec, 0, rec(), nil, nil, 5); err != nil {
+				t.Fatalf("RestoreInsert: %v", err)
+			}
+		}},
+		{"BuildConcurrentMeta", 1, "", func() {
+			if err := newDense("default/count-bcm").BuildConcurrentMeta(
+				[]uint64{9}, [][]float32{vec}, []Metadata{rec()}, 1); err != nil {
+				t.Fatalf("BuildConcurrentMeta: %v", err)
+			}
+		}},
+		{"named Insert", 1, "", func() {
+			if err := nc.Insert(1, namedVecs, rec(), 0); err != nil {
+				t.Fatalf("named Insert: %v", err)
+			}
+		}},
+		{"named SetPayload", 1, "", func() {
+			if err := nc.SetPayload(1, rec(), nil); err != nil {
+				t.Fatalf("named SetPayload: %v", err)
+			}
+		}},
+		{"MV Add", 1, "", func() {
+			if err := m.Add(1, tokens, rec()); err != nil {
+				t.Fatalf("MV Add: %v", err)
+			}
+		}},
+		{"MV MultiRestoreAdd", 1, "", func() {
+			if err := m.MultiRestoreAdd(2, tokens, rec(), nil, 5); err != nil {
+				t.Fatalf("MV MultiRestoreAdd: %v", err)
+			}
+		}},
+		{"MV MultiBulkBuild", 1, "", func() {
+			mb, merr := NewMultiVectorIndex(MultiVectorConfig{Dim: 4, M: 16, EfConstruction: 200, EfSearch: 64, Seed: 1})
+			if merr != nil {
+				t.Fatalf("NewMultiVectorIndex: %v", merr)
+			}
+			if _, berr := mb.MultiBulkBuild([]MultiScanRecord{{ID: 1, Tokens: tokens, Metadata: rec()}}, 1); berr != nil {
+				t.Fatalf("MultiBulkBuild: %v", berr)
+			}
+		}},
+		{"Upsert", 2, "delete-then-insert: the wrapper must reject before the delete", func() {
+			if err := c.Upsert(1, vec, "doc", 0, rec(), nil); err != nil {
+				t.Fatalf("Upsert: %v", err)
+			}
+		}},
+		{"StageBulkPayloads + BuildStaged", 2, "BuildStaged clears the stage buffer before the engine's gate runs", func() {
+			b := newDense("default/count-stage")
+			if err := b.StageBulkPayloads([]uint64{9}, [][]float32{vec}, []Metadata{rec()}); err != nil {
+				t.Fatalf("StageBulkPayloads: %v", err)
+			}
+			if err := b.BuildStaged(1); err != nil {
+				t.Fatalf("BuildStaged: %v", err)
+			}
+		}},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := countValidates(t, tc.run)
+			if got != tc.want {
+				msg := ""
+				if tc.why != "" {
+					msg = " (" + tc.why + ")"
+				}
+				t.Errorf("%s decoded the record %d times, want %d%s", tc.name, got, tc.want, msg)
+			}
+		})
+	}
+}
+
+// TestStagedBatchSurvivesARejectedRecord is the reason StageBulkPayloads keeps
+// the FULL gate even though BuildConcurrentMeta runs it again.
+//
+// BuildStaged hands the staged slices to the engine and clears the stage buffer
+// BEFORE the engine's gate runs, so a bad record that got past staging would be
+// discovered with the caller's whole batch already destroyed — a rejected write
+// taking unrelated, still-valid staged rows with it. Rejecting at stage time
+// keeps the buffer intact and names the offending row while the caller can still
+// fix it. Measured directly: downgrading the stage check to size-only leaves 0
+// staged rows after the failed build.
+func TestStagedBatchSurvivesARejectedRecord(t *testing.T) {
+	c, err := NewCollection("default/stage-survives", oversizeDenseConfig())
+	if err != nil {
+		t.Fatalf("NewCollection: %v", err)
+	}
+	vec := []float32{1, 0, 0, 0}
+	// A good batch first, so the test proves the REJECTED batch left it alone
+	// rather than that the buffer happened to be empty.
+	if err := c.StageBulkPayloads([]uint64{1, 2}, [][]float32{vec, vec},
+		[]Metadata{{"session": NewRecord(sessionRecordBytes(t))}, nil}); err != nil {
+		t.Fatalf("good stage: %v", err)
+	}
+	wantMalformed(t, "StageBulkPayloads", c.StageBulkPayloads(
+		[]uint64{3}, [][]float32{vec}, []Metadata{malformedRecord()}))
+
+	c.stageMu.Lock()
+	staged := len(c.stageIDs)
+	c.stageMu.Unlock()
+	if staged != 2 {
+		t.Fatalf("staged rows after a rejected stage = %d, want the 2 already there", staged)
+	}
+	// And the build still works, which is the whole point of refusing early.
+	if err := c.BuildStaged(1); err != nil {
+		t.Fatalf("BuildStaged after a rejected stage: %v, want nil", err)
+	}
+	for _, id := range []uint64{1, 2} {
+		if _, _, _, _, _, ok := c.Get(id); !ok {
+			t.Errorf("point %d did not survive to the build", id)
+		}
+	}
+}

--- a/vector/record_validate_test.go
+++ b/vector/record_validate_test.go
@@ -1,0 +1,542 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package vector
+
+import (
+	"bytes"
+	"errors"
+	"testing"
+
+	"github.com/rostamlabs/rostam/sdk/wire"
+)
+
+// Phase 1 stored record values without ever looking inside them, so a plain
+// set_payload could put arbitrary bytes under a payload key. The consequence
+// was not local to that point: a record IndexEntries cannot enumerate but
+// Resolve still answers from POISONS the key for the whole collection (every
+// path under it stops accelerating, for every point), and a later
+// vector_operate on the same key fails with wire.ErrOperateRecord.
+//
+// checkRecordValues now runs record.Validate — wire.DecodeRecord's acceptance
+// set — at every WIRE-REACHABLE ingest entry, so no newly stored record can be
+// in that state. The replay bodies keep the size-only check: they carry bytes
+// this store already accepted, and refusing to replay one would discard an
+// acked write.
+
+// malformedRecord is a schema mode byte followed by a torn schema blob: it
+// decodes far enough to be recognisably a record attempt and no further, which
+// is the shape a truncated or forged payload value really arrives in.
+func malformedRecord() Metadata {
+	return Metadata{"session": NewRecord([]byte{0x01, 0xFF})}
+}
+
+func wantMalformed(t *testing.T, what string, err error) {
+	t.Helper()
+	if err == nil {
+		t.Fatalf("%s: got nil error, want ErrRecordMalformed", what)
+	}
+	if !errors.Is(err, ErrRecordMalformed) {
+		t.Fatalf("%s: err = %v, want ErrRecordMalformed", what, err)
+	}
+}
+
+// TestMalformedRecordRejectedAtIngestDense covers the dense and IVF entry-point
+// family: insert, insert-if-absent, upsert, set-payload, overwrite and the bulk
+// stage/build path. Each rejects with ErrRecordMalformed and leaves the point
+// exactly as it was.
+func TestMalformedRecordRejectedAtIngestDense(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		cfg  Config
+	}{{"hnsw", oversizeDenseConfig()}, {"ivf", oversizeIVFConfig()}} {
+		t.Run(tc.name, func(t *testing.T) {
+			c, err := NewCollection("default/malformed", tc.cfg)
+			if err != nil {
+				t.Fatalf("NewCollection: %v", err)
+			}
+			vec := []float32{1, 0, 0, 0}
+			good := Metadata{"rc": NewInt(1)}
+			if err := c.Insert(1, vec, 0, good, nil); err != nil {
+				t.Fatalf("baseline Insert: %v", err)
+			}
+
+			wantMalformed(t, "Insert", c.Insert(2, vec, 0, malformedRecord(), nil))
+			if _, _, _, _, _, ok := c.Get(2); ok {
+				t.Fatal("rejected Insert still created point 2")
+			}
+
+			_, err = c.InsertIfAbsent(3, vec, 0, malformedRecord(), nil)
+			wantMalformed(t, "InsertIfAbsent", err)
+			if _, _, _, _, _, ok := c.Get(3); ok {
+				t.Fatal("rejected InsertIfAbsent still created point 3")
+			}
+
+			wantMalformed(t, "Upsert", c.Upsert(1, vec, "doc", 0, malformedRecord(), nil))
+			// Upsert is delete-then-insert: the point must survive a rejection.
+			_, meta, _, _, _, ok := c.Get(1)
+			if !ok {
+				t.Fatal("rejected Upsert deleted the existing point 1")
+			}
+			if got, gok := meta["rc"]; !gok || !got.Equal(NewInt(1)) {
+				t.Fatalf("point 1 payload changed after a rejected Upsert: %v", meta)
+			}
+
+			wantMalformed(t, "SetPayload", c.SetPayload(1, malformedRecord(), nil))
+			wantMalformed(t, "OverwritePayload", c.OverwritePayload(1, malformedRecord(), nil))
+			_, meta, _, _, _, _ = c.Get(1)
+			if got, gok := meta["rc"]; !gok || !got.Equal(NewInt(1)) {
+				t.Fatalf("point 1 payload changed after a rejected payload op: %v", meta)
+			}
+			if _, gok := meta["session"]; gok {
+				t.Fatal("rejected payload op still stored the malformed record")
+			}
+
+			// Bulk: the stage refuses the batch outright, so nothing is queued.
+			bulk, berr := NewCollection("default/malformed-bulk", tc.cfg)
+			if berr != nil {
+				t.Fatalf("NewCollection bulk: %v", berr)
+			}
+			wantMalformed(t, "StageBulkPayloads", bulk.StageBulkPayloads(
+				[]uint64{9}, [][]float32{vec}, []Metadata{malformedRecord()}))
+			wantMalformed(t, "BuildConcurrentMeta", bulk.BuildConcurrentMeta(
+				[]uint64{9}, [][]float32{vec}, []Metadata{malformedRecord()}, 1))
+			if n := bulk.Stats().Size; n != 0 {
+				t.Fatalf("rejected bulk build left %d points", n)
+			}
+		})
+	}
+}
+
+// TestMalformedRecordRejectedAtIngestNamed covers the named-vector family.
+func TestMalformedRecordRejectedAtIngestNamed(t *testing.T) {
+	nc, err := NewNamedCollection("default/named-malformed", namedTestConfig())
+	if err != nil {
+		t.Fatalf("NewNamedCollection: %v", err)
+	}
+	vecs := map[string][]float32{"title": {1, 0, 0, 0}, "image": {1, 0, 0}}
+	good := Metadata{"rc": NewInt(1)}
+	if err := nc.Insert(1, vecs, good, 0); err != nil {
+		t.Fatalf("baseline Insert: %v", err)
+	}
+
+	wantMalformed(t, "NamedInsert", nc.Insert(2, vecs, malformedRecord(), 0))
+	if _, _, _, _, ok := nc.Get(2); ok {
+		t.Fatal("rejected named Insert still created point 2")
+	}
+	wantMalformed(t, "NamedSetPayload", nc.SetPayload(1, malformedRecord(), nil))
+	wantMalformed(t, "NamedOverwritePayload", nc.OverwritePayload(1, malformedRecord(), nil))
+	_, payload, _, _, ok := nc.Get(1)
+	if !ok {
+		t.Fatal("point 1 disappeared")
+	}
+	if got, gok := payload["rc"]; !gok || !got.Equal(NewInt(1)) {
+		t.Fatalf("named payload changed after a rejected op: %v", payload)
+	}
+	if _, gok := payload["session"]; gok {
+		t.Fatal("rejected named payload op still stored the malformed record")
+	}
+}
+
+// TestMalformedRecordRejectedAtIngestMultiVector covers the multi-vector
+// family, including the versioned if-absent path that does NOT delegate to
+// AddIfAbsent and the wire-reachable MultiRestoreAdd pair.
+func TestMalformedRecordRejectedAtIngestMultiVector(t *testing.T) {
+	m, err := NewMultiVectorIndex(MultiVectorConfig{Dim: 4, M: 16, EfConstruction: 200, EfSearch: 64, Seed: 1})
+	if err != nil {
+		t.Fatalf("NewMultiVectorIndex: %v", err)
+	}
+	tokens := [][]float32{{1, 0, 0, 0}}
+	good := Metadata{"rc": NewInt(1)}
+	if err := m.Add(1, tokens, good); err != nil {
+		t.Fatalf("baseline Add: %v", err)
+	}
+
+	wantMalformed(t, "MVAdd", m.Add(2, tokens, malformedRecord()))
+	if _, _, _, ok := m.Get(2); ok {
+		t.Fatal("rejected MV Add still created doc 2")
+	}
+	_, err = m.AddIfAbsent(3, tokens, malformedRecord())
+	wantMalformed(t, "MVAddIfAbsent", err)
+	if _, _, _, ok := m.Get(3); ok {
+		t.Fatal("rejected MV AddIfAbsent still created doc 3")
+	}
+	_, err = m.MultiAddIfAbsentVersion(4, tokens, malformedRecord(), nil, 5)
+	wantMalformed(t, "MVMultiAddIfAbsentVersion", err)
+	if _, _, _, ok := m.Get(4); ok {
+		t.Fatal("rejected MV MultiAddIfAbsentVersion still created doc 4")
+	}
+
+	wantMalformed(t, "MVSetPayload", m.SetPayload(1, malformedRecord(), nil))
+	wantMalformed(t, "MVOverwritePayload", m.OverwritePayload(1, malformedRecord(), nil))
+	_, payload, _, ok := m.Get(1)
+	if !ok {
+		t.Fatal("doc 1 disappeared")
+	}
+	if got, gok := payload["rc"]; !gok || !got.Equal(NewInt(1)) {
+		t.Fatalf("MV payload changed after a rejected op: %v", payload)
+	}
+	if _, gok := payload["session"]; gok {
+		t.Fatal("rejected MV payload op still stored the malformed record")
+	}
+}
+
+// TestMalformedRecordRejectedAtWireReachableRestore is the half the phase-2
+// pre-flight scan added. The "restore" family is NOT all replay: ops/builtin.go
+// routes an ordinary WIRE insert to Collection.RestoreInsert/RestoreInsertAt
+// whenever the decoded args carry a non-zero version (the version-preserving
+// reinsert), and ops/multivector.go + ops/mv_batch.go route one to
+// MultiRestoreAddSparse. Those entries carry the CALLER's metadata, so they are
+// ingest and must apply the shape check like any other ingest entry.
+//
+// The engine-level bodies underneath them (idx.RestoreInsert, idx.RestorePayload,
+// the MV restoreAdd) stay size-only — TestRestorePathsSkipShapeValidation is the
+// other side of this ruling.
+func TestMalformedRecordRejectedAtWireReachableRestore(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		cfg  Config
+	}{{"hnsw", oversizeDenseConfig()}, {"ivf", oversizeIVFConfig()}} {
+		t.Run(tc.name, func(t *testing.T) {
+			c, err := NewCollection("default/malformed-restore", tc.cfg)
+			if err != nil {
+				t.Fatalf("NewCollection: %v", err)
+			}
+			vec := []float32{1, 0, 0, 0}
+			wantMalformed(t, "RestoreInsert", c.RestoreInsert(2, vec, 0, malformedRecord(), nil, nil, 5))
+			if _, _, _, _, _, ok := c.Get(2); ok {
+				t.Fatal("rejected RestoreInsert still created point 2")
+			}
+			wantMalformed(t, "RestoreInsertAt", c.RestoreInsertAt(3, vec, 0, malformedRecord(), nil, nil, 5, 1_000))
+			if _, _, _, _, _, ok := c.Get(3); ok {
+				t.Fatal("rejected RestoreInsertAt still created point 3")
+			}
+		})
+	}
+
+	t.Run("multivector", func(t *testing.T) {
+		m, err := NewMultiVectorIndex(MultiVectorConfig{Dim: 4, M: 16, EfConstruction: 200, EfSearch: 64, Seed: 1})
+		if err != nil {
+			t.Fatalf("NewMultiVectorIndex: %v", err)
+		}
+		tokens := [][]float32{{1, 0, 0, 0}}
+		wantMalformed(t, "MultiRestoreAdd", m.MultiRestoreAdd(1, tokens, malformedRecord(), nil, 5))
+		if _, _, _, ok := m.Get(1); ok {
+			t.Fatal("rejected MultiRestoreAdd still created doc 1")
+		}
+		wantMalformed(t, "MultiRestoreAddSparse", m.MultiRestoreAddSparse(2, tokens, malformedRecord(), nil, 5, nil))
+		if _, _, _, ok := m.Get(2); ok {
+			t.Fatal("rejected MultiRestoreAddSparse still created doc 2")
+		}
+	})
+}
+
+// TestWellFormedRecordStillAccepted is the guard against an over-broad gate:
+// the same table with the canonical session record must go through everywhere.
+// Without it, a Validate that rejected everything would pass every test above.
+func TestWellFormedRecordStillAccepted(t *testing.T) {
+	rec := func() Metadata { return Metadata{"session": NewRecord(sessionRecordBytes(t))} }
+
+	for _, tc := range []struct {
+		name string
+		cfg  Config
+	}{{"hnsw", oversizeDenseConfig()}, {"ivf", oversizeIVFConfig()}} {
+		t.Run(tc.name, func(t *testing.T) {
+			c, err := NewCollection("default/wellformed", tc.cfg)
+			if err != nil {
+				t.Fatalf("NewCollection: %v", err)
+			}
+			vec := []float32{1, 0, 0, 0}
+			if err := c.Insert(1, vec, 0, rec(), nil); err != nil {
+				t.Fatalf("Insert: %v", err)
+			}
+			if _, err := c.InsertIfAbsent(2, vec, 0, rec(), nil); err != nil {
+				t.Fatalf("InsertIfAbsent: %v", err)
+			}
+			if err := c.Upsert(1, vec, "doc", 0, rec(), nil); err != nil {
+				t.Fatalf("Upsert: %v", err)
+			}
+			if err := c.SetPayload(1, rec(), nil); err != nil {
+				t.Fatalf("SetPayload: %v", err)
+			}
+			if err := c.OverwritePayload(1, rec(), nil); err != nil {
+				t.Fatalf("OverwritePayload: %v", err)
+			}
+			if err := c.RestoreInsert(4, vec, 0, rec(), nil, nil, 5); err != nil {
+				t.Fatalf("RestoreInsert: %v", err)
+			}
+			if err := c.RestoreInsertAt(5, vec, 0, rec(), nil, nil, 5, 1_000); err != nil {
+				t.Fatalf("RestoreInsertAt: %v", err)
+			}
+
+			bulk, berr := NewCollection("default/wellformed-bulk", tc.cfg)
+			if berr != nil {
+				t.Fatalf("NewCollection bulk: %v", berr)
+			}
+			if err := bulk.StageBulkPayloads([]uint64{9}, [][]float32{vec}, []Metadata{rec()}); err != nil {
+				t.Fatalf("StageBulkPayloads: %v", err)
+			}
+			if err := bulk.BuildConcurrentMeta([]uint64{10}, [][]float32{vec}, []Metadata{rec()}, 1); err != nil {
+				t.Fatalf("BuildConcurrentMeta: %v", err)
+			}
+		})
+	}
+
+	t.Run("named", func(t *testing.T) {
+		nc, err := NewNamedCollection("default/named-wellformed", namedTestConfig())
+		if err != nil {
+			t.Fatalf("NewNamedCollection: %v", err)
+		}
+		vecs := map[string][]float32{"title": {1, 0, 0, 0}, "image": {1, 0, 0}}
+		if err := nc.Insert(1, vecs, rec(), 0); err != nil {
+			t.Fatalf("named Insert: %v", err)
+		}
+		if err := nc.SetPayload(1, rec(), nil); err != nil {
+			t.Fatalf("named SetPayload: %v", err)
+		}
+		if err := nc.OverwritePayload(1, rec(), nil); err != nil {
+			t.Fatalf("named OverwritePayload: %v", err)
+		}
+		if err := nc.RestoreInsert(2, vecs, nil, rec(), 0, nil, 5); err != nil {
+			t.Fatalf("named RestoreInsert: %v", err)
+		}
+	})
+
+	t.Run("multivector", func(t *testing.T) {
+		m, err := NewMultiVectorIndex(MultiVectorConfig{Dim: 4, M: 16, EfConstruction: 200, EfSearch: 64, Seed: 1})
+		if err != nil {
+			t.Fatalf("NewMultiVectorIndex: %v", err)
+		}
+		tokens := [][]float32{{1, 0, 0, 0}}
+		if err := m.Add(1, tokens, rec()); err != nil {
+			t.Fatalf("MV Add: %v", err)
+		}
+		if _, err := m.AddIfAbsent(2, tokens, rec()); err != nil {
+			t.Fatalf("MV AddIfAbsent: %v", err)
+		}
+		if _, err := m.MultiAddIfAbsentVersion(3, tokens, rec(), nil, 5); err != nil {
+			t.Fatalf("MV MultiAddIfAbsentVersion: %v", err)
+		}
+		if err := m.SetPayload(1, rec(), nil); err != nil {
+			t.Fatalf("MV SetPayload: %v", err)
+		}
+		if err := m.OverwritePayload(1, rec(), nil); err != nil {
+			t.Fatalf("MV OverwritePayload: %v", err)
+		}
+		if err := m.MultiRestoreAdd(4, tokens, rec(), nil, 5); err != nil {
+			t.Fatalf("MV MultiRestoreAdd: %v", err)
+		}
+	})
+}
+
+// TestRestorePathsSkipShapeValidation is the other half of the pre-flight
+// ruling. The REPLAY bodies — the engine-level RestoreInsert/RestorePayload, the
+// named RestoreInsert the WAL replays through, the MV restoreAdd — must accept a
+// malformed record, because they replay bytes this store already ACKED. A shape
+// check there would refuse to rebuild an acknowledged write, which is worse than
+// the poison it would prevent: the poison is a lost acceleration, this would be
+// lost data. They keep the size-only check, which cannot refuse anything the WAL
+// or a snapshot can actually hold.
+func TestRestorePathsSkipShapeValidation(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		cfg  Config
+	}{{"hnsw", oversizeDenseConfig()}, {"ivf", oversizeIVFConfig()}} {
+		t.Run(tc.name, func(t *testing.T) {
+			c, err := NewCollection("default/replay", tc.cfg)
+			if err != nil {
+				t.Fatalf("NewCollection: %v", err)
+			}
+			vec := []float32{1, 0, 0, 0}
+			if err := c.idx.RestoreInsert(1, vec, 0, malformedRecord(), nil, nil, 5); err != nil {
+				t.Fatalf("idx.RestoreInsert on a malformed record: %v, want nil (replay must not refuse acked data)", err)
+			}
+			if err := c.idx.RestoreInsertAt(2, vec, 0, malformedRecord(), nil, nil, 5, 1_000); err != nil {
+				t.Fatalf("idx.RestoreInsertAt on a malformed record: %v, want nil", err)
+			}
+			if err := c.idx.RestorePayload(1, malformedRecord(), nil, 6); err != nil {
+				t.Fatalf("idx.RestorePayload on a malformed record: %v, want nil", err)
+			}
+			_, meta, _, _, _, ok := c.Get(1)
+			if !ok {
+				t.Fatal("the replayed point is not live")
+			}
+			if got := meta["session"]; got.Kind != ValueRecord || !bytes.Equal(got.Rec, []byte{0x01, 0xFF}) {
+				t.Fatalf("the replayed record was not stored verbatim: %+v", got)
+			}
+		})
+	}
+
+	t.Run("named", func(t *testing.T) {
+		nc, err := NewNamedCollection("default/named-replay", namedTestConfig())
+		if err != nil {
+			t.Fatalf("NewNamedCollection: %v", err)
+		}
+		vecs := map[string][]float32{"title": {1, 0, 0, 0}, "image": {1, 0, 0}}
+		if err := nc.RestoreInsert(1, vecs, nil, malformedRecord(), 0, nil, 5); err != nil {
+			t.Fatalf("named RestoreInsert on a malformed record: %v, want nil", err)
+		}
+		nc.restorePayload(1, malformedRecord(), nil, 6)
+		_, payload, _, _, ok := nc.Get(1)
+		if !ok {
+			t.Fatal("the replayed named point is not live")
+		}
+		if got := payload["session"]; got.Kind != ValueRecord || !bytes.Equal(got.Rec, []byte{0x01, 0xFF}) {
+			t.Fatalf("the replayed named record was not stored verbatim: %+v", got)
+		}
+	})
+
+	t.Run("multivector", func(t *testing.T) {
+		m, err := NewMultiVectorIndex(MultiVectorConfig{Dim: 4, M: 16, EfConstruction: 200, EfSearch: 64, Seed: 1})
+		if err != nil {
+			t.Fatalf("NewMultiVectorIndex: %v", err)
+		}
+		tokens := [][]float32{{1, 0, 0, 0}}
+		if err := m.restoreAdd(1, tokens, malformedRecord(), nil, 5, nil); err != nil {
+			t.Fatalf("MV restoreAdd on a malformed record: %v, want nil", err)
+		}
+		m.restorePayload(1, malformedRecord(), nil, 6)
+		_, payload, _, ok := m.Get(1)
+		if !ok {
+			t.Fatal("the replayed MV doc is not live")
+		}
+		if got := payload["session"]; got.Kind != ValueRecord || !bytes.Equal(got.Rec, []byte{0x01, 0xFF}) {
+			t.Fatalf("the replayed MV record was not stored verbatim: %+v", got)
+		}
+	})
+}
+
+// TestWALReplayRestoresAMalformedRecord is the end-to-end statement of the same
+// ruling: a WAL holding a record this store accepted BEFORE the gate existed
+// still replays on reopen. The log record is written directly (the public entry
+// no longer produces one), then the store is closed and reopened, and replay
+// must rebuild the point rather than drop it.
+func TestWALReplayRestoresAMalformedRecord(t *testing.T) {
+	dir := t.TempDir()
+	cs, c := openMutateWALCollection(t, dir)
+
+	seq, err := c.wal.appendSetPayloadStaged(1, malformedRecord(), nil, 2)
+	if err != nil {
+		t.Fatalf("appendSetPayloadStaged: %v", err)
+	}
+	if err := c.wal.commitWaitStaged(seq); err != nil {
+		t.Fatalf("commitWaitStaged: %v", err)
+	}
+	if err := cs.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	cs2, err := OpenCollectionStore(dir)
+	if err != nil {
+		t.Fatalf("reopen: %v", err)
+	}
+	defer func() { _ = cs2.Close() }()
+	c2, ok := cs2.Get("docs")
+	if !ok {
+		t.Fatal("collection missing after reopen")
+	}
+	_, meta, _, _, version, ok := c2.Get(1)
+	if !ok {
+		t.Fatal("replay dropped the point holding a malformed record — an acked write was lost")
+	}
+	if version != 2 {
+		t.Fatalf("replayed version = %d, want 2", version)
+	}
+	if got := meta["session"]; got.Kind != ValueRecord || !bytes.Equal(got.Rec, []byte{0x01, 0xFF}) {
+		t.Fatalf("replay did not restore the record verbatim: %+v", got)
+	}
+}
+
+// BenchmarkCheckRecordValues puts the write-path cost of the shape check on the
+// record: a payload with no ValueRecord at all (the overwhelmingly common case,
+// which must stay free), the session fixture, and a table-heavy 64 KiB record,
+// which is where DecodeRecord's per-row allocation shows up.
+func BenchmarkCheckRecordValues(b *testing.B) {
+	sess := benchVectorSessionRecord(b)
+	large := benchVectorTableRecord(b, 64<<10)
+
+	for _, c := range []struct {
+		name string
+		m    Metadata
+	}{
+		{"no-record", Metadata{"country": NewString("DE"), "rc": NewInt(7)}},
+		{"session", Metadata{"session": NewRecord(sess)}},
+		{"table-64KiB", Metadata{"session": NewRecord(large)}},
+	} {
+		b.Run("shape/"+c.name, func(b *testing.B) {
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				if err := checkRecordValues(c.m); err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+		b.Run("size-only/"+c.name, func(b *testing.B) {
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				if err := checkRecordValuesSize(c.m); err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
+}
+
+// benchVectorSessionRecord is the canonical session record for a benchmark
+// (sessionRecordBytes needs a *testing.T).
+func benchVectorSessionRecord(b *testing.B) []byte {
+	b.Helper()
+	s := &wire.Schema{Version: 3, StoreNames: true, Fields: []wire.FieldDef{
+		{Name: "rc", Type: wire.OperateTypeU8},
+		{Name: "bal", Type: wire.OperateTypeI32},
+		{Name: "tag", Type: wire.OperateTypeBytes},
+	}}
+	if err := s.Validate(); err != nil {
+		b.Fatalf("schema invalid: %v", err)
+	}
+	enc := (&wire.Record{Mode: wire.OperateModeSchema, Schema: s, Fields: []wire.Field{
+		{Cell: wire.Cell{Type: wire.OperateTypeU8, U: 7}},
+		{Cell: wire.Cell{Type: wire.OperateTypeI32, U: su64(-5)}},
+		{Cell: wire.Cell{Type: wire.OperateTypeBytes, B: []byte("de")}},
+	}}).Encode()
+	if enc == nil {
+		b.Fatal("bench session record failed to encode")
+	}
+	return enc
+}
+
+// benchVectorTableRecord builds a schema-mode record whose single TABLE field
+// holds enough rows to reach roughly size bytes.
+func benchVectorTableRecord(b *testing.B, size int) []byte {
+	b.Helper()
+	s := &wire.Schema{Version: 1, StoreNames: true, Fields: []wire.FieldDef{
+		{Name: "t", Type: wire.OperateTypeTable, Table: &wire.TableDef{
+			KeyType: wire.OperateTypeU64,
+			Cols: []wire.ColumnDef{
+				{Name: "hi", Type: wire.OperateTypeU32},
+				{Name: "lo", Type: wire.OperateTypeU32},
+			},
+		}},
+	}}
+	if err := s.Validate(); err != nil {
+		b.Fatalf("schema invalid: %v", err)
+	}
+	const rowWidth = 16 // 8-byte key + two U32 columns
+	rows := make([]wire.Row, 0, size/rowWidth)
+	for i := 0; i < size/rowWidth; i++ {
+		key := make([]byte, 8)
+		for j := 0; j < 8; j++ {
+			key[j] = byte(uint64(i) >> (8 * j)) //nolint:gosec // bounded loop counter
+		}
+		rows = append(rows, wire.Row{Key: key, Cols: []wire.Col{
+			{Cell: wire.Cell{Type: wire.OperateTypeU32, U: uint64(i)}},     //nolint:gosec // bounded
+			{Cell: wire.Cell{Type: wire.OperateTypeU32, U: uint64(i) + 3}}, //nolint:gosec // bounded
+		}})
+	}
+	enc := (&wire.Record{Mode: wire.OperateModeSchema, Schema: s, Fields: []wire.Field{
+		{Cell: wire.Cell{Type: wire.OperateTypeTable}, Table: &wire.Table{Rows: rows}},
+	}}).Encode()
+	if enc == nil {
+		b.Fatal("bench table record failed to encode")
+	}
+	return enc
+}

--- a/vector_operate_cluster_test.go
+++ b/vector_operate_cluster_test.go
@@ -356,6 +356,58 @@ func TestVectorOperateRefusedDuringReshard(t *testing.T) {
 	}
 }
 
+// TestVectorOperateRefusedWhenDualRoutingCollapses is the case gating on
+// dualTargets' `dual` answer let through.
+//
+// A reshard whose state carries no old-gen pin (OldP == 0 — a meta entry
+// written by pre-upgrade code) takes dualTargets' backward-compat branch, which
+// returns dual=false as soon as the catalog has flipped to the new generation.
+// The reshard is still RUNNING: Status is only cleared later, and meta-followers
+// that have not applied the flip still route reads to the OLD generation. An
+// operate allowed through there applies its non-idempotent op-list to the new
+// generation alone, and the two generations hold different record bytes until
+// the old one is dropped.
+//
+// Gating on Status instead of on dual makes the refusal cover the whole reshard,
+// which is what ErrOperateDuringReshard's "retry after cutover" already promises.
+func TestVectorOperateRefusedWhenDualRoutingCollapses(t *testing.T) {
+	const (
+		coll       = "collapsed"
+		oldP, newP = 4, 8
+		id         = uint64(7)
+	)
+	ee := setupReshardingDense(t, coll, oldP, newP)
+	ctx := context.Background()
+
+	must(t, ee.VectorInsert(ctx, coll, id, []float32{1, 0, 0, 0}))
+
+	// Post-cutover, no old-gen pin: the catalog routes to the new gen and the
+	// reshard state names only the new one — dualTargets answers dual=false.
+	must(t, ee.catalog.SetPartitionsGen(coll, newP, 1))
+	must(t, ee.catalog.SetReshardState(coll, ReshardState{Status: 1, NewP: newP, NewGen: 1}))
+	if _, _, dual := ee.dualTargets(coll, id); dual {
+		t.Fatal("fixture is wrong: dualTargets still reports dual=true, so it does not exercise the collapse")
+	}
+
+	if _, _, _, err := ee.VectorOperate(ctx, coll, id, "session", bumpRC()); !errors.Is(err, ErrOperateDuringReshard) {
+		t.Fatalf("operate while a reshard is in progress but dual routing has collapsed = %v, "+
+			"want ErrOperateDuringReshard", err)
+	}
+	newPhys := string(ops.PartitionKeyGen(coll, 1, ops.PartitionOf(id, newP)))
+	if !physRecordAbsent(t, ee, newPhys, id, "session") {
+		t.Fatalf("the refused operate wrote a record to %q", newPhys)
+	}
+
+	// Same negative control as the dual-write case: with the reshard cleared the
+	// identical call goes through, so the gate is the STATUS and nothing else.
+	must(t, ee.catalog.SetReshardState(coll, ReshardState{Status: 0}))
+	found, res, _, err := ee.VectorOperate(ctx, coll, id, "session", bumpRC())
+	must(t, err)
+	if !found || retRC(t, res) != 1 {
+		t.Fatalf("operate after the reshard cleared: found=%v res=%+v, want rc=1", found, res)
+	}
+}
+
 // TestVectorOperateMissingPointFlagThroughFanOut: an absent point is the
 // not-found FLAG, never an error — the same contract set_payload has.
 func TestVectorOperateMissingPointFlagThroughFanOut(t *testing.T) {
@@ -500,6 +552,85 @@ func TestVectorOperateNamedAndMVThroughStoreAndFanOut(t *testing.T) {
 			must(t, err)
 			if found {
 				t.Fatalf("fan %s on an absent id: found=true, want false", fam.op)
+			}
+		})
+	}
+}
+
+// bumpRCNoCreate is bumpRC with create = NONE: against a payload key that holds
+// no record it is the error case ops.ErrVectorRecordAbsent, not a silent no-op.
+func bumpRCNoCreate() *wire.OperateArgs {
+	a := bumpRC()
+	a.Create = wire.OperateCreateNone
+	return a
+}
+
+// TestVectorOperateRecordAbsentIsTheSameSentinelOnEveryBackend pins the error
+// contract Store.VectorOperate documents: create = NONE against a payload key
+// holding no record is ops.ErrVectorRecordAbsent, whichever Store implementation
+// the caller holds.
+//
+// The three backends disagreed before this. Direct returned the sentinel;
+// replicated embedded returned it stringified across the Raft boundary, where
+// errors.Is stops matching; and the networked path answered StatusNotFound,
+// which the client turns into its own not-found and the root store into
+// ErrNotFound. A caller writing errors.Is(err, ops.ErrVectorRecordAbsent) — the
+// check the interface doc tells them to write — got a different answer per
+// deployment mode.
+//
+// found stays false and version stays 0 on all three: the call changed nothing.
+func TestVectorOperateRecordAbsentIsTheSameSentinelOnEveryBackend(t *testing.T) {
+	const (
+		coll = "docs"
+		id   = uint64(1)
+	)
+	backends := []struct {
+		name  string
+		build func(t *testing.T) Store
+	}{
+		{"embedded", func(t *testing.T) Store {
+			s := newSingleEmbedded(t)
+			waitLeaderEmbedded(t, s)
+			return s
+		}},
+		{"direct", func(t *testing.T) Store { return newSingleDirect(t) }},
+		{"networked", func(t *testing.T) Store {
+			reg := ops.NewRegistry()
+			must(t, ops.RegisterBuiltins(reg))
+			srv, err := NewDirectServer("127.0.0.1:0", DirectConfig{Ops: reg})
+			must(t, err)
+			t.Cleanup(func() { _ = srv.Close() })
+			s, err := NewClient(ClientConfig{Servers: []string{srv.Addr()}, Ops: reg})
+			must(t, err)
+			t.Cleanup(func() { _ = s.Close() })
+			return s
+		}},
+	}
+	for _, b := range backends {
+		t.Run(b.name, func(t *testing.T) {
+			s := b.build(t)
+			ctx := context.Background()
+			// The point EXISTS and carries no record under "session": an absent
+			// point would be the found=false flag, which is a different outcome.
+			seedOperateCollection(t, s, coll, 0, 1)
+
+			found, res, version, err := s.VectorOperate(ctx, coll, id, "session", bumpRCNoCreate())
+			if !errors.Is(err, ops.ErrVectorRecordAbsent) {
+				t.Fatalf("create=NONE against a keyless payload = %v, want ops.ErrVectorRecordAbsent", err)
+			}
+			if found || res != nil || version != 0 {
+				t.Fatalf("refused call returned (found=%v, res=%v, version=%d); want the zero outcome", found, res, version)
+			}
+
+			// Negative control: with a record present the same call applies, so
+			// the normalisation cannot be swallowing a real success.
+			if _, _, _, err := s.VectorOperate(ctx, coll, id, "session", bumpRC()); err != nil {
+				t.Fatalf("seed operate: %v", err)
+			}
+			found, res, _, err = s.VectorOperate(ctx, coll, id, "session", bumpRCNoCreate())
+			must(t, err)
+			if !found || retRC(t, res) != 2 {
+				t.Fatalf("create=NONE with a record present: found=%v res=%+v, want rc=2", found, res)
 			}
 		})
 	}

--- a/vector_operate_cluster_test.go
+++ b/vector_operate_cluster_test.go
@@ -1,0 +1,505 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package rostam
+
+// Cluster-plumbing tests for vector_operate: the three Store implementations
+// (embedded, networked, direct), the partitioned fan-out, and the reshard
+// refusal.
+//
+// What these tests pin that no lower layer can:
+//
+//   - the CAS precondition survives EVERY Store path. The vector_set_payload
+//     siblings drop it on three of their four paths (networkedStore encodes with
+//     the non-CAS encoder, directStore takes `_ ...WriteOpts`, fanSetPayload
+//     decodes with the non-CAS decoder), so "mirror set_payload" is exactly the
+//     wrong instinct here and each path gets its own regression guard.
+//   - an operate on a partitioned collection reaches the OWNING partition and
+//     only it.
+//   - an operate is REFUSED while a reshard is dual-writing: applying a
+//     non-idempotent op-list to both generations would double-count every ADD.
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/rostamlabs/rostam/ops"
+	"github.com/rostamlabs/rostam/sdk/wire"
+	"github.com/rostamlabs/rostam/vector"
+)
+
+// operateFieldPath addresses a dynamic-mode record field by name.
+func operateFieldPath(name string) wire.OperatePath {
+	return wire.OperatePath{Kind: wire.OperatePathField, Field: wire.OperateSeg{ByName: true, Name: name}}
+}
+
+// bumpRC is the canonical op-list these tests drive: ADD 1 to the by-name U64
+// field "rc", creating a dynamic-mode record when the payload key is empty, and
+// return the resulting value. Two calls therefore leave rc == 2.
+func bumpRC() *wire.OperateArgs {
+	return &wire.OperateArgs{
+		Create: wire.OperateCreateDynamic,
+		Ops: []wire.OperateOp{
+			{Opcode: wire.OperateOpADD, Type: wire.OperateTypeU64, Path: operateFieldPath("rc"), A: 1},
+		},
+		Rets: []wire.OperateRet{{Mode: wire.OperateRetValue, Path: operateFieldPath("rc")}},
+	}
+}
+
+// retRC decodes the single returned cell of a bumpRC result as a uint64.
+func retRC(t *testing.T, res *wire.OperateResult) uint64 {
+	t.Helper()
+	if res == nil {
+		t.Fatal("operate result is nil")
+	}
+	if res.Status != wire.OperateStatusOK {
+		t.Fatalf("operate status = %d, want OK", res.Status)
+	}
+	if len(res.Values) != 1 {
+		t.Fatalf("operate returned %d values, want 1", len(res.Values))
+	}
+	c, _, err := wire.DecodeTaggedCell(res.Values[0])
+	if err != nil {
+		t.Fatalf("DecodeTaggedCell: %v", err)
+	}
+	return c.U
+}
+
+// pointVersion reads a point's current CAS version through the Store API (the
+// batch-get row carries it on every backend), so a CAS test can supply the
+// RIGHT expected version rather than guessing at the engine's bump schedule.
+func pointVersion(t *testing.T, s Store, coll string, id uint64) uint64 {
+	t.Helper()
+	pts, _, err := s.VectorGetBatch(context.Background(), coll, []uint64{id}, false, false)
+	if err != nil {
+		t.Fatalf("VectorGetBatch %s/%d: %v", coll, id, err)
+	}
+	if len(pts) != 1 {
+		t.Fatalf("VectorGetBatch %s/%d returned %d points, want 1", coll, id, len(pts))
+	}
+	return pts[0].Version
+}
+
+// isCASConflict matches vector.ErrVersionConflict by identity AND by text: the
+// sentinel's identity does not survive the networked transport (the server
+// stringifies it onto the wire), so the text arm is what covers that path.
+func isCASConflict(err error) bool {
+	if err == nil {
+		return false
+	}
+	if errors.Is(err, vector.ErrVersionConflict) {
+		return true
+	}
+	s := strings.ToLower(err.Error())
+	return strings.Contains(s, "version") && (strings.Contains(s, "conflict") || strings.Contains(s, "mismatch"))
+}
+
+// physRecordAbsent reports whether the payload key holds no record on the given
+// PHYSICAL partition (the reshard test's "nothing was written" assertion).
+func physRecordAbsent(t *testing.T, ee *embedded, phys string, id uint64, key string) bool {
+	t.Helper()
+	body, err := ee.Call(context.Background(), "vector_get", ops.EncodeVectorGetArgs(phys, id, getFlags(false, true)))
+	if err != nil {
+		t.Fatalf("vector_get %q id=%d: %v", phys, id, err)
+	}
+	found, _, meta, _, _, err := ops.DecodeVectorGetResult(body)
+	if err != nil {
+		t.Fatalf("decode vector_get %q: %v", phys, err)
+	}
+	if !found {
+		return true
+	}
+	_, ok := meta[key]
+	return !ok
+}
+
+// seedOperateCollection creates a dense collection (P partitions; P<=1 =
+// unpartitioned) and inserts ids 1..n so every operate has a live point.
+func seedOperateCollection(t *testing.T, s Store, coll string, P, n int) {
+	t.Helper()
+	ctx := context.Background()
+	must(t, s.CreateCollection(ctx, coll, VectorConfig{
+		Dim: 4, Metric: vector.L2, M: 8, EfConstruction: 50, EfSearch: 32, Seed: 1, Partitions: P,
+	}))
+	for id := uint64(1); id <= uint64(n); id++ {
+		must(t, s.VectorInsert(ctx, coll, id, []float32{float32(id), 0, 0, 0}))
+	}
+}
+
+// TestVectorOperateUnpartitionedPassThrough is the baseline: on an
+// UNPARTITIONED embedded collection two operate calls through Store.VectorOperate
+// create the record and increment it, returning 1 then 2.
+func TestVectorOperateUnpartitionedPassThrough(t *testing.T) {
+	s := newSingleEmbedded(t)
+	waitLeaderEmbedded(t, s)
+	ctx := context.Background()
+	seedOperateCollection(t, s, "docs", 0, 1)
+
+	found, res, err := s.VectorOperate(ctx, "docs", 1, "session", bumpRC())
+	must(t, err)
+	if !found {
+		t.Fatal("first operate: found=false, want true (the point exists)")
+	}
+	if got := retRC(t, res); got != 1 {
+		t.Fatalf("first operate rc = %d, want 1", got)
+	}
+
+	found, res, err = s.VectorOperate(ctx, "docs", 1, "session", bumpRC())
+	must(t, err)
+	if !found {
+		t.Fatal("second operate: found=false")
+	}
+	if got := retRC(t, res); got != 2 {
+		t.Fatalf("second operate rc = %d, want 2", got)
+	}
+}
+
+// TestVectorOperatePartitionedRoutesToOwningPartition drives 40 points on a P=4
+// collection: each gets a record, each is incremented twice, each reads back
+// rc == 2, and each point lives on ONLY its owning physical partition (proving
+// the operate reached the partition the id routes to, not some other one).
+func TestVectorOperatePartitionedRoutesToOwningPartition(t *testing.T) {
+	const (
+		coll = "parted"
+		P    = 4
+		N    = 40
+	)
+	s := newSingleEmbedded(t)
+	waitLeaderEmbedded(t, s)
+	ee := s.(*embedded)
+	ctx := context.Background()
+	seedOperateCollection(t, s, coll, P, N)
+
+	for id := uint64(1); id <= N; id++ {
+		for round := 1; round <= 2; round++ {
+			found, res, err := s.VectorOperate(ctx, coll, id, "session", bumpRC())
+			if err != nil {
+				t.Fatalf("operate id=%d round=%d: %v", id, round, err)
+			}
+			if !found {
+				t.Fatalf("operate id=%d round=%d: found=false", id, round)
+			}
+			if got := retRC(t, res); got != uint64(round) { //nolint:gosec // round is 1 or 2
+				t.Fatalf("operate id=%d round=%d: rc = %d, want %d", id, round, got, round)
+			}
+		}
+	}
+
+	// Every point sits on exactly one physical partition: its owning one.
+	for id := uint64(1); id <= N; id++ {
+		own := ops.PartitionOf(id, P)
+		for p := 0; p < P; p++ {
+			phys := string(ops.PartitionKeyGen(coll, 0, p))
+			got := physVecExists(t, ee, phys, id)
+			if want := p == own; got != want {
+				t.Fatalf("id=%d present in %q = %v, want %v (owning partition is %d)", id, phys, got, want, own)
+			}
+		}
+		// And its record is on the owning partition, holding rc == 2.
+		phys := string(ops.PartitionKeyGen(coll, 0, own))
+		if physRecordAbsent(t, ee, phys, id, "session") {
+			t.Fatalf("id=%d: no record under %q on the owning partition %q", id, "session", phys)
+		}
+	}
+}
+
+// TestVectorOperateCASOverTheNetworkedPath is the networkedStore regression
+// guard: networkedStore.VectorSetPayload encodes with the NON-CAS encoder and
+// silently drops the precondition. A vector_operate must not — the wrong version
+// must conflict and the right version must apply.
+func TestVectorOperateCASOverTheNetworkedPath(t *testing.T) {
+	reg := ops.NewRegistry()
+	must(t, ops.RegisterBuiltins(reg))
+	srv, err := NewDirectServer("127.0.0.1:0", DirectConfig{Ops: reg})
+	must(t, err)
+	t.Cleanup(func() { _ = srv.Close() })
+
+	s, err := NewClient(ClientConfig{Servers: []string{srv.Addr()}, Ops: reg})
+	must(t, err)
+	t.Cleanup(func() { _ = s.Close() })
+
+	seedOperateCollection(t, s, "docs", 0, 1)
+	assertOperateCAS(t, s, "docs", 1)
+}
+
+// TestVectorOperateCASOverTheDirectPath is the directStore regression guard:
+// directStore.VectorSetPayload takes `_ ...WriteOpts` and throws the CAS
+// precondition away outright. On a single-node direct store there is no other
+// guard on a write, so dropping it is the whole failure.
+func TestVectorOperateCASOverTheDirectPath(t *testing.T) {
+	s := newSingleDirect(t)
+	seedOperateCollection(t, s, "docs", 0, 1)
+	assertOperateCAS(t, s, "docs", 1)
+}
+
+// assertOperateCAS drives the shared CAS contract against any Store: a wrong
+// expected version conflicts and changes nothing; the right one applies.
+func assertOperateCAS(t *testing.T, s Store, coll string, id uint64) {
+	t.Helper()
+	ctx := context.Background()
+
+	// Seed a record so the CAS attempts have something to fail against.
+	found, res, err := s.VectorOperate(ctx, coll, id, "session", bumpRC())
+	must(t, err)
+	if !found || retRC(t, res) != 1 {
+		t.Fatalf("seed operate: found=%v res=%+v", found, res)
+	}
+
+	ver := pointVersion(t, s, coll, id)
+	if ver == 0 {
+		t.Fatal("point version is 0 — this backend does not carry versions, the CAS test cannot run")
+	}
+
+	// Wrong version ⇒ conflict, nothing applied.
+	wrong := ver + 999
+	if _, _, err := s.VectorOperate(ctx, coll, id, "session", bumpRC(), WriteOpts{ExpectedVersion: &wrong}); !isCASConflict(err) {
+		t.Fatalf("operate with the WRONG expected version = %v, want a version conflict (the CAS guard was dropped)", err)
+	}
+	if _, res, err := s.VectorOperate(ctx, coll, id, "session", bumpRC()); err != nil || retRC(t, res) != 2 {
+		t.Fatalf("after the refused CAS the counter should read 2: err=%v res=%+v", err, res)
+	}
+
+	// Right version ⇒ applied.
+	right := pointVersion(t, s, coll, id)
+	found, res, err = s.VectorOperate(ctx, coll, id, "session", bumpRC(), WriteOpts{ExpectedVersion: &right})
+	must(t, err)
+	if !found || retRC(t, res) != 3 {
+		t.Fatalf("operate with the RIGHT expected version: found=%v res=%+v, want rc=3", found, res)
+	}
+}
+
+// TestVectorOperateCASSurvivesFanOut is the fan-out regression guard:
+// fanSetPayload decodes with the NON-CAS decoder, so a partitioned set_payload
+// loses the guard entirely. fanOperate must thread it through.
+func TestVectorOperateCASSurvivesFanOut(t *testing.T) {
+	const (
+		coll = "parted"
+		P    = 4
+		id   = uint64(7)
+	)
+	s := newSingleEmbedded(t)
+	waitLeaderEmbedded(t, s)
+	emb := s.(*embedded)
+	fan := newFanoutDispatcher(emb, emb.node)
+	seedOperateCollection(t, s, coll, P, 10)
+
+	call := func(t *testing.T, exp uint64, hasExp bool) (bool, *wire.OperateResult, error) {
+		t.Helper()
+		args, err := wire.EncodeVectorOperateArgs(coll, id, "session", bumpRC(), exp, hasExp)
+		if err != nil {
+			t.Fatalf("EncodeVectorOperateArgs: %v", err)
+		}
+		body, cerr := fan.Call("vector_operate", args)
+		if cerr != nil {
+			return false, nil, cerr
+		}
+		return ops.DecodeVectorOperateResult(body)
+	}
+
+	// Seed the record through the fan-out itself.
+	found, res, err := call(t, 0, false)
+	must(t, err)
+	if !found || retRC(t, res) != 1 {
+		t.Fatalf("seed through fan-out: found=%v res=%+v", found, res)
+	}
+
+	ver := pointVersion(t, s, coll, id)
+	if _, _, err := call(t, ver+999, true); !isCASConflict(err) {
+		t.Fatalf("fan-out operate with the WRONG expected version = %v, want a version conflict "+
+			"(fanOperate dropped the CAS guard, exactly like fanSetPayload)", err)
+	}
+	found, res, err = call(t, ver, true)
+	must(t, err)
+	if !found || retRC(t, res) != 2 {
+		t.Fatalf("fan-out operate with the RIGHT expected version: found=%v res=%+v, want rc=2", found, res)
+	}
+}
+
+// TestVectorOperateRefusedDuringReshard pins the ruling: an operate is refused
+// while a reshard is dual-writing, because applying a non-idempotent op-list to
+// both generations double-counts every ADD and the disagreement survives
+// cutover. The refusal must write NOTHING to either generation, and clearing the
+// reshard state must make the identical call succeed.
+func TestVectorOperateRefusedDuringReshard(t *testing.T) {
+	const (
+		coll       = "dw"
+		oldP, newP = 4, 8
+		id         = uint64(7)
+	)
+	ee := setupReshardingDense(t, coll, oldP, newP)
+	ctx := context.Background()
+
+	oldPhys := string(ops.PartitionKeyGen(coll, 0, ops.PartitionOf(id, oldP)))
+	newPhys := string(ops.PartitionKeyGen(coll, 1, ops.PartitionOf(id, newP)))
+
+	// The insert dual-writes, so the point exists in BOTH generations.
+	must(t, ee.VectorInsert(ctx, coll, id, []float32{1, 0, 0, 0}))
+
+	_, _, err := ee.VectorOperate(ctx, coll, id, "session", bumpRC())
+	if !errors.Is(err, ErrOperateDuringReshard) {
+		t.Fatalf("operate during a reshard = %v, want ErrOperateDuringReshard", err)
+	}
+	for _, phys := range []string{oldPhys, newPhys} {
+		if !physRecordAbsent(t, ee, phys, id, "session") {
+			t.Fatalf("the refused operate wrote a record to %q", phys)
+		}
+	}
+
+	// Clearing the reshard state makes the identical call succeed.
+	must(t, ee.catalog.SetReshardState(coll, ReshardState{Status: 0}))
+	found, res, err := ee.VectorOperate(ctx, coll, id, "session", bumpRC())
+	must(t, err)
+	if !found || retRC(t, res) != 1 {
+		t.Fatalf("operate after the reshard cleared: found=%v res=%+v, want rc=1", found, res)
+	}
+}
+
+// TestVectorOperateMissingPointFlagThroughFanOut: an absent point is the
+// not-found FLAG, never an error — the same contract set_payload has.
+func TestVectorOperateMissingPointFlagThroughFanOut(t *testing.T) {
+	const (
+		coll = "parted"
+		P    = 4
+	)
+	s := newSingleEmbedded(t)
+	waitLeaderEmbedded(t, s)
+	emb := s.(*embedded)
+	fan := newFanoutDispatcher(emb, emb.node)
+	seedOperateCollection(t, s, coll, P, 4)
+
+	args, err := wire.EncodeVectorOperateArgs(coll, 9999, "session", bumpRC(), 0, false)
+	must(t, err)
+	body, err := fan.Call("vector_operate", args)
+	if err != nil {
+		t.Fatalf("operate on an absent point returned an error: %v (want the found=false FLAG)", err)
+	}
+	found, _, err := ops.DecodeVectorOperateResult(body)
+	must(t, err)
+	if found {
+		t.Fatal("operate on an absent point: found=true, want false")
+	}
+
+	// The Store path agrees.
+	found, _, err = s.VectorOperate(context.Background(), coll, 9999, "session", bumpRC())
+	must(t, err)
+	if found {
+		t.Fatal("Store.VectorOperate on an absent point: found=true, want false")
+	}
+}
+
+// TestVectorOperateAliasResolves drives the operate family through an ALIAS on a
+// partitioned collection — the dataPlaneAliasOps entry. Without it the alias name
+// is never rewritten, the route reports unpartitioned, and the op hits the empty
+// logical collection instead of the owning partition.
+func TestVectorOperateAliasResolves(t *testing.T) {
+	const (
+		real = "real"
+		prod = "prod"
+		P    = 4
+		id   = uint64(5)
+	)
+	s := newSingleEmbedded(t)
+	waitLeaderEmbedded(t, s)
+	emb := s.(*embedded)
+	fan := newFanoutDispatcher(emb, emb.node)
+	ctx := context.Background()
+	seedOperateCollection(t, s, real, P, 10)
+	must(t, emb.CreateAlias(ctx, prod, real))
+
+	args, err := wire.EncodeVectorOperateArgs(prod, id, "session", bumpRC(), 0, false)
+	must(t, err)
+	body, err := fan.Call("vector_operate", args)
+	must(t, err)
+	found, res, err := ops.DecodeVectorOperateResult(body)
+	must(t, err)
+	if !found || retRC(t, res) != 1 {
+		t.Fatalf("operate via alias through the dispatcher: found=%v res=%+v, want rc=1", found, res)
+	}
+
+	// The record landed on the REAL collection's owning partition.
+	phys := string(ops.PartitionKeyGen(real, 0, ops.PartitionOf(id, P)))
+	if physRecordAbsent(t, emb, phys, id, "session") {
+		t.Fatalf("operate via alias did not write to the real collection's owning partition %q", phys)
+	}
+
+	// The Store path resolves the alias too, and sees the SAME record.
+	found, res, err = s.VectorOperate(ctx, prod, id, "session", bumpRC())
+	must(t, err)
+	if !found || retRC(t, res) != 2 {
+		t.Fatalf("Store.VectorOperate via alias: found=%v res=%+v, want rc=2 (same record)", found, res)
+	}
+}
+
+// TestVectorOperateNamedAndMVThroughStoreAndFanOut covers the other two
+// families' Store methods and fan handlers on PARTITIONED collections, so the
+// three fan-out rows are each exercised rather than only the dense one.
+func TestVectorOperateNamedAndMVThroughStoreAndFanOut(t *testing.T) {
+	const (
+		P  = 4
+		id = uint64(3)
+	)
+	s := newSingleEmbedded(t)
+	waitLeaderEmbedded(t, s)
+	emb := s.(*embedded)
+	fan := newFanoutDispatcher(emb, emb.node)
+	ctx := context.Background()
+
+	must(t, s.VectorNamedCreateCollection(ctx, "named", map[string]NamedVectorParams{
+		"title": {Dim: 4, Metric: vector.Cosine},
+	}, P))
+	must(t, s.VectorNamedInsert(ctx, "named", id, map[string][]float32{"title": {1, 0, 0, 0}}, nil, 0))
+
+	must(t, s.VectorMVCreateCollection(ctx, "mv", MultiVectorConfig{
+		Dim: 4, M: 8, EfConstruction: 50, EfSearch: 32, Seed: 1, Partitions: P,
+	}))
+	must(t, s.VectorMVAdd(ctx, "mv", id, [][]float32{{1, 0, 0, 0}, {0, 1, 0, 0}}, nil))
+
+	for _, fam := range []struct {
+		op    string
+		coll  string
+		store func(ctx context.Context, a *wire.OperateArgs, opts ...WriteOpts) (bool, *wire.OperateResult, error)
+	}{
+		{
+			op: "vector_named_operate", coll: "named",
+			store: func(ctx context.Context, a *wire.OperateArgs, opts ...WriteOpts) (bool, *wire.OperateResult, error) {
+				return s.VectorNamedOperate(ctx, "named", id, "session", a, opts...)
+			},
+		},
+		{
+			op: "vector_mv_operate", coll: "mv",
+			store: func(ctx context.Context, a *wire.OperateArgs, opts ...WriteOpts) (bool, *wire.OperateResult, error) {
+				return s.VectorMVOperate(ctx, "mv", id, "session", a, opts...)
+			},
+		},
+	} {
+		t.Run(fam.op, func(t *testing.T) {
+			// Through the Store method.
+			found, res, err := fam.store(ctx, bumpRC())
+			must(t, err)
+			if !found || retRC(t, res) != 1 {
+				t.Fatalf("Store %s: found=%v res=%+v, want rc=1", fam.op, found, res)
+			}
+			// Through the fan-out dispatcher, onto the SAME record.
+			args, err := wire.EncodeVectorOperateArgs(fam.coll, id, "session", bumpRC(), 0, false)
+			must(t, err)
+			body, err := fan.Call(fam.op, args)
+			must(t, err)
+			found, res, err = ops.DecodeVectorOperateResult(body)
+			must(t, err)
+			if !found || retRC(t, res) != 2 {
+				t.Fatalf("fan %s: found=%v res=%+v, want rc=2", fam.op, found, res)
+			}
+			// An absent id is the not-found flag on both families too.
+			missing, err := wire.EncodeVectorOperateArgs(fam.coll, 9999, "session", bumpRC(), 0, false)
+			must(t, err)
+			body, err = fan.Call(fam.op, missing)
+			must(t, err)
+			found, _, err = ops.DecodeVectorOperateResult(body)
+			must(t, err)
+			if found {
+				t.Fatalf("fan %s on an absent id: found=true, want false", fam.op)
+			}
+		})
+	}
+}

--- a/vector_operate_cluster_test.go
+++ b/vector_operate_cluster_test.go
@@ -136,7 +136,7 @@ func TestVectorOperateUnpartitionedPassThrough(t *testing.T) {
 	ctx := context.Background()
 	seedOperateCollection(t, s, "docs", 0, 1)
 
-	found, res, err := s.VectorOperate(ctx, "docs", 1, "session", bumpRC())
+	found, res, _, err := s.VectorOperate(ctx, "docs", 1, "session", bumpRC())
 	must(t, err)
 	if !found {
 		t.Fatal("first operate: found=false, want true (the point exists)")
@@ -145,7 +145,7 @@ func TestVectorOperateUnpartitionedPassThrough(t *testing.T) {
 		t.Fatalf("first operate rc = %d, want 1", got)
 	}
 
-	found, res, err = s.VectorOperate(ctx, "docs", 1, "session", bumpRC())
+	found, res, _, err = s.VectorOperate(ctx, "docs", 1, "session", bumpRC())
 	must(t, err)
 	if !found {
 		t.Fatal("second operate: found=false")
@@ -173,7 +173,7 @@ func TestVectorOperatePartitionedRoutesToOwningPartition(t *testing.T) {
 
 	for id := uint64(1); id <= N; id++ {
 		for round := 1; round <= 2; round++ {
-			found, res, err := s.VectorOperate(ctx, coll, id, "session", bumpRC())
+			found, res, _, err := s.VectorOperate(ctx, coll, id, "session", bumpRC())
 			if err != nil {
 				t.Fatalf("operate id=%d round=%d: %v", id, round, err)
 			}
@@ -240,7 +240,7 @@ func assertOperateCAS(t *testing.T, s Store, coll string, id uint64) {
 	ctx := context.Background()
 
 	// Seed a record so the CAS attempts have something to fail against.
-	found, res, err := s.VectorOperate(ctx, coll, id, "session", bumpRC())
+	found, res, _, err := s.VectorOperate(ctx, coll, id, "session", bumpRC())
 	must(t, err)
 	if !found || retRC(t, res) != 1 {
 		t.Fatalf("seed operate: found=%v res=%+v", found, res)
@@ -253,16 +253,16 @@ func assertOperateCAS(t *testing.T, s Store, coll string, id uint64) {
 
 	// Wrong version ⇒ conflict, nothing applied.
 	wrong := ver + 999
-	if _, _, err := s.VectorOperate(ctx, coll, id, "session", bumpRC(), WriteOpts{ExpectedVersion: &wrong}); !isCASConflict(err) {
+	if _, _, _, err := s.VectorOperate(ctx, coll, id, "session", bumpRC(), WriteOpts{ExpectedVersion: &wrong}); !isCASConflict(err) {
 		t.Fatalf("operate with the WRONG expected version = %v, want a version conflict (the CAS guard was dropped)", err)
 	}
-	if _, res, err := s.VectorOperate(ctx, coll, id, "session", bumpRC()); err != nil || retRC(t, res) != 2 {
+	if _, res, _, err := s.VectorOperate(ctx, coll, id, "session", bumpRC()); err != nil || retRC(t, res) != 2 {
 		t.Fatalf("after the refused CAS the counter should read 2: err=%v res=%+v", err, res)
 	}
 
 	// Right version ⇒ applied.
 	right := pointVersion(t, s, coll, id)
-	found, res, err = s.VectorOperate(ctx, coll, id, "session", bumpRC(), WriteOpts{ExpectedVersion: &right})
+	found, res, _, err = s.VectorOperate(ctx, coll, id, "session", bumpRC(), WriteOpts{ExpectedVersion: &right})
 	must(t, err)
 	if !found || retRC(t, res) != 3 {
 		t.Fatalf("operate with the RIGHT expected version: found=%v res=%+v, want rc=3", found, res)
@@ -294,7 +294,8 @@ func TestVectorOperateCASSurvivesFanOut(t *testing.T) {
 		if cerr != nil {
 			return false, nil, cerr
 		}
-		return ops.DecodeVectorOperateResult(body)
+		found, res, _, derr := ops.DecodeVectorOperateResult(body)
+		return found, res, derr
 	}
 
 	// Seed the record through the fan-out itself.
@@ -336,7 +337,7 @@ func TestVectorOperateRefusedDuringReshard(t *testing.T) {
 	// The insert dual-writes, so the point exists in BOTH generations.
 	must(t, ee.VectorInsert(ctx, coll, id, []float32{1, 0, 0, 0}))
 
-	_, _, err := ee.VectorOperate(ctx, coll, id, "session", bumpRC())
+	_, _, _, err := ee.VectorOperate(ctx, coll, id, "session", bumpRC())
 	if !errors.Is(err, ErrOperateDuringReshard) {
 		t.Fatalf("operate during a reshard = %v, want ErrOperateDuringReshard", err)
 	}
@@ -348,7 +349,7 @@ func TestVectorOperateRefusedDuringReshard(t *testing.T) {
 
 	// Clearing the reshard state makes the identical call succeed.
 	must(t, ee.catalog.SetReshardState(coll, ReshardState{Status: 0}))
-	found, res, err := ee.VectorOperate(ctx, coll, id, "session", bumpRC())
+	found, res, _, err := ee.VectorOperate(ctx, coll, id, "session", bumpRC())
 	must(t, err)
 	if !found || retRC(t, res) != 1 {
 		t.Fatalf("operate after the reshard cleared: found=%v res=%+v, want rc=1", found, res)
@@ -374,14 +375,14 @@ func TestVectorOperateMissingPointFlagThroughFanOut(t *testing.T) {
 	if err != nil {
 		t.Fatalf("operate on an absent point returned an error: %v (want the found=false FLAG)", err)
 	}
-	found, _, err := ops.DecodeVectorOperateResult(body)
+	found, _, _, err := ops.DecodeVectorOperateResult(body)
 	must(t, err)
 	if found {
 		t.Fatal("operate on an absent point: found=true, want false")
 	}
 
 	// The Store path agrees.
-	found, _, err = s.VectorOperate(context.Background(), coll, 9999, "session", bumpRC())
+	found, _, _, err = s.VectorOperate(context.Background(), coll, 9999, "session", bumpRC())
 	must(t, err)
 	if found {
 		t.Fatal("Store.VectorOperate on an absent point: found=true, want false")
@@ -411,7 +412,7 @@ func TestVectorOperateAliasResolves(t *testing.T) {
 	must(t, err)
 	body, err := fan.Call("vector_operate", args)
 	must(t, err)
-	found, res, err := ops.DecodeVectorOperateResult(body)
+	found, res, _, err := ops.DecodeVectorOperateResult(body)
 	must(t, err)
 	if !found || retRC(t, res) != 1 {
 		t.Fatalf("operate via alias through the dispatcher: found=%v res=%+v, want rc=1", found, res)
@@ -424,7 +425,7 @@ func TestVectorOperateAliasResolves(t *testing.T) {
 	}
 
 	// The Store path resolves the alias too, and sees the SAME record.
-	found, res, err = s.VectorOperate(ctx, prod, id, "session", bumpRC())
+	found, res, _, err = s.VectorOperate(ctx, prod, id, "session", bumpRC())
 	must(t, err)
 	if !found || retRC(t, res) != 2 {
 		t.Fatalf("Store.VectorOperate via alias: found=%v res=%+v, want rc=2 (same record)", found, res)
@@ -458,24 +459,24 @@ func TestVectorOperateNamedAndMVThroughStoreAndFanOut(t *testing.T) {
 	for _, fam := range []struct {
 		op    string
 		coll  string
-		store func(ctx context.Context, a *wire.OperateArgs, opts ...WriteOpts) (bool, *wire.OperateResult, error)
+		store func(ctx context.Context, a *wire.OperateArgs, opts ...WriteOpts) (bool, *wire.OperateResult, uint64, error)
 	}{
 		{
 			op: "vector_named_operate", coll: "named",
-			store: func(ctx context.Context, a *wire.OperateArgs, opts ...WriteOpts) (bool, *wire.OperateResult, error) {
+			store: func(ctx context.Context, a *wire.OperateArgs, opts ...WriteOpts) (bool, *wire.OperateResult, uint64, error) {
 				return s.VectorNamedOperate(ctx, "named", id, "session", a, opts...)
 			},
 		},
 		{
 			op: "vector_mv_operate", coll: "mv",
-			store: func(ctx context.Context, a *wire.OperateArgs, opts ...WriteOpts) (bool, *wire.OperateResult, error) {
+			store: func(ctx context.Context, a *wire.OperateArgs, opts ...WriteOpts) (bool, *wire.OperateResult, uint64, error) {
 				return s.VectorMVOperate(ctx, "mv", id, "session", a, opts...)
 			},
 		},
 	} {
 		t.Run(fam.op, func(t *testing.T) {
 			// Through the Store method.
-			found, res, err := fam.store(ctx, bumpRC())
+			found, res, _, err := fam.store(ctx, bumpRC())
 			must(t, err)
 			if !found || retRC(t, res) != 1 {
 				t.Fatalf("Store %s: found=%v res=%+v, want rc=1", fam.op, found, res)
@@ -485,7 +486,7 @@ func TestVectorOperateNamedAndMVThroughStoreAndFanOut(t *testing.T) {
 			must(t, err)
 			body, err := fan.Call(fam.op, args)
 			must(t, err)
-			found, res, err = ops.DecodeVectorOperateResult(body)
+			found, res, _, err = ops.DecodeVectorOperateResult(body)
 			must(t, err)
 			if !found || retRC(t, res) != 2 {
 				t.Fatalf("fan %s: found=%v res=%+v, want rc=2", fam.op, found, res)
@@ -495,7 +496,7 @@ func TestVectorOperateNamedAndMVThroughStoreAndFanOut(t *testing.T) {
 			must(t, err)
 			body, err = fan.Call(fam.op, missing)
 			must(t, err)
-			found, _, err = ops.DecodeVectorOperateResult(body)
+			found, _, _, err = ops.DecodeVectorOperateResult(body)
 			must(t, err)
 			if found {
 				t.Fatalf("fan %s on an absent id: found=true, want false", fam.op)

--- a/wc_envelope_inner_op_test.go
+++ b/wc_envelope_inner_op_test.go
@@ -1,0 +1,75 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package rostam
+
+import (
+	"testing"
+
+	"github.com/rostamlabs/rostam/ops"
+	"github.com/rostamlabs/rostam/sdk/wire"
+)
+
+// TestWCEnvelopeInnerOpMatchesTheStoreWire closes the loop on the retry-guard
+// fix from BOTH ends, in the one module that can see both.
+//
+// The client decides whether an ambiguous failure may be retried by reading the
+// inner op name back out of the envelope (wire.WCEnvelopeInnerOp). That is only
+// sound if the name it reads is the name this store actually put on the wire, so
+// this pins wcWire's output — the real producer, through the real
+// ops.EncodeWCEnvelope — against both the peek and ops' own full decoder.
+//
+// Without this, the envelope layout could drift in ops and the client's guard
+// would quietly start reading garbage, which fails OPEN (a wrapped
+// vector_operate would look replayable again).
+func TestWCEnvelopeInnerOpMatchesTheStoreWire(t *testing.T) {
+	active := WriteOpts{WriteConsistencyFactor: 2}
+	for _, op := range []string{"vector_operate", "vector_named_operate", "vector_mv_operate", "operate", "vector_insert"} {
+		t.Run(op, func(t *testing.T) {
+			wireOp, wireArgs := wcWire(op, []byte("inner-args"), active)
+			if wireOp != wire.WCEnvelopeOp {
+				t.Fatalf("wcWire op = %q, want %q", wireOp, wire.WCEnvelopeOp)
+			}
+			peeked, ok := wire.WCEnvelopeInnerOp(wireArgs)
+			if !ok {
+				t.Fatalf("WCEnvelopeInnerOp could not read the frame wcWire built")
+			}
+			if peeked != op {
+				t.Fatalf("WCEnvelopeInnerOp = %q, want %q", peeked, op)
+			}
+			_, _, decoded, innerArgs, err := ops.DecodeWCEnvelope(wireArgs)
+			if err != nil {
+				t.Fatalf("DecodeWCEnvelope: %v", err)
+			}
+			if decoded != peeked {
+				t.Fatalf("peeked name %q disagrees with DecodeWCEnvelope's %q", peeked, decoded)
+			}
+			if string(innerArgs) != "inner-args" {
+				t.Fatalf("inner args = %q, want inner-args", innerArgs)
+			}
+		})
+	}
+}
+
+// TestWCEnvelopeOpConstantsAgree pins the two names to one value: ops aliases
+// the wire constant, and the client compares against the wire one.
+func TestWCEnvelopeOpConstantsAgree(t *testing.T) {
+	if ops.WCEnvelopeOp != wire.WCEnvelopeOp {
+		t.Fatalf("ops.WCEnvelopeOp = %q, wire.WCEnvelopeOp = %q; the two must be the same name", ops.WCEnvelopeOp, wire.WCEnvelopeOp)
+	}
+	if wire.WCEnvelopeOp != "__wc__" {
+		t.Fatalf("WCEnvelopeOp = %q, want __wc__ (a rename is a wire break)", wire.WCEnvelopeOp)
+	}
+}
+
+// TestWCInactiveOptsSendThePlainOp is the guard's other half: with inactive
+// opts no envelope is built at all, so the plain op name reaches the retry
+// decision unchanged and the pre-existing classification still applies.
+func TestWCInactiveOptsSendThePlainOp(t *testing.T) {
+	wireOp, wireArgs := wcWire("vector_operate", []byte("inner-args"), WriteOpts{})
+	if wireOp != "vector_operate" {
+		t.Fatalf("wcWire op = %q, want the plain vector_operate", wireOp)
+	}
+	if string(wireArgs) != "inner-args" {
+		t.Fatalf("wcWire args = %q, want the byte-identical inner args", wireArgs)
+	}
+}


### PR DESCRIPTION
Adds `vector_operate`: apply an `operate` op-list to the record stored under a vector point's payload key, atomically under the collection lock, in one replicated apply, with CAS and the leader-stamped clock, returning the same typed `OperateResult` as KV `operate`. Hot per-point counters, histograms and per-row tables in a payload no longer need a client read-modify-write. Phase 2 of the record-search design. **Phase 1 (#102) is merged; this PR is rebased onto and targets `main`.**

## What this adds

**Engine primitive.** `MutatePayloadRecordCAS[At]` on all four engines (dense, IVF, named, multi-vector): read the record under the key, hand it to a three-outcome mutator (changed / unchanged / error), store the result as a record or delete the key, enforce the 16 MiB bound, append one WAL record through the existing set-payload staged path (the RESULT bytes, so replay never re-runs the op-list), reindex exactly as `set_payload` does, bump the version only when something changed. A failed `CHECK` leaves the point byte-identical and unbumped with no WAL record. The named/MV WAL wrappers keep their deliberate `(version, err)` returns on append failure; regression tests pin that.

**Ingest-time record validation.** Every wire-reachable entry that accepts metadata (31 sites across the four engines, the collection wrappers, bulk stage/build, the MV batch fast path, and the version-preserving restore inserts) now rejects a record that `wire.DecodeRecord` rejects, so stored records are always well-formed from here on; pure WAL-replay bodies stay size-only. The phase-1 per-key fail-closed guard remains as defence in depth. `ErrRecordMalformed` and `ErrPayloadKeyNotRecord` map to 400 and the absent-record case to 404 on all three transports (TCP, HTTP, gRPC), matched by their exact serialised forms so the classification survives replication (sentinels are rebuilt as plain errors across Raft) without letting an unrelated internal error that merely contains the text through redaction.

**Wire and ops.** `vector_operate` args wrap the already-hardened operate codec (raw-`uint32` length guards before any `int` conversion, trailing-bytes rejection, the inner Key/TTL/ttlMode fields required empty; 12.8 M fuzz executions clean); three `ops` handlers (dense/named/MV) supply `applyRecordBytes` as the mutator with `tx.applyStamp()` as the only clock; routing rows beside `vector_set_payload` in every table.

**Cluster.** `Store.VectorOperate/VectorNamedOperate/VectorMVOperate` on the embedded, networked and direct stores, each threading the CAS guard; the partitioned fan-out; `vector_operate` is non-replayable on the client (a retry must never re-apply an `ADD`). While a reshard is dual-writing the op is refused with a retryable `ErrOperateDuringReshard` instead of being double-applied (the check races the start of a reshard by one dispatch; a catalog-epoch fence is a follow-up). A cluster test asserts byte-identical records on every replica after a `STAMP`-carrying op-list, including a record key that carries a per-key TTL: on an unstamped apply the mutator passes key deadlines through untouched (exactly as `set_payload` does) rather than consulting the replica's wall clock, so replicas cannot diverge on whether the key had expired; only the stamped apply expires deterministically. The reshard refusal is classified as retryable on all three transports, and the result carries the applied version so a CAS loop needs no re-read.

**Client and docs.** Typed `Collection.Operate` on the native Go client (dense); docs in the vector filtering page, the Go client page and the KV overview; changelog.

## Verification
Per-task tests incl. WAL mutate-close-reopen replay on all four engines, index exactness after mutation, byte-identical records on leader and follower, CAS on all three store paths, hostile-decoder sweeps, `GOARCH=386`, golangci-lint, `mkdocs build --strict`, the vector race lane, and the full suite (`-p 1`): 31 packages green including root and cluster.

## Follow-ups (not in this PR)
- **`shard.Config.EnableApplyStamp` is never enabled outside `shard`'s own tests** (nothing in `cmd/` or `cluster.Node` sets it), so replicated applies run unstamped today: `STAMP` in KV `operate` and in `vector_operate` resolves to 0 on every replica and the handlers take the wall-clock engine branch, exactly as `set_payload` does. Byte-agreement across replicas holds because the unstamped path never reads the clock for record mutation. Turning the stamp on is a mixed-version rollout decision, left to a dedicated change.
- `vector_set_payload` drops the CAS guard on the networked and direct store paths (pre-existing; found while threading it for `vector_operate`).
- A typed Go client for the named and multi-vector variants: the `Store` methods and ops handlers exist for all three families, but the typed client has no named/MV collection handle yet, so `Collection.Operate` covers dense only.
- A "pre-vetted" signal on `VectorIndex` so `UpsertCASKeyTTL` and `StageBulkPayloads → BuildStaged` pay one validation pass instead of two (the wrapper must validate before its irreversible delete / stage clear).
- An allocation-free full-structure record walker in `sdk/record` (validation currently builds the decoded tree: ~830 µs / 754 KB for a 64 KiB table-heavy record).
- `DecodeOperateArgs` returns no consumed length, so slack inside an over-declared inner frame is undetectable (pre-existing in KV `operate`).
- The point-liveness gate (is the POINT itself expired?) still reads the wall clock on an unstamped apply, the same all-or-nothing class `set_payload` has today: a replica past the point's own TTL rejects the whole op while another applies it, which is a divergence in *whether* the op applied, never in stored bytes. Documented at `vector/record_mutate.go`; the apply-stamp rollout removes it.
- `wire.ErrVectorArgsTruncated` (a truncated vector frame, raised at 349 decoder sites, 335 of them pre-existing) is still reported as a server fault on every transport; classifying it changes the status of every vector op and wants its own change with its own transport tests (the malformed-frame sibling `wire.ErrOperateArgs` is classified here, with an exact-form arm for the replicated path).
- HTTP/MCP surfaces for `vector_operate` (KV `operate` has none either; needs a JSON op-list dialect).
- Phase 3: KV index definitions and `kv_query`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `vector_operate` and its `vector_named_operate` / `vector_mv_operate` twins: apply an `operate` op-list to the record stored under a vector point's payload key, atomically under the collection lock, in one replicated apply with CAS and the leader-stamped clock, returning the same typed `OperateResult` as KV `operate` plus the applied version. Previously, updating a record inside a payload required a client read-modify-write.

**Bug Fixes**
- Every wire-reachable entry that stores a record now validates it at ingest — the MV bulk fast path included — and mutator-produced bytes are validated before storage, rejecting malformed records with a 400 instead of poisoning the payload key's index acceleration.
- The record errors, malformed-operate-frame errors, truncated-frame errors, and the reshard refusal are classified as client-facing (400/404/retryable) on TCP, HTTP, and gRPC; exact-form matching keeps the classification intact across replication.
- Only a stamped apply judges a per-key deadline; an unstamped one mutates the record in place and passes the deadline through, so replicas cannot diverge on whether the key expired.
- The client classifies enveloped writes by their inner op and declines nested envelopes, so a retried `vector_operate` cannot double-apply, and all three Store backends now return the same record-absent sentinel.

**Migration**
- `vector_operate` is non-replayable on the client and refused with a retryable error during a reshard's dual-write window.
- `STAMP` resolves to 0 on unstamped applies; enabling the apply stamp is a separate rollout decision.

<sup>Written for commit 65dc4a7b9225306b157c9bcf8ef16b585e4390d7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rostamlabs/rostam/pull/103?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added atomic operations for records stored in vector-point payloads, including conditional updates, named collections, and multi-vector collections.
  * Operations return updated record results and versions to support compare-and-swap workflows without rereading.
  * Added record validation during ingestion, rejecting malformed or oversized payloads consistently.

* **Bug Fixes**
  * Prevented non-replayable writes from being retried after uncertain connection failures.
  * Improved error handling and HTTP/gRPC status mapping for invalid records, missing records, conflicts, and resharding.

* **Documentation**
  * Added usage guidance for vector record operations, CAS retries, validation, and operation limitations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->