### PR TITLE
perf(operate): read the record into a pooled buffer

### DIFF
--- a/cache/bench_test.go
+++ b/cache/bench_test.go
@@ -111,3 +111,45 @@ func BenchmarkPageGrowthReport(b *testing.B) {
 	b.ReportMetric(float64(st.PagesAllocated), "pages")
 	b.ReportMetric(float64(st.BytesUsed)/float64(st.BytesAllocated)*100, "%used")
 }
+
+// BenchmarkRostamGetWithExpiry and its Into twin measure the read an apply-path
+// handler makes: the allocating form returns a fresh copy per hit, the Into form
+// copies into a reused buffer. Both COPY - the difference is the allocation.
+func BenchmarkRostamGetWithExpiry(b *testing.B) {
+	c, _ := New(DefaultConfig())
+	defer func() { _ = c.Close() }()
+	keys := buildKeys(benchN)
+	val := benchValue()
+	for _, k := range keys {
+		_ = c.Put(k, val, 0)
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if _, _, err := c.GetWithExpiry(keys[i%len(keys)]); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkRostamGetWithExpiryInto(b *testing.B) {
+	c, _ := New(DefaultConfig())
+	defer func() { _ = c.Close() }()
+	keys := buildKeys(benchN)
+	val := benchValue()
+	for _, k := range keys {
+		_ = c.Put(k, val, 0)
+	}
+
+	buf := make([]byte, 0, 512)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		out, _, err := c.GetWithExpiryInto(buf[:0], keys[i%len(keys)])
+		if err != nil {
+			b.Fatal(err)
+		}
+		buf = out
+	}
+}

--- a/cache/cache.go
+++ b/cache/cache.go
@@ -174,6 +174,23 @@ func (c *Cache) GetInto(dst, key []byte) ([]byte, error) {
 	return s.getIntoH(dst, key, h)
 }
 
+// GetWithExpiryInto is GetInto that ALSO surfaces the entry's stored absolute
+// expiry (ms since epoch; 0 = no expiry) — GetWithExpiry's allocation-free
+// counterpart. Like GetInto the value is COPIED into dst, never aliased.
+func (c *Cache) GetWithExpiryInto(dst, key []byte) (val []byte, expiryMs uint64, err error) {
+	h, s := c.shardForH(key)
+	return s.getIntoWithExpiryH(dst, key, h)
+}
+
+// GetWithExpiryIntoAt is GetWithExpiryInto with expiry evaluated against the
+// EXPLICIT clock nowMs rather than the wall clock — the apply-path counterpart,
+// matching GetWithExpiryAt. Keeping the clock explicit is what lets a replicated
+// apply use the pooled read without taking a wall-clock dependency.
+func (c *Cache) GetWithExpiryIntoAt(dst, key []byte, nowMs uint64) (val []byte, expiryMs uint64, err error) {
+	h, s := c.shardForH(key)
+	return s.getIntoWithExpiryAtH(dst, key, h, nowMs)
+}
+
 // Put inserts or replaces the value for key with the given TTL.
 // A TTL of zero means no expiry.
 func (c *Cache) Put(key, value []byte, ttl time.Duration) error {

--- a/cache/shard.go
+++ b/cache/shard.go
@@ -665,6 +665,31 @@ func (s *shard) getCore(key []byte, h, now uint64, allowPhysicalRemove bool) ([]
 // it; under PolicyRejectWrites it is lock-free. On miss/expiry dst is returned
 // unchanged (its original length) with ErrNotFound.
 func (s *shard) getIntoH(dst, key []byte, h uint64) ([]byte, error) {
+	out, _, err := s.getIntoCore(dst, key, h, s.now(), !s.cfg.Replicated)
+	return out, err
+}
+
+// getIntoWithExpiryH is getIntoH that ALSO surfaces the entry's stored absolute
+// expiry, mirroring getWithExpiryH's relationship to getH.
+func (s *shard) getIntoWithExpiryH(dst, key []byte, h uint64) ([]byte, uint64, error) {
+	return s.getIntoCore(dst, key, h, s.now(), !s.cfg.Replicated)
+}
+
+// getIntoWithExpiryAtH is the APPLY-path counterpart: expiry is judged against
+// the explicit leader-stamped nowMs and physical removal is always permitted,
+// exactly as getWithExpiryAtH does for the allocating read. Keeping the clock
+// explicit is what lets the apply path use the pooled read without reintroducing
+// a wall-clock dependency into replicated state.
+func (s *shard) getIntoWithExpiryAtH(dst, key []byte, h, nowMs uint64) ([]byte, uint64, error) {
+	s.advanceAppliedStamp(nowMs)
+	return s.getIntoCore(dst, key, h, nowMs, true)
+}
+
+// getIntoCore is getCore's append-into-dst twin: same probe, same clock and
+// reclamation rules, but the value is copied into the caller's buffer instead
+// of a fresh allocation. It is ALWAYS a copy, never an alias, so the owned-slice
+// contract is identical to getCore's.
+func (s *shard) getIntoCore(dst, key []byte, h, now uint64, allowPhysicalRemove bool) ([]byte, uint64, error) {
 	s.gets.Add(1)
 
 	if s.needsReadLockForGet() {
@@ -680,19 +705,19 @@ func (s *shard) getIntoH(dst, key []byte, h uint64) ([]byte, error) {
 		case lkCorrupt:
 			s.corrupt.Add(1)
 			s.misses.Add(1)
-			return dst, ErrNotFound
+			return dst, 0, ErrNotFound
 		case lkMiss:
 			s.misses.Add(1)
-			return dst, ErrNotFound
+			return dst, 0, ErrNotFound
 		}
-		if isExpired(exp, s.now()) {
-			if !s.cfg.Replicated {
+		if isExpired(exp, now) {
+			if allowPhysicalRemove {
 				s.dropExpiredLocked(h, ref)
 			}
 			s.misses.Add(1)
-			return dst, ErrNotFound
+			return dst, 0, ErrNotFound
 		}
-		return out, nil
+		return out, exp, nil
 	}
 
 	// Lock-free path: reject-writes (heap+mmap) and heap-mode ringbuf. The value
@@ -703,19 +728,19 @@ func (s *shard) getIntoH(dst, key []byte, h uint64) ([]byte, error) {
 	case lkCorrupt:
 		s.corrupt.Add(1)
 		s.misses.Add(1)
-		return dst, ErrNotFound
+		return dst, 0, ErrNotFound
 	case lkMiss:
 		s.misses.Add(1)
-		return dst, ErrNotFound
+		return dst, 0, ErrNotFound
 	}
-	if isExpired(exp, s.now()) {
-		if !s.cfg.Replicated {
+	if isExpired(exp, now) {
+		if allowPhysicalRemove {
 			s.dropExpiredLocked(h, ref)
 		}
 		s.misses.Add(1)
-		return dst, ErrNotFound
+		return dst, 0, ErrNotFound
 	}
-	return append(dst, v...), nil
+	return append(dst, v...), exp, nil
 }
 
 // dropExpiredLocked removes the entry for h if it still points at ref (i.e. the

--- a/ops/operate.go
+++ b/ops/operate.go
@@ -33,11 +33,13 @@ import (
 // prior record, with the same stamp, therefore always produce identical
 // stored bytes and identical expiries.
 //
-// cur aliasing: tx.GetWithExpiry's returned value aliases the cache's page.
-// applyRecordBytes copies it before making any change (openRecord ->
-// copyRecord) and returns its own, freshly allocated out; this handler never
-// writes through cur and never touches it again once applyRecordBytes has
-// been called.
+// cur ownership: tx.GetWithExpiryInto copies the stored record into a pooled
+// buffer, so cur is owned by this call rather than aliasing the cache's page.
+// It still must not outlive the handler - the buffer goes back to the pool on
+// return - and nothing here needs it to: applyRecordBytes copies it again
+// before making any change (openRecord -> copyRecord) and returns its own,
+// freshly allocated out, and this handler never writes through cur nor touches
+// it once applyRecordBytes has been called.
 // operateArgsPool recycles the decoded call. The op slice is the single
 // largest allocation on this path - one operate request carries up to
 // OperateMaxOps ops, and a caller that touches many keys in one call sends a

--- a/ops/operate.go
+++ b/ops/operate.go
@@ -49,6 +49,9 @@ import (
 // as handleOperate returns.
 var operateArgsPool = sync.Pool{New: func() any { return new(wire.OperateArgs) }}
 
+// operateReadBufPool backs the pooled record read in handleOperate.
+var operateReadBufPool = sync.Pool{New: func() any { b := make([]byte, 0, 512); return &b }}
+
 func handleOperate(tx *TxContext, args []byte) ([]byte, error) {
 	a, _ := operateArgsPool.Get().(*wire.OperateArgs)
 	defer func() {
@@ -72,7 +75,18 @@ func handleOperate(tx *TxContext, args []byte) ([]byte, error) {
 		return nil, err
 	}
 
-	cur, expiryMs, err := tx.GetWithExpiry(a.Key)
+	// Pooled read buffer: the stored record is only read here and by
+	// applyRecordBytes, which copies whatever it needs, so the bytes never
+	// outlive the call. GetWithExpiryInto copies into this buffer instead of
+	// allocating a fresh one per request - the read was the largest remaining
+	// allocation on this path after the args pool.
+	rb, _ := operateReadBufPool.Get().(*[]byte)
+	defer func() {
+		*rb = (*rb)[:0]
+		operateReadBufPool.Put(rb)
+	}()
+	cur, expiryMs, err := tx.GetWithExpiryInto((*rb)[:0], a.Key)
+	*rb = cur
 	absent := errors.Is(err, cache.ErrNotFound)
 	if err != nil && !absent {
 		return nil, err

--- a/ops/operate.go
+++ b/ops/operate.go
@@ -49,8 +49,23 @@ import (
 // as handleOperate returns.
 var operateArgsPool = sync.Pool{New: func() any { return new(wire.OperateArgs) }}
 
-// operateReadBufPool backs the pooled record read in handleOperate.
+// operateReadBufPool backs the pooled record read in handleOperate. Buffers
+// grown past maxPooledReadBuf are dropped rather than pooled, to bound retained
+// memory: a record may reach maxOperateRecordBytes, and a value written by a
+// plain put can be larger still - GetWithExpiryInto grows the buffer to hold it
+// before copyRecord rejects it - so pooling unconditionally would let a few
+// outsized keys pin a large array per pool slot. Same guard as the client's
+// kvArgsPool.
+const maxPooledReadBuf = 64 << 10
+
 var operateReadBufPool = sync.Pool{New: func() any { b := make([]byte, 0, 512); return &b }}
+
+func putOperateReadBuf(bp *[]byte) {
+	if cap(*bp) <= maxPooledReadBuf {
+		*bp = (*bp)[:0]
+		operateReadBufPool.Put(bp)
+	}
+}
 
 func handleOperate(tx *TxContext, args []byte) ([]byte, error) {
 	a, _ := operateArgsPool.Get().(*wire.OperateArgs)
@@ -81,10 +96,7 @@ func handleOperate(tx *TxContext, args []byte) ([]byte, error) {
 	// allocating a fresh one per request - the read was the largest remaining
 	// allocation on this path after the args pool.
 	rb, _ := operateReadBufPool.Get().(*[]byte)
-	defer func() {
-		*rb = (*rb)[:0]
-		operateReadBufPool.Put(rb)
-	}()
+	defer func() { putOperateReadBuf(rb) }()
 	cur, expiryMs, err := tx.GetWithExpiryInto((*rb)[:0], a.Key)
 	*rb = cur
 	absent := errors.Is(err, cache.ErrNotFound)

--- a/ops/operate_test.go
+++ b/ops/operate_test.go
@@ -560,3 +560,30 @@ func TestOperateOversizedStoredValueNotCopied(t *testing.T) {
 		t.Fatalf("a stored record under the cap must apply: %v", err)
 	}
 }
+
+// An outsized record must not leave its backing array in the pool. A value can
+// exceed maxOperateRecordBytes via a plain put, and the read buffer grows to
+// hold it before copyRecord rejects it, so without the cap a few such keys
+// would pin a large array per pool slot.
+func TestOperateReadBufNotPooledWhenOversized(t *testing.T) {
+	small := make([]byte, 0, 512)
+	putOperateReadBuf(&small)
+	if cap(small) != 512 {
+		t.Fatalf("a small buffer must keep its capacity, got %d", cap(small))
+	}
+
+	big := make([]byte, maxPooledReadBuf+1)
+	bp := &big
+	putOperateReadBuf(bp)
+
+	// Drain what the pool will hand back and assert none of it is oversized.
+	for i := 0; i < 64; i++ {
+		got, _ := operateReadBufPool.Get().(*[]byte)
+		if got == nil {
+			continue
+		}
+		if cap(*got) > maxPooledReadBuf {
+			t.Fatalf("pool returned an oversized buffer: cap=%d, limit=%d", cap(*got), maxPooledReadBuf)
+		}
+	}
+}

--- a/ops/runtime.go
+++ b/ops/runtime.go
@@ -151,21 +151,25 @@ func (tx *TxContext) Put(key, value []byte, ttl time.Duration) error {
 // wall-clock GetWithExpiry. Branches on applyStamped, not applyNowMs != 0, so a
 // stamp of 0 is still deterministic (see the field doc). The returned value
 // slice aliases the page backing store; copy if you need to retain it.
-// GetWithExpiryInto is GetWithExpiry appending into dst, so a handler that
-// reuses one buffer pays no allocation per hit. It honours the apply stamp
-// exactly as GetWithExpiry does.
-func (tx *TxContext) GetWithExpiryInto(dst, key []byte) (val []byte, expiryMs uint64, err error) {
-	if tx.applyStamped {
-		return tx.c.GetWithExpiryIntoAt(dst, key, tx.applyNowMs)
-	}
-	return tx.c.GetWithExpiryInto(dst, key)
-}
-
 func (tx *TxContext) GetWithExpiry(key []byte) (val []byte, expiryMs uint64, err error) {
 	if tx.applyStamped {
 		return tx.c.GetWithExpiryAt(key, tx.applyNowMs)
 	}
 	return tx.c.GetWithExpiry(key)
+}
+
+// GetWithExpiryInto is GetWithExpiry appending into dst, so a handler that
+// reuses one buffer pays no allocation per hit. It honours the apply stamp
+// exactly as GetWithExpiry does.
+//
+// Unlike GetWithExpiry the result does NOT alias the page backing store: the
+// value is copied into dst, so it is a caller-owned slice that may be mutated
+// and retained.
+func (tx *TxContext) GetWithExpiryInto(dst, key []byte) (val []byte, expiryMs uint64, err error) {
+	if tx.applyStamped {
+		return tx.c.GetWithExpiryIntoAt(dst, key, tx.applyNowMs)
+	}
+	return tx.c.GetWithExpiryInto(dst, key)
 }
 
 // PutAbs inserts or replaces the entry for key with a pre-computed ABSOLUTE

--- a/ops/runtime.go
+++ b/ops/runtime.go
@@ -151,6 +151,16 @@ func (tx *TxContext) Put(key, value []byte, ttl time.Duration) error {
 // wall-clock GetWithExpiry. Branches on applyStamped, not applyNowMs != 0, so a
 // stamp of 0 is still deterministic (see the field doc). The returned value
 // slice aliases the page backing store; copy if you need to retain it.
+// GetWithExpiryInto is GetWithExpiry appending into dst, so a handler that
+// reuses one buffer pays no allocation per hit. It honours the apply stamp
+// exactly as GetWithExpiry does.
+func (tx *TxContext) GetWithExpiryInto(dst, key []byte) (val []byte, expiryMs uint64, err error) {
+	if tx.applyStamped {
+		return tx.c.GetWithExpiryIntoAt(dst, key, tx.applyNowMs)
+	}
+	return tx.c.GetWithExpiryInto(dst, key)
+}
+
 func (tx *TxContext) GetWithExpiry(key []byte) (val []byte, expiryMs uint64, err error) {
 	if tx.applyStamped {
 		return tx.c.GetWithExpiryAt(key, tx.applyNowMs)


### PR DESCRIPTION
Third from the same profile, after #106 and #107. This is the largest allocation left on the operate path.

`handleOperate` reads the stored record with `GetWithExpiry`, which returns a fresh allocation per request — and it is immediately redundant: `applyRecordBytes` hands those bytes straight to `copyRecord`, which copies them again into a buffer with growth slack. So the path allocated twice for one record.

`GetInto` already exists as `Get`'s allocation-free counterpart, but there was no `GetWithExpiry` equivalent. This adds one and uses it.

```
BenchmarkRostamGetWithExpiry       256 B/op  1 allocs/op  ~300-325ns
BenchmarkRostamGetWithExpiryInto     0 B/op  0 allocs/op  ~196-218ns
```

## Still a copy, not an alias

The value is COPIED into the caller's buffer, never aliased, so the owned-slice contract is unchanged — this removes the allocation, not the copy.

Worth recording why it is not an alias, since the question comes up. A zero-copy alias **would** be sound in heap mode: `cache/doc.go` says a retired page is frozen and never mutated again, and the generation gate makes a reader either read immutable bytes or miss without reading them — which is exactly why `PolicyRejectWrites` already returns an alias. But it would change a documented public contract (*"Reads still return an owned copy (callers may mutate it)"*) for no saving beyond what the pooled buffer already gets, so it is not what this does.

## The clock is load-bearing

`getIntoH` is re-expressed over a clock-parameterised `getIntoCore`, matching `getCore`'s shape, and `getIntoWithExpiryAtH` advances the applied stamp like `getWithExpiryAtH`.

This is the part most worth reviewing. `GetInto` hardcodes `s.now()` and `!s.cfg.Replicated`. Reusing it directly from the apply path would have put a **wall-clock dependency into replicated state** — the divergence the `getCore`/`getAtH` split exists to prevent. `TxContext.GetWithExpiryInto` honours `applyStamped` exactly as `GetWithExpiry` does, so a replicated apply judges expiry on the leader stamp as before.

`getIntoH`'s own behaviour is unchanged: it now delegates with `s.now(), !s.cfg.Replicated`, the values it used inline.

## Scope

`handleOperate` only. `handleGet` is the other half of this allocation, but its value is returned to the server and copied into the response frame *after* the handler returns, so pooling it needs the dispatch layer to own the buffer's lifetime — a change in a different layer, not a handler tweak.

## Tests

`./cache/...` and `./ops/...` pass with `-race` (the cache suite is the one that matters here — this touches the lock-free read path), root-package tests pass, vet clean. New `BenchmarkRostamGetWithExpiry` / `...Into` pair in `cache/bench_test.go`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Changes `handleOperate` from allocating a fresh record slice to reading into a pooled buffer, removing the temporary per-record allocation while preserving copy semantics. Adds expiry-aware `Into` reads, including an explicit-clock variant so replicated applies continue using the leader’s stamped time.

- Buffers larger than 64 KiB are discarded instead of returned to the pool.
- The cache API returns caller-owned copies; `handleOperate` releases its buffer after applying the record.
- `handleGet` remains unchanged because its result must outlive the handler.
- Benchmarks reduce the read from 256 B and 1 allocation to 0 B and 0 allocations per operation.
- Adds coverage for stamped reads, buffer reuse, and oversized-buffer eviction.

<sup>Written for commit c307478ccb24a636568bf80159a7348687e3d944. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rostamlabs/rostam/pull/109?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added expiry-aware reads that return both cached values and their expiration timestamps.
  - Added support for reading values into caller-provided buffers, including reads evaluated at a specific point in time.
  - Transaction-based operations now support the new buffer-based reads while preserving apply-time expiry behavior.

- **Performance**
  - Reduced temporary memory allocations during operation processing through reusable read buffers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->