### PR TITLE
feat(kv): expose KV cache metrics, and count live evictions separately

### DIFF
--- a/cache/cache.go
+++ b/cache/cache.go
@@ -162,19 +162,6 @@ func (c *Cache) Get(key []byte) ([]byte, error) {
 	return s.getH(key, h)
 }
 
-// StatsNoWalk is Stats without the O(entries) reclaimable-bytes recomputation:
-// ReclaimableBytes is served from the last published figure (or 0). It is for a
-// caller that collects stats while holding a lock others need - the cluster
-// metrics scrape holds the node's shard mutex - where a walk would turn a
-// scrape into a stall on shard add/remove/shutdown.
-func (c *Cache) StatsNoWalk() Stats {
-	var agg Stats
-	for _, s := range c.shards {
-		agg.Add(s.snapshotNoWalk())
-	}
-	return agg
-}
-
 // GetInto appends the value for key to dst and returns the extended slice. It is
 // the allocation-free counterpart to Get: a caller in a hot loop passes its
 // reused buffer (dst[:0]) and incurs zero allocations per hit, instead of the

--- a/cache/cache.go
+++ b/cache/cache.go
@@ -300,29 +300,7 @@ func (c *Cache) Del(key []byte) (bool, error) {
 func (c *Cache) Stats() Stats {
 	var agg Stats
 	for _, s := range c.shards {
-		x := s.snapshot()
-		agg.Gets += x.Gets
-		agg.Hits += x.Hits
-		agg.Misses += x.Misses
-		agg.Puts += x.Puts
-		agg.Dels += x.Dels
-		agg.Expirations += x.Expirations
-		agg.Evictions += x.Evictions
-		agg.EvictionsLive += x.EvictionsLive
-		agg.Rejects += x.Rejects
-		agg.PagesAllocated += x.PagesAllocated
-		agg.BytesAllocated += x.BytesAllocated
-		agg.BytesUsed += x.BytesUsed
-		agg.CorruptionErrors += x.CorruptionErrors
-		agg.Compactions += x.Compactions
-		agg.CompactionsAborted += x.CompactionsAborted
-		agg.CompactionBytesReclaimed += x.CompactionBytesReclaimed
-		agg.CompactionDurationMs += x.CompactionDurationMs
-		agg.ReclaimableBytes += x.ReclaimableBytes
-		agg.OnlineRelocations += x.OnlineRelocations
-		agg.OnlineBytesRelocated += x.OnlineBytesRelocated
-		agg.OnlinePagesRetired += x.OnlinePagesRetired
-		agg.OnlinePagesRecycled += x.OnlinePagesRecycled
+		agg.Add(s.snapshot())
 	}
 	return agg
 }

--- a/cache/cache.go
+++ b/cache/cache.go
@@ -308,6 +308,7 @@ func (c *Cache) Stats() Stats {
 		agg.Dels += x.Dels
 		agg.Expirations += x.Expirations
 		agg.Evictions += x.Evictions
+		agg.EvictionsLive += x.EvictionsLive
 		agg.Rejects += x.Rejects
 		agg.PagesAllocated += x.PagesAllocated
 		agg.BytesAllocated += x.BytesAllocated

--- a/cache/cache.go
+++ b/cache/cache.go
@@ -162,6 +162,19 @@ func (c *Cache) Get(key []byte) ([]byte, error) {
 	return s.getH(key, h)
 }
 
+// StatsNoWalk is Stats without the O(entries) reclaimable-bytes recomputation:
+// ReclaimableBytes is served from the last published figure (or 0). It is for a
+// caller that collects stats while holding a lock others need - the cluster
+// metrics scrape holds the node's shard mutex - where a walk would turn a
+// scrape into a stall on shard add/remove/shutdown.
+func (c *Cache) StatsNoWalk() Stats {
+	var agg Stats
+	for _, s := range c.shards {
+		agg.Add(s.snapshotNoWalk())
+	}
+	return agg
+}
+
 // GetInto appends the value for key to dst and returns the extended slice. It is
 // the allocation-free counterpart to Get: a caller in a hot loop passes its
 // reused buffer (dst[:0]) and incurs zero allocations per hit, instead of the

--- a/cache/compact_online.go
+++ b/cache/compact_online.go
@@ -249,6 +249,25 @@ func (s *shard) reclaimableBytesNow() uint64 {
 // — keeping Stats() O(1) amortized regardless of scrape frequency. A concurrent stale
 // caller may recompute too; that is harmless (the walk is read-locked and idempotent, the
 // store is atomic).
+// reclaimableBytesCached is reclaimableBytesForStats WITHOUT the fallback walk:
+// it serves the last published figure, or 0 if none has been published yet. It
+// exists for callers that must not block - the cluster metrics scrape holds
+// n.shardMu across every hosted shard, and reclaimableBytesNow is an O(entries)
+// liveAndUsedBytes walk, so letting a scrape trigger one would let it stall
+// shard addition, removal and node shutdown for the length of that walk.
+//
+// The cost is freshness on one gauge, which a scrape can afford: the sweeper
+// republishes it as it runs.
+func (s *shard) reclaimableBytesCached() uint64 {
+	if !s.onlineCompactionEligible() {
+		return 0
+	}
+	if snap := s.reclaimableCache.Load(); snap != nil {
+		return snap.bytes
+	}
+	return 0
+}
+
 func (s *shard) reclaimableBytesForStats() uint64 {
 	if !s.onlineCompactionEligible() {
 		return 0

--- a/cache/compact_online.go
+++ b/cache/compact_online.go
@@ -249,25 +249,6 @@ func (s *shard) reclaimableBytesNow() uint64 {
 // — keeping Stats() O(1) amortized regardless of scrape frequency. A concurrent stale
 // caller may recompute too; that is harmless (the walk is read-locked and idempotent, the
 // store is atomic).
-// reclaimableBytesCached is reclaimableBytesForStats WITHOUT the fallback walk:
-// it serves the last published figure, or 0 if none has been published yet. It
-// exists for callers that must not block - the cluster metrics scrape holds
-// n.shardMu across every hosted shard, and reclaimableBytesNow is an O(entries)
-// liveAndUsedBytes walk, so letting a scrape trigger one would let it stall
-// shard addition, removal and node shutdown for the length of that walk.
-//
-// The cost is freshness on one gauge, which a scrape can afford: the sweeper
-// republishes it as it runs.
-func (s *shard) reclaimableBytesCached() uint64 {
-	if !s.onlineCompactionEligible() {
-		return 0
-	}
-	if snap := s.reclaimableCache.Load(); snap != nil {
-		return snap.bytes
-	}
-	return 0
-}
-
 func (s *shard) reclaimableBytesForStats() uint64 {
 	if !s.onlineCompactionEligible() {
 		return 0

--- a/cache/shard.go
+++ b/cache/shard.go
@@ -972,19 +972,8 @@ func (s *shard) delH(key []byte, h uint64) (bool, error) {
 }
 
 // snapshot returns a Stats snapshot. Caller-side concurrency safe.
-// snapshot reports this shard's counters, recomputing ReclaimableBytes when its
-// cached figure has gone stale. snapshotNoWalk is the variant for callers that
-// must not block; see reclaimableBytesCached.
-func (s *shard) snapshot() Stats { return s.snapshotWith(true) }
-
-// snapshotNoWalk is snapshot without the O(entries) reclaimable-bytes walk.
-func (s *shard) snapshotNoWalk() Stats { return s.snapshotWith(false) }
-
-func (s *shard) snapshotWith(allowWalk bool) Stats {
-	reclaimable := s.reclaimableBytesCached()
-	if allowWalk {
-		reclaimable = s.reclaimableBytesForStats()
-	}
+func (s *shard) snapshot() Stats {
+	reclaimable := s.reclaimableBytesForStats()
 	// Hits is derived: every read bumps gets on entry and bumps misses on any
 	// non-returning path, so Hits = Gets - Misses. Load misses BEFORE gets so an
 	// op in flight between the two loads can only leave gets >= misses (gets is

--- a/cache/shard.go
+++ b/cache/shard.go
@@ -1401,8 +1401,13 @@ func (s *shard) retirePageLocked(idx int) {
 	// (cur != ref) belongs to live data elsewhere and must not be tombstoned.
 	entries := old.entries()
 	tail := old.tail()
+	// Wall clock is correct here even under a replicated apply: these are
+	// observability counters, not stored state. The tombstone decision below is
+	// still cur == ref alone, so what the cache RETAINS stays deterministic
+	// across replicas; only the counter may differ by a sweep's worth.
+	now := s.now()
 	for cursor := old.head(); cursor < tail; {
-		key, value, _, err := decodeEntryFast(entries[cursor:tail])
+		key, value, expiryMs, err := decodeEntryFast(entries[cursor:tail])
 		if err != nil {
 			// Heap pages are written without a CRC and cannot be corrupted by
 			// anything external, so this is unreachable in practice; stop the walk
@@ -1414,11 +1419,14 @@ func (s *shard) retirePageLocked(idx int) {
 		t := s.tab.Load()
 		if slot, cur, ok := t.findSlot(h); ok && cur == ref {
 			t.tombstone(slot)
-			// The index still pointed here, so this was the live record for
-			// its key: displaced by capacity, not by TTL. Counted separately
-			// from evictions, which also covers entries a newer Put had
-			// already superseded.
-			s.evictionsLive.Add(1)
+			// Count it as a capacity loss only if it was BOTH index-current and
+			// still live. cur == ref alone would also catch an entry that had
+			// already expired but not yet been swept, which is TTL turnover
+			// wearing a capacity costume - and precisely the case a
+			// correctly-sized cache is full of.
+			if !isExpired(expiryMs, now) {
+				s.evictionsLive.Add(1)
+			}
 		}
 		s.evictions.Add(1)
 		cursor += entrySize(len(key), len(value))
@@ -1443,10 +1451,21 @@ func (s *shard) retirePageLocked(idx int) {
 // reads hold the read lock. Heap ringbuf never reaches here — it retires pages
 // by frozen replacement (retirePageLocked) so its reads can stay lock-free.
 func (s *shard) drainPageLocked(victim int) error {
+	// See retirePageLocked: wall clock is fine for a counter, the retained set
+	// stays decided by cur == ref alone.
+	now := s.now()
 	for !s.pages[victim].Empty() {
 		// Capture the entry's offset BEFORE EvictFront advances head, so we
 		// can reconstruct the slabRef of the copy being physically removed.
 		off := uint32(s.pages[victim].head()) //nolint:gosec // head < PageSize which is validated ≤ MaxInt32
+		// Read the expiry BEFORE evicting: EvictFront returns only the key, and
+		// evictionsLive must not count an entry that had already expired.
+		var headExpiryMs uint64
+		if ent := s.pages[victim].entries(); int(off) < s.pages[victim].tail() {
+			if _, _, exp, derr := decodeEntryFast(ent[off:s.pages[victim].tail()]); derr == nil {
+				headExpiryMs = exp
+			}
+		}
 		evictedKey, _, err := s.pages[victim].EvictFront()
 		if err != nil {
 			s.corrupt.Add(1)
@@ -1464,7 +1483,9 @@ func (s *shard) drainPageLocked(victim int) error {
 		t := s.tab.Load()
 		if slot, cur, ok := t.findSlot(h); ok && cur == ref {
 			t.tombstone(slot)
-			s.evictionsLive.Add(1)
+			if !isExpired(headExpiryMs, now) {
+				s.evictionsLive.Add(1)
+			}
 		}
 		s.evictions.Add(1)
 	}

--- a/cache/shard.go
+++ b/cache/shard.go
@@ -972,7 +972,19 @@ func (s *shard) delH(key []byte, h uint64) (bool, error) {
 }
 
 // snapshot returns a Stats snapshot. Caller-side concurrency safe.
-func (s *shard) snapshot() Stats {
+// snapshot reports this shard's counters, recomputing ReclaimableBytes when its
+// cached figure has gone stale. snapshotNoWalk is the variant for callers that
+// must not block; see reclaimableBytesCached.
+func (s *shard) snapshot() Stats { return s.snapshotWith(true) }
+
+// snapshotNoWalk is snapshot without the O(entries) reclaimable-bytes walk.
+func (s *shard) snapshotNoWalk() Stats { return s.snapshotWith(false) }
+
+func (s *shard) snapshotWith(allowWalk bool) Stats {
+	reclaimable := s.reclaimableBytesCached()
+	if allowWalk {
+		reclaimable = s.reclaimableBytesForStats()
+	}
 	// Hits is derived: every read bumps gets on entry and bumps misses on any
 	// non-returning path, so Hits = Gets - Misses. Load misses BEFORE gets so an
 	// op in flight between the two loads can only leave gets >= misses (gets is
@@ -999,7 +1011,7 @@ func (s *shard) snapshot() Stats {
 		CompactionBytesReclaimed: s.compactBytesReclaimed.Load(),
 		CompactionDurationMs:     s.compactNanos.Load() / uint64(time.Millisecond),
 
-		ReclaimableBytes:     s.reclaimableBytesForStats(),
+		ReclaimableBytes:     reclaimable,
 		OnlineRelocations:    s.relocations.Load(),
 		OnlineBytesRelocated: s.relocatedBytes.Load(),
 		OnlinePagesRetired:   s.relocatePagesGone.Load(),

--- a/cache/shard.go
+++ b/cache/shard.go
@@ -144,9 +144,12 @@ type shard struct {
 	dels        atomic.Uint64
 	expirations atomic.Uint64
 	evictions   atomic.Uint64
-	rejects     atomic.Uint64
-	pagesAlloc  atomic.Uint64
-	corrupt     atomic.Uint64
+	// evictionsLive counts only the evictions that displaced the entry the
+	// index still pointed at - a record lost to CAPACITY rather than TTL.
+	evictionsLive atomic.Uint64
+	rejects       atomic.Uint64
+	pagesAlloc    atomic.Uint64
+	corrupt       atomic.Uint64
 
 	// cold-compaction counters (cache/compact.go). Written once, at open, before
 	// the shard is published; atomic only so Stats can read them from any
@@ -984,6 +987,7 @@ func (s *shard) snapshot() Stats {
 		Dels:             s.dels.Load(),
 		Expirations:      s.expirations.Load(),
 		Evictions:        s.evictions.Load(),
+		EvictionsLive:    s.evictionsLive.Load(),
 		Rejects:          s.rejects.Load(),
 		PagesAllocated:   s.pagesAlloc.Load(),
 		BytesAllocated:   uint64(s.numPages()) * uint64(s.cfg.PageSize), //nolint:gosec // numPages and PageSize are always non-negative
@@ -1410,6 +1414,11 @@ func (s *shard) retirePageLocked(idx int) {
 		t := s.tab.Load()
 		if slot, cur, ok := t.findSlot(h); ok && cur == ref {
 			t.tombstone(slot)
+			// The index still pointed here, so this was the live record for
+			// its key: displaced by capacity, not by TTL. Counted separately
+			// from evictions, which also covers entries a newer Put had
+			// already superseded.
+			s.evictionsLive.Add(1)
 		}
 		s.evictions.Add(1)
 		cursor += entrySize(len(key), len(value))
@@ -1455,6 +1464,7 @@ func (s *shard) drainPageLocked(victim int) error {
 		t := s.tab.Load()
 		if slot, cur, ok := t.findSlot(h); ok && cur == ref {
 			t.tombstone(slot)
+			s.evictionsLive.Add(1)
 		}
 		s.evictions.Add(1)
 	}

--- a/cache/stats.go
+++ b/cache/stats.go
@@ -81,6 +81,34 @@ func (s Stats) HitRate() float64 {
 	return float64(s.Hits) / float64(s.Gets)
 }
 
+// Add accumulates o into s field by field. Cache.Stats uses it to fold its
+// shards together, and the cluster node-local scrape uses it to fold the
+// per-shard caches it hosts, so the field list lives in exactly one place.
+func (s *Stats) Add(o Stats) {
+	s.Gets += o.Gets
+	s.Hits += o.Hits
+	s.Misses += o.Misses
+	s.Puts += o.Puts
+	s.Dels += o.Dels
+	s.Expirations += o.Expirations
+	s.Evictions += o.Evictions
+	s.EvictionsLive += o.EvictionsLive
+	s.Rejects += o.Rejects
+	s.PagesAllocated += o.PagesAllocated
+	s.BytesAllocated += o.BytesAllocated
+	s.BytesUsed += o.BytesUsed
+	s.CorruptionErrors += o.CorruptionErrors
+	s.Compactions += o.Compactions
+	s.CompactionsAborted += o.CompactionsAborted
+	s.CompactionBytesReclaimed += o.CompactionBytesReclaimed
+	s.CompactionDurationMs += o.CompactionDurationMs
+	s.ReclaimableBytes += o.ReclaimableBytes
+	s.OnlineRelocations += o.OnlineRelocations
+	s.OnlineBytesRelocated += o.OnlineBytesRelocated
+	s.OnlinePagesRetired += o.OnlinePagesRetired
+	s.OnlinePagesRecycled += o.OnlinePagesRecycled
+}
+
 // WritePrometheus renders s in the Prometheus text exposition format. Counters
 // are cumulative since node start; sample and diff them for rates.
 //
@@ -97,13 +125,21 @@ func (s Stats) WritePrometheus(w io.Writer) error {
 		{"rostam_kv_gets_total", "KV reads served", s.Gets},
 		{"rostam_kv_hits_total", "KV reads that found a live entry", s.Hits},
 		{"rostam_kv_misses_total", "KV reads that found nothing", s.Misses},
-		{"rostam_kv_puts_total", "KV writes applied", s.Puts},
+		{"rostam_kv_puts_total", "KV write ATTEMPTS - incremented before a capacity rejection can return ErrFull, so it includes writes that failed", s.Puts},
 		{"rostam_kv_dels_total", "KV deletes applied", s.Dels},
 		{"rostam_kv_expirations_total", "entries retired because their TTL elapsed", s.Expirations},
 		{"rostam_kv_evictions_total", "entries displaced by ringbuf eviction, live or already superseded", s.Evictions},
 		{"rostam_kv_evictions_live_total", "entries displaced by ringbuf eviction that were still the live record for their key - lost to capacity, not TTL", s.EvictionsLive},
 		{"rostam_kv_rejects_total", "writes refused under PolicyRejectWrites", s.Rejects},
 		{"rostam_kv_corruption_errors_total", "CRC mismatches seen on read", s.CorruptionErrors},
+		{"rostam_kv_compactions_total", "page files rewritten live-only at shard open (mmap)", s.Compactions},
+		{"rostam_kv_compactions_aborted_total", "compactions decided against or abandoned; the original file was kept", s.CompactionsAborted},
+		{"rostam_kv_compaction_bytes_reclaimed_total", "page bytes dropped by those rewrites", s.CompactionBytesReclaimed},
+		{"rostam_kv_compaction_duration_ms_total", "milliseconds spent compacting at open - this is startup latency", s.CompactionDurationMs},
+		{"rostam_kv_online_relocations_total", "live entries relocated by online compaction", s.OnlineRelocations},
+		{"rostam_kv_online_bytes_relocated_total", "bytes moved by those relocations", s.OnlineBytesRelocated},
+		{"rostam_kv_online_pages_retired_total", "source pages fully evacuated and marked retired", s.OnlinePagesRetired},
+		{"rostam_kv_online_pages_recycled_total", "retired pages whose quarantine elapsed and were reset into writable space", s.OnlinePagesRecycled},
 	}
 	gauges := []struct {
 		name string
@@ -112,7 +148,7 @@ func (s Stats) WritePrometheus(w io.Writer) error {
 	}{
 		{"rostam_kv_pages_allocated", "cache pages currently allocated", s.PagesAllocated},
 		{"rostam_kv_bytes_allocated", "bytes backing those pages", s.BytesAllocated},
-		{"rostam_kv_bytes_used", "bytes of live entry data", s.BytesUsed},
+		{"rostam_kv_bytes_used", "bytes occupied by entries in resident pages, INCLUDING superseded and expired entries not yet reclaimed - occupancy, not live data", s.BytesUsed},
 		{"rostam_kv_reclaimable_bytes", "page bytes held by entries no longer reachable", s.ReclaimableBytes},
 	}
 

--- a/cache/stats.go
+++ b/cache/stats.go
@@ -2,6 +2,11 @@
 
 package cache
 
+import (
+	"fmt"
+	"io"
+)
+
 // Stats is a snapshot of cache counters.
 // Most fields are cumulative counters accumulated since cache creation (Gets, Hits,
 // Puts, Evictions, the Compaction* totals, …); sample and diff them for rates. The
@@ -10,13 +15,20 @@ package cache
 // report current capacity/occupancy, and ReclaimableBytes reports current ghost-byte
 // pressure (which compaction actively drives back down).
 type Stats struct {
-	Gets             uint64
-	Hits             uint64
-	Misses           uint64
-	Puts             uint64
-	Dels             uint64
-	Expirations      uint64 // expired by sweeper or lazy-on-read
-	Evictions        uint64 // displaced by ringbuf eviction
+	Gets        uint64
+	Hits        uint64
+	Misses      uint64
+	Puts        uint64
+	Dels        uint64
+	Expirations uint64 // expired by sweeper or lazy-on-read
+	Evictions   uint64 // entries displaced by ringbuf eviction, live or not
+	// EvictionsLive counts only those evictions that displaced the entry the
+	// index still pointed at: a record lost to CAPACITY rather than to its TTL.
+	// Evictions also covers entries a newer Put had already superseded, so
+	// EvictionsLive is the one to watch to decide whether a cache is sized for
+	// its working set. EvictionsLive > 0 with Expirations low means the budget,
+	// not the TTL, is deciding how long entries survive.
+	EvictionsLive    uint64
 	Rejects          uint64 // refused due to PolicyRejectWrites
 	PagesAllocated   uint64
 	BytesAllocated   uint64
@@ -67,4 +79,54 @@ func (s Stats) HitRate() float64 {
 		return 0
 	}
 	return float64(s.Hits) / float64(s.Gets)
+}
+
+// WritePrometheus renders s in the Prometheus text exposition format. Counters
+// are cumulative since node start; sample and diff them for rates.
+//
+// rostam_kv_evictions_live_total is the one worth alerting on: it counts
+// records displaced because the cache was full rather than because their TTL
+// elapsed. A cache sized for its working set holds that near zero and retires
+// entries through rostam_kv_expirations_total instead.
+func (s Stats) WritePrometheus(w io.Writer) error {
+	counters := []struct {
+		name string
+		help string
+		val  uint64
+	}{
+		{"rostam_kv_gets_total", "KV reads served", s.Gets},
+		{"rostam_kv_hits_total", "KV reads that found a live entry", s.Hits},
+		{"rostam_kv_misses_total", "KV reads that found nothing", s.Misses},
+		{"rostam_kv_puts_total", "KV writes applied", s.Puts},
+		{"rostam_kv_dels_total", "KV deletes applied", s.Dels},
+		{"rostam_kv_expirations_total", "entries retired because their TTL elapsed", s.Expirations},
+		{"rostam_kv_evictions_total", "entries displaced by ringbuf eviction, live or already superseded", s.Evictions},
+		{"rostam_kv_evictions_live_total", "entries displaced by ringbuf eviction that were still the live record for their key - lost to capacity, not TTL", s.EvictionsLive},
+		{"rostam_kv_rejects_total", "writes refused under PolicyRejectWrites", s.Rejects},
+		{"rostam_kv_corruption_errors_total", "CRC mismatches seen on read", s.CorruptionErrors},
+	}
+	gauges := []struct {
+		name string
+		help string
+		val  uint64
+	}{
+		{"rostam_kv_pages_allocated", "cache pages currently allocated", s.PagesAllocated},
+		{"rostam_kv_bytes_allocated", "bytes backing those pages", s.BytesAllocated},
+		{"rostam_kv_bytes_used", "bytes of live entry data", s.BytesUsed},
+		{"rostam_kv_reclaimable_bytes", "page bytes held by entries no longer reachable", s.ReclaimableBytes},
+	}
+
+	for _, c := range counters {
+		if _, err := fmt.Fprintf(w, "# HELP %s %s\n# TYPE %s counter\n%s %d\n",
+			c.name, c.help, c.name, c.name, c.val); err != nil {
+			return err
+		}
+	}
+	for _, g := range gauges {
+		if _, err := fmt.Fprintf(w, "# HELP %s %s\n# TYPE %s gauge\n%s %d\n",
+			g.name, g.help, g.name, g.name, g.val); err != nil {
+			return err
+		}
+	}
+	return nil
 }

--- a/cache/stats_kv_test.go
+++ b/cache/stats_kv_test.go
@@ -152,3 +152,36 @@ func TestEvictionsLiveExcludesExpiredEntries(t *testing.T) {
 			grew, st.Evictions)
 	}
 }
+
+// StatsNoWalk must never trigger the reclaimable-bytes recomputation, because
+// the cluster scrape calls it while holding the node's shard mutex. It agrees
+// with Stats on every counter; only ReclaimableBytes may lag.
+func TestStatsNoWalkMatchesStatsOnCounters(t *testing.T) {
+	cfg := DefaultConfig()
+	cfg.NumShards = 2
+	cfg.TTLSweepIntervalMs = 0
+	c, err := New(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = c.Close() }()
+
+	for i := range 200 {
+		k := fmt.Appendf(nil, "k-%04d", i)
+		if err := c.Put(k, []byte("v"), 0); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := c.Get(k); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	full, lean := c.Stats(), c.StatsNoWalk()
+	full.ReclaimableBytes, lean.ReclaimableBytes = 0, 0
+	if full != lean {
+		t.Errorf("StatsNoWalk disagrees with Stats outside ReclaimableBytes:\n full %+v\n lean %+v", full, lean)
+	}
+	if lean.Gets == 0 || lean.Puts == 0 {
+		t.Errorf("counters did not come through: %+v", lean)
+	}
+}

--- a/cache/stats_kv_test.go
+++ b/cache/stats_kv_test.go
@@ -1,0 +1,100 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package cache
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+// EvictionsLive must count records displaced because the cache ran out of
+// room, and must NOT count records that simply reached their TTL - that is the
+// whole point of having it beside Evictions.
+func TestEvictionsLiveCountsCapacityNotTTL(t *testing.T) {
+	cfg := DefaultConfig()
+	cfg.NumShards = 1
+	cfg.MaxMemoryPerShard = 8 << 20
+	cfg.PageSize = 1 << 20
+	cfg.AtCapPolicy = PolicyRingbufEvict
+	c, err := New(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = c.Close() }()
+
+	// Write well past the budget with no TTL, so nothing can expire and the
+	// only way an entry leaves is capacity.
+	val := make([]byte, 4<<10)
+	for i := range 4000 {
+		k := []byte("capacity-key-" + strings.Repeat("x", i%8) + string(rune('a'+i%26)) + string(rune('a'+(i/26)%26)) + string(rune('a'+(i/676)%26)))
+		if err := c.Put(k, val, 0); err != nil {
+			t.Fatalf("put %d: %v", i, err)
+		}
+	}
+
+	st := c.Stats()
+	if st.EvictionsLive == 0 {
+		t.Fatalf("no live evictions after overfilling the budget: %+v", st)
+	}
+	if st.Expirations != 0 {
+		t.Errorf("nothing had a TTL, so Expirations must be 0, got %d", st.Expirations)
+	}
+	if st.EvictionsLive > st.Evictions {
+		t.Errorf("EvictionsLive (%d) cannot exceed Evictions (%d)", st.EvictionsLive, st.Evictions)
+	}
+}
+
+func TestStatsWritePrometheus(t *testing.T) {
+	var buf bytes.Buffer
+	s := Stats{Gets: 7, Hits: 5, Evictions: 9, EvictionsLive: 4, BytesUsed: 123}
+	if err := s.WritePrometheus(&buf); err != nil {
+		t.Fatal(err)
+	}
+	out := buf.String()
+	for _, want := range []string{
+		"# TYPE rostam_kv_gets_total counter\nrostam_kv_gets_total 7\n",
+		"# TYPE rostam_kv_evictions_live_total counter\nrostam_kv_evictions_live_total 4\n",
+		"# TYPE rostam_kv_bytes_used gauge\nrostam_kv_bytes_used 123\n",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("exposition missing:\n%q\ngot:\n%s", want, out)
+		}
+	}
+}
+
+// Rewriting ONE key fills the ring with superseded versions: every entry the
+// eviction sweep walks is stale except the newest, so Evictions climbs while
+// EvictionsLive stays near zero. This is what separates the two counters -
+// without the cur == ref guard they would move together.
+func TestEvictionsLiveExcludesSupersededEntries(t *testing.T) {
+	cfg := DefaultConfig()
+	cfg.NumShards = 1
+	cfg.MaxMemoryPerShard = 8 << 20
+	cfg.PageSize = 1 << 20
+	cfg.AtCapPolicy = PolicyRingbufEvict
+	c, err := New(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = c.Close() }()
+
+	key := []byte("one-hot-key")
+	val := make([]byte, 64<<10)
+	for range 400 {
+		if err := c.Put(key, val, 0); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	st := c.Stats()
+	if st.Evictions == 0 {
+		t.Fatalf("expected the ring to evict while rewriting one key: %+v", st)
+	}
+	// Only the newest version is ever the live record, so essentially every
+	// eviction here displaced a superseded entry.
+	if st.EvictionsLive > st.Evictions/10 {
+		t.Errorf("EvictionsLive=%d is too close to Evictions=%d; the cur == ref guard is not filtering superseded entries",
+			st.EvictionsLive, st.Evictions)
+	}
+}

--- a/cache/stats_kv_test.go
+++ b/cache/stats_kv_test.go
@@ -4,8 +4,10 @@ package cache
 
 import (
 	"bytes"
+	"fmt"
 	"strings"
 	"testing"
+	"time"
 )
 
 // EvictionsLive must count records displaced because the cache ran out of
@@ -96,5 +98,52 @@ func TestEvictionsLiveExcludesSupersededEntries(t *testing.T) {
 	if st.EvictionsLive > st.Evictions/10 {
 		t.Errorf("EvictionsLive=%d is too close to Evictions=%d; the cur == ref guard is not filtering superseded entries",
 			st.EvictionsLive, st.Evictions)
+	}
+}
+
+// An entry that expired but has not been swept yet is still index-current, so
+// the cur == ref guard alone would count its eviction as capacity pressure.
+// It is TTL turnover, and a correctly-sized cache is full of exactly this.
+func TestEvictionsLiveExcludesExpiredEntries(t *testing.T) {
+	cfg := DefaultConfig()
+	cfg.NumShards = 1
+	cfg.MaxMemoryPerShard = 8 << 20
+	cfg.PageSize = 1 << 20
+	cfg.AtCapPolicy = PolicyRingbufEvict
+	c, err := New(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = c.Close() }()
+
+	// Fill with entries that expire almost immediately, each under its own key
+	// so none supersedes another.
+	val := make([]byte, 4<<10)
+	for i := range 1200 {
+		if err := c.Put(fmt.Appendf(nil, "ttl-key-%06d", i), val, time.Millisecond); err != nil {
+			t.Fatalf("put %d: %v", i, err)
+		}
+	}
+	time.Sleep(30 * time.Millisecond) // everything written so far is now expired
+
+	// Now drive eviction with fresh, long-lived entries. The pages being
+	// reclaimed are full of expired-but-unswept records.
+	before := c.Stats().EvictionsLive
+	for i := range 1200 {
+		if err := c.Put(fmt.Appendf(nil, "live-key-%06d", i), val, time.Hour); err != nil {
+			t.Fatalf("put %d: %v", i, err)
+		}
+	}
+
+	st := c.Stats()
+	if st.Evictions == 0 {
+		t.Fatalf("expected evictions while overfilling: %+v", st)
+	}
+	// The expired entries must not be booked as capacity loss. Some genuinely
+	// live ones may be evicted late in the run, so allow a small margin rather
+	// than demanding exactly zero.
+	if grew := st.EvictionsLive - before; grew > st.Evictions/4 {
+		t.Errorf("EvictionsLive grew by %d of %d evictions; expired-but-unswept entries are being counted as capacity loss",
+			grew, st.Evictions)
 	}
 }

--- a/cache/stats_kv_test.go
+++ b/cache/stats_kv_test.go
@@ -152,36 +152,3 @@ func TestEvictionsLiveExcludesExpiredEntries(t *testing.T) {
 			grew, st.Evictions)
 	}
 }
-
-// StatsNoWalk must never trigger the reclaimable-bytes recomputation, because
-// the cluster scrape calls it while holding the node's shard mutex. It agrees
-// with Stats on every counter; only ReclaimableBytes may lag.
-func TestStatsNoWalkMatchesStatsOnCounters(t *testing.T) {
-	cfg := DefaultConfig()
-	cfg.NumShards = 2
-	cfg.TTLSweepIntervalMs = 0
-	c, err := New(cfg)
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer func() { _ = c.Close() }()
-
-	for i := range 200 {
-		k := fmt.Appendf(nil, "k-%04d", i)
-		if err := c.Put(k, []byte("v"), 0); err != nil {
-			t.Fatal(err)
-		}
-		if _, err := c.Get(k); err != nil {
-			t.Fatal(err)
-		}
-	}
-
-	full, lean := c.Stats(), c.StatsNoWalk()
-	full.ReclaimableBytes, lean.ReclaimableBytes = 0, 0
-	if full != lean {
-		t.Errorf("StatsNoWalk disagrees with Stats outside ReclaimableBytes:\n full %+v\n lean %+v", full, lean)
-	}
-	if lean.Gets == 0 || lean.Puts == 0 {
-		t.Errorf("counters did not come through: %+v", lean)
-	}
-}

--- a/cache/stats_kv_test.go
+++ b/cache/stats_kv_test.go
@@ -110,6 +110,11 @@ func TestEvictionsLiveExcludesExpiredEntries(t *testing.T) {
 	cfg.MaxMemoryPerShard = 8 << 20
 	cfg.PageSize = 1 << 20
 	cfg.AtCapPolicy = PolicyRingbufEvict
+	// Disable the background sweeper: this test needs expired-but-unswept pages
+	// to still be there when eviction reaches them, which is the whole scenario.
+	// Left at DefaultConfig's 1000ms the sweeper can reclaim them first and the
+	// test flakes. Same convention as b3b_sweeper_test.go.
+	cfg.TTLSweepIntervalMs = 0
 	c, err := New(cfg)
 	if err != nil {
 		t.Fatal(err)

--- a/cluster/admin_ops.go
+++ b/cluster/admin_ops.go
@@ -273,6 +273,7 @@ func (n *Node) registerAdminOps() {
 		opShardReadIndexName: n.handleShardReadIndex,
 		ops.ReadyOp:          n.handleReady,
 		ops.ReplMetricsOp:    n.handleReplMetrics,
+		ops.KVMetricsOp:      n.handleKVMetrics,
 		// Shard-scoped leg of the WASM-registration broadcast: proposes to the
 		// ONE group named in its payload and never re-broadcasts. See
 		// wasm_broadcast.go.

--- a/cluster/kv_metrics.go
+++ b/cluster/kv_metrics.go
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package cluster
+
+import (
+	"bytes"
+
+	"github.com/rostamlabs/rostam/cache"
+)
+
+// handleKVMetrics renders THIS node's KV cache stats as Prometheus text,
+// aggregated across every shard it hosts.
+//
+// It must be node-local. The registry's __kv_metrics__ handler reads the cache
+// behind one TxContext, and in cluster mode a shardless op routes to shard 0 —
+// so dispatching it through the normal path would report a single shard's cache
+// and could forward the scrape to whichever node owns that shard, which is not
+// the node the operator asked. Dispatching off n.adminOps (like __ready__ and
+// __repl_metrics__) keeps the answer about the node that received it.
+func (n *Node) handleKVMetrics(_ []byte) ([]byte, error) {
+	var agg cache.Stats
+	for _, s := range n.snapshotShards() {
+		if s == nil {
+			continue
+		}
+		agg.Add(s.Stats().Cache)
+	}
+	var buf bytes.Buffer
+	if err := agg.WritePrometheus(&buf); err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), nil
+}

--- a/cluster/kv_metrics.go
+++ b/cluster/kv_metrics.go
@@ -19,12 +19,19 @@ import (
 // __repl_metrics__) keeps the answer about the node that received it.
 func (n *Node) handleKVMetrics(_ []byte) ([]byte, error) {
 	var agg cache.Stats
-	for _, s := range n.snapshotShards() {
+	// Hold shardMu across the whole read, rather than iterating a
+	// snapshotShards() copy: that helper releases the lock before returning, so
+	// a store it handed back can be closed by RemoveShardOwner while this loop
+	// is still calling Stats() on it. Reading stats is cheap and non-blocking,
+	// so holding the read lock here costs nothing worth the race.
+	n.shardMu.RLock()
+	for _, s := range n.shards {
 		if s == nil {
 			continue
 		}
 		agg.Add(s.Stats().Cache)
 	}
+	n.shardMu.RUnlock()
 	var buf bytes.Buffer
 	if err := agg.WritePrometheus(&buf); err != nil {
 		return nil, err

--- a/cluster/kv_metrics.go
+++ b/cluster/kv_metrics.go
@@ -18,29 +18,32 @@ import (
 // the node the operator asked. Dispatching off n.adminOps (like __ready__ and
 // __repl_metrics__) keeps the answer about the node that received it.
 //
-// The lock is taken PER SHARD rather than once around the loop. Stats on an
-// eligible mmap shard can recompute reclaimable bytes with an O(entries) walk,
-// and RemoveShardOwner nils the slot under the write lock before closing the
-// store — so the read lock is what keeps a store alive across the call, but
-// holding it across every shard would let one scrape stall shard add/remove and
-// node shutdown for the sum of all their walks. Per shard, a waiting writer gets
-// in at the next release, after at most one walk. The cost is that the shards
-// are not sampled at one instant, which a counter scrape can afford.
+// The read lock is held across the WHOLE loop, and the shards must be read from
+// n.shards under it rather than from a snapshotShards() copy. Both shutdown
+// paths close a store the caller may still be holding: RemoveShardOwner nils the
+// slot under the write lock and closes after releasing, and Node.Close closes
+// every store IN PLACE without nilling anything — so after it runs the slots are
+// non-nil and unmapped. Releasing the lock between shards would let either land
+// mid-iteration and turn the next CacheStats into a read of unmapped memory.
+//
+// The cost is that a scrape can delay shard add/remove and node shutdown, since
+// Stats recomputes reclaimable bytes with an O(entries) walk. That exposure is
+// narrow and bounded: only an mmap + replicated + reject-writes shard walks at
+// all (onlineCompactionEligible — every other configuration returns 0 without
+// touching an entry), and reclaimableStatsTTL rate-limits it to once per 2s per
+// shard. Serving the gauge from a cache instead is not an option: nothing
+// publishes that cache unless OnlineCompaction is on, which it is not by
+// default, so the scrape would report a permanent 0.
 func (n *Node) handleKVMetrics(_ []byte) ([]byte, error) {
 	var agg cache.Stats
-	for i := 0; ; i++ {
-		n.shardMu.RLock()
-		if i >= len(n.shards) {
-			n.shardMu.RUnlock()
-			break
+	n.shardMu.RLock()
+	for _, s := range n.shards {
+		if s == nil {
+			continue
 		}
-		var st cache.Stats
-		if s := n.shards[i]; s != nil {
-			st = s.CacheStats()
-		}
-		n.shardMu.RUnlock()
-		agg.Add(st)
+		agg.Add(s.CacheStats())
 	}
+	n.shardMu.RUnlock()
 	var buf bytes.Buffer
 	if err := agg.WritePrometheus(&buf); err != nil {
 		return nil, err

--- a/cluster/kv_metrics.go
+++ b/cluster/kv_metrics.go
@@ -17,28 +17,30 @@ import (
 // and could forward the scrape to whichever node owns that shard, which is not
 // the node the operator asked. Dispatching off n.adminOps (like __ready__ and
 // __repl_metrics__) keeps the answer about the node that received it.
+//
+// The lock is taken PER SHARD rather than once around the loop. Stats on an
+// eligible mmap shard can recompute reclaimable bytes with an O(entries) walk,
+// and RemoveShardOwner nils the slot under the write lock before closing the
+// store — so the read lock is what keeps a store alive across the call, but
+// holding it across every shard would let one scrape stall shard add/remove and
+// node shutdown for the sum of all their walks. Per shard, a waiting writer gets
+// in at the next release, after at most one walk. The cost is that the shards
+// are not sampled at one instant, which a counter scrape can afford.
 func (n *Node) handleKVMetrics(_ []byte) ([]byte, error) {
 	var agg cache.Stats
-	// Hold shardMu across the whole read, rather than iterating a
-	// snapshotShards() copy: that helper releases the lock before returning, so
-	// a store it handed back can be closed by RemoveShardOwner while this loop
-	// is still calling Stats() on it. (RemoveShardOwner nils the slot under the
-	// write lock and closes AFTER releasing, so holding the read lock is what
-	// keeps the store alive for the call.)
-	//
-	// CacheStatsNoWalk, not Stats: the full read recomputes reclaimable bytes
-	// with an O(entries) walk on eligible mmap shards, and doing that under
-	// shardMu would let a metrics scrape stall shard add/remove and node
-	// shutdown for the length of the walk. A scrape takes the last published
-	// figure instead.
-	n.shardMu.RLock()
-	for _, s := range n.shards {
-		if s == nil {
-			continue
+	for i := 0; ; i++ {
+		n.shardMu.RLock()
+		if i >= len(n.shards) {
+			n.shardMu.RUnlock()
+			break
 		}
-		agg.Add(s.CacheStatsNoWalk())
+		var st cache.Stats
+		if s := n.shards[i]; s != nil {
+			st = s.CacheStats()
+		}
+		n.shardMu.RUnlock()
+		agg.Add(st)
 	}
-	n.shardMu.RUnlock()
 	var buf bytes.Buffer
 	if err := agg.WritePrometheus(&buf); err != nil {
 		return nil, err

--- a/cluster/kv_metrics.go
+++ b/cluster/kv_metrics.go
@@ -22,14 +22,21 @@ func (n *Node) handleKVMetrics(_ []byte) ([]byte, error) {
 	// Hold shardMu across the whole read, rather than iterating a
 	// snapshotShards() copy: that helper releases the lock before returning, so
 	// a store it handed back can be closed by RemoveShardOwner while this loop
-	// is still calling Stats() on it. Reading stats is cheap and non-blocking,
-	// so holding the read lock here costs nothing worth the race.
+	// is still calling Stats() on it. (RemoveShardOwner nils the slot under the
+	// write lock and closes AFTER releasing, so holding the read lock is what
+	// keeps the store alive for the call.)
+	//
+	// CacheStatsNoWalk, not Stats: the full read recomputes reclaimable bytes
+	// with an O(entries) walk on eligible mmap shards, and doing that under
+	// shardMu would let a metrics scrape stall shard add/remove and node
+	// shutdown for the length of the walk. A scrape takes the last published
+	// figure instead.
 	n.shardMu.RLock()
 	for _, s := range n.shards {
 		if s == nil {
 			continue
 		}
-		agg.Add(s.Stats().Cache)
+		agg.Add(s.CacheStatsNoWalk())
 	}
 	n.shardMu.RUnlock()
 	var buf bytes.Buffer

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -24,7 +24,6 @@ Notable user-visible changes. Entries that alter existing behaviour are marked
   the signal that the memory budget, not the TTL, is deciding how long entries
   survive.
 
-
 - **Filter and index `operate` records stored in vector payloads.** A payload
   value of kind `record` (the bytes `operate` writes) can now be addressed
   directly by filters: a path like `session/rc`, `session/b/42/hi`, or

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -5,6 +5,26 @@ Notable user-visible changes. Entries that alter existing behaviour are marked
 
 ## Unreleased
 
+- **KV cache metrics are now scrapeable, and capacity loss is distinguishable
+  from TTL turnover.** A KV-only node previously reported nothing about itself:
+  `/metrics` renders dense-collection stats and returns an empty body without a
+  vector store, and `cache.Stats()` was only surfaced through the Raft path a
+  single-node deployment never runs. A new shardless read-only op
+  `__kv_metrics__`, served at `/kv-metrics` and `/v1/kv-metrics`, renders the
+  node's cache counters as Prometheus text. In cluster mode it is dispatched
+  node-locally (like `__ready__`/`__repl_metrics__`) and aggregates every shard
+  the receiving node hosts, rather than routing to one shard's cache.
+
+  Alongside it, `rostam_kv_evictions_live_total` separates records displaced
+  because the cache was **full** from records that simply reached their TTL.
+  `rostam_kv_evictions_total` counts every entry a reclaimed page held —
+  including versions a newer write had already superseded and entries that had
+  expired but not yet been swept — so it overstates what a cache actually lost.
+  The `_live_` counter rising while `rostam_kv_expirations_total` stays low is
+  the signal that the memory budget, not the TTL, is deciding how long entries
+  survive.
+
+
 - **Filter and index `operate` records stored in vector payloads.** A payload
   value of kind `record` (the bytes `operate` writes) can now be addressed
   directly by filters: a path like `session/rc`, `session/b/42/hi`, or

--- a/httpapi/httpapi.go
+++ b/httpapi/httpapi.go
@@ -137,8 +137,13 @@ func Handler(disp Dispatcher, opts Options) http.Handler {
 	// KV cache stats. Its own endpoint rather than folded into /metrics: that
 	// one renders dense-collection stats and is empty on a KV-only node, and
 	// merging them would change what existing vector scrapers receive.
-	mux.HandleFunc("GET /kv/metrics", a.kvMetrics)
-	mux.HandleFunc("GET /v1/kv/metrics", a.kvMetrics)
+	//
+	// Deliberately NOT under /v1/kv/: a literal segment beats a wildcard in
+	// ServeMux, so "GET /v1/kv/metrics" would shadow "GET /v1/kv/{key}" and make
+	// a key literally named "metrics" unreadable. Keep this surface out of the
+	// key namespace.
+	mux.HandleFunc("GET /kv-metrics", a.kvMetrics)
+	mux.HandleFunc("GET /v1/kv-metrics", a.kvMetrics)
 	// Replication observability (#6): per-hosted-shard mode / primary / ISR vs
 	// min-ISR / per-backup lag as JSON via the __repl_metrics__ read op.
 	// Auth-exempt like /v1/ready — an ops/infra probe carries no token.

--- a/httpapi/httpapi.go
+++ b/httpapi/httpapi.go
@@ -134,6 +134,11 @@ func Handler(disp Dispatcher, opts Options) http.Handler {
 	// stats via the __metrics__ read op.
 	mux.HandleFunc("GET /metrics", a.metrics)
 	mux.HandleFunc("GET /v1/metrics", a.metrics)
+	// KV cache stats. Its own endpoint rather than folded into /metrics: that
+	// one renders dense-collection stats and is empty on a KV-only node, and
+	// merging them would change what existing vector scrapers receive.
+	mux.HandleFunc("GET /kv/metrics", a.kvMetrics)
+	mux.HandleFunc("GET /v1/kv/metrics", a.kvMetrics)
 	// Replication observability (#6): per-hosted-shard mode / primary / ISR vs
 	// min-ISR / per-backup lag as JSON via the __repl_metrics__ read op.
 	// Auth-exempt like /v1/ready — an ops/infra probe carries no token.

--- a/httpapi/metrics_test.go
+++ b/httpapi/metrics_test.go
@@ -49,3 +49,57 @@ func TestHTTPMetrics(t *testing.T) {
 		}
 	}
 }
+
+// TestHTTPKVMetrics covers the KV scrape surface: both route aliases return 200
+// with the Prometheus content type and an exposition body carrying the cache
+// counters — including on a node with no vector collections, which is exactly
+// where /metrics returns nothing.
+func TestHTTPKVMetrics(t *testing.T) {
+	h, cleanup := newTestAPI(t)
+	defer cleanup()
+
+	for _, path := range []string{"/kv-metrics", "/v1/kv-metrics"} {
+		rec := do(t, h, "GET", path, "", nil)
+		if rec.Code != http.StatusOK {
+			t.Fatalf("GET %s = %d (%s)", path, rec.Code, rec.Body)
+		}
+		if ct := rec.Header().Get("Content-Type"); !strings.HasPrefix(ct, "text/plain") {
+			t.Errorf("GET %s content-type = %q, want text/plain", path, ct)
+		}
+		body := rec.Body.String()
+		for _, want := range []string{
+			"# TYPE rostam_kv_gets_total counter",
+			"# TYPE rostam_kv_evictions_live_total counter",
+			"# TYPE rostam_kv_bytes_used gauge",
+		} {
+			if !strings.Contains(body, want) {
+				t.Errorf("GET %s missing %q in:\n%s", path, want, body)
+			}
+		}
+	}
+}
+
+// The KV metrics routes must not live under /v1/kv/: a literal segment beats a
+// wildcard in ServeMux, so a route there would shadow GET /v1/kv/{key} and make
+// a key of that name unreadable. This pins the behaviour rather than the path.
+func TestKVMetricsDoesNotShadowKeyGet(t *testing.T) {
+	h, cleanup := newTestAPI(t)
+	defer cleanup()
+
+	const val = "stored-value-not-cache-stats"
+	rec := do(t, h, "PUT", "/v1/kv/metrics", `{"value":"`+val+`"}`, nil)
+	if rec.Code != http.StatusOK && rec.Code != http.StatusCreated && rec.Code != http.StatusNoContent {
+		t.Fatalf("PUT /v1/kv/metrics = %d (%s)", rec.Code, rec.Body)
+	}
+
+	rec = do(t, h, "GET", "/v1/kv/metrics", "", nil)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("GET /v1/kv/metrics = %d (%s)", rec.Code, rec.Body)
+	}
+	if got := rec.Body.String(); !strings.Contains(got, val) {
+		t.Errorf("a key named \"metrics\" is shadowed by the metrics route; got:\n%s", got)
+	}
+	if strings.Contains(rec.Body.String(), "rostam_kv_gets_total") {
+		t.Error("GET /v1/kv/metrics returned cache stats instead of the stored key")
+	}
+}

--- a/httpapi/vector.go
+++ b/httpapi/vector.go
@@ -81,6 +81,20 @@ func (a *api) metrics(w http.ResponseWriter, r *http.Request) {
 	_, _ = w.Write(body)
 }
 
+// kvMetrics serves the node's KV cache stats as Prometheus text via the
+// __kv_metrics__ read op. Separate from /metrics on purpose: that endpoint
+// renders dense-collection stats and returns an empty body on a KV-only node,
+// and folding the two together would change what existing vector scrapers see.
+func (a *api) kvMetrics(w http.ResponseWriter, r *http.Request) {
+	body, ok := a.call(w, r, ops.KVMetricsOp, nil)
+	if !ok {
+		return
+	}
+	w.Header().Set("Content-Type", "text/plain; version=0.0.4; charset=utf-8")
+	w.WriteHeader(http.StatusOK)
+	_, _ = w.Write(body)
+}
+
 // replication serves the per-hosted-shard replication view (mode, primary, ISR
 // vs min-ISR, per-backup lag) as JSON. Like ready it is auth-exempt (an ops
 // probe carries no token) and dispatches directly: the __repl_metrics__ op

--- a/ops/builtin.go
+++ b/ops/builtin.go
@@ -97,6 +97,9 @@ var builtinHandlers = map[string]Handler{
 	// Prometheus stats. follow-up: a clustered scrape would gather + concatenate
 	// each shard's exposition; today it serves the node it is dispatched to.
 	wire.MetricsOp: handleMetrics,
+	// __kv_metrics__ is the KV-side twin of __metrics__: cache counters as
+	// Prometheus text, shardless and read-only.
+	wire.KVMetricsOp: handleKVMetrics,
 	// __repl_metrics__ is a shardless REPLICATION-observability op. The default
 	// handler here reports no replicated shards (correct for single-node / Direct,
 	// which replicates nothing). In cluster mode cluster.Node intercepts it in its
@@ -639,6 +642,18 @@ func handleMetrics(tx *TxContext, _ []byte) ([]byte, error) {
 	}
 	var buf bytes.Buffer
 	if err := tx.vectors.WritePrometheusAll(&buf); err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), nil
+}
+
+// handleKVMetrics renders the node's KV cache stats as Prometheus text. It is
+// the KV counterpart to handleMetrics, which covers the vector side and emits
+// nothing on a KV-only node — so before this a cache-only Rostam reported
+// nothing about itself over the wire.
+func handleKVMetrics(tx *TxContext, _ []byte) ([]byte, error) {
+	var buf bytes.Buffer
+	if err := tx.c.Stats().WritePrometheus(&buf); err != nil {
 		return nil, err
 	}
 	return buf.Bytes(), nil

--- a/ops/wire_aliases.go
+++ b/ops/wire_aliases.go
@@ -56,6 +56,7 @@ const (
 	MaxPutBatchSize             = wire.MaxPutBatchSize
 	CollectionsOp               = wire.CollectionsOp
 	MetricsOp                   = wire.MetricsOp
+	KVMetricsOp                 = wire.KVMetricsOp
 	OpKeysAdd                   = wire.OpKeysAdd
 	OpKeysList                  = wire.OpKeysList
 	OpKeysRevoke                = wire.OpKeysRevoke

--- a/sdk/wire/builtin.go
+++ b/sdk/wire/builtin.go
@@ -64,6 +64,13 @@ const MetricsOp = "__metrics__"
 // per-hosted-shard replication state (mode / primary / ISR / min-ISR / lag).
 const ReplMetricsOp = "__repl_metrics__"
 
+// KVMetricsOp is a shardless READ-ONLY op rendering the node's KV cache stats
+// in the Prometheus text format. __metrics__ covers the VECTOR side and emits
+// nothing on a KV-only node, so without this a cache-only Rostam reports
+// nothing about itself: hit rate, eviction pressure and occupancy were all
+// invisible from outside the process.
+const KVMetricsOp = "__kv_metrics__"
+
 // CollectionsOp is the shardless op that enumerates the local node's dense
 // collections. Its result is the name list (EncodeCollectionsResult); the HTTP
 // /v1/collections handler renders it as JSON. Like __metrics__ it reads the SAME

--- a/sdk/wire/builtin_routing.go
+++ b/sdk/wire/builtin_routing.go
@@ -77,6 +77,7 @@ var BuiltinOps = []BuiltinOp{
 	{ReadyOp, OpReadOnly, nil, RouteLayoutNone, false},
 	{MetricsOp, OpReadOnly, nil, RouteLayoutNone, false},
 	{ReplMetricsOp, OpReadOnly, nil, RouteLayoutNone, false},
+	{KVMetricsOp, OpReadOnly, nil, RouteLayoutNone, false},
 	{CollectionsOp, OpReadOnly, nil, RouteLayoutNone, false},
 
 	{"vector_create_collection", OpReadWrite, routeAt1.ke, routeAt1.layout, false},

--- a/shard/store.go
+++ b/shard/store.go
@@ -851,10 +851,10 @@ func (s *Store) LastIndex() uint64 { return s.raft.LastIndex() }
 // signal online rebalancing polls on a joining replica.
 func (s *Store) RaftAppliedIndex() uint64 { return s.raft.AppliedIndex() }
 
-// CacheStatsNoWalk returns this shard's CACHE stats without the O(entries)
-// reclaimable-bytes recomputation, for a caller collecting under a lock others
-// need. See cache.Cache.StatsNoWalk.
-func (s *Store) CacheStatsNoWalk() cache.Stats { return s.cache.StatsNoWalk() }
+// CacheStats returns this shard's CACHE stats only, without the raft half that
+// Stats also collects. The KV metrics scrape wants the cache counters and
+// nothing else.
+func (s *Store) CacheStats() cache.Stats { return s.cache.Stats() }
 
 // Stats returns combined cache + raft stats.
 func (s *Store) Stats() Stats {

--- a/shard/store.go
+++ b/shard/store.go
@@ -851,6 +851,11 @@ func (s *Store) LastIndex() uint64 { return s.raft.LastIndex() }
 // signal online rebalancing polls on a joining replica.
 func (s *Store) RaftAppliedIndex() uint64 { return s.raft.AppliedIndex() }
 
+// CacheStatsNoWalk returns this shard's CACHE stats without the O(entries)
+// reclaimable-bytes recomputation, for a caller collecting under a lock others
+// need. See cache.Cache.StatsNoWalk.
+func (s *Store) CacheStatsNoWalk() cache.Stats { return s.cache.StatsNoWalk() }
+
 // Stats returns combined cache + raft stats.
 func (s *Store) Stats() Stats {
 	return Stats{


### PR DESCRIPTION
A KV-only node currently reports nothing about itself. `__metrics__` renders dense-collection stats and returns an **empty body** without a vector store, so hit rate, eviction pressure and occupancy are all invisible from outside the process. `cache.Stats()` exists, but the only thing that surfaces it is `shard.Store.Stats()` — the Raft path a single-node Direct server never runs.

## `__kv_metrics__`

A shardless read-only op rendering `cache.Stats` as Prometheus text, served at `/kv/metrics` and `/v1/kv/metrics`.

On a KV-only node that is **1913 bytes of exposition** where `/metrics` returns 1.

Deliberately **not** folded into `/metrics`: that endpoint is the dense-collection surface, and merging the two would change what existing vector scrapers receive. Happy to merge them if you would rather have one scrape target.

## `EvictionsLive`

`Evictions` counts every entry a reclaimed page held — including ones a newer `Put` had already superseded — so it overstates what a cache actually lost. That makes it the wrong number for the question operators actually ask: *is this cache too small?*

`EvictionsLive` increments only inside the `cur == ref` guard, i.e. when the index still pointed at the entry being displaced. Read together:

- `EvictionsLive` climbing while `Expirations` stays low ⇒ **the budget, not the TTL, is deciding how long entries survive**
- `Evictions` high but `EvictionsLive` near zero ⇒ the ring is mostly reclaiming superseded versions, which is healthy

## Tests

Both claims are covered, and both tests fail without the change:

- `TestEvictionsLiveCountsCapacityNotTTL` — overfill a budget with no TTL anywhere: live evictions appear, `Expirations` stays 0.
- `TestEvictionsLiveExcludesSupersededEntries` — rewrite a single key until the ring recycles: `Evictions` climbs, `EvictionsLive` stays under a tenth of it. Moving the counter back outside the guard fails this one, which is what makes it worth having.
- `TestStatsWritePrometheus` — exposition format, types and values.

`./cache/...`, `./ops/...`, `./httpapi/...`, `./sdk/...` pass; vet clean. Verified end to end against a running KV-only server.

## Why

Sizing a cache is currently guesswork from the outside — you can watch RSS plateau and infer that eviction started, but not how much live data is being dropped. These two counters make that a measurement.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Gives KV-only nodes a Prometheus metrics endpoint they previously lacked (their `/metrics` response was empty), and splits live evictions out of the total so capacity pressure is visible. Serves `cache.Stats` at `/kv-metrics` and `/v1/kv-metrics`; `/metrics` is unchanged so existing vector scrapers are unaffected.

**New Features**
- Adds `EvictionsLive`, counting evictions that displaced the index-current, still-live entry; `Evictions` continues to count superseded and expired entries.
- Adds the `__kv_metrics__` read-only op; in cluster mode it aggregates every shard the receiving node hosts, holding the node lock for the whole scrape because `Node.Close` unmaps stores in place — releasing per shard could let shutdown land mid-scrape and turn the next read into unmapped memory. The lock cost is bounded: only mmap + replicated + reject-writes shards ever walk, and the reclaimable figure refreshes at most once per 2s per shard.
- Routes sit outside `/v1/kv/` so a key literally named "metrics" stays readable.

<sup>Written for commit 0d50cccb6ad2960933c8e90d31be9839f388b8c8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rostamlabs/rostam/pull/114?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added Prometheus-formatted KV cache metrics through `/kv-metrics` and `/v1/kv-metrics`.
  - Added metrics for live capacity evictions, total evictions, cache usage, compaction, and other KV counters.
  - Added the `__kv_metrics__` cluster operation for retrieving node-local KV metrics.
- **Bug Fixes**
  - Prevented the metrics route from shadowing keys named `metrics` under `/v1/kv/`.
  - Improved metrics collection so writers are not blocked across the entire multi-shard stats walk.
- **Documentation**
  - Documented the new endpoints, operation, and distinction between live evictions and other reclamation causes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->