### PR TITLE
perf(operate): make the operate encode/decode path allocation-free for pooling callers

### DIFF
--- a/ops/operate.go
+++ b/ops/operate.go
@@ -52,6 +52,12 @@ var operateArgsPool = sync.Pool{New: func() any { return new(wire.OperateArgs) }
 func handleOperate(tx *TxContext, args []byte) ([]byte, error) {
 	a, _ := operateArgsPool.Get().(*wire.OperateArgs)
 	defer func() {
+		// Clear before recycling: the ops hold Bytes/Name/path-Key slices into
+		// the request buffer, and a pooled entry holding them would pin that
+		// buffer until its next use. Only the live prefix needs it - the
+		// decoder already clears anything it leaves past the new length.
+		clear(a.Ops)
+		clear(a.Rets)
 		*a = wire.OperateArgs{Ops: a.Ops[:0], Rets: a.Rets[:0]}
 		operateArgsPool.Put(a)
 	}()

--- a/ops/operate.go
+++ b/ops/operate.go
@@ -54,8 +54,15 @@ func handleOperate(tx *TxContext, args []byte) ([]byte, error) {
 	defer func() {
 		// Clear before recycling: the ops hold Bytes/Name/path-Key slices into
 		// the request buffer, and a pooled entry holding them would pin that
-		// buffer until its next use. Only the live prefix needs it - the
-		// decoder already clears anything it leaves past the new length.
+		// buffer until its next use.
+		//
+		// Clearing the live prefix is enough, by induction on this reset
+		// rather than on anything the decoder does: an entry is handed back
+		// with length 0 and a fully cleared array, so the next decode can only
+		// dirty [0:len) and this clear puts it back. (The decoder's own
+		// shrink-clear never fires here - it triggers on a SHRINK, and a
+		// pooled entry always arrives at length 0. It is there for callers
+		// that reuse a dst without a pool.)
 		clear(a.Ops)
 		clear(a.Rets)
 		*a = wire.OperateArgs{Ops: a.Ops[:0], Rets: a.Rets[:0]}

--- a/ops/operate.go
+++ b/ops/operate.go
@@ -4,6 +4,7 @@ package ops
 
 import (
 	"errors"
+	"sync"
 
 	"github.com/rostamlabs/rostam/cache"
 	"github.com/rostamlabs/rostam/sdk/wire"
@@ -37,9 +38,24 @@ import (
 // copyRecord) and returns its own, freshly allocated out; this handler never
 // writes through cur and never touches it again once applyRecordBytes has
 // been called.
+// operateArgsPool recycles the decoded call. The op slice is the single
+// largest allocation on this path - one operate request carries up to
+// OperateMaxOps ops, and a session-cache style caller sends ~4 per key it
+// touches - so decoding a fresh one per request dominated the server's
+// allocation volume. Same pattern as schemaEnginePool/dynamicEnginePool.
+//
+// The decoded args alias the request buffer and applyRecordBytes only reads
+// them during the call, so the struct is safe to return to the pool as soon
+// as handleOperate returns.
+var operateArgsPool = sync.Pool{New: func() any { return new(wire.OperateArgs) }}
+
 func handleOperate(tx *TxContext, args []byte) ([]byte, error) {
-	a, err := wire.DecodeOperateArgs(args)
-	if err != nil {
+	a, _ := operateArgsPool.Get().(*wire.OperateArgs)
+	defer func() {
+		*a = wire.OperateArgs{Ops: a.Ops[:0], Rets: a.Rets[:0]}
+		operateArgsPool.Put(a)
+	}()
+	if err := wire.DecodeOperateArgsInto(a, args); err != nil {
 		return nil, err
 	}
 

--- a/sdk/wire/operate.go
+++ b/sdk/wire/operate.go
@@ -331,6 +331,19 @@ const minRetBytes = 1 + 1
 // than silently truncating or wrapping, for any field that cannot be
 // represented on the wire or that exceeds a cap (design doc §2.7).
 func EncodeOperateArgs(a *OperateArgs) ([]byte, error) {
+	return AppendOperateArgs(nil, a)
+}
+
+// AppendOperateArgs is EncodeOperateArgs appending into dst (reusing its
+// capacity when large enough), for a hot-loop caller that pools the buffer —
+// the same pair EncodeKeyArgs/AppendKeyArgs already form for point ops.
+// Passing dst=nil reproduces EncodeOperateArgs's bytes exactly. The returned
+// slice may alias dst.
+//
+// A caller that pools dst across calls allocates nothing here once the buffer
+// has grown to the largest op list it builds: an operate call's encoding is
+// otherwise dominated by appendOp growing a fresh buffer per call.
+func AppendOperateArgs(dst []byte, a *OperateArgs) ([]byte, error) {
 	if len(a.Key) > 0xFFFF {
 		return nil, ErrOperateCap
 	}
@@ -356,7 +369,11 @@ func EncodeOperateArgs(a *OperateArgs) ([]byte, error) {
 		return nil, ErrOperateArgs
 	}
 
-	buf := make([]byte, 0, 2+len(a.Key)+8+1+1+2+len(a.Schema)+2+2)
+	n := 2 + len(a.Key) + 8 + 1 + 1 + 2 + len(a.Schema) + 2 + 2
+	buf := dst[:0]
+	if cap(buf) < n {
+		buf = make([]byte, 0, n)
+	}
 	buf = binary.BigEndian.AppendUint16(buf, uint16(len(a.Key))) //nolint:gosec // bounded by the check above
 	buf = append(buf, a.Key...)
 	buf = binary.BigEndian.AppendUint64(buf, uint64(a.TTL/time.Millisecond)) //nolint:gosec // duration to milliseconds always non-negative

--- a/sdk/wire/operate.go
+++ b/sdk/wire/operate.go
@@ -421,26 +421,52 @@ func AppendOperateArgs(dst []byte, a *OperateArgs) ([]byte, error) {
 // bound, and it closes the KV operate path (where args is the whole request
 // body) at the same time.
 func DecodeOperateArgs(b []byte) (*OperateArgs, error) {
-	a, n, err := decodeOperateArgsN(b)
-	if err != nil {
+	a := new(OperateArgs)
+	if err := DecodeOperateArgsInto(a, b); err != nil {
 		return nil, err
-	}
-	if n != len(b) {
-		return nil, ErrOperateArgs
 	}
 	return a, nil
 }
 
+// DecodeOperateArgsInto is DecodeOperateArgs decoding into dst, reusing the
+// capacity of dst.Ops and dst.Rets instead of allocating a fresh slice per
+// call. It is for a hot-path caller that pools the struct: the server decodes
+// one OperateArgs per operate request, and that op slice is the single largest
+// allocation on the apply path (an op list of n bidders x ~4 ops per bidder).
+//
+// Every field of dst is overwritten, so a pooled dst carries nothing from its
+// previous use. A dst that already has capacity KEEPS it, so a frame carrying
+// no ops decodes to an empty-but-non-nil dst.Ops where DecodeOperateArgs
+// would return nil - read len(dst.Ops), never dst.Ops == nil. A fresh dst
+// (nil slices) decodes identically to DecodeOperateArgs.
+//
+// A path addressed by NAME still allocates that name's string per segment;
+// schema mode addresses by position and so decodes with no allocation at all
+// once dst has grown.
+//
+// The same aliasing rule applies as for DecodeOperateArgs: Key, Schema, Bytes,
+// Name and path-Key fields may point into b, so dst must not outlive b.
+func DecodeOperateArgsInto(dst *OperateArgs, b []byte) error {
+	n, err := decodeOperateArgsN(dst, b)
+	if err != nil {
+		return err
+	}
+	if n != len(b) {
+		return ErrOperateArgs
+	}
+	return nil
+}
+
 // decodeOperateArgsN is DecodeOperateArgs' body, reporting how many bytes it
 // consumed so the exported wrapper can insist that be all of them.
-func decodeOperateArgsN(b []byte) (*OperateArgs, int, error) {
+func decodeOperateArgsN(dst *OperateArgs, b []byte) (int, error) {
 	if len(b) < 2 {
-		return nil, 0, ErrShortArgs
+		return 0, ErrShortArgs
 	}
 	klen := int(binary.BigEndian.Uint16(b[0:2]))
 	off := 2
 	if len(b)-off < klen {
-		return nil, 0, ErrShortArgs
+		return 0, ErrShortArgs
 	}
 	var key []byte
 	if klen > 0 {
@@ -449,11 +475,11 @@ func decodeOperateArgsN(b []byte) (*OperateArgs, int, error) {
 	off += klen
 
 	if len(b)-off < 8+1+1+2 { // ttlMs(8) + ttlMode(1) + create(1) + schemaLen(2)
-		return nil, 0, ErrShortArgs
+		return 0, ErrShortArgs
 	}
 	ttl, err := ttlFromMs(binary.BigEndian.Uint64(b[off : off+8]))
 	if err != nil {
-		return nil, 0, err
+		return 0, err
 	}
 	off += 8
 	ttlMode := b[off]
@@ -461,16 +487,16 @@ func decodeOperateArgsN(b []byte) (*OperateArgs, int, error) {
 	create := b[off]
 	off++
 	if ttlMode > OperateTTLCreateOnly {
-		return nil, 0, ErrOperateArgs
+		return 0, ErrOperateArgs
 	}
 	if create > OperateCreateDynamic {
-		return nil, 0, ErrOperateArgs
+		return 0, ErrOperateArgs
 	}
 
 	schemaLen := int(binary.BigEndian.Uint16(b[off : off+2]))
 	off += 2
 	if len(b)-off < schemaLen {
-		return nil, 0, ErrShortArgs
+		return 0, ErrShortArgs
 	}
 	var schema []byte
 	if schemaLen > 0 {
@@ -479,7 +505,7 @@ func decodeOperateArgsN(b []byte) (*OperateArgs, int, error) {
 	off += schemaLen
 
 	if len(b)-off < 2 {
-		return nil, 0, ErrShortArgs
+		return 0, ErrShortArgs
 	}
 	nOps := int(binary.BigEndian.Uint16(b[off : off+2]))
 	off += 2
@@ -488,18 +514,23 @@ func decodeOperateArgsN(b []byte) (*OperateArgs, int, error) {
 	// than a call may carry), while a count the remaining bytes cannot
 	// possibly hold is a truncated frame.
 	if nOps > OperateMaxOps {
-		return nil, 0, ErrOperateCap
+		return 0, ErrOperateCap
 	}
 	if !CountFitsIn(nOps, len(b)-off, minOpBytes) {
-		return nil, 0, ErrShortArgs
+		return 0, ErrShortArgs
 	}
-	var ops []OperateOp
+	// dst.Ops[:0] on a nil slice is still nil, so a fresh dst keeps
+	// DecodeOperateArgs's "nil when the frame carries none" shape while a
+	// pooled one reuses whatever capacity it already had.
+	ops := dst.Ops[:0]
 	if nOps > 0 {
-		ops = make([]OperateOp, 0, nOps)
+		if cap(ops) < nOps {
+			ops = make([]OperateOp, 0, nOps)
+		}
 		for i := 0; i < nOps; i++ {
 			op, n, oerr := decodeOp(b[off:])
 			if oerr != nil {
-				return nil, 0, oerr
+				return 0, oerr
 			}
 			ops = append(ops, op)
 			off += n
@@ -507,30 +538,32 @@ func decodeOperateArgsN(b []byte) (*OperateArgs, int, error) {
 	}
 
 	if len(b)-off < 2 {
-		return nil, 0, ErrShortArgs
+		return 0, ErrShortArgs
 	}
 	nRet := int(binary.BigEndian.Uint16(b[off : off+2]))
 	off += 2
 	if nRet > OperateMaxRet {
-		return nil, 0, ErrOperateCap
+		return 0, ErrOperateCap
 	}
 	if !CountFitsIn(nRet, len(b)-off, minRetBytes) {
-		return nil, 0, ErrShortArgs
+		return 0, ErrShortArgs
 	}
-	var rets []OperateRet
+	rets := dst.Rets[:0]
 	if nRet > 0 {
-		rets = make([]OperateRet, 0, nRet)
+		if cap(rets) < nRet {
+			rets = make([]OperateRet, 0, nRet)
+		}
 		for i := 0; i < nRet; i++ {
 			ret, n, rerr := decodeRet(b[off:])
 			if rerr != nil {
-				return nil, 0, rerr
+				return 0, rerr
 			}
 			rets = append(rets, ret)
 			off += n
 		}
 	}
 
-	return &OperateArgs{
+	*dst = OperateArgs{
 		Key:     key,
 		TTL:     ttl,
 		TTLMode: ttlMode,
@@ -538,7 +571,8 @@ func decodeOperateArgsN(b []byte) (*OperateArgs, int, error) {
 		Schema:  schema,
 		Ops:     ops,
 		Rets:    rets,
-	}, off, nil
+	}
+	return off, nil
 }
 
 // EncodeOperateResult encodes an operate result frame (design doc §3.4):

--- a/sdk/wire/operate.go
+++ b/sdk/wire/operate.go
@@ -440,6 +440,9 @@ func DecodeOperateArgs(b []byte) (*OperateArgs, error) {
 // would return nil - read len(dst.Ops), never dst.Ops == nil. A fresh dst
 // (nil slices) decodes identically to DecodeOperateArgs.
 //
+// On error dst is reset to empty rather than left untouched - see the error
+// branch for why.
+//
 // A path addressed by NAME still allocates that name's string per segment;
 // schema mode addresses by position and so decodes with no allocation at all
 // once dst has grown.
@@ -448,11 +451,20 @@ func DecodeOperateArgs(b []byte) (*OperateArgs, error) {
 // Name and path-Key fields may point into b, so dst must not outlive b.
 func DecodeOperateArgsInto(dst *OperateArgs, b []byte) error {
 	n, err := decodeOperateArgsN(dst, b)
-	if err != nil {
-		return err
+	if err == nil && n != len(b) {
+		err = ErrOperateArgs
 	}
-	if n != len(b) {
-		return ErrOperateArgs
+	if err != nil {
+		// dst is left EMPTY, not untouched: the decoder appends into dst's
+		// backing array as it goes, so a call that fails partway has already
+		// overwritten elements that dst's old length still covers. Resetting
+		// is the only cheap state a caller can rely on, and clearing releases
+		// the failed call's buffer.
+		ops, rets := dst.Ops[:0], dst.Rets[:0]
+		clear(ops[:cap(ops)])
+		clear(rets[:cap(rets)])
+		*dst = OperateArgs{Ops: ops, Rets: rets}
+		return err
 	}
 	return nil
 }
@@ -522,10 +534,13 @@ func decodeOperateArgsN(dst *OperateArgs, b []byte) (int, error) {
 	// dst.Ops[:0] on a nil slice is still nil, so a fresh dst keeps
 	// DecodeOperateArgs's "nil when the frame carries none" shape while a
 	// pooled one reuses whatever capacity it already had.
+	oldOps := len(dst.Ops)
 	ops := dst.Ops[:0]
+	reusedOps := true
 	if nOps > 0 {
 		if cap(ops) < nOps {
 			ops = make([]OperateOp, 0, nOps)
+			reusedOps = false
 		}
 		for i := 0; i < nOps; i++ {
 			op, n, oerr := decodeOp(b[off:])
@@ -548,10 +563,13 @@ func decodeOperateArgsN(dst *OperateArgs, b []byte) (int, error) {
 	if !CountFitsIn(nRet, len(b)-off, minRetBytes) {
 		return 0, ErrShortArgs
 	}
+	oldRets := len(dst.Rets)
 	rets := dst.Rets[:0]
+	reusedRets := true
 	if nRet > 0 {
 		if cap(rets) < nRet {
 			rets = make([]OperateRet, 0, nRet)
+			reusedRets = false
 		}
 		for i := 0; i < nRet; i++ {
 			ret, n, rerr := decodeRet(b[off:])
@@ -561,6 +579,17 @@ func decodeOperateArgsN(dst *OperateArgs, b []byte) (int, error) {
 			rets = append(rets, ret)
 			off += n
 		}
+	}
+
+	// A reused slice that shrank still holds the previous call's ops past its
+	// new length, and those keep that call's request buffer alive. Clearing
+	// just the shrink delta is enough: by induction everything past the old
+	// length was already cleared by the decode that shrank it.
+	if reusedOps && len(ops) < oldOps {
+		clear(ops[len(ops):oldOps])
+	}
+	if reusedRets && len(rets) < oldRets {
+		clear(rets[len(rets):oldRets])
 	}
 
 	*dst = OperateArgs{

--- a/sdk/wire/operate_test.go
+++ b/sdk/wire/operate_test.go
@@ -449,16 +449,70 @@ func TestDecodeOperateArgsIntoZeroAllocOnWarmDst(t *testing.T) {
 	}
 }
 
-// A frame that fails to decode must not leave the caller's dst holding the
-// previous call's data.
-func TestDecodeOperateArgsIntoRejectsTrailingBytes(t *testing.T) {
-	b, err := EncodeOperateArgs(sampleArgs())
+// A failed decode must leave dst EMPTY, not holding the previous call's data.
+// The decoder appends into dst's backing array as it goes, so a call that
+// fails partway has already overwritten elements the old length still covers -
+// a reusing caller that trusted the old contents would read a mix of two calls.
+func TestDecodeOperateArgsIntoResetsOnError(t *testing.T) {
+	good, err := EncodeOperateArgs(sessionShapedArgs(8))
 	if err != nil {
 		t.Fatal(err)
 	}
 	dst := new(OperateArgs)
-	if err = DecodeOperateArgsInto(dst, append(append([]byte(nil), b...), 0xFF)); err == nil {
-		t.Fatal("trailing bytes must be rejected")
+	if err = DecodeOperateArgsInto(dst, good); err != nil {
+		t.Fatal(err)
+	}
+	if len(dst.Ops) == 0 {
+		t.Fatal("seed decode produced no ops; the test proves nothing")
+	}
+
+	for name, bad := range map[string][]byte{
+		"trailing bytes": append(append([]byte(nil), good...), 0xFF),
+		"truncated":      good[:len(good)-1],
+		"truncated hard": good[:len(good)/2],
+	} {
+		if err = DecodeOperateArgsInto(dst, bad); err == nil {
+			t.Fatalf("%s: expected an error", name)
+		}
+		if len(dst.Ops) != 0 || len(dst.Rets) != 0 || dst.Key != nil || dst.Schema != nil {
+			t.Errorf("%s: dst not reset after a failed decode: %+v", name, dst)
+		}
+		// Re-seed so the next case starts from a populated dst again.
+		if err = DecodeOperateArgsInto(dst, good); err != nil {
+			t.Fatal(err)
+		}
+	}
+}
+
+// Shrinking a reused dst must not leave the previous call's ops reachable past
+// the new length - they alias that call's request buffer and would pin it.
+func TestDecodeOperateArgsIntoClearsStaleTail(t *testing.T) {
+	big, err := EncodeOperateArgs(sessionShapedArgs(16))
+	if err != nil {
+		t.Fatal(err)
+	}
+	small, err := EncodeOperateArgs(sessionShapedArgs(1))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	dst := new(OperateArgs)
+	if err = DecodeOperateArgsInto(dst, big); err != nil {
+		t.Fatal(err)
+	}
+	bigLen := len(dst.Ops)
+	if err = DecodeOperateArgsInto(dst, small); err != nil {
+		t.Fatal(err)
+	}
+	if len(dst.Ops) >= bigLen {
+		t.Fatalf("small frame decoded to %d ops, want fewer than %d", len(dst.Ops), bigLen)
+	}
+
+	tail := dst.Ops[:cap(dst.Ops)][len(dst.Ops):bigLen]
+	for i := range tail {
+		if !reflect.DeepEqual(tail[i], OperateOp{}) {
+			t.Fatalf("stale op at tail index %d still set: %+v", i, tail[i])
+		}
 	}
 }
 
@@ -483,6 +537,7 @@ func sessionShapedArgs(nBidders int) *OperateArgs {
 			OperateOp{Opcode: OperateOpADD, Type: OperateTypeFromSchema, Path: col(2), A: 1},
 		)
 	}
+	a.Rets = append(a.Rets, OperateRet{Mode: OperateRetCount, Path: OperatePath{Kind: OperatePathField, Field: OperateSeg{Pos: 3}}})
 	return a
 }
 

--- a/sdk/wire/operate_test.go
+++ b/sdk/wire/operate_test.go
@@ -320,3 +320,62 @@ func TestDecodeOperateResultCountErrors(t *testing.T) {
 		t.Fatalf("nRet within the cap but past the byte budget: err = %v, want ErrShortArgs", err)
 	}
 }
+
+// AppendOperateArgs must be byte-identical to EncodeOperateArgs whether it
+// allocates its own buffer or reuses one, or a pooling caller would put
+// different bytes on the wire than a plain one.
+func TestAppendOperateArgsMatchesEncode(t *testing.T) {
+	a := sampleArgs()
+	want, err := EncodeOperateArgs(a)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	nilDst, err := AppendOperateArgs(nil, a)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(nilDst, want) {
+		t.Errorf("nil dst:\n got %x\nwant %x", nilDst, want)
+	}
+
+	// A buffer too small to hold even the header, and one large enough for the
+	// whole frame, must both produce the same bytes.
+	for _, size := range []int{0, 4, len(want), 4 * len(want)} {
+		got, aErr := AppendOperateArgs(make([]byte, 0, size), a)
+		if aErr != nil {
+			t.Fatal(aErr)
+		}
+		if !reflect.DeepEqual(got, want) {
+			t.Errorf("dst cap %d:\n got %x\nwant %x", size, got, want)
+		}
+	}
+
+	// Dirty buffers must be overwritten, not appended to.
+	dirty := make([]byte, 8*len(want))
+	for i := range dirty {
+		dirty[i] = 0xAA
+	}
+	got, err := AppendOperateArgs(dirty, a)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("dirty dst:\n got %x\nwant %x", got, want)
+	}
+}
+
+// The reason the function exists: a pooled buffer must make the encode
+// allocation-free once it has grown.
+func TestAppendOperateArgsZeroAllocOnWarmBuffer(t *testing.T) {
+	a := sampleArgs()
+	buf, err := AppendOperateArgs(nil, a)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if n := testing.AllocsPerRun(100, func() {
+		buf, _ = AppendOperateArgs(buf[:0], a)
+	}); n != 0 {
+		t.Errorf("AppendOperateArgs on a warm buffer allocated %v times, want 0", n)
+	}
+}

--- a/sdk/wire/operate_test.go
+++ b/sdk/wire/operate_test.go
@@ -3,6 +3,7 @@
 package wire
 
 import (
+	"bytes"
 	"encoding/binary"
 	"errors"
 	"math"
@@ -377,5 +378,139 @@ func TestAppendOperateArgsZeroAllocOnWarmBuffer(t *testing.T) {
 		buf, _ = AppendOperateArgs(buf[:0], a)
 	}); n != 0 {
 		t.Errorf("AppendOperateArgs on a warm buffer allocated %v times, want 0", n)
+	}
+}
+
+// A pooled dst must decode byte-identically to a fresh one, and must carry
+// nothing from its previous use - a stale Key or Schema would be read as the
+// current call's.
+func TestDecodeOperateArgsIntoMatchesDecode(t *testing.T) {
+	full, err := EncodeOperateArgs(sampleArgs())
+	if err != nil {
+		t.Fatal(err)
+	}
+	// A deliberately different second frame: no ops, no rets, no schema.
+	bare, err := EncodeOperateArgs(&OperateArgs{Key: []byte("k"), Create: OperateCreateDynamic})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, order := range [][][]byte{{full, bare}, {bare, full}, {full, full}, {bare, bare}} {
+		dst := new(OperateArgs)
+		for i, frame := range order {
+			want, dErr := DecodeOperateArgs(frame)
+			if dErr != nil {
+				t.Fatal(dErr)
+			}
+			if iErr := DecodeOperateArgsInto(dst, frame); iErr != nil {
+				t.Fatal(iErr)
+			}
+			// Compared field by field rather than with DeepEqual: a reused
+			// dst keeps its slice capacity, so an op-less frame decodes to
+			// an EMPTY Ops rather than the nil a fresh decode produces.
+			// Semantically identical, and len() is what every caller uses.
+			if !bytes.Equal(dst.Key, want.Key) || dst.TTL != want.TTL ||
+				dst.TTLMode != want.TTLMode || dst.Create != want.Create ||
+				!bytes.Equal(dst.Schema, want.Schema) ||
+				!reflect.DeepEqual(dst.Ops, want.Ops) && (len(dst.Ops) != 0 || len(want.Ops) != 0) ||
+				!reflect.DeepEqual(dst.Rets, want.Rets) && (len(dst.Rets) != 0 || len(want.Rets) != 0) {
+				t.Fatalf("reuse %d:\n got %+v\nwant %+v", i, dst, want)
+			}
+		}
+	}
+}
+
+// Reuse must not allocate once the op slice has grown. Uses schema-POSITION
+// paths only: a path addressed by NAME decodes its name with string(b[...]),
+// which allocates per segment no matter how the op slice is managed. Schema
+// mode - the hot path this pool exists for - always addresses by position.
+func TestDecodeOperateArgsIntoZeroAllocOnWarmDst(t *testing.T) {
+	positional := &OperateArgs{
+		Key: []byte("session:42"), Create: OperateCreateSchema,
+		Schema: sessionSchema().Encode(),
+		Ops: []OperateOp{
+			{Opcode: OperateOpADD, Type: OperateTypeFromSchema, Path: OperatePath{Kind: OperatePathField, Field: OperateSeg{Pos: 0}}, A: 1},
+			{Opcode: OperateOpSHL, Type: OperateTypeFromSchema, Path: OperatePath{Kind: OperatePathCol, Field: OperateSeg{Pos: 3}, Key: []byte{1, 0, 0, 0, 0, 0, 0, 0}, Col: OperateSeg{Pos: 0}}, A: 2},
+		},
+		Rets: []OperateRet{{Mode: OperateRetCount, Path: OperatePath{Kind: OperatePathField, Field: OperateSeg{Pos: 3}}}},
+	}
+	b, err := EncodeOperateArgs(positional)
+	if err != nil {
+		t.Fatal(err)
+	}
+	dst := new(OperateArgs)
+	if err = DecodeOperateArgsInto(dst, b); err != nil {
+		t.Fatal(err)
+	}
+	if n := testing.AllocsPerRun(100, func() {
+		_ = DecodeOperateArgsInto(dst, b)
+	}); n != 0 {
+		t.Errorf("DecodeOperateArgsInto on a warm dst allocated %v times, want 0", n)
+	}
+}
+
+// A frame that fails to decode must not leave the caller's dst holding the
+// previous call's data.
+func TestDecodeOperateArgsIntoRejectsTrailingBytes(t *testing.T) {
+	b, err := EncodeOperateArgs(sampleArgs())
+	if err != nil {
+		t.Fatal(err)
+	}
+	dst := new(OperateArgs)
+	if err = DecodeOperateArgsInto(dst, append(append([]byte(nil), b...), 0xFF)); err == nil {
+		t.Fatal("trailing bytes must be rejected")
+	}
+}
+
+// sessionShapedArgs is a realistic hot-path call: one record touched for
+// nBidders keys, ~4 position-addressed ops each, the shape a session cache
+// sends per auction.
+func sessionShapedArgs(nBidders int) *OperateArgs {
+	a := &OperateArgs{
+		Key: []byte("session:42"), Create: OperateCreateSchema,
+		TTL: 2 * time.Hour, TTLMode: OperateTTLSet,
+		Schema: sessionSchema().Encode(),
+	}
+	for i := range nBidders {
+		row := []byte{byte(i), byte(i >> 8), 0, 0, 0, 0, 0, 0}
+		col := func(c uint32) OperatePath {
+			return OperatePath{Kind: OperatePathCol, Field: OperateSeg{Pos: 3}, Key: row, Col: OperateSeg{Pos: c}}
+		}
+		a.Ops = append(a.Ops,
+			OperateOp{Opcode: OperateOpADD, Type: OperateTypeFromSchema, Path: col(0), A: 1},
+			OperateOp{Opcode: OperateOpSHL, Type: OperateTypeFromSchema, Path: col(1), A: 2},
+			OperateOp{Opcode: OperateOpOR, Type: OperateTypeFromSchema, Path: col(1), A: 3},
+			OperateOp{Opcode: OperateOpADD, Type: OperateTypeFromSchema, Path: col(2), A: 1},
+		)
+	}
+	return a
+}
+
+func BenchmarkDecodeOperateArgs(b *testing.B) {
+	buf, err := EncodeOperateArgs(sessionShapedArgs(16))
+	if err != nil {
+		b.Fatal(err)
+	}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for b.Loop() {
+		if _, err := DecodeOperateArgs(buf); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkDecodeOperateArgsInto(b *testing.B) {
+	buf, err := EncodeOperateArgs(sessionShapedArgs(16))
+	if err != nil {
+		b.Fatal(err)
+	}
+	dst := new(OperateArgs)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for b.Loop() {
+		if err := DecodeOperateArgsInto(dst, buf); err != nil {
+			b.Fatal(err)
+		}
 	}
 }

--- a/sdk/wire/operate_test.go
+++ b/sdk/wire/operate_test.go
@@ -500,18 +500,27 @@ func TestDecodeOperateArgsIntoClearsStaleTail(t *testing.T) {
 	if err = DecodeOperateArgsInto(dst, big); err != nil {
 		t.Fatal(err)
 	}
-	bigLen := len(dst.Ops)
+	bigOps, bigRets := len(dst.Ops), len(dst.Rets)
 	if err = DecodeOperateArgsInto(dst, small); err != nil {
 		t.Fatal(err)
 	}
-	if len(dst.Ops) >= bigLen {
-		t.Fatalf("small frame decoded to %d ops, want fewer than %d", len(dst.Ops), bigLen)
+	if len(dst.Ops) >= bigOps {
+		t.Fatalf("small frame decoded to %d ops, want fewer than %d", len(dst.Ops), bigOps)
 	}
 
-	tail := dst.Ops[:cap(dst.Ops)][len(dst.Ops):bigLen]
-	for i := range tail {
-		if !reflect.DeepEqual(tail[i], OperateOp{}) {
-			t.Fatalf("stale op at tail index %d still set: %+v", i, tail[i])
+	opTail := dst.Ops[:cap(dst.Ops)][len(dst.Ops):bigOps]
+	for i := range opTail {
+		if !reflect.DeepEqual(opTail[i], OperateOp{}) {
+			t.Fatalf("stale op at tail index %d still set: %+v", i, opTail[i])
+		}
+	}
+	if len(dst.Rets) >= bigRets {
+		t.Fatalf("small frame decoded to %d rets, want fewer than %d", len(dst.Rets), bigRets)
+	}
+	retTail := dst.Rets[:cap(dst.Rets)][len(dst.Rets):bigRets]
+	for i := range retTail {
+		if !reflect.DeepEqual(retTail[i], OperateRet{}) {
+			t.Fatalf("stale ret at tail index %d still set: %+v", i, retTail[i])
 		}
 	}
 }
@@ -536,8 +545,13 @@ func sessionShapedArgs(nBidders int) *OperateArgs {
 			OperateOp{Opcode: OperateOpOR, Type: OperateTypeFromSchema, Path: col(1), A: 3},
 			OperateOp{Opcode: OperateOpADD, Type: OperateTypeFromSchema, Path: col(2), A: 1},
 		)
+		// One return per key, so Rets scales with nBidders too - a fixed-size
+		// Rets would leave the rets shrink-clear path untested.
+		a.Rets = append(a.Rets, OperateRet{
+			Mode: OperateRetValue,
+			Path: OperatePath{Kind: OperatePathRow, Field: OperateSeg{Pos: 3}, Key: row},
+		})
 	}
-	a.Rets = append(a.Rets, OperateRet{Mode: OperateRetCount, Path: OperatePath{Kind: OperatePathField, Field: OperateSeg{Pos: 3}}})
 	return a
 }
 


### PR DESCRIPTION
Two allocations on the `operate` path, found while profiling a workload that sends one operate call per request with a wide op list.

## 1. `AppendOperateArgs` — client side

`EncodeOperateArgs` allocates a fresh buffer per call and grows it as the op list appends. There was no append variant, so a caller building one operate call per request could not avoid it.

Added `AppendOperateArgs(dst, a)`, mirroring the `EncodeKeyArgs`/`AppendKeyArgs` pair that already exists for point ops. `EncodeOperateArgs` becomes `AppendOperateArgs(nil, a)`, so its bytes are unchanged by construction.

## 2. Pooled decode — server side

`handleOperate` decoded a fresh `*OperateArgs` per request. In a heap profile of that workload `decodeOperateArgsN` was the **single largest allocation site on the server, two thirds of all `alloc_space`**, essentially all of it immediately garbage:

```
ops = make([]OperateOp, 0, nOps)
```

Added `DecodeOperateArgsInto(dst, b)`, which fills a caller-owned `OperateArgs` and reuses the capacity of its `Ops`/`Rets` slices, and pooled the struct in `handleOperate` — the same pattern `schemaEnginePool`/`dynamicEnginePool` already use for the engines. The decoded args alias the request buffer and `applyRecordBytes` only reads them during the call, so the struct is safe to recycle as soon as the handler returns.

`DecodeOperateArgs` keeps its exact behaviour as the one-shot wrapper, so no caller changes.

## Numbers

```
BenchmarkDecodeOperateArgs        9472 B/op   1 allocs/op   ~5.5-8.9us
BenchmarkDecodeOperateArgsInto       0 B/op   0 allocs/op       ~2.2us
```

## Two behaviours worth reviewing

- A **reused** `dst` keeps its slice capacity, so a frame carrying no ops decodes to an empty-but-non-nil `Ops` where a fresh decode yields `nil`. The doc comment says to read `len()`, never a nil check. A fresh `dst` decodes identically to `DecodeOperateArgs`.
- Paths addressed by **name** still allocate that name's string per segment (`string(b[...])`). Schema mode addresses by position and decodes with no allocation at all. The zero-alloc test uses position-addressed paths for that reason.

## Tests

New in `sdk/wire/operate_test.go`:
- `AppendOperateArgs` byte-identical to `EncodeOperateArgs` across nil / small / exact / oversized / dirty `dst`
- `DecodeOperateArgsInto` matches `DecodeOperateArgs` across every reuse order of a full frame and a bare one (catches state carried between uses)
- `AllocsPerRun == 0` for both on a warm buffer
- a failed decode leaves `dst` empty rather than holding the previous call
- trailing-byte rejection still holds through the `Into` path

`./sdk/...`, `./ops/...` and the root package's operate tests pass with `-race`.