### PR TITLE
docs(pbisr,cluster): correct the minISR-floor enforcement comments

### DIFF
--- a/cluster/pb_shrink.go
+++ b/cluster/pb_shrink.go
@@ -25,11 +25,13 @@ import (
 // the stalled pipeline resumes — provably without losing any acked write (the
 // no-acked-loss / no-false-commit proofs live on Engine.ShrinkISR).
 //
-// THE minISR FLOOR IS ENFORCED HERE. OpSetShardISR's FSM apply is epoch-guarded
-// but does NOT check minISR (meta_fsm.go), so a shrink that would drop the ISR
-// below the durability floor must be refused by THIS driver — the shard then
-// stays stalled (H3: choose unavailability over durability loss). decidePBShrink
-// is the pure, floor-enforcing decision; pbShrinkDriver.tick is its plumbing.
+// THE minISR FLOOR IS ENFORCED HERE, FIRST. This driver refuses to even request a
+// shrink that would drop the ISR below the durability floor — the shard then stays
+// stalled (H3: choose unavailability over durability loss). decidePBShrink is the
+// pure, floor-enforcing decision; pbShrinkDriver.tick is its plumbing. The FSM apply
+// of OpSetShardISR ALSO rejects a below-floor set as a structural backstop (see
+// meta_fsm.go), so a floor breach needs BOTH this driver's check to be bypassed AND
+// the FSM guard to be absent — the driver is the first line, not the only one.
 
 // pbShrinkRequest is a decided ISR shrink: at epoch, set shard's ISR to newISR
 // (the current ISR minus the confirmed-dead members). The caller commits it via
@@ -41,7 +43,8 @@ type pbShrinkRequest struct {
 }
 
 // decidePBShrink decides whether to shrink one shard's ISR to drop its stalled
-// members, ENFORCING THE minISR FLOOR (the FSM does not). It returns ok=false —
+// members, ENFORCING THE minISR FLOOR as the first line (the FSM apply enforces it
+// too, as a backstop — see meta_fsm.go's OpSetShardISR). It returns ok=false —
 // no shrink — when there is nothing removable, or when removing the dead members
 // would take the ISR below minISR (the shard then stays stalled: unavailability
 // over durability, H3). The PRIMARY is never a removal candidate (a dead primary

--- a/shard/pbisr/pb_pipeline.go
+++ b/shard/pbisr/pb_pipeline.go
@@ -361,8 +361,9 @@ func (e *Engine) windowWait(ctx context.Context) error {
 // commit against the smaller set without losing any acked write. It is the
 // engine-side landing point for a committed OpSetShardISR(epoch, newISR); the
 // control-plane driver calls it only AFTER observing that op committed in the
-// local MetaFSM, and only when |newISR| >= minISR (the floor is the DRIVER's
-// responsibility — the FSM does not enforce it).
+// local MetaFSM, and only when |newISR| >= minISR (the driver enforces the floor
+// as the first line; the meta FSM's OpSetShardISR apply also rejects a below-floor
+// set as a structural backstop — so a below-floor ISR can never commit at all).
 //
 // It is a NO-OP unless the shrink is for the engine's CURRENT epoch AND this node
 // still holds that epoch's lease (epoch == e.epoch && e.leaseEpoch == epoch): a

--- a/shard/pbisr/pb_pipeline.go
+++ b/shard/pbisr/pb_pipeline.go
@@ -363,7 +363,9 @@ func (e *Engine) windowWait(ctx context.Context) error {
 // control-plane driver calls it only AFTER observing that op committed in the
 // local MetaFSM, and only when |newISR| >= minISR (the driver enforces the floor
 // as the first line; the meta FSM's OpSetShardISR apply also rejects a below-floor
-// set as a structural backstop — so a below-floor ISR can never commit at all).
+// set as a structural backstop — so a below-floor set can never commit VIA
+// OpSetShardISR. The failover reset to {primary} via OpSetShardEpoch is a
+// deliberate, non-floor-checked exception — grow then re-widens above the floor).
 //
 // It is a NO-OP unless the shrink is for the engine's CURRENT epoch AND this node
 // still holds that epoch's lease (epoch == e.epoch && e.leaseEpoch == epoch): a


### PR DESCRIPTION
Two files described the minISR floor as driver-only, contradicting a durability invariant the rest of the tree relies on.

`cluster/pb_shrink.go` (the driver header and `decidePBShrink`) and `shard/pbisr/pb_pipeline.go`'s `ShrinkISR` state that `OpSetShardISR`'s FSM apply does **not** check minISR, and that the driver is therefore the only line of defense. That's stale: `cluster/meta_fsm.go`'s `OpSetShardISR` apply already rejects an empty ISR unconditionally, and a non-empty set below `MetaState.MinISR` when a floor is seeded — a structural backstop. `pb_grow.go`'s abandon-compensation path even relies on it explicitly ("the FSM floor rejects a below-floor re-narrow").

So the comments contradicted each other on whether a below-floor ISR can commit. This rewords all three sites to describe the real two-layer defense: the driver is the **first** line (refuses to request a below-floor shrink), and the FSM apply is the **backstop** (a below-floor ISR can never commit even if the driver's check is bypassed).

Comment-only; no behavior change. `go build` clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Corrects the minISR-floor enforcement comments in `cluster/pb_shrink.go` and `shard/pbisr/pb_pipeline.go` to match the real two-layer defense: the driver refuses below-floor shrinks, and the meta FSM's `OpSetShardISR` apply rejects a below-floor set as a structural backstop. The old comments claimed the FSM didn't enforce minISR, which contradicted the code. The backstop is scoped to `OpSetShardISR`; the failover reset to `{primary}` via `OpSetShardEpoch` is a deliberate, non-floor-checked exception. Comment-only; no behavior change.

<sup>Written for commit 016e1bbd895cd5130b1c60e5e7dc6fd6ce7b63c5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rostamlabs/rostam/pull/110?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified that minimum ISR requirements are enforced by the driver.
  - Documented an additional structural safeguard that rejects ISR configurations below the configured minimum.
  - Updated shrink-related documentation to accurately describe validation behavior across the system.
  - No functional behavior or public interfaces were changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->