### PR TITLE
feat(kv): expose how many keys a node holds

### DIFF
--- a/cache/shard.go
+++ b/cache/shard.go
@@ -1029,6 +1029,7 @@ func (s *shard) snapshot() Stats {
 	// always bumped first), never underflowing the subtraction.
 	misses := s.misses.Load()
 	gets := s.gets.Load()
+	live, tomb := s.entries()
 	return Stats{
 		Gets:             gets,
 		Hits:             gets - misses,
@@ -1042,6 +1043,8 @@ func (s *shard) snapshot() Stats {
 		PagesAllocated:   s.pagesAlloc.Load(),
 		BytesAllocated:   uint64(s.numPages()) * uint64(s.cfg.PageSize), //nolint:gosec // numPages and PageSize are always non-negative
 		BytesUsed:        s.bytesUsed(),
+		Entries:          live,
+		Tombstones:       tomb,
 		CorruptionErrors: s.corrupt.Load(),
 
 		Compactions:              s.compactions.Load(),
@@ -1055,6 +1058,19 @@ func (s *shard) snapshot() Stats {
 		OnlinePagesRetired:   s.relocatePagesGone.Load(),
 		OnlinePagesRecycled:  s.relocatePagesRecycled.Load(),
 	}
+}
+
+// entries reports the index's occupied and tombstoned slot counts. Both are
+// writer-only bookkeeping guarded by s.mu, so this takes the read lock the same
+// way bytesUsed does; it is a pair of int reads, not a walk.
+//
+// The table pointer is swapped atomically on rehash, and a rehash is a writer,
+// so holding the read lock is also what makes the Load stable for the duration.
+func (s *shard) entries() (live, tomb uint64) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	t := s.tab.Load()
+	return uint64(t.live), uint64(t.tomb) //nolint:gosec // both are non-negative slot counts
 }
 
 func (s *shard) bytesUsed() uint64 {

--- a/cache/stats.go
+++ b/cache/stats.go
@@ -28,11 +28,20 @@ type Stats struct {
 	// EvictionsLive is the one to watch to decide whether a cache is sized for
 	// its working set. EvictionsLive > 0 with Expirations low means the budget,
 	// not the TTL, is deciding how long entries survive.
-	EvictionsLive    uint64
-	Rejects          uint64 // refused due to PolicyRejectWrites
-	PagesAllocated   uint64
-	BytesAllocated   uint64
-	BytesUsed        uint64
+	EvictionsLive  uint64
+	Rejects        uint64 // refused due to PolicyRejectWrites
+	PagesAllocated uint64
+	BytesAllocated uint64
+	BytesUsed      uint64
+	// Entries is the number of keys the index currently holds, and Tombstones
+	// the deleted-but-not-yet-reclaimed slots beside them. Entries is the only
+	// way to answer "how many keys fit in this budget": every other gauge here
+	// is bytes, and bytes_used mixes live records with superseded copies. It
+	// cannot be derived from the counters either -- misses tracks distinct keys
+	// only until the first eviction, after which an evicted key that returns
+	// misses again.
+	Entries          uint64
+	Tombstones       uint64
 	CorruptionErrors uint64 // CRC mismatches on read
 
 	// Cold compaction at shard open (mmap only; cache/compact.go). These are the
@@ -97,6 +106,8 @@ func (s *Stats) Add(o Stats) {
 	s.PagesAllocated += o.PagesAllocated
 	s.BytesAllocated += o.BytesAllocated
 	s.BytesUsed += o.BytesUsed
+	s.Entries += o.Entries
+	s.Tombstones += o.Tombstones
 	s.CorruptionErrors += o.CorruptionErrors
 	s.Compactions += o.Compactions
 	s.CompactionsAborted += o.CompactionsAborted
@@ -149,6 +160,8 @@ func (s Stats) WritePrometheus(w io.Writer) error {
 		{"rostam_kv_pages_allocated", "cache pages currently allocated", s.PagesAllocated},
 		{"rostam_kv_bytes_allocated", "bytes backing those pages", s.BytesAllocated},
 		{"rostam_kv_bytes_used", "bytes occupied by entries in resident pages, INCLUDING superseded and expired entries not yet reclaimed - occupancy, not live data", s.BytesUsed},
+		{"rostam_kv_entries", "keys currently held in the index - divide bytes_used by this for the real average key size, and use it as the denominator the eviction counters lack", s.Entries},
+		{"rostam_kv_tombstones", "index slots holding a deleted key that has not been reclaimed; a large share of entries means the index wants compacting", s.Tombstones},
 		{"rostam_kv_reclaimable_bytes", "page bytes held by entries no longer reachable", s.ReclaimableBytes},
 	}
 

--- a/cache/stats.go
+++ b/cache/stats.go
@@ -12,8 +12,10 @@ import (
 // Puts, Evictions, the Compaction* totals, …); sample and diff them for rates. The
 // exceptions are point-in-time GAUGES that RISE and FALL and must NOT be diffed as
 // counters (a decrease is not wraparound): PagesAllocated, BytesAllocated and BytesUsed
-// report current capacity/occupancy, and ReclaimableBytes reports current ghost-byte
-// pressure (which compaction actively drives back down).
+// report current capacity/occupancy, ReclaimableBytes reports current ghost-byte
+// pressure (which compaction actively drives back down), and Entries/Tombstones report
+// the index's current occupancy (both fall on delete, and Tombstones falls again when
+// a rehash reclaims the slots).
 type Stats struct {
 	Gets        uint64
 	Hits        uint64
@@ -36,10 +38,16 @@ type Stats struct {
 	// Entries is the number of keys the index currently holds, and Tombstones
 	// the deleted-but-not-yet-reclaimed slots beside them. Entries is the only
 	// way to answer "how many keys fit in this budget": every other gauge here
-	// is bytes, and bytes_used mixes live records with superseded copies. It
-	// cannot be derived from the counters either -- misses tracks distinct keys
-	// only until the first eviction, after which an evicted key that returns
-	// misses again.
+	// is bytes. It cannot be derived from the counters either -- misses tracks
+	// distinct keys only until the first eviction, after which an evicted key
+	// that returns misses again.
+	//
+	// BytesUsed/Entries is occupancy per indexed key, NOT the size of a record:
+	// BytesUsed counts superseded and expired copies too, so overwriting one key
+	// repeatedly raises the ratio while the record itself is unchanged. That is
+	// the right figure to divide a memory budget by -- the dead copies occupy
+	// the budget as surely as the live ones -- but it is not an average record
+	// size, and a dashboard should not label it one.
 	Entries          uint64
 	Tombstones       uint64
 	CorruptionErrors uint64 // CRC mismatches on read
@@ -160,7 +168,7 @@ func (s Stats) WritePrometheus(w io.Writer) error {
 		{"rostam_kv_pages_allocated", "cache pages currently allocated", s.PagesAllocated},
 		{"rostam_kv_bytes_allocated", "bytes backing those pages", s.BytesAllocated},
 		{"rostam_kv_bytes_used", "bytes occupied by entries in resident pages, INCLUDING superseded and expired entries not yet reclaimed - occupancy, not live data", s.BytesUsed},
-		{"rostam_kv_entries", "keys currently held in the index - divide bytes_used by this for the real average key size, and use it as the denominator the eviction counters lack", s.Entries},
+		{"rostam_kv_entries", "keys currently held in the index - the denominator the eviction counters lack, and what to divide a memory budget by; bytes_used/entries is occupancy per key INCLUDING superseded copies, not the size of one record", s.Entries},
 		{"rostam_kv_tombstones", "index slots holding a deleted key that has not been reclaimed; a large share of entries means the index wants compacting", s.Tombstones},
 		{"rostam_kv_reclaimable_bytes", "page bytes held by entries no longer reachable", s.ReclaimableBytes},
 	}

--- a/cache/stats.go
+++ b/cache/stats.go
@@ -42,12 +42,13 @@ type Stats struct {
 	// distinct keys only until the first eviction, after which an evicted key
 	// that returns misses again.
 	//
-	// BytesUsed/Entries is occupancy per indexed key, NOT the size of a record:
-	// BytesUsed counts superseded and expired copies too, so overwriting one key
-	// repeatedly raises the ratio while the record itself is unchanged. That is
-	// the right figure to divide a memory budget by -- the dead copies occupy
-	// the budget as surely as the live ones -- but it is not an average record
-	// size, and a dashboard should not label it one.
+	// BytesUsed/Entries is occupancy per indexed key, NOT the size of a record.
+	// BytesUsed counts every byte no live key owns: superseded copies, expired
+	// entries not yet swept, and the ghost bytes behind deleted slots. So
+	// overwriting, expiry and deletion each raise the ratio while the records
+	// are unchanged. It is the right figure to divide a memory budget by, since
+	// all of that occupies the budget, but a dashboard must not label it an
+	// average record size.
 	Entries          uint64
 	Tombstones       uint64
 	CorruptionErrors uint64 // CRC mismatches on read
@@ -168,7 +169,7 @@ func (s Stats) WritePrometheus(w io.Writer) error {
 		{"rostam_kv_pages_allocated", "cache pages currently allocated", s.PagesAllocated},
 		{"rostam_kv_bytes_allocated", "bytes backing those pages", s.BytesAllocated},
 		{"rostam_kv_bytes_used", "bytes occupied by entries in resident pages, INCLUDING superseded and expired entries not yet reclaimed - occupancy, not live data", s.BytesUsed},
-		{"rostam_kv_entries", "keys currently held in the index - the denominator the eviction counters lack, and what to divide a memory budget by; bytes_used/entries is occupancy per key INCLUDING superseded copies, not the size of one record", s.Entries},
+		{"rostam_kv_entries", "keys currently held in the index - the denominator the eviction counters lack, and what to divide a memory budget by; bytes_used/entries is occupancy per key INCLUDING superseded, expired and deleted-but-unreclaimed bytes, not the size of one record", s.Entries},
 		{"rostam_kv_tombstones", "index slots holding a deleted key that has not been reclaimed; a large share of entries means the index wants compacting", s.Tombstones},
 		{"rostam_kv_reclaimable_bytes", "page bytes held by entries no longer reachable", s.ReclaimableBytes},
 	}

--- a/cache/stats_kv_test.go
+++ b/cache/stats_kv_test.go
@@ -152,3 +152,57 @@ func TestEvictionsLiveExcludesExpiredEntries(t *testing.T) {
 			grew, st.Evictions)
 	}
 }
+
+// Entries must track the live key count through the operations that change it,
+// not merely be non-zero: it is the only gauge that answers "how many keys fit
+// in this budget", and it is the one figure that cannot be derived from the
+// counters once eviction starts.
+func TestEntriesTracksLiveKeys(t *testing.T) {
+	cfg := DefaultConfig()
+	cfg.NumShards = 2
+	cfg.TTLSweepIntervalMs = 0
+	c, err := New(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = c.Close() }()
+
+	if got := c.Stats().Entries; got != 0 {
+		t.Errorf("fresh cache has %d entries, want 0", got)
+	}
+
+	const n = 300
+	for i := range n {
+		if err := c.Put(fmt.Appendf(nil, "k-%04d", i), []byte("v"), 0); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if got := c.Stats().Entries; got != n {
+		t.Errorf("after %d distinct puts, entries = %d, want %d", n, got, n)
+	}
+
+	// Overwrites are not new keys.
+	for i := range n {
+		if err := c.Put(fmt.Appendf(nil, "k-%04d", i), []byte("vv"), 0); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if got := c.Stats().Entries; got != n {
+		t.Errorf("after overwriting every key, entries = %d, want %d (overwrites are not new keys)", got, n)
+	}
+
+	// A delete removes a key and leaves a tombstone behind.
+	const del = 50
+	for i := range del {
+		if _, err := c.Del(fmt.Appendf(nil, "k-%04d", i)); err != nil {
+			t.Fatal(err)
+		}
+	}
+	st := c.Stats()
+	if st.Entries != n-del {
+		t.Errorf("after %d deletes, entries = %d, want %d", del, st.Entries, n-del)
+	}
+	if st.Tombstones == 0 {
+		t.Error("deletes left no tombstones; the gauge cannot show when the index wants compacting")
+	}
+}

--- a/cache/stats_kv_test.go
+++ b/cache/stats_kv_test.go
@@ -202,7 +202,10 @@ func TestEntriesTracksLiveKeys(t *testing.T) {
 	if st.Entries != n-del {
 		t.Errorf("after %d deletes, entries = %d, want %d", del, st.Entries, n-del)
 	}
-	if st.Tombstones == 0 {
-		t.Error("deletes left no tombstones; the gauge cannot show when the index wants compacting")
+	// Exactly del: each delete removes a distinct present key and nothing here
+	// rehashes the slots away. Checking only for non-zero would pass for any
+	// positive value, including one that mistakenly returned Entries.
+	if st.Tombstones != del {
+		t.Errorf("after %d distinct deletes, tombstones = %d, want exactly %d", del, st.Tombstones, del)
 	}
 }

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -49,9 +49,12 @@ Notable user-visible changes. Entries that alter existing behaviour are marked
   eviction, after which an evicted key that comes back misses again and the
   inference breaks; that is precisely when the question matters.
 
-  `bytes_used / entries` gives the real average key size (`bytes_used` alone
-  mixes live records with superseded copies), and `entries` is the denominator
-  the eviction counters previously lacked. `tombstones` counts deleted slots not
+  `entries` is the denominator the eviction counters previously lacked, and what
+  to divide a memory budget by. Note what the ratio is and is not:
+  `bytes_used / entries` is occupancy per indexed key INCLUDING the superseded
+  copies each key leaves behind — the right figure for sizing a budget, but not
+  an average record size, since overwriting one key repeatedly raises it while
+  the record is unchanged. `tombstones` counts deleted slots not
   yet reclaimed — a large share of `entries` means the index wants compacting.
 
   Both come from counters the index already maintains, read under the same lock

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -51,10 +51,12 @@ Notable user-visible changes. Entries that alter existing behaviour are marked
 
   `entries` is the denominator the eviction counters previously lacked, and what
   to divide a memory budget by. Note what the ratio is and is not:
-  `bytes_used / entries` is occupancy per indexed key INCLUDING the superseded
-  copies each key leaves behind — the right figure for sizing a budget, but not
-  an average record size, since overwriting one key repeatedly raises it while
-  the record is unchanged. `tombstones` counts deleted slots not
+  `bytes_used / entries` is occupancy per indexed key INCLUDING every byte no
+  live key owns — superseded copies, TTL-expired entries not yet swept, and the
+  ghost bytes of deleted slots. It is the right figure for sizing a budget,
+  since all of that occupies the budget, but it is not an average record size:
+  overwriting, expiry and deletion each raise it while the records themselves
+  are unchanged. `tombstones` counts deleted slots not
   yet reclaimed — a large share of `entries` means the index wants compacting.
 
   Both come from counters the index already maintains, read under the same lock

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -42,6 +42,21 @@ Notable user-visible changes. Entries that alter existing behaviour are marked
   CALL, not per key, so splitting an oversized read across several `operate`
   calls is the remedy.
 
+- **`rostam_kv_entries` and `rostam_kv_tombstones`: how many keys a node is
+  actually holding.** The KV metrics covered reads, writes, evictions and bytes,
+  but never the count of the thing being stored — so "how many keys fit in this
+  budget" had no answer. It could be inferred from `misses` only until the first
+  eviction, after which an evicted key that comes back misses again and the
+  inference breaks; that is precisely when the question matters.
+
+  `bytes_used / entries` gives the real average key size (`bytes_used` alone
+  mixes live records with superseded copies), and `entries` is the denominator
+  the eviction counters previously lacked. `tombstones` counts deleted slots not
+  yet reclaimed — a large share of `entries` means the index wants compacting.
+
+  Both come from counters the index already maintains, read under the same lock
+  `bytes_used` uses. No walk.
+
 - **`get` and `operate` can be served without allocating a reply at all.** The
   reply payload was the last per-call allocation on a KV node: `tx.Get` copies
   the stored value into a fresh slice for every read, and `operate` builds its


### PR DESCRIPTION
The KV metrics cover reads, writes, evictions and bytes — but never the count of the thing being stored. So "how many keys fit in this budget" has no answer from the endpoint.

It could be inferred from `misses` while nothing had been removed. That stops working at the first eviction: an evicted key that comes back misses again, and the inference silently becomes wrong. Which is exactly when the question gets asked.

## What this adds

| metric | |
|---|---|
| `rostam_kv_entries` | keys the index currently holds |
| `rostam_kv_tombstones` | deleted slots not yet reclaimed |

`bytes_used / entries` gives the real average key size — `bytes_used` on its own mixes live records with superseded copies, so it overstates per-key cost by whatever the overwrite ratio is. And `entries` is the denominator the eviction counters have always lacked: `evictions_live` is hard to act on without knowing the resident population it came from.

`tombstones` is one line more from the same source, and tells you when the index wants compacting.

## Cost

Both are counters `indexTable` already maintains (`live` / `tomb`), read under the same `s.mu.RLock()` that `bytesUsed` takes — a pair of `int` reads, not a walk. Holding that lock is also what makes the atomic table `Load` stable, since a rehash is a writer.

## Test

`TestEntriesTracksLiveKeys` pins the behaviour rather than non-emptiness:

- a fresh cache reads 0
- N distinct puts read N
- overwriting every key leaves it at N (overwrites are not new keys)
- deletes lower `entries` and raise `tombstones`

Checked by mutation: making `entries` count tombstones as well — the most plausible way to get this wrong — fails it with `entries = 300, want 250`. An earlier mutation that zeroed the field only broke the build, which proves nothing, so I used a value error instead.

`cache` and `ops` pass; `golangci-lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `rostam_kv_entries` and `rostam_kv_tombstones` so a KV node's live key count is observable. Previously it could only be inferred from `misses`, which silently breaks after the first eviction.

Both gauges come from counters the index already maintains, read under the same lock as `bytesUsed`; no walk. `entries` gives the eviction counters their missing denominator, and `bytes_used / entries` is occupancy per indexed key (including superseded copies, expired entries not yet swept, and the ghost bytes behind deleted slots) — not an average record size; overwriting, expiry, and deletion each raise it while the records are unchanged. `tombstones` shows when the index wants compacting.

**Tests**
- `TestEntriesTracksLiveKeys` pins behavior: a fresh cache reads 0, N distinct puts read N, overwrites keep it at N, deletes lower `entries` and raise `tombstones` by the exact delete count.

<sup>Written for commit 9800c9d5a7af37e32556318097f3c90070f212c4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rostamlabs/rostam/pull/123?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

