### PR TITLE
perf(wire): reserve the operate reply frame exactly

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -5,6 +5,24 @@ Notable user-visible changes. Entries that alter existing behaviour are marked
 
 ## Unreleased
 
+- **The `operate` reply frame is built in one allocation, whatever it returns.**
+  `EncodeOperateResult` reserved room for each value's 4-byte length prefix but
+  not for the value BYTES, so any non-empty return made `append` grow the array —
+  on exactly the calls asking for the most data back. It also reserved a
+  `failedOp` field that only a failed CHECK ever writes. The size is now computed
+  exactly, and a test pins it (`cap == len` on the finished frame).
+
+  `BenchmarkEncodeOperateResult`, 32-byte values:
+
+  | values | before | after |
+  |---|---|---|
+  | 1 | 64 B, 2 allocs | 48 B, 1 alloc |
+  | 4 | 360 B, 4 allocs | 160 B, 1 alloc |
+  | 16 | 2112 B, 5 allocs | 640 B, 1 alloc |
+
+  Roughly 2.6x faster at 16 values. A call that returns nothing was already one
+  tiny allocation and still is.
+
 - **A warm `operate` write allocates nothing for the record itself.** The apply
   path worked on a private copy of the stored record (`copyRecord`), one
   allocation per call and — after the result frame moved to the stack — the last

