### PR TITLE
docs(operate): describe the pooled decode in generic terms

### DIFF
--- a/ops/operate.go
+++ b/ops/operate.go
@@ -40,8 +40,8 @@ import (
 // been called.
 // operateArgsPool recycles the decoded call. The op slice is the single
 // largest allocation on this path - one operate request carries up to
-// OperateMaxOps ops, and a session-cache style caller sends ~4 per key it
-// touches - so decoding a fresh one per request dominated the server's
+// OperateMaxOps ops, and a caller that touches many keys in one call sends a
+// few ops per key - so decoding a fresh one per request dominated the server's
 // allocation volume. Same pattern as schemaEnginePool/dynamicEnginePool.
 //
 // The decoded args alias the request buffer and applyRecordBytes only reads

--- a/sdk/wire/operate.go
+++ b/sdk/wire/operate.go
@@ -432,7 +432,7 @@ func DecodeOperateArgs(b []byte) (*OperateArgs, error) {
 // capacity of dst.Ops and dst.Rets instead of allocating a fresh slice per
 // call. It is for a hot-path caller that pools the struct: the server decodes
 // one OperateArgs per operate request, and that op slice is the single largest
-// allocation on the apply path (an op list of n bidders x ~4 ops per bidder).
+// allocation on the apply path (an op list of n keys x ~4 ops per key).
 //
 // Every field of dst is overwritten, so a pooled dst carries nothing from its
 // previous use. A dst that already has capacity KEEPS it, so a frame carrying

--- a/sdk/wire/operate_test.go
+++ b/sdk/wire/operate_test.go
@@ -454,7 +454,7 @@ func TestDecodeOperateArgsIntoZeroAllocOnWarmDst(t *testing.T) {
 // fails partway has already overwritten elements the old length still covers -
 // a reusing caller that trusted the old contents would read a mix of two calls.
 func TestDecodeOperateArgsIntoResetsOnError(t *testing.T) {
-	good, err := EncodeOperateArgs(sessionShapedArgs(8))
+	good, err := EncodeOperateArgs(manyRowArgs(8))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -487,11 +487,11 @@ func TestDecodeOperateArgsIntoResetsOnError(t *testing.T) {
 // Shrinking a reused dst must not leave the previous call's ops reachable past
 // the new length - they alias that call's request buffer and would pin it.
 func TestDecodeOperateArgsIntoClearsStaleTail(t *testing.T) {
-	big, err := EncodeOperateArgs(sessionShapedArgs(16))
+	big, err := EncodeOperateArgs(manyRowArgs(16))
 	if err != nil {
 		t.Fatal(err)
 	}
-	small, err := EncodeOperateArgs(sessionShapedArgs(1))
+	small, err := EncodeOperateArgs(manyRowArgs(1))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -525,16 +525,15 @@ func TestDecodeOperateArgsIntoClearsStaleTail(t *testing.T) {
 	}
 }
 
-// sessionShapedArgs is a realistic hot-path call: one record touched for
-// nBidders keys, ~4 position-addressed ops each, the shape a session cache
-// sends per auction.
-func sessionShapedArgs(nBidders int) *OperateArgs {
+// manyRowArgs is a wide hot-path call: one record touched for nRows keys with
+// ~4 position-addressed ops each, plus one return per key.
+func manyRowArgs(nRows int) *OperateArgs {
 	a := &OperateArgs{
 		Key: []byte("session:42"), Create: OperateCreateSchema,
 		TTL: 2 * time.Hour, TTLMode: OperateTTLSet,
 		Schema: sessionSchema().Encode(),
 	}
-	for i := range nBidders {
+	for i := range nRows {
 		row := []byte{byte(i), byte(i >> 8), 0, 0, 0, 0, 0, 0}
 		col := func(c uint32) OperatePath {
 			return OperatePath{Kind: OperatePathCol, Field: OperateSeg{Pos: 3}, Key: row, Col: OperateSeg{Pos: c}}
@@ -545,7 +544,7 @@ func sessionShapedArgs(nBidders int) *OperateArgs {
 			OperateOp{Opcode: OperateOpOR, Type: OperateTypeFromSchema, Path: col(1), A: 3},
 			OperateOp{Opcode: OperateOpADD, Type: OperateTypeFromSchema, Path: col(2), A: 1},
 		)
-		// One return per key, so Rets scales with nBidders too - a fixed-size
+		// One return per key, so Rets scales with nRows too - a fixed-size
 		// Rets would leave the rets shrink-clear path untested.
 		a.Rets = append(a.Rets, OperateRet{
 			Mode: OperateRetValue,
@@ -556,7 +555,7 @@ func sessionShapedArgs(nBidders int) *OperateArgs {
 }
 
 func BenchmarkDecodeOperateArgs(b *testing.B) {
-	buf, err := EncodeOperateArgs(sessionShapedArgs(16))
+	buf, err := EncodeOperateArgs(manyRowArgs(16))
 	if err != nil {
 		b.Fatal(err)
 	}
@@ -570,7 +569,7 @@ func BenchmarkDecodeOperateArgs(b *testing.B) {
 }
 
 func BenchmarkDecodeOperateArgsInto(b *testing.B) {
-	buf, err := EncodeOperateArgs(sessionShapedArgs(16))
+	buf, err := EncodeOperateArgs(manyRowArgs(16))
 	if err != nil {
 		b.Fatal(err)
 	}


### PR DESCRIPTION
Comment and naming cleanup on top of #106. No behaviour change.

The comments and the test helper added with the pooled decode described the caller that motivated the change rather than the shape of the call, which is what the code actually depends on. This rewords them to the shape — a wide op list over many keys in one call — which is both more accurate and more useful to a reader who has a different caller.

- `sessionShapedArgs` → `manyRowArgs`, `nBidders` → `nRows`
- `sdk/wire/operate.go`: "an op list of n bidders x ~4 ops per bidder" → "n keys x ~4 ops per key"
- `ops/operate.go`: the `operateArgsPool` comment now describes a caller that touches many keys per call

The helper builds the identical frame, so every assertion and benchmark around it is unchanged. `./sdk/...` and `./ops/...` pass with `-race`; vet clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Rewords the pooled decode comments and test helper to describe the call shape itself rather than the caller that motivated the change; no behavior change. The helper builds the identical frame, so all assertions and benchmarks are unchanged.

- Renames `sessionShapedArgs` to `manyRowArgs` and `nBidders` to `nRows`.
- Comments now describe "n keys x ~4 ops per key" instead of "n bidders x ~4 ops per bidder".
- `./sdk/...` and `./ops/...` pass with `-race`; vet is clean.

<sup>Written for commit 46de73ff1746312af957845cf0d9b7f331c49ef7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rostamlabs/rostam/pull/108?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

