### PR TITLE
fix(kv): bound the bytes an operate call's returns may produce

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -19,8 +19,14 @@ Notable user-visible changes. Entries that alter existing behaviour are marked
   charged as each return is evaluated, so a call that would cross it is refused
   with `wire.ErrOperateCap` before the bytes are materialised — the peak a
   refused call reaches is the budget plus one value, not the whole list. The
-  refusal also reaches the client as the cap error it is rather than as
-  "internal error"; it was previously unclassified at the TCP edge.
+  Every `operate` cap refusal also reaches the client as the refusal it is,
+  on all three transports: `wire.ErrOperateCap` was unclassified at the TCP,
+  REST and gRPC edges alike, so a caller that had simply asked for too much was
+  answered "internal error" (500 / `Internal`) instead of a 400 /
+  `InvalidArgument` naming the cap. It is now matched both by sentinel and by
+  exact message shape, which is what makes it work on a cluster: an `operate`
+  APPLIES inside the Raft FSM, so the engine's own caps come back rebuilt and
+  lose `errors.Is` identity on the way out.
 
   **Behaviour change:** a call whose returns exceed 16 MiB in total now fails
   (with the record unchanged, like every other cap) where it previously

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -5,33 +5,42 @@ Notable user-visible changes. Entries that alter existing behaviour are marked
 
 ## Unreleased
 
-- **`operate` now bounds the total BYTES its returns may produce, not just how
-  many of them there are.** `maxRet` capped the return-spec list at 4096, but a
-  spec is a few bytes on the wire and a record-kind `VALUE` copies the whole
-  record — so a 8 KiB request asking for 4096 record values against a 64 KiB
-  record returned 256 MiB and allocated 288 MiB of heap, a 32,701x
+- **Breaking: `operate` now bounds the total BYTES its returns may produce, not
+  just how many of them there are.** `maxRet` capped the return-spec list at
+  4096, but a spec is a few bytes on the wire and a record-kind `VALUE` copies
+  the whole record — so an 8 KiB request asking for 4096 record values against
+  a 64 KiB record returned 256 MiB and allocated 288 MiB of heap, a 32,701x
   amplification, and against the 16 MiB record cap the worst case was ~64 GiB
   from one small call. None of it could ever have reached the caller: a reply
   that large is far past the 16 MiB frame limit, so the memory was spent only
   to be thrown away.
 
-  A new cap, `maxRetBytes` (16 MiB, the same order as the frame limit), is
-  charged as each return is evaluated, so a call that would cross it is refused
-  with `wire.ErrOperateCap` before the bytes are materialised — the peak a
-  refused call reaches is the budget plus one value, not the whole list. The
-  Every `operate` cap refusal also reaches the client as the refusal it is,
-  on all three transports: `wire.ErrOperateCap` was unclassified at the TCP,
-  REST and gRPC edges alike, so a caller that had simply asked for too much was
+  A new cap, `maxRetBytes`, is charged as each return is evaluated, so a call
+  that would cross it is refused with `wire.ErrOperateCap` before the full
+  return list is materialised — the peak a refused call reaches is the budget
+  plus the one value that crossed it, not the whole list. Its value is
+  16,711,680 B: the 16 MiB frame limit less a flat 64 KiB, which is what the
+  reply's own framing and the result envelope (a length per value, plus the
+  status, count and `failedOp` fields) need alongside the values. A budget of
+  exactly 16 MiB would have made the largest ACCEPTED call fail at the
+  transport instead, which is the same refusal arriving later and naming the
+  wrong cause.
+
+  Every `operate` cap refusal also reaches the client as the refusal it is, on
+  all three transports: `wire.ErrOperateCap` was unclassified at the TCP, REST
+  and gRPC edges alike, so a caller that had simply asked for too much was
   answered "internal error" (500 / `Internal`) instead of a 400 /
   `InvalidArgument` naming the cap. It is now matched both by sentinel and by
   exact message shape, which is what makes it work on a cluster: an `operate`
   APPLIES inside the Raft FSM, so the engine's own caps come back rebuilt and
   lose `errors.Is` identity on the way out.
 
-  **Behaviour change:** a call whose returns exceed 16 MiB in total now fails
-  (with the record unchanged, like every other cap) where it previously
-  allocated gigabytes and, on any real transport, failed to frame the reply
-  afterwards. Ask for fewer returns, or narrower paths than the whole record.
+  **What to do about it:** a call whose returns come to more than 16,711,680 B
+  in total now fails with the record unchanged, like every other cap, where it
+  previously applied the ops and then failed to frame the reply. Ask for fewer
+  returns, or for narrower paths than the whole record — the budget is per
+  CALL, not per key, so splitting an oversized read across several `operate`
+  calls is the remedy.
 
 - **`get` and `operate` can be served without allocating a reply at all.** The
   reply payload was the last per-call allocation on a KV node: `tx.Get` copies

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -5,6 +5,28 @@ Notable user-visible changes. Entries that alter existing behaviour are marked
 
 ## Unreleased
 
+- **`operate` now bounds the total BYTES its returns may produce, not just how
+  many of them there are.** `maxRet` capped the return-spec list at 4096, but a
+  spec is a few bytes on the wire and a record-kind `VALUE` copies the whole
+  record — so a 8 KiB request asking for 4096 record values against a 64 KiB
+  record returned 256 MiB and allocated 288 MiB of heap, a 32,701x
+  amplification, and against the 16 MiB record cap the worst case was ~64 GiB
+  from one small call. None of it could ever have reached the caller: a reply
+  that large is far past the 16 MiB frame limit, so the memory was spent only
+  to be thrown away.
+
+  A new cap, `maxRetBytes` (16 MiB, the same order as the frame limit), is
+  charged as each return is evaluated, so a call that would cross it is refused
+  with `wire.ErrOperateCap` before the bytes are materialised — the peak a
+  refused call reaches is the budget plus one value, not the whole list. The
+  refusal also reaches the client as the cap error it is rather than as
+  "internal error"; it was previously unclassified at the TCP edge.
+
+  **Behaviour change:** a call whose returns exceed 16 MiB in total now fails
+  (with the record unchanged, like every other cap) where it previously
+  allocated gigabytes and, on any real transport, failed to frame the reply
+  afterwards. Ask for fewer returns, or narrower paths than the whole record.
+
 - **`get` and `operate` can be served without allocating a reply at all.** The
   reply payload was the last per-call allocation on a KV node: `tx.Get` copies
   the stored value into a fresh slice for every read, and `operate` builds its

--- a/docs/kv/overview.md
+++ b/docs/kv/overview.md
@@ -335,7 +335,7 @@ until it has walked it, verifies ordering on read.
 | `maxNameBytes` | 4096 B | all names stored in one record |
 | `maxRecordBytes` | 16 MiB | the record's total encoded size after apply |
 | `maxOps`, `maxRet` | 4096 each | ops and return specs per call |
