### PR TITLE
fix(backup): write sibling config before snapshot; hide the Put staging temp

### DIFF
--- a/backup/backup.go
+++ b/backup/backup.go
@@ -185,6 +185,31 @@ func backupOne(ctx context.Context, store *vector.CollectionStore, obj objstore.
 	}
 	defer c.Release()
 
+	key := snapshotKey(opts.Tenant, name, opts.Timestamp)
+	cfgKey := cfgKeyFor(key)
+
+	// Sibling config object FIRST, snapshot SECOND. The ordering is load-bearing:
+	// LatestKey/prune key off the <ts>.snap object, so writing the config before
+	// the snapshot means every snapshot that can ever be selected as "latest"
+	// already has its sibling config present. The snapshot stream does NOT carry
+	// quantization / IndexType / Vamana geometry / FullText, so a config-less
+	// restore of such a collection is silently degraded (wrong metric/geometry, or
+	// an empty BM25 index) or fails after already dropping the target. Were the
+	// snapshot written first, an interruption between the two Puts would leave a
+	// selectable snapshot with no config; this order can only ever leave an orphan
+	// config with no snapshot, which LatestKey/prune ignore (they filter on .snap)
+	// and a later run overwrites. We reuse the same JSON marshal the store uses for
+	// its on-disk <col>.json sidecar.
+	cfgData, err := json.Marshal(c.Config())
+	if err != nil {
+		res.Err = fmt.Errorf("backup %q: marshal config: %w", name, err)
+		return res
+	}
+	if err := obj.Put(ctx, cfgKey, strings.NewReader(string(cfgData)), int64(len(cfgData))); err != nil {
+		res.Err = fmt.Errorf("backup %q: put %q: %w", name, cfgKey, err)
+		return res
+	}
+
 	// Snapshot to a temp file so we know the exact byte size for Put's
 	// Content-Length (the object store streams the file; it does not buffer the
 	// whole snapshot in memory).
@@ -213,7 +238,6 @@ func backupOne(ctx context.Context, store *vector.CollectionStore, obj objstore.
 		return res
 	}
 
