### PR TITLE
perf(operate): return the result by value, not on the heap

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -5,16 +5,22 @@ Notable user-visible changes. Entries that alter existing behaviour are marked
 
 ## Unreleased
 
-- **`operate` costs one allocation per call instead of two.** The result frame
-  was built as `&wire.OperateResult{...}` and handed back up the apply path, one
-  32-byte heap object per call. It never outlives the handler — the op encodes it
-  and drops it — so it is now returned by value and stays on the caller's stack.
-  Measured on `BenchmarkOperateSchemaExistingRow` and
+- **The `operate` APPLY path costs one allocation per call instead of two.** The
+  result frame was built as `&wire.OperateResult{...}` and returned up the apply
+  path, one 32-byte heap object per call. It never outlives the handler — the op
+  encodes it and drops it — so it is now returned by value, removing that
+  per-call heap allocation. Measured on `BenchmarkOperateSchemaExistingRow` and
   `BenchmarkOperateDynamicExistingRow`: 2 allocs/op to 1, with bytes down by
   exactly the struct. The one remaining allocation is the private record copy the
-  design doc's §2.6 budget allows, and a test now pins that budget. Small in
-  bytes, but this was the largest allocation site by OBJECT count on a production
-  node, and object count is what GC scan cost tracks.
+  design doc's §2.6 budget allows, and a test now pins that budget.
+
+  Scope: this is `applyRecordBytes`, not a whole `operate` call. Encoding the
+  reply still allocates its response buffer in `EncodeOperateResult`, and
+  `vector_operate` still heap-allocates one result, because the mutation
+  callback captures its address — unchanged in count there, just moved. Small in
+  bytes, since the struct is 32 of them, but on a production node this was the
+  largest single allocation site by object COUNT, which is what allocator and
+  sweep work track and what paces GC cycles.
 
 - **KV cache metrics are now scrapeable, and capacity loss is distinguishable
   from TTL turnover.** A KV-only node previously reported nothing about itself:

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -5,6 +5,17 @@ Notable user-visible changes. Entries that alter existing behaviour are marked
 
 ## Unreleased
 
+- **`operate` costs one allocation per call instead of two.** The result frame
+  was built as `&wire.OperateResult{...}` and handed back up the apply path, one
+  32-byte heap object per call. It never outlives the handler — the op encodes it
+  and drops it — so it is now returned by value and stays on the caller's stack.
+  Measured on `BenchmarkOperateSchemaExistingRow` and
+  `BenchmarkOperateDynamicExistingRow`: 2 allocs/op to 1, with bytes down by
+  exactly the struct. The one remaining allocation is the private record copy the
+  design doc's §2.6 budget allows, and a test now pins that budget. Small in
+  bytes, but this was the largest allocation site by OBJECT count on a production
+  node, and object count is what GC scan cost tracks.
+
 - **KV cache metrics are now scrapeable, and capacity loss is distinguishable
   from TTL turnover.** A KV-only node previously reported nothing about itself:
   `/metrics` renders dense-collection stats and returns an empty body without a

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -19,8 +19,10 @@ Notable user-visible changes. Entries that alter existing behaviour are marked
   `vector_operate` still heap-allocates one result, because the mutation
   callback captures its address — unchanged in count there, just moved. Small in
   bytes, since the struct is 32 of them, but on a production node this was the
-  largest single allocation site by object COUNT, which is what allocator and
-  sweep work track and what paces GC cycles.
+  largest single allocation site by object COUNT, and object count is what
+  allocator and sweep work follow. It is not what paces GC — that is heap bytes
+  against GOGC, and 32 bytes a call barely moves it — nor what mark cost
+  follows, which is live pointer-bearing memory.
 
 - **KV cache metrics are now scrapeable, and capacity loss is distinguishable
   from TTL turnover.** A KV-only node previously reported nothing about itself:

--- a/ops/operate.go
+++ b/ops/operate.go
@@ -160,5 +160,5 @@ func handleOperate(tx *TxContext, args []byte) ([]byte, error) {
 		}
 	}
 
-	return wire.EncodeOperateResult(res)
+	return wire.EncodeOperateResult(&res)
 }