-| `maxRetBytes` | 16 MiB | total bytes one call's returns may produce |
+| `maxRetBytes` | 16,711,680 B | total bytes one call's returns may produce |
 
 Hitting any cap is an **error with the record left unchanged** — never an
 implicit eviction. Row and column growth is charged against these budgets

--- a/docs/kv/overview.md
+++ b/docs/kv/overview.md
@@ -335,6 +335,7 @@ until it has walked it, verifies ordering on read.
 | `maxNameBytes` | 4096 B | all names stored in one record |
 | `maxRecordBytes` | 16 MiB | the record's total encoded size after apply |
 | `maxOps`, `maxRet` | 4096 each | ops and return specs per call |
+| `maxRetBytes` | 16 MiB | total bytes one call's returns may produce |
 
 Hitting any cap is an **error with the record left unchanged** — never an
 implicit eviction. Row and column growth is charged against these budgets

--- a/grpcapi/error_findings_test.go
+++ b/grpcapi/error_findings_test.go
@@ -327,3 +327,38 @@ func TestGrpcErrorTruncatedOperateFrameIsInvalidArgument(t *testing.T) {
 		}
 	})
 }
+
+// TestGrpcErrorOperateCapIsInvalidArgument is the parity guard for
+// wire.ErrOperateCap: the refusal every design doc §2.7 cap raises — too many
+// ops, too many return specs, returns over the byte budget, a record grown
+// past the size backstop. gRPC reaches it through vector_operate, which drives
+// the same applyRecordBytes the KV op does, so it answers InvalidArgument here,
+// matching HTTP's 400 and the binary transport's client-facing message.
+// Unclassified it fell to Internal, which reads as a server fault for a caller
+// that had simply asked for too much.
+func TestGrpcErrorOperateCapIsInvalidArgument(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		err  error
+	}{
+		{"sentinel", wire.ErrOperateCap},
+		{"wrapped (%w, exercises errIs identity)", fmt.Errorf("vector_operate: %w", wire.ErrOperateCap)},
+		// The clustered shape, and the one the sentinel arm cannot reach — the
+		// COMMON one for this sentinel, because a clustered operate APPLIES
+		// inside the FSM, so the engine's own caps are all raised behind
+		// shard.decodePBResult and come back rebuilt with errors.New.
+		{"stringified across replication, real bare shape", errors.New(wire.ErrOperateCap.Error())},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := status.Code(grpcError(tc.err)); got != codes.InvalidArgument {
+				t.Errorf("grpcError(%v) = %v, want InvalidArgument", tc.err, got)
+			}
+		})
+	}
+	t.Run("negative/unrelated fault wrapping the sentinel with a foreign prefix", func(t *testing.T) {
+		err := errors.New("apply: " + wire.ErrOperateCap.Error())
+		if got := status.Code(grpcError(err)); got != codes.Internal {
+			t.Errorf("grpcError(%v) = %v, want Internal", err, got)
+		}
+	})
+}

--- a/grpcapi/server.go
+++ b/grpcapi/server.go
@@ -278,7 +278,23 @@ func grpcError(err error) error {
 		// unclassified, a truncated frame read as a server fault.
 		wire.IsOperateArgsMessage(err.Error()),
 		errIs(err, wire.ErrVectorArgsTruncated),
-		wire.IsVectorArgsTruncatedMessage(err.Error()):
+		wire.IsVectorArgsTruncatedMessage(err.Error()),
+		// wire.ErrOperateCap rides in the same bucket, by both arms: a call
+		// refused for exceeding one of the design doc §2.7 caps — too many ops,
+		// too many return specs, returns that would produce more bytes than
+		// OperateMaxRetBytes, or a record grown past the size backstop. The
+		// caller chose its own request shape and the remedy is to ask for less,
+		// so it is InvalidArgument like the malformed frame, matching HTTP's
+		// 400; the message names only "a cap was exceeded" — no key, no path,
+		// no size — so it is safe verbatim.
+		//
+		// gRPC reaches this through vector_operate, which drives the same
+		// applyRecordBytes the KV op does. The message-shape arm carries the
+		// clustered case: an operate APPLIES inside the FSM, so every cap the
+		// engine enforces comes back through shard.decodePBResult rebuilt with
+		// errors.New and the sentinel arm cannot see it.
+		errIs(err, wire.ErrOperateCap),
+		wire.IsOperateCapMessage(err.Error()):
 		// wire.ErrOperateArgs: a malformed operate frame — a vector_operate or a KV
 		// operate whose args do not decode, or which names a second target or a
 		// TTL the op does not carry (DecodeVectorOperateArgs /
@@ -287,9 +303,10 @@ func grpcError(err error) error {
 		// fault. The message names no key, no path and no size — only that the
 		// arguments are invalid — so it is safe verbatim.
 		//
-		// Sentinel only, no message-shape arm: this error is raised by the
-		// decoder the handler itself calls, so it reaches the classifier with its
-		// identity intact.
+		// Sentinel AND message shape, as every error in this case carries: the
+		// sentinel arm covers the direct path, where the decoder the handler
+		// itself calls hands the error back with its identity intact, and the
+		// message-shape arm covers the clustered one described above.
 		return status.Error(codes.InvalidArgument, err.Error())
 	case errIs(err, vector.ErrInvalidDim, vector.ErrInvalidMetric, vector.ErrInvalidM,
 		vector.ErrInvalidQuant, vector.ErrInvalidIVFPQ, vector.ErrInvalidIVFPQM,

--- a/httpapi/error_findings_test.go
+++ b/httpapi/error_findings_test.go
@@ -565,6 +565,41 @@ func TestStatusForErrorTruncatedOperateFrame(t *testing.T) {
 	})
 }
 
+// TestStatusForErrorOperateCap is the parity guard for wire.ErrOperateCap: the
+// refusal every design doc §2.7 cap raises — too many ops, too many return
+// specs, returns over the byte budget, a record grown past the size backstop.
+// REST reaches it through vector_operate, which drives the same
+// applyRecordBytes the KV op does, so it answers 400 here, matching the binary
+// transport (server.TestMapResultOperateCapIsClientFacing) and gRPC's
+// InvalidArgument. Unclassified it was a redacted 500, which told a caller that
+// had simply asked for too much that the server had faulted.
+func TestStatusForErrorOperateCap(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		err  error
+	}{
+		{"sentinel", wire.ErrOperateCap},
+		{"wrapped (%w, exercises errors.Is identity)", fmt.Errorf("vector_operate: %w", wire.ErrOperateCap)},
+		// The clustered shape, and the one the sentinel arm cannot reach — the
+		// COMMON one for this sentinel, because a clustered operate APPLIES
+		// inside the FSM, so the engine's own caps are all raised behind
+		// shard.decodePBResult and come back rebuilt with errors.New.
+		{"stringified across Raft, real bare shape", errors.New(wire.ErrOperateCap.Error())},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := statusForError(tc.err); got != http.StatusBadRequest {
+				t.Errorf("statusForError = %d, want 400", got)
+			}
+		})
+	}
+	t.Run("negative/unrelated fault wrapping the sentinel with a foreign prefix", func(t *testing.T) {
+		err := errors.New("apply: " + wire.ErrOperateCap.Error())
+		if got := statusForError(err); got != http.StatusInternalServerError {
+			t.Errorf("statusForError(%v) = %d, want 500", err, got)
+		}
+	})
+}
+
 // The kv_query refusals, kept in sync with server.clientFacingErr: permanent
 // ones are 400 (the caller must change the query), retryable ones are 503 (the
 // caller should come back). Unclassified they were a redacted 500, which tells

