### PR TITLE
perf(operate): pool the record working buffer

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -5,6 +5,25 @@ Notable user-visible changes. Entries that alter existing behaviour are marked
 
 ## Unreleased
 
+- **A warm `operate` write allocates nothing for the record itself.** The apply
+  path worked on a private copy of the stored record (`copyRecord`), one
+  allocation per call and — after the result frame moved to the stack — the last
+  one left in `applyRecordBytes`. `handleOperate` now supplies that buffer from a
+  pool and keeps it across calls, so a steady-state record is patched in a
+  recycled array. A record that grew keeps the larger array, which also stops
+  `insertGap` reallocating on every write once a record reaches its working size.
+
+  Measured through the handler (`BenchmarkOperateHandlerExistingRow`): 2
+  allocs/op to 1, 169 B/op to 71. The call is ~3% slower in `ns/op` — about
+  14 ns for the pool round trip — which is the trade. The remaining allocation
+  is the reply frame `EncodeOperateResult` builds.
+
+  The recycled buffer is the one `out` points at, not the one passed in:
+  `insertGap` REPLACES the array when a record outgrows it. `out` aliases the
+  scratch whenever the record fit, so a caller holding those bytes past its next
+  call holds a buffer someone else is writing — `tx.Put` copies into the page
+  arena, so the store itself never does.
+
 - **The `operate` APPLY path costs one allocation per call instead of two.** The
   result frame was built as `&wire.OperateResult{...}` and returned up the apply
   path, one 32-byte heap object per call. It never outlives the handler — the op

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -11,7 +11,10 @@ Notable user-visible changes. Entries that alter existing behaviour are marked
   one left in `applyRecordBytes`. `handleOperate` now supplies that buffer from a
   pool and keeps it across calls, so a steady-state record is patched in a
   recycled array. A record that grew keeps the larger array, which also stops
-  `insertGap` reallocating on every write once a record reaches its working size.
+  `insertGap` reallocating on every write once a record reaches its working
+  size — up to 64 KiB. Past that the buffer is dropped rather than pooled (the
+  same bound the read buffer uses), so records larger than that keep
+  reallocating and only lose the result-frame allocation.
 
   Measured through the handler (`BenchmarkOperateHandlerExistingRow`): 2
   allocs/op to 1, 169 B/op to 71. The call is ~3% slower in `ns/op` — about

--- a/ops/operate.go
+++ b/ops/operate.go
@@ -62,6 +62,21 @@ const maxPooledReadBuf = 64 << 10
 
 var operateReadBufPool = sync.Pool{New: func() any { b := make([]byte, 0, 512); return &b }}
 