--- a/sdk/wire/operate.go
+++ b/sdk/wire/operate.go
@@ -621,7 +621,18 @@ func EncodeOperateResult(r *OperateResult) ([]byte, error) {
 	if r.Status != OperateStatusOK && r.Status != OperateStatusCheckFailed {
 		return nil, ErrOperateArgs
 	}
-	buf := make([]byte, 0, 1+2+2+len(r.Values)*4)
+	// Exact, not an estimate: the old reservation counted the 4-byte length
+	// prefix per value but not the value BYTES, so any non-empty return forced
+	// append to grow the array at least once — a second allocation on exactly
+	// the calls that ask for the most data back.
+	n := 1 + 2 + len(r.Values)*4
+	if r.Status == OperateStatusCheckFailed {
+		n += 2 // failedOp is written only for this status
+	}
+	for _, v := range r.Values {
+		n += len(v)
+	}
+	buf := make([]byte, 0, n)
 	buf = append(buf, r.Status)
 	if r.Status == OperateStatusCheckFailed {
 		buf = binary.BigEndian.AppendUint16(buf, r.FailedOp)

--- a/sdk/wire/operate_test.go
+++ b/sdk/wire/operate_test.go
@@ -585,9 +585,10 @@ func BenchmarkDecodeOperateArgsInto(b *testing.B) {
 }
 
 // BenchmarkEncodeOperateResult measures the reply frame with return values in
-// it — the case the capacity reservation has to get right. With no values the
-// frame is 5 bytes and the tiny allocator handles it; with values, an
-// under-reserved buffer makes append grow the array.
+// it — the case the capacity reservation has to get right. An OK frame with no
+// values is 3 bytes (status u8 + nRet u16; failedOp is written only for a failed
+// CHECK) and the tiny allocator handles it. With values, an under-reserved
+// buffer makes append grow the array.
 func BenchmarkEncodeOperateResult(b *testing.B) {
 	for _, n := range []int{1, 4, 16} {
 		r := &OperateResult{Status: OperateStatusOK, Values: make([][]byte, n)}
@@ -596,7 +597,7 @@ func BenchmarkEncodeOperateResult(b *testing.B) {
 		}
 		b.Run(fmt.Sprintf("values=%d", n), func(b *testing.B) {
 			b.ReportAllocs()
-			for i := 0; i < b.N; i++ {
+			for b.Loop() {
 				if _, err := EncodeOperateResult(r); err != nil {
 					b.Fatal(err)
 				}

--- a/sdk/wire/operate_test.go
+++ b/sdk/wire/operate_test.go
@@ -6,6 +6,7 @@ import (
 	"bytes"
 	"encoding/binary"
 	"errors"
+	"fmt"
 	"math"
 	"reflect"
 	"strings"
@@ -580,5 +581,64 @@ func BenchmarkDecodeOperateArgsInto(b *testing.B) {
 		if err := DecodeOperateArgsInto(dst, buf); err != nil {
 			b.Fatal(err)
 		}
+	}
+}
+
+// BenchmarkEncodeOperateResult measures the reply frame with return values in
+// it — the case the capacity reservation has to get right. With no values the
+// frame is 5 bytes and the tiny allocator handles it; with values, an
+// under-reserved buffer makes append grow the array.
+func BenchmarkEncodeOperateResult(b *testing.B) {
+	for _, n := range []int{1, 4, 16} {
+		r := &OperateResult{Status: OperateStatusOK, Values: make([][]byte, n)}
+		for i := range r.Values {
+			r.Values[i] = make([]byte, 32) // a scalar-ish return
+		}
+		b.Run(fmt.Sprintf("values=%d", n), func(b *testing.B) {
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				if _, err := EncodeOperateResult(r); err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
+}
+
+// The reservation must be EXACT: append never grows the array, so the frame
+// comes back with cap == len. A formula that under-counts (the length prefixes
+// without the value bytes, say) regrows and fails this; one that over-counts
+// wastes the slack and fails it too. Covers both statuses, since failedOp is
+// written only for OperateStatusCheckFailed.
+func TestEncodeOperateResultReservesExactly(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		status uint8
+		vals   [][]byte
+	}{
+		{"ok/no values", OperateStatusOK, nil},
+		{"ok/one empty value", OperateStatusOK, [][]byte{{}}},
+		{"ok/mixed sizes", OperateStatusOK, [][]byte{make([]byte, 1), make([]byte, 300), make([]byte, 8)}},
+		{"check failed/no values", OperateStatusCheckFailed, nil},
+		{"check failed/with values", OperateStatusCheckFailed, [][]byte{make([]byte, 64), make([]byte, 7)}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			b, err := EncodeOperateResult(&OperateResult{Status: tc.status, FailedOp: 3, Values: tc.vals})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if cap(b) != len(b) {
+				t.Errorf("frame is %d bytes in a %d-byte array; the reservation is not exact", len(b), cap(b))
+			}
+			// And it must still decode back to what went in.
+			got, derr := DecodeOperateResult(b)
+			if derr != nil {
+				t.Fatalf("DecodeOperateResult: %v", derr)
+			}
+			if got.Status != tc.status || len(got.Values) != len(tc.vals) {
+				t.Errorf("round trip: status=%d values=%d, want status=%d values=%d",
+					got.Status, len(got.Values), tc.status, len(tc.vals))
+			}
+		})
 	}
 }


### PR DESCRIPTION
Independent of #116/#117 — `sdk/wire` only, branches off `main`.

`EncodeOperateResult` reserved `1 + 2 + 2 + len(Values)*4`. That counts each value's 4-byte length prefix but **not the value bytes**, so any non-empty return made `append` grow the array — on exactly the calls asking for the most data back. It also always reserved the `failedOp` field, which only `OperateStatusCheckFailed` writes, so a plain OK frame came back 2 bytes short of its own capacity.

The size is now computed exactly.

## Measured

`BenchmarkEncodeOperateResult` (new), 32-byte values, `-count=3`:

| values | before | after |
|---|---|---|
| 1 | 64 B/op, 2 allocs, ~82 ns | 48 B/op, **1 alloc**, ~31 ns |
| 4 | 360 B/op, 4 allocs, ~240 ns | 160 B/op, **1 alloc**, ~88 ns |
| 16 | 2112 B/op, 5 allocs, ~861 ns | 640 B/op, **1 alloc**, ~330 ns |

Roughly 2.6x faster and 3.3x smaller at 16 values. A call that returns nothing was already a single tiny allocation and still is — this only moves calls that use return specs.

## Test

`TestEncodeOperateResultReservesExactly` asserts `cap == len` on the finished frame across both statuses and a mix of value sizes, plus a decode round trip. An under-counting formula regrows and fails it; an over-counting one leaves slack and fails it too.

Checked by mutation — restoring the old expression fails it in **both** directions, which is how the over-reservation surfaced:

```
frame is 3 bytes in a 5-byte array; the reservation is not exact      (OK, no values)
frame is 324 bytes in a 640-byte array; the reservation is not exact  (3 values)
```

## Note on the benchmark

The existing `BenchmarkOperateSchemaExistingRowWithReturns` cannot measure this — it calls `applyRecordBytes` directly and never encodes a frame. I measured against it first and got a flat result before noticing, hence the new benchmark in `sdk/wire`.

## Context

This is the safe part of the reply-path allocation work. Pooling the reply buffer itself is **not** safe inside `ops`: `directStore.Call` is public API (`store.go:56`) that hands handler bytes straight to in-process application code, which may retain them — the hazard `cache/compact_online.go:77` already cites when it keeps online compaction opt-in. Making the reply poolable would need ownership decided at the transport boundary, which means either a breaking `ops.Handler` signature change or an optional append-style registration. That is an API decision, not a perf tweak, and is deliberately not in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `EncodeOperateResult` so the reply frame's buffer is sized exactly and replies with values build in a single allocation. The old formula counted each value's 4-byte length prefix but not the value bytes, and always reserved the `failedOp` field, so non-empty replies regrew the buffer mid-append and OK frames came back 2 bytes short of capacity — now roughly 2.6x faster at 16 values.

**Tests and benchmark**
- `TestEncodeOperateResultReservesExactly` pins `cap == len` on the finished frame across both statuses and a mix of value sizes, plus a decode round trip; under- or over-reservation fails it, verified by mutation.
- The new `BenchmarkEncodeOperateResult` measures the encode path, which the existing benchmark skips by calling `applyRecordBytes` directly; a changelog entry records the new allocation profile.

<sup>Written for commit bc37e28e087fc8bc5611edf486091348de08c2c3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rostamlabs/rostam/pull/118?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved encoding efficiency for operation results, preventing unnecessary buffer growth when returning non-empty values.
  * Preserved correct handling of successful and check-failed result frames.

* **Tests**
  * Added coverage verifying exact buffer sizing and round-trip decoding.
  * Added benchmarks demonstrating reduced allocations and faster encoding.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->