--- a/ops/operate_apply.go
+++ b/ops/operate_apply.go
@@ -59,9 +59,9 @@ type engines struct {
 // means "delete the key" rather than "store nothing" (design doc §2.5). out is
 // never an alias of cur: the caller can write it back without thinking about
 // the store's own page.
-func applyRecordBytes(cur []byte, a *wire.OperateArgs, stampMs int64) ([]byte, bool, *wire.OperateResult, error) {
+func applyRecordBytes(cur []byte, a *wire.OperateArgs, stampMs int64) ([]byte, bool, wire.OperateResult, error) {
 	if len(a.Ops) > wire.OperateMaxOps || len(a.Rets) > wire.OperateMaxRet {
-		return nil, false, nil, wire.ErrOperateCap
+		return nil, false, wire.OperateResult{}, wire.ErrOperateCap
 	}
 	es := engines{
 		se: schemaEnginePool.Get().(*schemaEngine),   //nolint:errcheck,forcetypeassert // the pool's New returns exactly this
@@ -75,24 +75,24 @@ func applyRecordBytes(cur []byte, a *wire.OperateArgs, stampMs int64) ([]byte, b
 	return out, deleted, res, err
 }
 
-func applyWithEngine(es engines, cur []byte, a *wire.OperateArgs, stampMs int64) ([]byte, bool, *wire.OperateResult, error) {
+func applyWithEngine(es engines, cur []byte, a *wire.OperateArgs, stampMs int64) ([]byte, bool, wire.OperateResult, error) {
 	e, err := openRecord(es, cur, a)
 	if err != nil {
-		return nil, false, nil, err
+		return nil, false, wire.OperateResult{}, err
 	}
 
 	status, failedOp, err := applyOps(e, a.Ops, stampMs)
 	if err != nil {
-		return nil, false, nil, err
+		return nil, false, wire.OperateResult{}, err
 	}
 	if status == wire.OperateStatusCheckFailed {
 		// The op list aborts with the record unchanged, and the returns are
 		// evaluated against that unchanged record.
 		vals, verr := retsBefore(es, cur, a.Rets)
 		if verr != nil {
-			return nil, false, nil, verr
+			return nil, false, wire.OperateResult{}, verr
 		}
-		return nil, false, &wire.OperateResult{Status: status, FailedOp: failedOp, Values: vals}, nil
+		return nil, false, wire.OperateResult{Status: status, FailedOp: failedOp, Values: vals}, nil
 	}
 
 	if e.empty() {
@@ -100,16 +100,16 @@ func applyWithEngine(es engines, cur []byte, a *wire.OperateArgs, stampMs int64)
 		// is nothing left to resolve a path against.
 		vals, verr := absentRets(a.Rets)
 		if verr != nil {
-			return nil, false, nil, verr
+			return nil, false, wire.OperateResult{}, verr
 		}
-		return nil, true, &wire.OperateResult{Status: wire.OperateStatusOK, Values: vals}, nil
+		return nil, true, wire.OperateResult{Status: wire.OperateStatusOK, Values: vals}, nil
 	}
 
 	out := e.bytes()
 	// §2.7's backstop, checked on the finished record: a call that would store
 	// an over-large record fails with the record unchanged.
 	if len(out) > maxOperateRecordBytes {
-		return nil, false, nil, wire.ErrOperateCap
+		return nil, false, wire.OperateResult{}, wire.ErrOperateCap
 	}
 	// The returns see the record as it now is, so a record path is present
 	// even when this call created it — ref.present is "existed before the
@@ -118,9 +118,9 @@ func applyWithEngine(es engines, cur []byte, a *wire.OperateArgs, stampMs int64)
 	e.setExisted(true)
 	vals, verr := evalRets(e, a.Rets)
 	if verr != nil {
-		return nil, false, nil, verr
+		return nil, false, wire.OperateResult{}, verr
 	}
-	return out, false, &wire.OperateResult{Status: wire.OperateStatusOK, Values: vals}, nil
+	return out, false, wire.OperateResult{Status: wire.OperateStatusOK, Values: vals}, nil
 }
 
 // openRecord resolves the call's `create` parameter against the stored record

--- a/ops/operate_apply_noalloc_test.go
+++ b/ops/operate_apply_noalloc_test.go
@@ -1,0 +1,63 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package ops
+
+import (
+	"testing"
+
+	"github.com/rostamlabs/rostam/sdk/wire"
+)
+
+// resultIsZero reports whether r is the zero result — what applyRecordBytes
+// returns alongside an error. OperateResult holds a slice, so it is not
+// comparable with ==.
+func resultIsZero(r wire.OperateResult) bool {
+	return r.Status == 0 && r.FailedOp == 0 && r.Values == nil
+}
+
+// applyRecordBytes must cost exactly the ONE allocation the design doc's §2.6
+// budget allows on the in-place path: the private record copy openRecord makes
+// (copyRecord). Everything else on the call is pooled or stack-held — the
+// engines come from schemaEnginePool/dynamicEnginePool, and a call with no
+// return specs builds no values slice.
+//
+// The result used to be a second allocation: returned as
+// &wire.OperateResult{...}, one 32-byte heap object per call, it was the
+// largest allocation site by OBJECT count on a production node (29% of all
+// objects, against 1.4% of bytes, since the struct is small). Returning it by
+// value leaves it on the caller's stack. A regression to a pointer return — or
+// anything else that escapes — pushes this back over budget.
+func TestApplyRecordBytesInPlaceUpdateCostsOneAlloc(t *testing.T) {
+	s := &wire.Schema{Version: 1, Fields: []wire.FieldDef{{Name: "rc", Type: wire.OperateTypeU16}}}
+	create := &wire.OperateArgs{
+		Create: wire.OperateCreateSchema,
+		Schema: s.Encode(),
+		Ops: []wire.OperateOp{
+			{Opcode: wire.OperateOpADD, Type: opFromSchema, Path: fieldPath(0), A: 1}},
+	}
+	rec, _, _, err := applyRecordBytes(nil, create, 1)
+	if err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	upd := &wire.OperateArgs{
+		Create: wire.OperateCreateNone,
+		Ops: []wire.OperateOp{
+			{Opcode: wire.OperateOpADD, Type: opFromSchema, Path: fieldPath(0), A: 1}},
+	}
+	// Warm the engine pools so the first call's pool fill is not counted.
+	if _, _, _, err := applyRecordBytes(rec, upd, 2); err != nil {
+		t.Fatalf("warm: %v", err)
+	}
+
+	got := testing.AllocsPerRun(200, func() {
+		out, deleted, res, aerr := applyRecordBytes(rec, upd, 3)
+		if aerr != nil || deleted || out == nil || res.Status != wire.OperateStatusOK {
+			t.Fatalf("apply: err=%v deleted=%v out=%x status=%d", aerr, deleted, out, res.Status)
+		}
+	})
+	// The record copy, and nothing else.
+	if got != 1 {
+		t.Errorf("applyRecordBytes allocated %.1f objects per in-place scalar update; want 1 (the record copy alone)", got)
+	}
+}

--- a/ops/operate_apply_noalloc_test.go
+++ b/ops/operate_apply_noalloc_test.go
@@ -19,7 +19,8 @@ func resultIsZero(r wire.OperateResult) bool {
 // budget allows on the in-place path: the private record copy openRecord makes
 // (copyRecord). Everything else on the call is pooled or stack-held — the
 // engines come from schemaEnginePool/dynamicEnginePool, and a call with no
-// return specs builds no values slice.
+// return specs builds no values slice. Pool reliance is why this is skipped
+// under -race, matching TestSchemaEngineAllocs and TestDynamicEngineAllocs.
 //
 // The result used to be a second allocation: returned as
 // &wire.OperateResult{...}, one 32-byte heap object per call, it was the
@@ -28,6 +29,9 @@ func resultIsZero(r wire.OperateResult) bool {
 // value leaves it on the caller's stack. A regression to a pointer return — or
 // anything else that escapes — pushes this back over budget.
 func TestApplyRecordBytesInPlaceUpdateCostsOneAlloc(t *testing.T) {
+	if raceEnabled {
+		t.Skip("sync.Pool.Put randomly drops items under -race by design, which defeats this allocation budget; see race_detect_test.go")
+	}
 	s := &wire.Schema{Version: 1, Fields: []wire.FieldDef{{Name: "rc", Type: wire.OperateTypeU16}}}
 	create := &wire.OperateArgs{
 		Create: wire.OperateCreateSchema,

--- a/ops/operate_dynamic_engine_test.go
+++ b/ops/operate_dynamic_engine_test.go
@@ -442,7 +442,7 @@ func TestDynamicEngineNeverPanics(t *testing.T) {
 			before := append([]byte(nil), in...)
 			out, deleted, res, err := safeApply(in, args)
 			if err != nil {
-				if out != nil || deleted || res != nil {
+				if out != nil || deleted || !resultIsZero(res) {
 					t.Fatalf("error path returned output for %x: out=%x deleted=%v res=%+v", in, out, deleted, res)
 				}
 			} else if out != nil {

--- a/ops/operate_engine_test.go
+++ b/ops/operate_engine_test.go
@@ -776,19 +776,19 @@ func bytesApply(rec *wire.Record, a *wire.OperateArgs, stampMs int64) (*wire.Rec
 	if err != nil {
 		return nil, nil, err
 	}
-	if res != nil && res.Status == wire.OperateStatusCheckFailed {
+	if res.Status == wire.OperateStatusCheckFailed {
 		// A no-op: nothing is stored, and the record the suite sees is the
 		// one it passed in.
-		return rec, res, nil
+		return rec, &res, nil
 	}
 	if deleted || len(out) == 0 {
-		return nil, res, nil
+		return nil, &res, nil
 	}
 	got, derr := wire.DecodeRecord(out)
 	if derr != nil {
 		return nil, nil, fmt.Errorf("engine produced undecodable bytes %x: %w", out, derr)
 	}
-	return got, res, nil
+	return got, &res, nil
 }
 
 // TestApplyOpsTrimByCol pins the narrowing of TRIM's eviction-column operand.

--- a/ops/operate_schema_engine_test.go
+++ b/ops/operate_schema_engine_test.go
@@ -165,7 +165,7 @@ func TestSchemaRecordSizeCap(t *testing.T) {
 	if !errors.Is(err, wire.ErrOperateCap) {
 		t.Fatalf("err=%v, want ErrOperateCap", err)
 	}
-	if out != nil || deleted || res != nil {
+	if out != nil || deleted || !resultIsZero(res) {
 		t.Fatalf("a failed call returned out=%x deleted=%v res=%+v", out, deleted, res)
 	}
 	if !bytes.Equal(base, before) {
@@ -213,7 +213,7 @@ func TestSchemaEngineNeverPanics(t *testing.T) {
 			before := append([]byte(nil), in...)
 			out, deleted, res, err := safeApply(in, args)
 			if err != nil {
-				if out != nil || deleted || res != nil {
+				if out != nil || deleted || !resultIsZero(res) {
 					t.Fatalf("error path returned output for %x: out=%x deleted=%v res=%+v", in, out, deleted, res)
 				}
 			} else if out != nil {
@@ -241,7 +241,7 @@ func TestSchemaEngineNeverPanics(t *testing.T) {
 // safeApply re-panics with the frame that caused it: a bare panic from deep
 // inside the engine says nothing about which of the thousand corpus entries
 // reached it, and that input is the whole finding.
-func safeApply(cur []byte, a *wire.OperateArgs) (out []byte, deleted bool, res *wire.OperateResult, err error) {
+func safeApply(cur []byte, a *wire.OperateArgs) (out []byte, deleted bool, res wire.OperateResult, err error) {
 	defer func() {
 		if r := recover(); r != nil {
 			panic(fmt.Sprintf("applyRecordBytes panicked on %x: %v", cur, r))
@@ -553,7 +553,7 @@ func TestMigrateSizeCapAllFixedTarget(t *testing.T) {
 	if !errors.Is(err, wire.ErrOperateCap) {
 		t.Fatalf("err=%v, want ErrOperateCap", err)
 	}
-	if out != nil || deleted || res != nil {
+	if out != nil || deleted || !resultIsZero(res) {
 		t.Fatalf("a refused migration returned out=%x deleted=%v res=%+v", out, deleted, res)
 	}
 	if !bytes.Equal(stored, base) {

--- a/ops/operate_test.go
+++ b/ops/operate_test.go
@@ -535,7 +535,7 @@ func TestOperateOversizedStoredValueNotCopied(t *testing.T) {
 	if !errors.Is(err, wire.ErrOperateRecord) {
 		t.Fatalf("err = %v, want wire.ErrOperateRecord", err)
 	}
-	if out != nil || deleted || res != nil {
+	if out != nil || deleted || !resultIsZero(res) {
 		t.Fatalf("the rejected call returned out=%x deleted=%v res=%+v", out, deleted, res)
 	}
 

--- a/ops/vector_operate.go
+++ b/ops/vector_operate.go
@@ -58,7 +58,7 @@ func IsVectorRecordAbsentMessage(s string) bool {
 // Both error returns pass vector.RecordUnchanged explicitly. The engine tests
 // err != nil first, so the action is never read on an error — but a bare zero
 // would silently read as RecordStore if that order ever changed.
-func vectorOperateMutator(a *wire.OperateArgs, stampMs int64, res **wire.OperateResult) vector.RecordMutator {
+func vectorOperateMutator(a *wire.OperateArgs, stampMs int64, res *wire.OperateResult) vector.RecordMutator {
 	return func(old []byte, exists bool) ([]byte, vector.RecordMutation, error) {
 		var cur []byte
 		if exists {
@@ -172,7 +172,7 @@ func vectorOperateBody(tx *TxContext, args []byte, apply recordMutateApply) ([]b
 	}
 	cas := vector.CASCond{Expected: expected, Has: hasExpected}
 	stampMs, stamped := tx.applyStamp()
-	var res *wire.OperateResult
+	var res wire.OperateResult
 	fn := vectorOperateMutator(a, stampMs, &res)
 
 	applied, version, err := apply(tx.vectors, name, id, pk, fn, cas, stampMs, stamped)
@@ -184,7 +184,7 @@ func vectorOperateBody(tx *TxContext, args []byte, apply recordMutateApply) ([]b
 	// failed CHECK). Returning it lets a CAS loop feed the next attempt straight
 	// from this result instead of re-reading the point, which is both a round trip
 	// and a race.
-	return wire.EncodeVectorOperateResult(applied, res, version)
+	return wire.EncodeVectorOperateResult(applied, &res, version)
 }
 
 // handleNamedVectorOperate is handleVectorOperate against a named-vector


### PR DESCRIPTION
`applyWithEngine` built its result as `&wire.OperateResult{...}` — one 32-byte heap object per `operate` call. It never outlives the handler (`ops/operate.go` encodes it and drops it), so nothing needs a heap pointer. Returning it by value removes that per-call heap allocation.

## Why this line

Small in bytes, largest in objects. On a production node, this single line was **3,407,976 allocations — 29% of every object the server allocated** — against 1.4% of `alloc_space`, because the struct is only 32 bytes. It is invisible in `alloc_space` and dominant in `alloc_objects`. Allocation count is what allocator and sweep work follow. It is not what paces a GC cycle — Go paces on heap bytes against GOGC, and 32 bytes a call barely moves that — nor what mark cost follows, which is live pointer-bearing memory.

For context, the same profile's object counts:

| site | objects | share |
|---|---|---|
| `applyWithEngine` (this line) | 3,407,976 | **29.0%** |
| `copyRecord` | 3,123,952 | 26.6% |
| `cache.getCore` | 1,972,152 | 16.8% |
| `insertGap` | 1,667,546 | 14.2% |
| `EncodeOperateResult` | 1,114,129 | 9.5% |

## Measured

```
BenchmarkOperateSchemaExistingRow    24659 B/op  2 allocs/op  ->  24627 B/op  1 allocs/op
BenchmarkOperateDynamicExistingRow   18495 B/op  2 allocs/op  ->  18463 B/op  1 allocs/op
```

`-count=3` each, both modes. Bytes fall by exactly the struct; `ns/op` is unchanged within noise. `go build -gcflags=-m` confirms the KV path's result does not reach the heap.

## Scope — what this does NOT cover

- **A whole `operate` call still allocates its reply buffer** in `EncodeOperateResult` (9.5% of objects above, though Go's tiny allocator batches the empty-result case roughly 3:1). Pooling it means establishing when the transport is done with the bytes, which deserves its own review rather than being bundled here.
- **`vector_operate` is unchanged in allocation count, not improved.** Its `res` escapes because the mutation callback captures its address — `gcflags=-m` reports `vector_operate.go:175:6: moved to heap: res`. The allocation moved out of `applyWithEngine`; it did not go away on that path.

## Why by value

Rather than a `sync.Pool` or an out-parameter: it keeps the ~25 test call sites that discard the result with `_` compiling untouched, and it carries no object-lifetime risk — no pool to return to, nothing that can be used after being handed back. The result's nil-ness carried no information, since every `nil` return already coincided with a non-nil error.

## The remaining allocation

`openRecord`'s private record copy (`copyRecord`), the one allocation the design doc's §2.6 budget allows on the in-place path. `TestApplyRecordBytesInPlaceUpdateCostsOneAlloc` pins that budget at exactly 1, so a regression to a pointer return — or anything else that escapes — fails. It is skipped under `-race`, like `TestSchemaEngineAllocs` and `TestDynamicEngineAllocs`, because the race detector drops ~1/4 of `sync.Pool.Put` by design and the budget relies on the engine pools.

`wire.OperateResult` holds a slice and so is not comparable with `==`; the tests asserting that a failed call reports no result now check the zero value explicitly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