--- a/httpapi/httpapi.go
+++ b/httpapi/httpapi.go
@@ -701,7 +701,24 @@ func statusForError(err error) int {
 		wire.IsOperateArgsMessage(err.Error()),
 		errors.Is(err, wire.ErrOperateArgs),
 		wire.IsVectorArgsTruncatedMessage(err.Error()),
-		errors.Is(err, wire.ErrVectorArgsTruncated):
+		errors.Is(err, wire.ErrVectorArgsTruncated),
+		// wire.ErrOperateCap rides in the same bucket, by both arms: a call
+		// refused for exceeding one of the design doc §2.7 caps — too many ops,
+		// too many return specs, returns that would produce more bytes than
+		// OperateMaxRetBytes, or a record grown past the size backstop. The
+		// caller chose the shape of its own request and the remedy is to ask
+		// for less, so it is a 400 like the malformed frame above, not a server
+		// fault; the message names only "a cap was exceeded" — no key, no path,
+		// no size — so it is safe verbatim.
+		//
+		// REST reaches this through vector_operate, which drives the same
+		// applyRecordBytes the KV op does, and the message-shape arm matters
+		// MORE here than for ErrOperateArgs: a clustered operate APPLIES inside
+		// the FSM, so every cap the engine enforces (not just the frame-level
+		// ones) comes back through shard.decodePBResult rebuilt with
+		// errors.New, with no errors.Is identity left for the sentinel arm.
+		errors.Is(err, wire.ErrOperateCap),
+		wire.IsOperateCapMessage(err.Error()):
 		return http.StatusBadRequest
 	case errors.Is(err, ops.ErrVectorRecordAbsent),
 		// The clustered path stringifies the sentinel across the Raft boundary, so

--- a/ops/operate_engine.go
+++ b/ops/operate_engine.go
@@ -431,11 +431,23 @@ func applyOps(e engine, ops []wire.OperateOp, stampMs int64) (uint8, uint16, err
 // applied uniformly across scalar, row, table, and record paths, and it is
 // the only absent-path mechanism an engine needs to support: value() and
 // count() are never asked to report absence themselves.
+//
+// Byte budget: wire.OperateMaxRet bounds how MANY specs a call may carry, and
+// nothing about how much they produce — a record-kind VALUE copies the whole
+// record, so a list at the count cap asks for OperateMaxRet record copies,
+// all held live in the returned slice at once (4096 specs against a 16 MiB
+// record is 64 GiB, from a request of a few kilobytes). So the bytes are
+// charged against wire.OperateMaxRetBytes here, INSIDE the loop, and the call
+// is refused the moment the next value would cross it: the peak this can
+// reach is the budget plus the single value that crossed it, never the whole
+// list. Counts are charged too — they are a handful of bytes each, but the
+// accounting is of what the returns really produce, not of a subset of it.
 func evalRets(e engine, rets []wire.OperateRet) ([][]byte, error) {
 	if len(rets) == 0 {
 		return nil, nil
 	}
 	out := make([][]byte, 0, len(rets))
+	total := 0
 	for i := range rets {
 		r := &rets[i]
 		if r.Mode != wire.OperateRetValue && r.Mode != wire.OperateRetCount {
@@ -449,26 +461,30 @@ func evalRets(e engine, rets []wire.OperateRet) ([][]byte, error) {
 		if err != nil {
 			return nil, err
 		}
-		if !nd.present {
-			if r.Mode == wire.OperateRetCount {
-				out = append(out, appendCountValue(0))
-			} else {
-				out = append(out, []byte{wire.OperateTypeUnset})
+		var v []byte
+		switch {
+		case !nd.present && r.Mode == wire.OperateRetCount:
+			v = appendCountValue(0)
+		case !nd.present:
+			v = []byte{wire.OperateTypeUnset}
+		case r.Mode == wire.OperateRetCount:
+			n, cerr := e.count(nd)
+			if cerr != nil {
+				return nil, cerr
 			}
-			continue
-		}
-		if r.Mode == wire.OperateRetCount {
-			n, err := e.count(nd)
+			v = appendCountValue(n)
+		default:
+			v, err = e.value(nd)
 			if err != nil {
 				return nil, err
 			}
-			out = append(out, appendCountValue(n))
-			continue
 		}
-		v, err := e.value(nd)
-		if err != nil {
-			return nil, err
+		// Written as a subtraction so the running total cannot overflow: total
+		// never exceeds the budget, so the right-hand side is always >= 0.
+		if len(v) > wire.OperateMaxRetBytes-total {
+			return nil, wire.ErrOperateCap
 		}
+		total += len(v)
 		out = append(out, v)
 	}
 	return out, nil

--- a/ops/operate_ret_budget_test.go
+++ b/ops/operate_ret_budget_test.go
@@ -1,0 +1,178 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package ops
+
+// The byte budget on an operate call's returns (wire.OperateMaxRetBytes).
+//
+// wire.OperateMaxRet bounds the return-spec COUNT, which says nothing about
+// how much those specs produce: a record-kind VALUE copies the whole record,
+// so a return list at the count cap asks for OperateMaxRet full copies held
+// live at once. Against the 16 MiB record cap that is 64 GiB from a request
+// of a few kilobytes, and none of it could ever be framed back — a reply that
+// large is far past server.MaxFrameSize. These tests pin the refusal, its
+// boundary, and the fact that the refusal happens while the values are being
+// built rather than after they all exist.
+
+import (
+	"bytes"
+	"errors"
+	"runtime"
+	"testing"
+
+	"github.com/rostamlabs/rostam/sdk/wire"
+)
+
+// retBudgetRecord builds a dynamic-mode record holding one BYTES field at the
+// per-value cap (~64 KiB) and returns its stored bytes together with the size
+// one record-kind VALUE produces for it — which is the whole record, so the
+// two are the same length. The size is measured rather than computed: the
+// budget arithmetic below derives its spec counts from it, so it must be what
+// the engine really emits.
+func retBudgetRecord(t *testing.T) ([]byte, int) {
+	t.Helper()
+	blob := bytes.Repeat([]byte{0xAB}, wire.OperateMaxBytesLen)
+	rec, deleted, res, err := applyRecordBytes(nil, &wire.OperateArgs{
+		Create: wire.OperateCreateDynamic,
+		Ops: []wire.OperateOp{
+			{Opcode: wire.OperateOpSET, Type: wire.OperateTypeBytes, Path: namePath("blob"), Bytes: blob},
+		},
+		Rets: []wire.OperateRet{{Mode: wire.OperateRetValue, Path: recPath()}},
+	}, 0)
+	if err != nil || deleted || rec == nil {
+		t.Fatalf("seed: err=%v deleted=%v rec=%v", err, deleted, rec == nil)
+	}
+	if res.Status != wire.OperateStatusOK || len(res.Values) != 1 {
+		t.Fatalf("seed result: status=%d values=%d", res.Status, len(res.Values))
+	}
+	if !bytes.Equal(res.Values[0], rec) {
+		t.Fatalf("a record VALUE should be the stored record: %d bytes vs %d", len(res.Values[0]), len(rec))
+	}
+	return rec, len(res.Values[0])
+}
+
+// recordValueRets is n return specs, each asking for the whole record.
+func recordValueRets(n int) []wire.OperateRet {
+	rets := make([]wire.OperateRet, n)
+	for i := range rets {
+		rets[i] = wire.OperateRet{Mode: wire.OperateRetValue, Path: recPath()}
+	}
+	return rets
+}
+
+// The headline: a return list within the COUNT cap but far past the byte
+// budget is refused. Before the budget existed this call returned 256 MiB of
+// values — a 32,701x amplification of the ~8 KiB request that asked for it.
+func TestOperateRetBytesBudgetRefusesAmplifiedReturns(t *testing.T) {
+	rec, _ := retBudgetRecord(t)
+	_, _, _, err := applyRecordBytes(rec, &wire.OperateArgs{
+		Create: wire.OperateCreateNone,
+		Rets:   recordValueRets(wire.OperateMaxRet),
+	}, 0)
+	if !errors.Is(err, wire.ErrOperateCap) {
+		t.Fatalf("%d record-VALUE rets against a %d-byte record: err=%v, want wire.ErrOperateCap",
+			wire.OperateMaxRet, len(rec), err)
+	}
+}
+
+// The boundary: the largest return list that fits the budget still returns
+// every value intact, and one more identical spec is refused. Both counts are
+// derived from the constants, so widening either cap keeps the test honest.
+func TestOperateRetBytesBudgetBoundary(t *testing.T) {
+	rec, valLen := retBudgetRecord(t)
+	fits := wire.OperateMaxRetBytes / valLen
+	if fits < 2 || fits > wire.OperateMaxRet {
+		t.Fatalf("budget %d / value %d = %d specs, which is not inside the count cap %d — the test needs a different record size",
+			wire.OperateMaxRetBytes, valLen, fits, wire.OperateMaxRet)
+	}
+
+	_, _, res, err := applyRecordBytes(rec, &wire.OperateArgs{
+		Create: wire.OperateCreateNone, Rets: recordValueRets(fits)}, 0)
+	if err != nil {
+		t.Fatalf("%d rets (%d bytes, budget %d): %v", fits, fits*valLen, wire.OperateMaxRetBytes, err)
+	}
+	if res.Status != wire.OperateStatusOK || len(res.Values) != fits {
+		t.Fatalf("status=%d values=%d, want OK and %d", res.Status, len(res.Values), fits)
+	}
+	for i, v := range res.Values {
+		if len(v) != valLen {
+			t.Fatalf("value %d is %d bytes, want the whole %d-byte record", i, len(v), valLen)
+		}
+		if !bytes.Equal(v, res.Values[0]) {
+			t.Fatalf("value %d differs from value 0 — the values under the budget must be intact", i)
+		}
+	}
+
+	_, _, _, err = applyRecordBytes(rec, &wire.OperateArgs{
+		Create: wire.OperateCreateNone, Rets: recordValueRets(fits + 1)}, 0)
+	if !errors.Is(err, wire.ErrOperateCap) {
+		t.Fatalf("%d rets (%d bytes, budget %d): err=%v, want wire.ErrOperateCap",
+			fits+1, (fits+1)*valLen, wire.OperateMaxRetBytes, err)
+	}
+}
+
+// The refusal must happen INSIDE the return loop, so the peak a refused call
+// reaches is the budget plus the single value that crossed it — not the whole
+// list. A pre-pass that predicted sizes, or a check after the fact, would let
+// the 256 MiB be built and then thrown away, which is the regression this
+// guards: the bound is deliberately loose (its job is to separate "roughly
+// the budget" from "everything materialised"), not a precise measurement.
+func TestOperateRetBytesBudgetBoundsPeakAllocation(t *testing.T) {
+	if raceEnabled {
+		t.Skip("the race detector's own bookkeeping inflates allocation, and the engine pools this leans on drop items under -race; see race_detect_test.go")
+	}
+	rec, _ := retBudgetRecord(t)
+	a := &wire.OperateArgs{
+		Create: wire.OperateCreateNone,
+		Rets:   recordValueRets(wire.OperateMaxRet),
+	}
+	// Warm the engine pools so their fill is not charged to the measurement.
+	if _, _, _, err := applyRecordBytes(rec, a, 0); !errors.Is(err, wire.ErrOperateCap) {
+		t.Fatalf("warm: err=%v, want wire.ErrOperateCap", err)
+	}
+
+	var before, after runtime.MemStats
+	runtime.ReadMemStats(&before)
+	if _, _, _, err := applyRecordBytes(rec, a, 0); !errors.Is(err, wire.ErrOperateCap) {
+		t.Fatalf("measured call: err=%v, want wire.ErrOperateCap", err)
+	}
+	runtime.ReadMemStats(&after)
+
+	// TotalAlloc is cumulative, so it measures what the call allocated
+	// regardless of what the collector did meanwhile.
+	got := after.TotalAlloc - before.TotalAlloc
+	limit := uint64(4 * (wire.OperateMaxRetBytes + maxOperateRecordBytes))
+	if got > limit {
+		t.Errorf("a refused %d-ret call allocated %d bytes; want at most %d (the budget plus a record, times four)",
+			wire.OperateMaxRet, got, limit)
+	}
+}
+
+// The CHECK_FAILED path evaluates the same return specs against the pre-call
+// record, through a second engine opened on those bytes (retsBefore). It is a
+// separate call into evalRets, so it needs the same bound: an aborted call is
+// exactly as good a lever for the amplification as a successful one.
+func TestOperateRetBytesBudgetOnCheckFailed(t *testing.T) {
+	rec, _ := retBudgetRecord(t)
+	a := &wire.OperateArgs{
+		Create: wire.OperateCreateNone,
+		Ops: []wire.OperateOp{
+			// "blob" exists, so ABSENT is false and the whole list aborts.
+			{Opcode: wire.OperateOpCHECK, Aux: wire.OperateCmpAbsent, Path: namePath("blob")},
+		},
+		Rets: recordValueRets(wire.OperateMaxRet),
+	}
+	if _, _, _, err := applyRecordBytes(rec, a, 0); !errors.Is(err, wire.ErrOperateCap) {
+		t.Fatalf("CHECK_FAILED with over-budget rets: err=%v, want wire.ErrOperateCap", err)
+	}
+
+	// The same aborted call with one ret is still a plain CHECK_FAILED, so the
+	// refusal above is the budget and not the abort.
+	a.Rets = recordValueRets(1)
+	_, _, res, err := applyRecordBytes(rec, a, 0)
+	if err != nil {
+		t.Fatalf("CHECK_FAILED with one ret: %v", err)
+	}
+	if res.Status != wire.OperateStatusCheckFailed || len(res.Values) != 1 {
+		t.Fatalf("status=%d values=%d, want CHECK_FAILED and 1 value", res.Status, len(res.Values))
+	}
+}

--- a/ops/operate_ret_budget_test.go
+++ b/ops/operate_ret_budget_test.go
@@ -30,7 +30,37 @@ import (
 // the engine really emits.
 func retBudgetRecord(t *testing.T) ([]byte, int) {
 	t.Helper()
-	blob := bytes.Repeat([]byte{0xAB}, wire.OperateMaxBytesLen)
+	return retBudgetRecordWithBlob(t, wire.OperateMaxBytesLen)
+}
+
+// retBudgetRecordOfValueLen builds the same shape of record sized so that one
+// record-kind VALUE is EXACTLY want bytes. The blob length is solved for by
+// measuring, not computed from the encoding: the record framing around the
+// blob (mode byte, field count, name, type tag, length prefix) is the encoder's
+// business, and a test that re-derived it would pass while disagreeing with it.
+func retBudgetRecordOfValueLen(t *testing.T, want int) ([]byte, int) {
+	t.Helper()
+	blobLen := want
+	for range 8 {
+		rec, valLen := retBudgetRecordWithBlob(t, blobLen)
+		if valLen == want {
+			return rec, valLen
+		}
+		// The framing overhead is a handful of bytes and varies only where the
+		// blob's uvarint length prefix changes width, so correcting by the
+		// shortfall converges immediately.
+		blobLen += want - valLen
+		if blobLen < 1 || blobLen > wire.OperateMaxBytesLen {
+			t.Fatalf("cannot size a record to a %d-byte VALUE: blob would have to be %d bytes", want, blobLen)
+		}
+	}
+	t.Fatalf("record sizing did not converge on a %d-byte VALUE", want)
+	return nil, 0
+}
+
+func retBudgetRecordWithBlob(t *testing.T, blobLen int) ([]byte, int) {
+	t.Helper()
+	blob := bytes.Repeat([]byte{0xAB}, blobLen)
 	rec, deleted, res, err := applyRecordBytes(nil, &wire.OperateArgs{
 		Create: wire.OperateCreateDynamic,
 		Ops: []wire.OperateOp{
@@ -74,21 +104,37 @@ func TestOperateRetBytesBudgetRefusesAmplifiedReturns(t *testing.T) {
 	}
 }
 
-// The boundary: the largest return list that fits the budget still returns
-// every value intact, and one more identical spec is refused. Both counts are
-// derived from the constants, so widening either cap keeps the test honest.
+// The boundary, tested at EQUALITY rather than near it: a return list whose
+// bytes come to exactly wire.OperateMaxRetBytes is accepted with every value
+// intact, and one more identical spec is refused.
+//
+// Equality is the case worth pinning. A floored count would leave the accepted
+// call short of the cap, and an off-by-one that wrongly rejected an exactly-full
+// budget would sail through. So the record is sized so its VALUE divides the
+// budget exactly (4096 bytes into 16,711,680 = 4080 specs, inside the 4096
+// count cap) and the test FAILS LOUDLY if that stops holding, rather than
+// quietly falling back to a floor.
 func TestOperateRetBytesBudgetBoundary(t *testing.T) {
-	rec, valLen := retBudgetRecord(t)
-	fits := wire.OperateMaxRetBytes / valLen
-	if fits < 2 || fits > wire.OperateMaxRet {
-		t.Fatalf("budget %d / value %d = %d specs, which is not inside the count cap %d — the test needs a different record size",
-			wire.OperateMaxRetBytes, valLen, fits, wire.OperateMaxRet)
+	const valueSize = 4096
+	if wire.OperateMaxRetBytes%valueSize != 0 {
+		t.Fatalf("budget %d is no longer a multiple of %d, so this test can no longer hit the cap exactly — pick a value size that divides it",
+			wire.OperateMaxRetBytes, valueSize)
 	}
+	fits := wire.OperateMaxRetBytes / valueSize
+	if fits < 2 || fits > wire.OperateMaxRet {
+		t.Fatalf("budget %d / value %d = %d specs, which is not inside the count cap %d — the test needs a different value size",
+			wire.OperateMaxRetBytes, valueSize, fits, wire.OperateMaxRet)
+	}
+	rec, valLen := retBudgetRecordOfValueLen(t, valueSize)
 
 	_, _, res, err := applyRecordBytes(rec, &wire.OperateArgs{
 		Create: wire.OperateCreateNone, Rets: recordValueRets(fits)}, 0)
 	if err != nil {
-		t.Fatalf("%d rets (%d bytes, budget %d): %v", fits, fits*valLen, wire.OperateMaxRetBytes, err)
+		t.Fatalf("%d rets totalling exactly the budget (%d bytes): %v", fits, fits*valLen, err)
+	}
+	if fits*valLen != wire.OperateMaxRetBytes {
+		t.Fatalf("the accepted call produced %d bytes, not the budget's %d — this is meant to be the exactly-full case",
+			fits*valLen, wire.OperateMaxRetBytes)
 	}
 	if res.Status != wire.OperateStatusOK || len(res.Values) != fits {
 		t.Fatalf("status=%d values=%d, want OK and %d", res.Status, len(res.Values), fits)

--- a/sdk/wire/operate.go
+++ b/sdk/wire/operate.go
@@ -42,6 +42,26 @@ func IsOperateArgsMessage(s string) bool {
 	return s == ErrOperateArgs.Error()
 }
 
+// IsOperateCapMessage reports whether s is the EXACT serialised form of an
+// ErrOperateCap error. It is IsOperateArgsMessage's twin, for the same
+// boundary and by the same rule: a KV operate decodes AND applies inside the
+// FSM apply, so on a cluster a cap refusal comes back through
+// shard.decodePBResult rebuilt with errors.New, errors.Is identity is gone,
+// and a sentinel-only classifier redacts "you asked for more than the caps
+// allow" to "internal error".
+//
+// ErrOperateCap's text is fixed, with nothing interpolated into it and no
+// server-side site wrapping it: every producer — the wire codecs here, the
+// cell and math helpers, and every guard in ops (the op/ret count caps, the
+// return byte budget, the record-size backstop, and the engines' row, column
+// and width checks) — returns it bare. So exact equality is the whole
+// matcher. It is deliberately not a strings.Contains: a bare substring check
+// would make any internal fault that merely mentions the sentinel text
+// client-facing.
+func IsOperateCapMessage(s string) bool {
+	return s == ErrOperateCap.Error()
+}
+
 // OperateSeg addresses one hop of an OperatePath (design doc §2.4/§3.5): a
 // field or column identified by its schema position, or, for a record that
 // stores names, by name.

--- a/sdk/wire/operate_const.go
+++ b/sdk/wire/operate_const.go
@@ -227,12 +227,31 @@ const (
 	// not: a return spec is a few bytes on the wire, but a record-kind VALUE
 	// copies the whole record, so a return list at the count cap can ask for
 	// OperateMaxRet * maxRecordBytes of live copies from a request of a few
-	// kilobytes. It is the same order as server.MaxFrameSize, so a reply above
-	// this could not be framed back to the caller whatever the engine built —
-	// the bytes would only be materialised to be thrown away. Charging it as
-	// the returns are evaluated is what makes the refusal happen BEFORE that,
-	// rather than after the memory is already spent.
-	OperateMaxRetBytes = 16 << 20
+	// kilobytes. Charging the bytes as the returns are evaluated is what makes
+	// the refusal happen before the whole list is materialised, rather than
+	// after the memory is already spent.
+	//
+	// It is server.MaxFrameSize (16 MiB) MINUS room for everything that rides
+	// around the values in the reply, so that a call this cap ACCEPTS is one
+	// the transport can actually send. A budget of exactly MaxFrameSize would
+	// make the largest accepted call die at the edge as "response exceeds
+	// MaxFrameSize" instead of here, which is the same refusal arriving later
+	// and less usefully. What has to fit alongside the values:
+	//
+	//	5                    the response frame's own status + payloadLen
+	//	                     (server.clampResponse bounds 1+4+len(payload))
+	//	5 + 4*OperateMaxRet  the result envelope AppendOperateResult writes:
+	//	                     status, nRet, the CHECK_FAILED-only failedOp, and
+	//	                     a 4-byte length per value = 16,389 at the cap
+	//	13                   EncodeVectorOperateResult's wrapper on the vector
+	//	                     path: found, an inner length, a trailing version
+	//
+	// 16,407 bytes at the worst case, rounded up to a flat 64 KiB so the number
+	// stays legible and the caps above can move without re-deriving it.
+	// server.TestOperateRetBudgetFramesWithinMaxFrameSize encodes a reply at
+	// exactly this budget and pins that it frames, so the two constants cannot
+	// drift apart silently.
+	OperateMaxRetBytes = 16<<20 - 64<<10
 )
 
 // Errors returned by the operate wire codec and, downstream, its apply engine.

--- a/sdk/wire/operate_const.go
+++ b/sdk/wire/operate_const.go
@@ -222,6 +222,17 @@ const (
 	// OperateMaxRet bounds a call's return-spec list, and with it the value
 	// count a result frame may carry; it bounds CPU per apply.
 	OperateMaxRet = 4096
+	// OperateMaxRetBytes bounds the TOTAL bytes a call's returns may produce,
+	// across the whole list rather than per value. OperateMaxRet alone does
+	// not: a return spec is a few bytes on the wire, but a record-kind VALUE
+	// copies the whole record, so a return list at the count cap can ask for
+	// OperateMaxRet * maxRecordBytes of live copies from a request of a few
+	// kilobytes. It is the same order as server.MaxFrameSize, so a reply above
+	// this could not be framed back to the caller whatever the engine built —
+	// the bytes would only be materialised to be thrown away. Charging it as
+	// the returns are evaluated is what makes the refusal happen BEFORE that,
+	// rather than after the memory is already spent.
+	OperateMaxRetBytes = 16 << 20
 )
 
 // Errors returned by the operate wire codec and, downstream, its apply engine.

--- a/server/handlers.go
+++ b/server/handlers.go
@@ -299,7 +299,16 @@ func clientFacingErr(err error) bool {
 		wire.IsOperateArgsMessage(err.Error()),
 		errors.Is(err, wire.ErrOperateArgs),
 		wire.IsVectorArgsTruncatedMessage(err.Error()),
-		errors.Is(err, wire.ErrVectorArgsTruncated):
+		errors.Is(err, wire.ErrVectorArgsTruncated),
+		// wire.ErrOperateCap: an operate call refused for exceeding one of the
+		// call-shape caps — too many ops, too many return specs, or returns
+		// that would produce more bytes than OperateMaxRetBytes. Every one of
+		// those is a fact about the request the caller itself built, with an
+		// obvious remedy (ask for less), and the message names only "a cap was
+		// exceeded" — no key, no path, no size. Same bucket and same reasoning
+		// as the malformed frame above; unclassified, a caller asking for too
+		// much read back as a server fault.
+		errors.Is(err, wire.ErrOperateCap):
 		return true
 	case errors.Is(err, ops.ErrOperateDuringReshard),
 		// ops.ErrOperateDuringReshard: a vector_operate against a collection a

--- a/server/handlers.go
+++ b/server/handlers.go
@@ -301,14 +301,25 @@ func clientFacingErr(err error) bool {
 		wire.IsVectorArgsTruncatedMessage(err.Error()),
 		errors.Is(err, wire.ErrVectorArgsTruncated),
 		// wire.ErrOperateCap: an operate call refused for exceeding one of the
-		// call-shape caps — too many ops, too many return specs, or returns
-		// that would produce more bytes than OperateMaxRetBytes. Every one of
-		// those is a fact about the request the caller itself built, with an
-		// obvious remedy (ask for less), and the message names only "a cap was
+		// design doc §2.7 caps — too many ops, too many return specs, returns
+		// that would produce more bytes than OperateMaxRetBytes, or a record
+		// the call would grow past the size backstop. Every one of those is a
+		// fact about the request the caller itself built, with an obvious
+		// remedy (ask for less), and the message names only "a cap was
 		// exceeded" — no key, no path, no size. Same bucket and same reasoning
 		// as the malformed frame above; unclassified, a caller asking for too
 		// much read back as a server fault.
-		errors.Is(err, wire.ErrOperateCap):
+		//
+		// Sentinel AND exact message shape, both arms load-bearing, for exactly
+		// the reason spelled out above — and MORE so than for ErrOperateArgs. A
+		// KV operate does not merely decode inside the FSM apply, it APPLIES
+		// there, so every cap the engine enforces (not just the frame-level
+		// ones) is raised behind shard.decodePBResult and reaches this
+		// classifier rebuilt with errors.New. On a cluster the sentinel arm
+		// covers almost none of them. wire.IsOperateCapMessage, not
+		// strings.Contains, for the usual reason.
+		errors.Is(err, wire.ErrOperateCap),
+		wire.IsOperateCapMessage(err.Error()):
 		return true
 	case errors.Is(err, ops.ErrOperateDuringReshard),
 		// ops.ErrOperateDuringReshard: a vector_operate against a collection a

--- a/server/operate_ret_budget_frame_test.go
+++ b/server/operate_ret_budget_frame_test.go
@@ -1,0 +1,100 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package server
+
+// The cross-package invariant between wire.OperateMaxRetBytes and
+// MaxFrameSize: a return list the operate byte budget ACCEPTS must encode to a
+// reply this transport can actually send.
+//
+// The two constants live in different packages and neither can reference the
+// other — wire is below server, and ops (which enforces the budget) must not
+// import server at all — so nothing but a test holds them together. Without
+// this, the budget could be raised to exactly MaxFrameSize again and the
+// largest accepted call would die at the edge as "response exceeds
+// MaxFrameSize": the same refusal, arriving after the work instead of before
+// it, and naming the wrong cause.
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/rostamlabs/rostam/sdk/wire"
+)
+
+// budgetFullResult is an OperateResult carrying exactly wire.OperateMaxRetBytes
+// of values, spread over as many 4096-byte entries as that divides into — the
+// same shape ops.TestOperateRetBytesBudgetBoundary pins as the largest accepted
+// call.
+func budgetFullResult(t *testing.T, status uint8) *wire.OperateResult {
+	t.Helper()
+	const valueSize = 4096
+	if wire.OperateMaxRetBytes%valueSize != 0 {
+		t.Fatalf("budget %d is no longer a multiple of %d", wire.OperateMaxRetBytes, valueSize)
+	}
+	n := wire.OperateMaxRetBytes / valueSize
+	if n > wire.OperateMaxRet {
+		t.Fatalf("%d values is past the count cap %d", n, wire.OperateMaxRet)
+	}
+	one := bytes.Repeat([]byte{0xCD}, valueSize)
+	vals := make([][]byte, n)
+	for i := range vals {
+		vals[i] = one
+	}
+	// FailedOp is only written for CHECK_FAILED, which is the point of running
+	// this for both statuses: that shape is two bytes longer.
+	return &wire.OperateResult{Status: status, FailedOp: 7, Values: vals}
+}
+
+// TestOperateRetBudgetFramesWithinMaxFrameSize is the guard the
+// wire.OperateMaxRetBytes doc comment names. A reply at exactly the budget must
+// survive clampResponse untouched, on both result statuses and on the vector
+// wrapper, which adds a further 13 bytes.
+func TestOperateRetBudgetFramesWithinMaxFrameSize(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		status uint8
+	}{
+		{"OK", wire.OperateStatusOK},
+		// CHECK_FAILED writes the extra failedOp field, so it is the larger of
+		// the two envelopes and the one the headroom has to cover.
+		{"CHECK_FAILED (carries failedOp)", wire.OperateStatusCheckFailed},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			payload, err := wire.EncodeOperateResult(budgetFullResult(t, tc.status))
+			if err != nil {
+				t.Fatalf("EncodeOperateResult: %v", err)
+			}
+			assertFrames(t, "operate", payload)
+
+			vpayload, err := wire.EncodeVectorOperateResult(true, budgetFullResult(t, tc.status), 1)
+			if err != nil {
+				t.Fatalf("EncodeVectorOperateResult: %v", err)
+			}
+			if len(vpayload) <= len(payload) {
+				t.Fatalf("the vector wrapper should be the larger frame: %d vs %d", len(vpayload), len(payload))
+			}
+			assertFrames(t, "vector_operate", vpayload)
+		})
+	}
+}
+
+// assertFrames pins that clampResponse passes payload through unchanged. It
+// reports the headroom left either way, because that number is the whole
+// subject: a failure here means the budget and the frame limit have drifted
+// into each other, and the margin says by how much.
+func assertFrames(t *testing.T, what string, payload []byte) {
+	t.Helper()
+	frame := 1 + 4 + len(payload) // exactly what clampResponse bounds
+	gotStatus, gotPayload := clampResponse(StatusOK, payload)
+	if gotStatus != StatusOK {
+		msg, _ := DecodeErrorPayload(gotPayload)
+		t.Fatalf("%s reply at exactly the %d-byte return budget did not frame: %q\n"+
+			"  frame %d > MaxFrameSize %d, over by %d — wire.OperateMaxRetBytes and server.MaxFrameSize have drifted",
+			what, wire.OperateMaxRetBytes, msg, frame, MaxFrameSize, frame-MaxFrameSize)
+	}
+	if len(gotPayload) != len(payload) {
+		t.Fatalf("%s: clampResponse rewrote the payload (%d bytes to %d)", what, len(payload), len(gotPayload))
+	}
+	t.Logf("%s reply at the full return budget: %d-byte frame, %d bytes of MaxFrameSize headroom left",
+		what, frame, MaxFrameSize-frame)
+}

--- a/server/redaction_test.go
+++ b/server/redaction_test.go
@@ -540,6 +540,70 @@ func TestMapResultTruncatedOperateFrameIsClientFacing(t *testing.T) {
 	})
 }
 
+// TestMapResultOperateCapIsClientFacing pins the design doc §2.7 cap refusal
+// as the caller's own request shape. wire.ErrOperateCap is what every cap
+// raises — too many ops, too many return specs, returns over the byte budget
+// (OperateMaxRetBytes), a record the call would grow past the size backstop,
+// and the engines' row/column/width checks. Each names nothing but "a cap was
+// exceeded", and each has the same remedy: ask for less. Unclassified, a
+// caller that had simply asked for too much was told the server had faulted,
+// with nothing left to act on.
+//
+// The message-shape arm carries more weight here than it does for
+// ErrOperateArgs. A KV operate does not merely decode inside the FSM apply, it
+// APPLIES there, so every cap the ENGINE enforces is raised behind
+// shard.decodePBResult and reaches this classifier rebuilt with errors.New. On
+// a cluster the sentinel arm sees almost none of them.
+func TestMapResultOperateCapIsClientFacing(t *testing.T) {
+	disp := &fakeDispatcher{}
+	// A real production shape, not a hand-written sentinel: a call whose return
+	// list is one spec past OperateMaxRet, which AppendOperateArgs refuses.
+	_, encErr := wire.EncodeOperateArgs(&wire.OperateArgs{
+		Rets: make([]wire.OperateRet, wire.OperateMaxRet+1),
+	})
+	if !errors.Is(encErr, wire.ErrOperateCap) {
+		t.Fatalf("codec fixture drifted: err = %v, want wire.ErrOperateCap", encErr)
+	}
+	for _, tc := range []struct {
+		name string
+		err  error
+	}{
+		{"sentinel", wire.ErrOperateCap},
+		{"wrapped (%w, exercises errors.Is identity)", fmt.Errorf("operate: %w", wire.ErrOperateCap)},
+		{"as the codec actually returns it", encErr},
+		// The clustered shape, and the one the sentinel arm cannot reach — the
+		// COMMON one for this sentinel, per the note above.
+		{"stringified across Raft, real bare shape", errors.New(wire.ErrOperateCap.Error())},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			status, payload := mapResult(disp, nil, tc.err, "")
+			if status != StatusError {
+				t.Fatalf("status = %d, want StatusError (%d)", status, StatusError)
+			}
+			msg, _ := DecodeErrorPayload(payload)
+			if msg == "internal error" {
+				t.Fatalf("a cap refusal was redacted to %q — the caller's own request shape reads as a server fault", msg)
+			}
+			if msg != tc.err.Error() {
+				t.Fatalf("payload = %q, want the verbatim message %q", msg, tc.err.Error())
+			}
+		})
+	}
+	// Negative control: an unrelated internal fault that merely mentions the
+	// sentinel text must STAY redacted. This is what an exact-equality matcher
+	// buys over a strings.Contains arm.
+	t.Run("negative/unrelated fault wrapping the sentinel with a foreign prefix", func(t *testing.T) {
+		err := errors.New("apply: " + wire.ErrOperateCap.Error())
+		status, payload := mapResult(disp, nil, err, "")
+		if status != StatusError {
+			t.Fatalf("status = %d, want StatusError (%d)", status, StatusError)
+		}
+		if msg, _ := DecodeErrorPayload(payload); msg != "internal error" {
+			t.Fatalf("payload = %q, want the redacted message", msg)
+		}
+	})
+}
+
 // The kv_query refusals must cross the TCP edge unredacted.
 //
 // This edge is not only the client's: a kv_query fans out to every shard group,


### PR DESCRIPTION
`operate` capped its return-spec list by **count** only (`OperateMaxRet`, 4096) and by nothing at all in **bytes**. A return spec is a few bytes on the wire, but a record-kind `VALUE` copies the whole record per spec, and every copy is held live in one `[][]byte` until the call finishes.

Measured on main: an **8,210-byte request** carrying 4096 record-value rets against a 64 KiB record returned 256 MiB of values and allocated **288 MiB of heap** — a 32,701x amplification. Records are capped at 16 MiB, so the worst case is ~64 GiB: an OOM kill from one small request. None of it could ever reach the caller either — `MaxFrameSize` is 16 MiB, so a reply that large fails to frame whatever the engine built. The memory was spent purely to be thrown away.

`vector_operate` drives the same `applyRecordBytes`, so it had the same exposure.

## The fix

`wire.OperateMaxRetBytes` (16 MiB, the same order as `MaxFrameSize`) bounds the total, and `evalRets` charges each value against it **inside the loop**, as the values are produced. The placement is the fix, not the constant: a pre-pass that predicted sizes, or a check after the fact, would still let the whole list be materialised first. Charged in the loop, a refused call peaks at the budget plus the single value that crossed it — never 4096 records. Both entries into `evalRets` are covered: the success path and the `CHECK_FAILED` path that re-evaluates the rets against the pre-call record.

Measured after: **19 MB** for the same attack shape.

## Classification

`wire.ErrOperateCap` was absent from all three classifiers, so every cap refusal — too many ops, too many rets, and now too many returned bytes — reached the caller redacted as `internal error`. It now has a sentinel arm and an exact-form message-shape arm (`wire.IsOperateCapMessage`, never `strings.Contains`) at each edge: `clientFacingErr` (TCP), `statusForError` (400), `grpcError` (`InvalidArgument`). The message-shape arm is what makes it work on a cluster: a KV operate decodes inside the FSM apply, and `shard.decodePBResult` rebuilds the error with `errors.New`, so `errors.Is` stops matching across that boundary — the same reason the neighbouring `ErrOperateArgs` arm carries one. The matcher is exact equality because all 40 producers of `ErrOperateCap` return it bare, with no `%w` wrap anywhere in the tree.

## Tests

- `TestOperateRetBytesBudgetRefusesAmplifiedReturns` — the headline shape.
- `TestOperateRetBytesBudgetBoundary` — the count that exactly fills the budget succeeds with every value intact; one more is refused. Counts derived from the constants, not hard-coded.
- `TestOperateRetBytesBudgetBoundsPeakAllocation` — heap delta around the refused call, bounded by budget + one record. Skipped under `-race` per the package convention.
- `TestOperateRetBytesBudgetOnCheckFailed` — the abort path refuses identically, with a control proving the refusal is the budget and not the abort.
- One classification test per edge (`server`, `httpapi`, `grpcapi`), each covering the sentinel, a `%w` wrap, the shape the codec really returns, and the stringified-across-Raft form, plus a foreign-prefix negative control.

Each behavioural test was verified to fail with the guard disabled.

## Gates

`gofmt -l`, `go build ./...`, `go vet ./...`, `go test ./ops/... ./sdk/... ./server/ ./httpapi/ ./grpcapi/`, and `GOARCH=386 go test ./sdk/wire/ ./ops/` — all clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
`operate` now charges a byte budget (`OperateMaxRetBytes`, 16,711,680 B) against the total bytes its returns produce, charged inside the loop as values are built, so a call that would cross it is refused before the full list is materialised. `wire.ErrOperateCap` is now classified at every transport edge, so cap refusals reach callers as a 400 / `InvalidArgument` instead of a redacted `internal error`.

- Before, only the return count was capped; a ~8 KB request for 4096 record values returned 256 MiB (worst case ~64 GiB) that could never fit in a frame anyway.
- The budget is 16 MiB less a flat 64 KiB for the reply's own framing and envelope, so the largest accepted call still fits `MaxFrameSize`; at exactly 16 MiB it would pass apply and then fail at the transport.
- A refused call peaks at the budget plus the single value that crossed it — never the whole list — on both the success path and the `CHECK_FAILED` path.
- `vector_operate` drives the same apply path and gets the same bound.
- Behavior change: calls whose returns exceed the budget now fail with the record unchanged instead of materialising gigabytes and then failing to frame the reply.

**Error classification**

- Too many ops, too many rets, or too many returned bytes now map to client-facing (TCP), 400 (REST), and `InvalidArgument` (gRPC), matching the existing malformed-operate-frame bucket.
- The sentinel is also matched by exact message shape, because a clustered operate applies inside the Raft FSM and errors rebuilt there with `errors.New` lose `errors.Is` identity.
- Exact-equality matching keeps unrelated internal faults that merely mention the text redacted.

<sup>Written for commit ae79994415c9524dacc82b39d965fdb638d72eae. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rostamlabs/rostam/pull/122?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Limited total `operate` return data to 16 MiB per call.
  - Oversized results are rejected before being fully materialized.
  - Added consistent client-facing error handling for cap violations across binary, HTTP, and gRPC interfaces.

- **Documentation**
  - Documented the new 16 MiB return-data limit in the key-value operation limits table.

- **Bug Fixes**
  - Cap violations now return clear client errors instead of being incorrectly reported as internal server failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->