+// operateWriteBufPool backs the private record copy the apply path works on
+// (copyRecord). It is separate from operateReadBufPool because a call needs
+// BOTH at once: the stored bytes are read into one and copied into the other,
+// which the engine then patches in place. Same maxPooledReadBuf guard, for the
+// same reason — a record may reach maxOperateRecordBytes, and pooling
+// unconditionally would let a few outsized keys pin a large array per slot.
+var operateWriteBufPool = sync.Pool{New: func() any { b := make([]byte, 0, 512); return &b }}
+
+func putOperateWriteBuf(bp *[]byte) {
+	if cap(*bp) <= maxPooledReadBuf {
+		*bp = (*bp)[:0]
+		operateWriteBufPool.Put(bp)
+	}
+}
+
 func putOperateReadBuf(bp *[]byte) {
 	if cap(*bp) <= maxPooledReadBuf {
 		*bp = (*bp)[:0]
@@ -109,8 +124,25 @@ func handleOperate(tx *TxContext, args []byte) ([]byte, error) {
 		cur = nil
 	}
 
+	// The apply path's working copy of the record. Recycling it is what makes a
+	// warm in-place update allocate nothing: copyRecord reuses this array, and a
+	// record that grew keeps the larger array for the next call, so insertGap
+	// stops reallocating on every write to a steady-state record.
+	//
+	// *wb = out, not the buffer passed in: insertGap REPLACES the array when the
+	// record outgrows it, so out is what must be recycled. Recycling the old
+	// array instead would hand a second caller a buffer while out still aliased
+	// the one the engine actually wrote — and pool the smaller array forever.
+	// Guarded on out != nil so a delete or a failed CHECK (both of which return
+	// no bytes) keeps whatever capacity the slot already had.
+	wb, _ := operateWriteBufPool.Get().(*[]byte)
+	defer func() { putOperateWriteBuf(wb) }()
+
 	stampMs, _ := tx.applyStamp()
-	out, deleted, res, err := applyRecordBytes(cur, a, stampMs)
+	out, deleted, res, err := applyRecordBytesInto((*wb)[:0], cur, a, stampMs)
+	if out != nil {
+		*wb = out
+	}
 	if err != nil {
 		if errors.Is(err, errOperateAbsent) {
 			// design doc §3.5: create = NONE against an absent key is the

--- a/ops/operate.go
+++ b/ops/operate.go
@@ -133,12 +133,22 @@ func handleOperate(tx *TxContext, args []byte) ([]byte, error) {
 	// record that grew keeps the larger array for the next call, so insertGap
 	// stops reallocating on every write to a steady-state record.
 	//
-	// *wb = out, not the buffer passed in: insertGap REPLACES the array when the
-	// record outgrows it, so out is what must be recycled. Recycling the old
-	// array instead would hand a second caller a buffer while out still aliased
-	// the one the engine actually wrote — and pool the smaller array forever.
-	// Guarded on out != nil so a delete or a failed CHECK (both of which return
-	// no bytes) keeps whatever capacity the slot already had.
+	// *wb = out, not the buffer passed in, is a CAPACITY contract rather than a
+	// safety one. insertGap replaces the array when the record outgrows it, and
+	// at that point the two arrays no longer alias — recycling the original
+	// would be harmless, it would just pool the smaller array forever and make
+	// the next call reallocate. Keeping out is what lets a record that reached
+	// its working size stop growing on every write. Guarded on out != nil so a
+	// delete or a failed CHECK (both of which return no bytes) keeps whatever
+	// capacity the slot already had.
+	//
+	// The real lifetime constraint is ordering, and the defer supplies it: the
+	// buffer goes back to the pool only after tx.Put has copied the record into
+	// the page arena and after the reply frame has been encoded, so nothing
+	// still reads out when it is recycled.
+	//
+	// Buffers grown past maxPooledReadBuf are dropped rather than pooled, so a
+	// record larger than that does not keep its array across calls.
 	wb, _ := operateWriteBufPool.Get().(*[]byte)
 	defer func() { putOperateWriteBuf(wb) }()
 

--- a/ops/operate.go
+++ b/ops/operate.go
@@ -36,10 +36,14 @@ import (
 // cur ownership: tx.GetWithExpiryInto copies the stored record into a pooled
 // buffer, so cur is owned by this call rather than aliasing the cache's page.
 // It still must not outlive the handler - the buffer goes back to the pool on
-// return - and nothing here needs it to: applyRecordBytes copies it again
-// before making any change (openRecord -> copyRecord) and returns its own,
-// freshly allocated out, and this handler never writes through cur nor touches
-// it once applyRecordBytes has been called.
+// return - and nothing here needs it to: the apply path copies it again before
+// making any change (openRecord -> copyRecord) and this handler never writes
+// through cur nor touches it once the apply has been called.
+//
+// out ownership: out comes from a SECOND pooled buffer (operateWriteBufPool),
+// not a fresh allocation, and may alias it. It is valid until this handler's
+// deferred recycle, which is after tx.Put has copied the bytes into the page
+// arena and after the reply frame has been encoded.
 // operateArgsPool recycles the decoded call. The op slice is the single
 // largest allocation on this path - one operate request carries up to
 // OperateMaxOps ops, and a caller that touches many keys in one call sends a

--- a/ops/operate_apply.go
+++ b/ops/operate_apply.go
@@ -60,6 +60,21 @@ type engines struct {
 // never an alias of cur: the caller can write it back without thinking about
 // the store's own page.
 func applyRecordBytes(cur []byte, a *wire.OperateArgs, stampMs int64) ([]byte, bool, wire.OperateResult, error) {
+	return applyRecordBytesInto(nil, cur, a, stampMs)
+}
+
+// applyRecordBytesInto is applyRecordBytes with a caller-owned scratch buffer
+// for the private record copy — the one allocation the in-place path otherwise
+// costs (design doc §2.6).
+//
+// scratch may be nil, in which case this is exactly applyRecordBytes. The
+// returned out ALIASES scratch whenever it fit, and is a fresh larger array
+// whenever the record had to grow (insertGap replaces the buffer rather than
+// extending it), so a caller recycling the scratch must keep what out points
+// at, never what it passed in. out stays valid until the caller reuses the
+// scratch: tx.Put copies the bytes into the shard's page arena (encodeEntry),
+// so the store never holds onto it.
+func applyRecordBytesInto(scratch, cur []byte, a *wire.OperateArgs, stampMs int64) ([]byte, bool, wire.OperateResult, error) {
 	if len(a.Ops) > wire.OperateMaxOps || len(a.Rets) > wire.OperateMaxRet {
 		return nil, false, wire.OperateResult{}, wire.ErrOperateCap
 	}
@@ -67,7 +82,7 @@ func applyRecordBytes(cur []byte, a *wire.OperateArgs, stampMs int64) ([]byte, b
 		se: schemaEnginePool.Get().(*schemaEngine),   //nolint:errcheck,forcetypeassert // the pool's New returns exactly this
 		de: dynamicEnginePool.Get().(*dynamicEngine), //nolint:errcheck,forcetypeassert // the pool's New returns exactly this
 	}
-	out, deleted, res, err := applyWithEngine(es, cur, a, stampMs)
+	out, deleted, res, err := applyWithEngine(es, scratch, cur, a, stampMs)
 	es.se.clear()
 	es.de.clear()
 	schemaEnginePool.Put(es.se)
@@ -75,8 +90,8 @@ func applyRecordBytes(cur []byte, a *wire.OperateArgs, stampMs int64) ([]byte, b
 	return out, deleted, res, err
 }
 
-func applyWithEngine(es engines, cur []byte, a *wire.OperateArgs, stampMs int64) ([]byte, bool, wire.OperateResult, error) {
-	e, err := openRecord(es, cur, a)
+func applyWithEngine(es engines, scratch, cur []byte, a *wire.OperateArgs, stampMs int64) ([]byte, bool, wire.OperateResult, error) {
+	e, err := openRecord(es, scratch, cur, a)
 	if err != nil {
 		return nil, false, wire.OperateResult{}, err
 	}
@@ -126,7 +141,7 @@ func applyWithEngine(es engines, cur []byte, a *wire.OperateArgs, stampMs int64)
 // openRecord resolves the call's `create` parameter against the stored record
 // (design doc §3.5) and returns an engine over a private, patchable copy of
 // the bytes to apply the ops to.
-func openRecord(es engines, cur []byte, a *wire.OperateArgs) (modeEngine, error) {
+func openRecord(es engines, scratch, cur []byte, a *wire.OperateArgs) (modeEngine, error) {
 	if cur == nil {
 		return createRecord(es, a)
 	}
@@ -160,7 +175,7 @@ func openRecord(es engines, cur []byte, a *wire.OperateArgs) (modeEngine, error)
 		return nil, wire.ErrOperateArgs
 	}
 
-	buf, err := copyRecord(cur)
+	buf, err := copyRecord(scratch, cur)
 	if err != nil {
 		return nil, err
 	}
@@ -246,13 +261,22 @@ func openMode(es engines, buf []byte, existed bool) (modeEngine, error) {
 // which stores them by reference in the arena. That is sound only because this
 // function allocates a new buffer per call (and createRecord allocates fresh).
 // Do not turn this into a pooled or reused buffer without changing that contract.
-func copyRecord(cur []byte) ([]byte, error) {
+// copyRecord copies cur into dst, reusing dst's array when it is already large
+// enough and allocating only when it is not. The +64 of slack is what a first
+// splice or row insert grows into without reallocating (see insertGap).
+//
+// dst is the CALLER's buffer: applyRecordBytesInto threads handleOperate's
+// pooled scratch down to here, so a warm pool makes the in-place apply path
+// allocate nothing at all. Passing nil is the allocating path every other
+// caller takes.
+func copyRecord(dst, cur []byte) ([]byte, error) {
 	if len(cur) > maxOperateRecordBytes {
 		return nil, wire.ErrOperateRecord
 	}
-	buf := make([]byte, len(cur), len(cur)+64)
-	copy(buf, cur)
-	return buf, nil
+	if cap(dst) < len(cur)+64 {
+		dst = make([]byte, 0, len(cur)+64)
+	}
+	return append(dst[:0], cur...), nil
 }
 
 // retsBefore evaluates the return specs against the pre-call record after a
@@ -268,7 +292,12 @@ func retsBefore(es engines, cur []byte, rets []wire.OperateRet) ([][]byte, error
 	// Re-opening the pre-call bytes reuses the same pooled engines: the
 	// working copy they were pointing at is discarded whole by a failed
 	// CHECK, so nothing in it is still needed.
-	buf, err := copyRecord(cur)
+	//
+	// It does NOT reuse the apply scratch, deliberately. This is the aborted
+	// path, not the hot one, and the values below alias the buffer they are
+	// read out of — sharing the scratch here would tie their lifetime to a
+	// buffer the handler is about to recycle, for no gain on any real call.
+	buf, err := copyRecord(nil, cur)
 	if err != nil {
 		return nil, err
 	}

--- a/ops/operate_apply.go
+++ b/ops/operate_apply.go
@@ -67,13 +67,18 @@ func applyRecordBytes(cur []byte, a *wire.OperateArgs, stampMs int64) ([]byte, b
 // for the private record copy — the one allocation the in-place path otherwise
 // costs (design doc §2.6).
 //
-// scratch may be nil, in which case this is exactly applyRecordBytes. The
-// returned out ALIASES scratch whenever it fit, and is a fresh larger array
-// whenever the record had to grow (insertGap replaces the buffer rather than
-// extending it), so a caller recycling the scratch must keep what out points
-// at, never what it passed in. out stays valid until the caller reuses the
-// scratch: tx.Put copies the bytes into the shard's page arena (encodeEntry),
-// so the store never holds onto it.
+// scratch may be nil, in which case this is exactly applyRecordBytes.
+//
+// The returned out ALIASES scratch whenever scratch's array had room — which
+// includes a record that GREW, since insertGap extends in place while capacity
+// allows (`cap(buf)-old >= n`) and only allocates a replacement when it does
+// not. So growth alone does not tell a caller whether out is a new array;
+// capacity does, and the caller cannot see it. That is why a caller recycling
+// the scratch must recycle what out POINTS AT and never what it passed in:
+// either could be the live array.
+//
+// out stays valid until the caller reuses the scratch. tx.Put copies the bytes
+// into the shard's page arena (encodeEntry), so the store never holds onto it.
 func applyRecordBytesInto(scratch, cur []byte, a *wire.OperateArgs, stampMs int64) ([]byte, bool, wire.OperateResult, error) {
 	if len(a.Ops) > wire.OperateMaxOps || len(a.Rets) > wire.OperateMaxRet {
 		return nil, false, wire.OperateResult{}, wire.ErrOperateCap
@@ -258,9 +263,14 @@ func openMode(es engines, buf []byte, existed bool) (modeEngine, error) {
 //
 // FRESHNESS IS LOAD-BEARING FOR A CALLER OUTSIDE THIS PACKAGE. vector's
 // RecordMutator contract hands ownership of the returned bytes to the engine,
-// which stores them by reference in the arena. That is sound only because this
-// function allocates a new buffer per call (and createRecord allocates fresh).
-// Do not turn this into a pooled or reused buffer without changing that contract.
+// which stores them BY REFERENCE in the arena. That is sound only while the
+// bytes are freshly allocated, so vector must keep calling applyRecordBytes —
+// the nil-scratch path, where this function allocates per call and createRecord
+// allocates fresh. Do not hand the vector path a scratch buffer.
+//
+// The KV path may reuse one (applyRecordBytesInto, from handleOperate's pool)
+// for the opposite reason: tx.Put COPIES the record into the shard's page arena
+// (encodeEntry), so the store holds no reference once Put returns.
 // copyRecord copies cur into dst, reusing dst's array when it is already large
 // enough and allocating only when it is not. The +64 of slack is what a first
 // splice or row insert grows into without reallocating (see insertGap).

--- a/ops/operate_apply.go
+++ b/ops/operate_apply.go
@@ -73,12 +73,17 @@ func applyRecordBytes(cur []byte, a *wire.OperateArgs, stampMs int64) ([]byte, b
 // includes a record that GREW, since insertGap extends in place while capacity
 // allows (`cap(buf)-old >= n`) and only allocates a replacement when it does
 // not. So growth alone does not tell a caller whether out is a new array;
-// capacity does, and the caller cannot see it. That is why a caller recycling
-// the scratch must recycle what out POINTS AT and never what it passed in:
-// either could be the live array.
+// capacity does, and the caller cannot see it.
 //
-// out stays valid until the caller reuses the scratch. tx.Put copies the bytes
-// into the shard's page arena (encodeEntry), so the store never holds onto it.
+// A caller recycling the scratch should recycle what out POINTS AT, but that is
+// a CAPACITY contract, not a safety one: when growth allocated a replacement the
+// two arrays no longer alias, so keeping the original is harmless — it just
+// discards the larger array and makes the next call grow again.
+//
+// The safety constraint is ordering: out stays valid only until the caller
+// reuses the scratch, so everything that reads out must happen first. tx.Put
+// copies the bytes into the shard's page arena (encodeEntry), so the store
+// itself never holds onto it.
 func applyRecordBytesInto(scratch, cur []byte, a *wire.OperateArgs, stampMs int64) ([]byte, bool, wire.OperateResult, error) {
 	if len(a.Ops) > wire.OperateMaxOps || len(a.Rets) > wire.OperateMaxRet {
 		return nil, false, wire.OperateResult{}, wire.ErrOperateCap

--- a/ops/operate_apply_noalloc_test.go
+++ b/ops/operate_apply_noalloc_test.go
@@ -65,3 +65,113 @@ func TestApplyRecordBytesInPlaceUpdateCostsOneAlloc(t *testing.T) {
 		t.Errorf("applyRecordBytes allocated %.1f objects per in-place scalar update; want 1 (the record copy alone)", got)
 	}
 }
+
+// With the caller's scratch supplying the record copy, an in-place update
+// allocates nothing at all: the engines come from pools, the copy reuses the
+// scratch array, and no return specs means no values slice. This is the budget
+// handleOperate actually runs at on a warm pool.
+func TestApplyRecordBytesIntoWarmScratchIsZeroAlloc(t *testing.T) {
+	if raceEnabled {
+		t.Skip("sync.Pool.Put randomly drops items under -race by design, which defeats this allocation budget; see race_detect_test.go")
+	}
+	rec, upd := seedScalarRecord(t)
+	scratch := make([]byte, 0, len(rec)+64)
+	if _, _, _, err := applyRecordBytesInto(scratch, rec, upd, 2); err != nil {
+		t.Fatalf("warm: %v", err)
+	}
+
+	got := testing.AllocsPerRun(200, func() {
+		out, _, _, aerr := applyRecordBytesInto(scratch, rec, upd, 3)
+		if aerr != nil || out == nil {
+			t.Fatalf("apply: err=%v out=%x", aerr, out)
+		}
+	})
+	if got != 0 {
+		t.Errorf("applyRecordBytesInto allocated %.1f objects per in-place update with a warm scratch; want 0", got)
+	}
+}
+
+// out ALIASES the caller's scratch whenever the record fits in it. That is the
+// contract handleOperate depends on — it is why the handler must consume out
+// (tx.Put copies into the page arena) before the scratch is recycled, and why
+// it recycles what out points at rather than what it passed in. A change that
+// quietly started returning an independent array would make the pooling
+// pointless; one that kept aliasing after a GROW would make it unsafe.
+func TestApplyRecordBytesIntoOutAliasesScratchOnlyWhenItFits(t *testing.T) {
+	rec, upd := seedScalarRecord(t)
+
+	roomy := make([]byte, 0, len(rec)+64)
+	out, _, _, err := applyRecordBytesInto(roomy, rec, upd, 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(out) == 0 || &out[:1][0] != &roomy[:1][0] {
+		t.Error("out does not alias a scratch big enough to hold it; the record copy was allocated instead of reused")
+	}
+
+	// Too small to hold the record: copyRecord must allocate, and out must NOT
+	// point into the buffer the caller still owns.
+	tiny := make([]byte, 0, 1)
+	out, _, _, err = applyRecordBytesInto(tiny, rec, upd, 2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(out) == 0 || &out[:1][0] == &tiny[:1][0] {
+		t.Error("out aliases a scratch too small for the record")
+	}
+}
+
+// Two keys alternating through the handler, each with its own value, driven by
+// the real pooled buffer. TestOperatePersistsAcrossCalls already loops one key
+// with one op, which a buffer mix-up would survive: the bytes are identical
+// every call, so recycling the wrong array is invisible. Interleaving two keys
+// whose stored records differ is the case that catches it.
+func TestOperateHandlerInterleavedKeysKeepSeparateRecords(t *testing.T) {
+	_, tx := newTestSetup(t)
+	a, b := []byte("pool-key-a"), []byte("pool-key-b")
+
+	// 3 calls on a, 1 on b, interleaved so b's write lands between a's.
+	for i, key := range [][]byte{a, a, b, a} {
+		if res := callOperate(t, tx, 0, addField0(key)); res.Status != wire.OperateStatusOK {
+			t.Fatalf("call %d on %s: status %v", i, key, res.Status)
+		}
+	}
+
+	for _, tc := range []struct {
+		key  []byte
+		want uint64
+	}{{a, 3}, {b, 1}} {
+		v, err := tx.Get(tc.key)
+		if err != nil {
+			t.Fatalf("Get %s: %v", tc.key, err)
+		}
+		rec, err := wire.DecodeRecord(v)
+		if err != nil {
+			t.Fatalf("DecodeRecord %s: %v", tc.key, err)
+		}
+		if got := rec.Fields[0].Cell.U; got != tc.want {
+			t.Errorf("%s field 0 = %d, want %d", tc.key, got, tc.want)
+		}
+	}
+}
+
+// seedScalarRecord builds a one-U16-field schema record plus the ADD args that
+// update it in place.
+func seedScalarRecord(t *testing.T) (rec []byte, upd *wire.OperateArgs) {
+	t.Helper()
+	s := &wire.Schema{Version: 1, Fields: []wire.FieldDef{{Name: "rc", Type: wire.OperateTypeU16}}}
+	rec, _, _, err := applyRecordBytes(nil, &wire.OperateArgs{
+		Create: wire.OperateCreateSchema,
+		Schema: s.Encode(),
+		Ops: []wire.OperateOp{
+			{Opcode: wire.OperateOpADD, Type: opFromSchema, Path: fieldPath(0), A: 1}},
+	}, 1)
+	if err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	return rec, &wire.OperateArgs{
+		Create: wire.OperateCreateNone,
+		Ops: []wire.OperateOp{
+			{Opcode: wire.OperateOpADD, Type: opFromSchema, Path: fieldPath(0), A: 1}},
+	}
+}

--- a/ops/operate_apply_noalloc_test.go
+++ b/ops/operate_apply_noalloc_test.go
@@ -91,33 +91,92 @@ func TestApplyRecordBytesIntoWarmScratchIsZeroAlloc(t *testing.T) {
 	}
 }
 
-// out ALIASES the caller's scratch whenever the record fits in it. That is the
-// contract handleOperate depends on — it is why the handler must consume out
-// (tx.Put copies into the page arena) before the scratch is recycled, and why
-// it recycles what out points at rather than what it passed in. A change that
-// quietly started returning an independent array would make the pooling
-// pointless; one that kept aliasing after a GROW would make it unsafe.
-func TestApplyRecordBytesIntoOutAliasesScratchOnlyWhenItFits(t *testing.T) {
+// out ALIASES the caller's scratch whenever scratch's ARRAY had room, and that
+// is what handleOperate's recycling turns on. Growth does not decide it:
+// insertGap extends in place while `cap(buf)-old >= n` holds, so a record that
+// grew can still be sitting in the caller's array. Only exhausting the capacity
+// produces a new one. The three cases below are fits / grows-within-capacity /
+// too-small, and the middle one is the reason handleOperate must recycle what
+// out points at rather than what it passed in — neither growth nor its absence
+// tells it which array is live.
+func TestApplyRecordBytesIntoOutAliasesScratchWhileCapacityLasts(t *testing.T) {
 	rec, upd := seedScalarRecord(t)
 
+	// Compare backing arrays, not contents. Guarded on CAP, not len: the
+	// scratch buffers here are len 0 with spare capacity, and reslicing one to
+	// [:1] within its capacity is legal and addresses the same array.
+	sameArray := func(a, b []byte) bool {
+		return cap(a) > 0 && cap(b) > 0 && &a[:1][0] == &b[:1][0]
+	}
+
+	// 1. In-place update into a scratch with room: aliases.
 	roomy := make([]byte, 0, len(rec)+64)
 	out, _, _, err := applyRecordBytesInto(roomy, rec, upd, 1)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(out) == 0 || &out[:1][0] != &roomy[:1][0] {
-		t.Error("out does not alias a scratch big enough to hold it; the record copy was allocated instead of reused")
+	if !sameArray(out, roomy) {
+		t.Error("in-place update did not reuse a scratch big enough to hold it")
 	}
 
-	// Too small to hold the record: copyRecord must allocate, and out must NOT
-	// point into the buffer the caller still owns.
-	tiny := make([]byte, 0, 1)
-	out, _, _, err = applyRecordBytesInto(tiny, rec, upd, 2)
+	// 2. A row insert GROWS the record (insertGap). With slack to grow into it
+	//    still aliases — the case the old version of this test never reached.
+	grower := sessionArgsFor(keyU64(7))
+	grower.Create = wire.OperateCreateSchema
+	base, _, _, err := applyRecordBytes(nil, sessionArgsFor(keyU64(1)), 1)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(out) == 0 || &out[:1][0] == &tiny[:1][0] {
+	roomyGrow := make([]byte, 0, len(base)+4096) // plenty of slack for a new row
+	out, _, _, err = applyRecordBytesInto(roomyGrow, base, grower, 2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(out) <= len(base) {
+		t.Fatalf("the record did not grow: %d bytes from %d", len(out), len(base))
+	}
+	if !sameArray(out, roomyGrow) {
+		t.Error("a record that grew WITHIN the scratch's capacity should still alias it")
+	}
+
+	// 3. Too small for the initial copy: a fresh array, and the caller's buffer
+	//    is untouched.
+	tiny := make([]byte, 0, 1)
+	out, _, _, err = applyRecordBytesInto(tiny, rec, upd, 3)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if sameArray(out, tiny) {
 		t.Error("out aliases a scratch too small for the record")
+	}
+}
+
+// The budget handleOperate itself runs at, which is what this PR changes. The
+// test above supplies a scratch by hand and so still passes if handleOperate
+// stops using the pool, or stops keeping the returned buffer; this one fails.
+// The single remaining allocation is the reply frame EncodeOperateResult builds.
+func TestOperateHandlerWarmCallCostsOneAlloc(t *testing.T) {
+	if raceEnabled {
+		t.Skip("sync.Pool.Put randomly drops items under -race by design, which defeats this allocation budget; see race_detect_test.go")
+	}
+	_, tx := newTestSetup(t)
+	args, err := wire.EncodeOperateArgs(addField0([]byte("warm-budget-key")))
+	if err != nil {
+		t.Fatal(err)
+	}
+	for i := 0; i < 3; i++ { // create, then warm both pools
+		if _, err := handleOperate(tx, args); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	got := testing.AllocsPerRun(200, func() {
+		if _, err := handleOperate(tx, args); err != nil {
+			t.Fatal(err)
+		}
+	})
+	if got != 1 {
+		t.Errorf("handleOperate allocated %.1f objects per warm call; want 1 (the reply frame alone)", got)
 	}
 }
 

--- a/ops/operate_bench_test.go
+++ b/ops/operate_bench_test.go
@@ -4,8 +4,9 @@ package ops
 
 // Benchmarks for the design doc's §2.6 in-place byte-patching claim: applying
 // a small op list to an existing record should cost one allocation for the
-// record copy and one for the result frame, independent of how many rows the
-// record holds. These measure that against the tree oracle, which rebuilds
+// record copy, independent of how many rows the record holds. (The result frame
+// used to be a second one; it is returned by value now.) Through handleOperate
+// the record copy comes from a pool too — see BenchmarkOperateHandlerExistingRow. These measure that against the tree oracle, which rebuilds
 // the whole record on every call, to quantify the win the byte engines exist
 // for.
 //
@@ -21,6 +22,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/rostamlabs/rostam/cache"
 	"github.com/rostamlabs/rostam/sdk/wire"
 )
 
@@ -199,5 +201,36 @@ func BenchmarkOperateFreshRowInserts(b *testing.B) {
 				}
 			}
 		})
+	}
+}
+
+// BenchmarkOperateHandlerExistingRow drives a whole call through handleOperate,
+// which is the only way the pooled buffers get exercised: every other benchmark
+// here calls applyRecordBytes directly and so never touches them. What is left
+// per call after the pools is the reply frame EncodeOperateResult builds.
+func BenchmarkOperateHandlerExistingRow(b *testing.B) {
+	cfg := cache.DefaultConfig()
+	cfg.NumShards = 1
+	c, err := cache.New(cfg)
+	if err != nil {
+		b.Fatal(err)
+	}
+	b.Cleanup(func() { _ = c.Close() })
+	tx := NewTxContext(c)
+
+	args, err := wire.EncodeOperateArgs(addField0([]byte("bench-handler-key")))
+	if err != nil {
+		b.Fatal(err)
+	}
+	if _, err := handleOperate(tx, args); err != nil { // create, and warm the pools
+		b.Fatal(err)
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if _, err := handleOperate(tx, args); err != nil {
+			b.Fatal(err)
+		}
 	}
 }

--- a/ops/operate_test.go
+++ b/ops/operate_test.go
@@ -561,6 +561,31 @@ func TestOperateOversizedStoredValueNotCopied(t *testing.T) {
 	}
 }
 
+// The write pool needs the same bound as the read pool: a record that grew past
+// the cap must not leave its backing array behind, or a few outsized keys pin a
+// large array per pool slot. The mirror of
+// TestOperateReadBufNotPooledWhenOversized.
+func TestOperateWriteBufNotPooledWhenOversized(t *testing.T) {
+	small := make([]byte, 0, 512)
+	putOperateWriteBuf(&small)
+	if cap(small) != 512 {
+		t.Fatalf("a small buffer must keep its capacity, got %d", cap(small))
+	}
+
+	big := make([]byte, maxPooledReadBuf+1)
+	putOperateWriteBuf(&big)
+
+	for i := 0; i < 64; i++ {
+		got, _ := operateWriteBufPool.Get().(*[]byte)
+		if got == nil {
+			continue
+		}
+		if cap(*got) > maxPooledReadBuf {
+			t.Fatalf("pool returned an oversized buffer: cap=%d, limit=%d", cap(*got), maxPooledReadBuf)
+		}
+	}
+}
+
 // An outsized record must not leave its backing array in the pool. A value can
 // exceed maxOperateRecordBytes via a plain put, and the read buffer grows to
 // hold it before copyRecord rejects it, so without the cap a few such keys


### PR DESCRIPTION
**Stacked on #116** — base branch is `perf/operate-result-noalloc`. Review that one first; this diff is only the pooling commit.

`copyRecord` allocated the apply path's private record copy on every call. After #116 moved the result frame to the stack, it was the last allocation left in `applyRecordBytes` — and **26.6% of every object the production server allocated** (3,123,952 of 11.75M). `handleOperate` now supplies that buffer from a pool and keeps it across calls.

## Measured

```
BenchmarkOperateHandlerExistingRow   169 B/op  2 allocs/op  ->  71 B/op  1 allocs/op
```

`-count=4` each side, baseline being #116's tip so this isolates the pooling.

**It costs ~3% in `ns/op`**: 473–490 baseline against 489–499 here, consistent across all four runs, so the cost is real rather than noise. That is roughly 14 ns for the pool round trip, on a call whose client-observed latency is about 1 ms. Half the allocations for 14 ns is the trade; flagging it rather than quoting only the allocation win.

`BenchmarkOperateHandlerExistingRow` is new. Every existing `operate` benchmark calls `applyRecordBytes` directly and so never touches the pools — worth knowing if you compare against their numbers.

## Shape

`applyRecordBytesInto` threads a caller-owned scratch down to `copyRecord`; `applyRecordBytes` stays as a nil-scratch wrapper, so the ~25 existing call sites are untouched. The pool is separate from `operateReadBufPool` because a call needs both at once — stored bytes are read into one and copied into the other — with the same `maxPooledReadBuf` bound for the same reason.

A record that grew keeps the larger array, so `insertGap` also stops reallocating on every write once a record reaches its working size. That is where the rest of the win comes from: `insertGap` was another 14.2% of objects.

## What the lifetime turns on

Two things, both pinned by tests:

- **`handleOperate` recycles what `out` points at, not what it passed in.** `insertGap` REPLACES the array when a record outgrows it. Recycling the input would pool the smaller array forever *and* hand a second caller a buffer `out` still aliased.
- **`out` aliases the scratch whenever the record fit, and must not when it grew.** `TestApplyRecordBytesIntoOutAliasesScratchOnlyWhenItFits` pins both directions. `tx.Put` copies into the page arena (`encodeEntry`), so the store never retains it — but a caller holding those bytes past its next call holds a buffer someone else is writing.

`retsBefore` keeps allocating on purpose: it is the aborted-CHECK path, and the values it returns alias the buffer they are read out of, so sharing the scratch there would tie their lifetime to a buffer the handler is about to recycle — for no gain on any real call.

## Tests

- `TestApplyRecordBytesIntoWarmScratchIsZeroAlloc` — 0 allocations with a warm scratch.
- `TestApplyRecordBytesIntoOutAliasesScratchOnlyWhenItFits` — the aliasing contract, both directions.
- `TestOperateHandlerInterleavedKeysKeepSeparateRecords` — two keys interleaved through the real handler. `TestOperatePersistsAcrossCalls` loops one key with one op, which a buffer mix-up survives because the bytes are identical every call.

Both allocation tests were checked by mutation: making `copyRecord` ignore its buffer and always allocate fails both, and they pass reverted. They are skipped under `-race`, like the other allocation budgets here, since the race detector drops ~1/4 of `sync.Pool.Put` by design.

`ops`, `sdk/*` and `go test -race ./ops/` all pass locally.

## Still open

The reply path — `EncodeOperateResult`'s frame plus `getCore`'s value copy on reads, together ~26% of objects. Both are reply payloads, and `server/epollserver.go` already establishes that `gnet.Write` does not retain the buffer, so what is missing is a payload-ownership contract at the dispatch boundary, not safety analysis. Its own PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pools the operate apply path's record working buffer so warm in-place updates allocate nothing. `copyRecord` allocated a private record copy per call — 26.6% of the production server's allocations — and `handleOperate` now draws it from a pool and keeps it across calls.

**Measured**
- `BenchmarkOperateHandlerExistingRow`: 2 allocs/op (169 B) → 1 (71 B).
- `ns/op` rises ~3% (~14 ns) for the pool round trip.
- The remaining allocation per call is the reply frame `EncodeOperateResult` builds.
- `BenchmarkOperateHandlerExistingRow` is new; existing `operate` benchmarks call `applyRecordBytes` directly.

**Lifetime contract**
- `handleOperate` recycles what `out` points at, not what it passed in: `insertGap` extends the array in place while capacity allows and only allocates a replacement when it does not, so `out` aliases the scratch whenever the scratch had room, including after growth.
- A caller holding `out` past its next call holds a buffer someone else is writing; `tx.Put` copies into the page arena, so the store never retains the scratch.
- `retsBefore` keeps allocating because its return values alias the buffer they were read from.
- `applyRecordBytesInto` threads the caller's scratch down to `copyRecord`; `applyRecordBytes` stays a nil-scratch wrapper, so existing call sites are unchanged. Vector must stay on that path — its `RecordMutator` stores the bytes by reference in the arena.
- A grown record keeps the larger array, which also stops `insertGap` reallocating per write once the record reaches its working size; arrays past `maxPooledReadBuf` are dropped rather than pooled.
- Tests pin the aliasing contract's three cases, the warm zero-alloc path, `handleOperate`'s one-alloc budget, the write pool's size bound, and interleaved keys that would catch a buffer mix-up.

<sup>Written for commit 61b3eadb2199a460ddbab8993d481e15e7ea0923. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rostamlabs/rostam/pull/117?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved warm existing-record updates by reusing internal write buffers, reducing memory allocations and allocation volume.
  * Preserved efficient buffer reuse as records grow within the supported size limit.
  * Added safeguards to avoid retaining oversized buffers.

* **Testing**
  * Added coverage for allocation counts, buffer reuse, interleaved record updates, and oversized-buffer handling.
  * Added benchmarking for repeated updates to existing records.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->