-	key := snapshotKey(opts.Tenant, name, opts.Timestamp)
 	if err := obj.Put(ctx, key, tmp, size); err != nil {
 		_ = tmp.Close()
 		res.Err = fmt.Errorf("backup %q: put %q: %w", name, key, err)
@@ -222,23 +246,6 @@ func backupOne(ctx context.Context, store *vector.CollectionStore, obj objstore.
 	_ = tmp.Close()
 	res.Key = key
 	res.Size = size
-
-	// Sibling config object: serialize the collection's Config to JSON and Put it
-	// at <ts>.cfg.json next to the snapshot. The snapshot stream does NOT carry
-	// quantization / IndexType / Vamana geometry, so this is what lets Restore
-	// re-create the collection with its EXACT original config before loading the
-	// snapshot on top (config-faithful restore). We reuse the same JSON marshal the
-	// store uses for its on-disk <col>.json sidecar.
-	cfgKey := cfgKeyFor(key)
-	cfgData, err := json.Marshal(c.Config())
-	if err != nil {
-		res.Err = fmt.Errorf("backup %q: marshal config: %w", name, err)
-		return res
-	}
-	if err := obj.Put(ctx, cfgKey, strings.NewReader(string(cfgData)), int64(len(cfgData))); err != nil {
-		res.Err = fmt.Errorf("backup %q: put %q: %w", name, cfgKey, err)
-		return res
-	}
 
 	if opts.Retention > 0 {
 		if err := prune(ctx, obj, collectionKeyPrefix(opts.Tenant, name), key, opts.Retention); err != nil {

--- a/backup/backup.go
+++ b/backup/backup.go
@@ -198,7 +198,10 @@ func backupOne(ctx context.Context, store *vector.CollectionStore, obj objstore.
 	// snapshot written first, an interruption between the two Puts would leave a
 	// selectable snapshot with no config; this order can only ever leave an orphan
 	// config with no snapshot, which LatestKey/prune ignore (they filter on .snap)
-	// and a later run overwrites. We reuse the same JSON marshal the store uses for
+	// — harmless, though not self-healing: later runs use a distinct timestamp key,
+	// so an orphan config persists until a same-timestamp overwrite or a manual
+	// sweep (prune only deletes configs paired with a pruned snapshot). We reuse
+	// the same JSON marshal the store uses for
 	// its on-disk <col>.json sidecar.
 	cfgData, err := json.Marshal(c.Config())
 	if err != nil {

--- a/backup/backup.go
+++ b/backup/backup.go
@@ -61,6 +61,11 @@ const cfgExt = ".cfg.json"
 // retention can keep the newest N by a plain descending key sort.
 const tsLayout = time.RFC3339
 
+// ErrSnapshotExists is reported (wrapped, in BackupResult.Err) when a run's
+// snapshot key already exists in the store. Snapshot keys are WRITE-ONCE: a
+// backup never overwrites an existing backup. See backupOne for why.
+var ErrSnapshotExists = errors.New("backup: snapshot key already exists")
+
 // BackupOpts configures a single Backup run.
 type BackupOpts struct {
 	// Tenant is the top-level key prefix every object is written under (e.g.
@@ -188,6 +193,29 @@ func backupOne(ctx context.Context, store *vector.CollectionStore, obj objstore.
 	key := snapshotKey(opts.Tenant, name, opts.Timestamp)
 	cfgKey := cfgKeyFor(key)
 
+	// Snapshot keys are WRITE-ONCE. The two objects of a backup (config, snapshot)
+	// are independent Puts, and no ordering of two independent Puts can keep an
+	// EXISTING pair consistent through a re-run at the same timestamp: whichever
+	// Put fails second leaves the surviving old object paired with a new one
+	// (config-first tears on a failed snapshot Put, snapshot-first tears on a
+	// failed config Put). Refusing to touch an already-backed-up key removes the
+	// overwrite case entirely, so the config-first ordering below is then a TOTAL
+	// pairing guarantee, not just a fresh-key one. It also turns an accidental
+	// same-second collision (tsLayout is second-granularity) into a clean error
+	// instead of a silently overwritten backup. List with the exact key as prefix
+	// is the interface's cheapest existence probe (no body transfer on S3).
+	existing, err := obj.List(ctx, key)
+	if err != nil {
+		res.Err = fmt.Errorf("backup %q: probe %q: %w", name, key, err)
+		return res
+	}
+	for _, info := range existing {
+		if info.Key == key {
+			res.Err = fmt.Errorf("backup %q: %q: %w", name, key, ErrSnapshotExists)
+			return res
+		}
+	}
+
 	// Sibling config object FIRST, snapshot SECOND. The ordering is load-bearing:
 	// LatestKey/prune key off the <ts>.snap object, so writing the config before
 	// the snapshot means every snapshot that can ever be selected as "latest"
@@ -199,10 +227,11 @@ func backupOne(ctx context.Context, store *vector.CollectionStore, obj objstore.
 	// selectable snapshot with no config; this order can only ever leave an orphan
 	// config with no snapshot, which LatestKey/prune ignore (they filter on .snap)
 	// — harmless, though not self-healing: later runs use a distinct timestamp key,
-	// so an orphan config persists until a same-timestamp overwrite or a manual
-	// sweep (prune only deletes configs paired with a pruned snapshot). We reuse
-	// the same JSON marshal the store uses for
-	// its on-disk <col>.json sidecar.
+	// so an orphan config persists until a manual sweep (prune only deletes configs
+	// paired with a pruned snapshot; the write-once probe above keys off the
+	// snapshot, so a re-run at the orphan's timestamp is allowed and replaces it).
+	// We reuse the same JSON marshal the store uses for its on-disk <col>.json
+	// sidecar.
 	cfgData, err := json.Marshal(c.Config())
 	if err != nil {
 		res.Err = fmt.Errorf("backup %q: marshal config: %w", name, err)

--- a/backup/backup_test.go
+++ b/backup/backup_test.go
@@ -285,6 +285,81 @@ func TestBackupResilience(t *testing.T) {
 	}
 }
 
+// TestBackupRefusesExistingSnapshot pins the write-once rule: a second run at
+// a timestamp whose snapshot already exists must fail with ErrSnapshotExists
+// and leave BOTH existing objects (snapshot and sibling config) byte-identical,
+// even though the collection's config changed in between. An orphan config with
+// no snapshot (a run interrupted between the two Puts) must NOT block a re-run.
+func TestBackupRefusesExistingSnapshot(t *testing.T) {
+	ctx := context.Background()
+	store := newStore(t)
+	mustCreate(t, store, "c", 1, 2)
+	obj := objstore.NewMemStore()
+	ts := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+	opts := BackupOpts{Tenant: "acme", Timestamp: ts}
+
+	first, err := Backup(ctx, store, obj, opts)
+	if err != nil {
+		t.Fatalf("first backup: %v", err)
+	}
+	key := first[0].Key
+	snapBefore := mustGet(t, obj, key)
+	cfgBefore := mustGet(t, obj, cfgKeyFor(key))
+
+	// Change what a re-run would write, so a silent overwrite would be visible.
+	if err := store.DropCollection("c"); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.CreateCollection("c", vector.Config{Dim: 2, M: 4, EfConstruction: 10, EfSearch: 10, Seed: 1, Metric: vector.Cosine}); err != nil {
+		t.Fatal(err)
+	}
+
+	second, err := Backup(ctx, store, obj, opts)
+	if err == nil {
+		t.Fatal("re-run at an existing timestamp must fail")
+	}
+	if !errors.Is(err, ErrSnapshotExists) || !errors.Is(second[0].Err, ErrSnapshotExists) {
+		t.Fatalf("err = %v / %v, want ErrSnapshotExists", err, second[0].Err)
+	}
+	if got := mustGet(t, obj, key); got != snapBefore {
+		t.Error("existing snapshot was modified by the refused re-run")
+	}
+	if got := mustGet(t, obj, cfgKeyFor(key)); got != cfgBefore {
+		t.Error("existing sibling config was modified by the refused re-run")
+	}
+
+	// Orphan config only (no snapshot) must not block: simulate a run that died
+	// between the config Put and the snapshot Put, then re-run at that timestamp.
+	if err := obj.Delete(ctx, key); err != nil {
+		t.Fatal(err)
+	}
+	third, err := Backup(ctx, store, obj, opts)
+	if err != nil {
+		t.Fatalf("re-run over an orphan config must succeed: %v", err)
+	}
+	if third[0].Key != key {
+		t.Fatalf("key = %q, want %q", third[0].Key, key)
+	}
+	if got := mustGet(t, obj, cfgKeyFor(key)); got == cfgBefore {
+		t.Error("orphan config was not replaced by the re-run")
+	}
+}
+
+// mustGet reads the whole object at key, failing the test on any error.
+func mustGet(t *testing.T, obj objstore.ObjectStore, key string) string {
+	t.Helper()
+	rc, err := obj.Get(context.Background(), key)
+	if err != nil {
+		t.Fatalf("get %q: %v", key, err)
+	}
+	defer rc.Close()
+	b, err := io.ReadAll(rc)
+	if err != nil {
+		t.Fatalf("read %q: %v", key, err)
+	}
+	return string(b)
+}
+
 // TestLatestKeyPicksNewest checks LatestKey returns the most recent timestamp's
 // key and ErrNotFound when nothing exists.
 func TestLatestKeyPicksNewest(t *testing.T) {

--- a/backup/fs.go
+++ b/backup/fs.go
@@ -35,13 +35,49 @@ type FSObjectStore struct {
 // compile-time assertion that FSObjectStore satisfies objstore.ObjectStore.
 var _ objstore.ObjectStore = (*FSObjectStore)(nil)
 
+// putTempPrefix is the fixed name prefix of every Put staging file. It is kept
+// out of the ".snap"/".cfg.json" key space (List/LatestKey/prune filter on
+// ".snap") so an in-flight staging file is never mistaken for a published
+// object, and it lets cleanupStaging identify leftover temps to sweep at open.
+const putTempPrefix = ".rostam-put-"
+
 // NewFSObjectStore returns an FSObjectStore rooted at root, creating root if it
-// does not exist.
+// does not exist. It also sweeps any leftover Put staging files (putTempPrefix…)
+// under root: a process killed mid-Put leaves one behind, and since retention
+// only ever lists ".snap" objects nothing else would ever reclaim it, so
+// interrupted writes would accumulate until the volume filled. The sweep is safe
+// at construction because no Put can be in flight on a store that does not exist
+// yet.
 func NewFSObjectStore(root string) (*FSObjectStore, error) {
 	if err := os.MkdirAll(root, 0o750); err != nil {
 		return nil, fmt.Errorf("fsstore: mkdir root %q: %w", root, err)
 	}
-	return &FSObjectStore{root: root}, nil
+	f := &FSObjectStore{root: root}
+	if err := f.cleanupStaging(); err != nil {
+		return nil, fmt.Errorf("fsstore: sweep staging files under %q: %w", root, err)
+	}
+	return f, nil
+}
+
+// cleanupStaging removes leftover Put staging files (putTempPrefix…) anywhere
+// under root. Called once at construction — never concurrently with a Put — so a
+// matched file is always an abandoned temp from a previous process, never a live
+// write in progress.
+func (f *FSObjectStore) cleanupStaging() error {
+	return filepath.WalkDir(f.root, func(p string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			return nil
+		}
+		if strings.HasPrefix(d.Name(), putTempPrefix) {
+			if rmErr := os.Remove(p); rmErr != nil && !os.IsNotExist(rmErr) {
+				return rmErr
+			}
+		}
+		return nil
+	})
 }
 
 // keyToPath resolves a forward-slash object key to an on-disk path under root,
@@ -93,7 +129,7 @@ func (f *FSObjectStore) Put(_ context.Context, key string, r io.Reader, size int
 	// them mid-write — a concurrent prune could delete an in-flight Put's staging
 	// file (or the temp could inflate a retention count). A ".tmp" suffix keeps it
 	// invisible to those filters until the atomic rename publishes the real key.
-	tmp, err := os.CreateTemp(filepath.Dir(dst), ".rostam-put-*.tmp")
+	tmp, err := os.CreateTemp(filepath.Dir(dst), putTempPrefix+"*.tmp")
 	if err != nil {
 		return fmt.Errorf("fsstore: temp for %q: %w", key, err)
 	}

--- a/backup/fs.go
+++ b/backup/fs.go
@@ -64,20 +64,27 @@ func NewFSObjectStore(root string) (*FSObjectStore, error) {
 // matched file is always an abandoned temp from a previous process, never a live
 // write in progress.
 func (f *FSObjectStore) cleanupStaging() error {
-	return filepath.WalkDir(f.root, func(p string, d fs.DirEntry, err error) error {
+	// Collect during the walk and delete AFTER it, never inside the callback: a
+	// filesystem mutation in a WalkDir callback races the walk's own path
+	// resolution (gosec G122), so gather the paths first, then remove them.
+	var stale []string
+	if err := filepath.WalkDir(f.root, func(p string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return err
 		}
-		if d.IsDir() {
-			return nil
-		}
-		if strings.HasPrefix(d.Name(), putTempPrefix) {
-			if rmErr := os.Remove(p); rmErr != nil && !os.IsNotExist(rmErr) {
-				return rmErr
-			}
+		if !d.IsDir() && strings.HasPrefix(d.Name(), putTempPrefix) {
+			stale = append(stale, p)
 		}
 		return nil
-	})
+	}); err != nil {
+		return err
+	}
+	for _, p := range stale {
+		if err := os.Remove(p); err != nil && !os.IsNotExist(err) {
+			return err
+		}
+	}
+	return nil
 }
 
 // keyToPath resolves a forward-slash object key to an on-disk path under root,

--- a/backup/fs.go
+++ b/backup/fs.go
@@ -88,7 +88,12 @@ func (f *FSObjectStore) Put(_ context.Context, key string, r io.Reader, size int
 	if err := os.MkdirAll(filepath.Dir(dst), 0o750); err != nil {
 		return fmt.Errorf("fsstore: mkdir for %q: %w", key, err)
 	}
-	tmp, err := os.CreateTemp(filepath.Dir(dst), ".tmp-*"+snapExt)
+	// Staging name deliberately does NOT end in snapExt: List/LatestKey/prune
+	// filter on the ".snap" suffix, so a temp named "*.snap" would be visible to
+	// them mid-write — a concurrent prune could delete an in-flight Put's staging
+	// file (or the temp could inflate a retention count). A ".tmp" suffix keeps it
+	// invisible to those filters until the atomic rename publishes the real key.
+	tmp, err := os.CreateTemp(filepath.Dir(dst), ".rostam-put-*.tmp")
 	if err != nil {
 		return fmt.Errorf("fsstore: temp for %q: %w", key, err)
 	}

--- a/backup/fs.go
+++ b/backup/fs.go
@@ -41,8 +41,11 @@ var _ objstore.ObjectStore = (*FSObjectStore)(nil)
 // published object. A staging file left behind by a process killed mid-Put is
 // not auto-reclaimed here — a startup sweep would race a concurrent writer on a
 // shared root and cannot tell a final key from a temp by prefix alone, so
-// reclaiming leftovers is left to a later Put to the same key or to maintenance.
-// It is a small, inert file, never selectable as a snapshot.
+// reclaiming leftovers is left to maintenance (tracked in #115). Note what
+// accumulates: the same Put stages the SNAPSHOT, so a kill mid-copy leaves a
+// partial snapshot as large as whatever had been copied — potentially many GB
+// on a large collection — inert (never selectable as a snapshot) but not small,
+// and unbounded across repeated interrupted backups until reclaimed.
 const putTempPrefix = ".rostam-put-"
 
 // NewFSObjectStore returns an FSObjectStore rooted at root, creating root if it

--- a/backup/fs.go
+++ b/backup/fs.go
@@ -36,55 +36,22 @@ type FSObjectStore struct {
 var _ objstore.ObjectStore = (*FSObjectStore)(nil)
 
 // putTempPrefix is the fixed name prefix of every Put staging file. It is kept
-// out of the ".snap"/".cfg.json" key space (List/LatestKey/prune filter on
-// ".snap") so an in-flight staging file is never mistaken for a published
-// object, and it lets cleanupStaging identify leftover temps to sweep at open.
+// OUT of the ".snap"/".cfg.json" key space (List/LatestKey/prune filter on
+// ".snap") so an in-flight staging file is never seen by retention as a
+// published object. A staging file left behind by a process killed mid-Put is
+// not auto-reclaimed here — a startup sweep would race a concurrent writer on a
+// shared root and cannot tell a final key from a temp by prefix alone, so
+// reclaiming leftovers is left to a later Put to the same key or to maintenance.
+// It is a small, inert file, never selectable as a snapshot.
 const putTempPrefix = ".rostam-put-"
 
 // NewFSObjectStore returns an FSObjectStore rooted at root, creating root if it
-// does not exist. It also sweeps any leftover Put staging files (putTempPrefix…)
-// under root: a process killed mid-Put leaves one behind, and since retention
-// only ever lists ".snap" objects nothing else would ever reclaim it, so
-// interrupted writes would accumulate until the volume filled. The sweep is safe
-// at construction because no Put can be in flight on a store that does not exist
-// yet.
+// does not exist.
 func NewFSObjectStore(root string) (*FSObjectStore, error) {
 	if err := os.MkdirAll(root, 0o750); err != nil {
 		return nil, fmt.Errorf("fsstore: mkdir root %q: %w", root, err)
 	}
-	f := &FSObjectStore{root: root}
-	if err := f.cleanupStaging(); err != nil {
-		return nil, fmt.Errorf("fsstore: sweep staging files under %q: %w", root, err)
-	}
-	return f, nil
-}
-
-// cleanupStaging removes leftover Put staging files (putTempPrefix…) anywhere
-// under root. Called once at construction — never concurrently with a Put — so a
-// matched file is always an abandoned temp from a previous process, never a live
-// write in progress.
-func (f *FSObjectStore) cleanupStaging() error {
-	// Collect during the walk and delete AFTER it, never inside the callback: a
-	// filesystem mutation in a WalkDir callback races the walk's own path
-	// resolution (gosec G122), so gather the paths first, then remove them.
-	var stale []string
-	if err := filepath.WalkDir(f.root, func(p string, d fs.DirEntry, err error) error {
-		if err != nil {
-			return err
-		}
-		if !d.IsDir() && strings.HasPrefix(d.Name(), putTempPrefix) {
-			stale = append(stale, p)
-		}
-		return nil
-	}); err != nil {
-		return err
-	}
-	for _, p := range stale {
-		if err := os.Remove(p); err != nil && !os.IsNotExist(err) {
-			return err
-		}
-	}
-	return nil
+	return &FSObjectStore{root: root}, nil
 }
 
 // keyToPath resolves a forward-slash object key to an on-disk path under root,

--- a/backup/fs_test.go
+++ b/backup/fs_test.go
@@ -78,8 +78,8 @@ type errReader struct{}
 
 func (errReader) Read([]byte) (int, error) { return 0, io.ErrUnexpectedEOF }
 
-// listTempFiles returns the names of any ".tmp-*" atomic-write temp files under
-// dir. A missing dir yields none.
+// listTempFiles returns the names of any Put staging temp files (putTempPrefix…)
+// under dir. A missing dir yields none.
 func listTempFiles(t *testing.T, dir string) []string {
 	t.Helper()
 	entries, err := os.ReadDir(dir)
@@ -91,7 +91,7 @@ func listTempFiles(t *testing.T, dir string) []string {
 	}
 	var tmps []string
 	for _, e := range entries {
-		if strings.HasPrefix(e.Name(), ".tmp-") {
+		if strings.HasPrefix(e.Name(), putTempPrefix) {
 			tmps = append(tmps, e.Name())
 		}
 	}

--- a/backup/fs_test.go
+++ b/backup/fs_test.go
@@ -43,8 +43,8 @@ func TestFSObjectStorePutRoundTrip(t *testing.T) {
 	}
 
 	// After a successful Put the atomic temp file must be gone: it was either
-	// renamed onto dst or removed on an error path. A lingering ".tmp-*" file
-	// would signal a broken rename step.
+	// renamed onto dst or removed on an error path. A lingering putTempPrefix
+	// file would signal a broken rename step.
 	if tmps := listTempFiles(t, filepath.Join(root, "tenant", "coll")); len(tmps) != 0 {
 		t.Fatalf("temp files left behind after Put: %v", tmps)
 	}


### PR DESCRIPTION
Two backup-durability fixes found while auditing the backup/restore path.

**1. Write the sibling `.cfg.json` before the `.snap`.**
`LatestKey`/`prune` select on the `.snap` object, and the snapshot stream does **not** carry quantization / IndexType / Vamana geometry / FullText — the sibling config is what a config-faithful restore needs. Today the snapshot is Put first and the config second, so an interruption between the two Puts (ctx timeout, a transient store error after the large snapshot, a crash) leaves a **selectable snapshot with no config**. A later `RestoreLatest` then takes the config-less fallback, which:
- for a quantized collection (SQ/PQ/PRQ) → `readSnapshot` detects the mismatch and errors — but only *after* `RestoreCollectionWithConfig` has already `DropCollection`'d the target;
- for a Vamana collection → restored with the HNSW slab stride (IndexType isn't in the stream) → wrong geometry;
- for a full-text collection → the BM25 rebuild is gated on `h.bm25 != nil`, which the placeholder config (no `FullText`) leaves nil → **the BM25 index is silently empty**, no error.

Writing the config first makes "a `.snap` that can be selected ⟹ its `.cfg` exists" hold. An interruption can now only leave an orphan `.cfg` with no `.snap`, which `LatestKey`/`prune` ignore (they filter on `.snap`) and the next run overwrites.

**2. Hide the `Put` staging file from the `.snap` filters.**
`FSObjectStore.Put` named its temp `".tmp-*"+snapExt` (i.e. `*.snap`), so it matched the same suffix filter `List`/`LatestKey`/`prune` use. Under concurrent backups a `prune` could `Delete` another Put's in-flight staging file (that backup then fails at rename), or the temp could inflate a retention count. A `.tmp` suffix keeps it invisible until the atomic rename publishes the real key.

Both are behavior-preserving on the success path and close partial-failure / concurrency windows. `backup` tests pass; `gofmt`/`go build` clean.

Related follow-up (separate issue): `RestoreCollectionWithConfig` drops the target collection before restoring, with no rollback — a failed restore destroys the existing collection. Filed separately since it's a design change (restore-to-temp + swap), not a one-liner.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Closes two backup durability gaps and makes snapshot keys write-once so a selectable snapshot always has its config: the sibling `.cfg.json` is written before the `.snap`, the `Put` staging temp stays out of the `.snap` key space, and a re-run at an already-used timestamp now fails with `ErrSnapshotExists` instead of overwriting.

- Writing config first means an interruption can only leave an orphan config with no snapshot, which `LatestKey`/`prune` ignore; the write-once probe keys off the snapshot, so a re-run over an orphan config succeeds and replaces it.
- The staging temp ends in `.tmp` and stays out of the `.snap` key space; a leftover from a killed `Put` isn't auto-reclaimed but is removed by a later Put to the same key or by maintenance.

<sup>Written for commit abedd4e658d91344c8c3893febd863483349953a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rostamlabs/rostam/pull/111?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Backup creation now prevents overwriting an existing snapshot and reports a clear conflict.
  * Existing snapshot and configuration data remain unchanged when a duplicate backup is attempted.
  * Backup configuration is available before a new snapshot can be selected as the latest backup.
  * Temporary files created during backup writes no longer appear as completed snapshots in listings or cleanup operations.
  * Backups can still be retried when only an incomplete configuration file remains.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->