### PR TITLE
perf(backup): walk only the prefix's subtree in FSObjectStore.List

### DIFF
--- a/backup/fs.go
+++ b/backup/fs.go
@@ -157,18 +157,32 @@ func (f *FSObjectStore) Get(_ context.Context, key string) (io.ReadCloser, error
 	return file, nil
 }
 
-// List walks root and returns every object whose key begins with prefix (the
-// path relative to root, in forward-slash form), sorted by key. Directories are
-// not reported. A still-empty root yields no objects (nil), not an error.
+// List walks the subtree implied by prefix and returns every object whose key
+// begins with prefix (the path relative to root, in forward-slash form), sorted
+// by key. Directories are not reported. A still-empty root, or a prefix whose
+// directory does not exist yet, yields no objects (nil), not an error.
 //
-// NOTE: like the S3 store, List BUFFERS every matching key in memory (it walks
-// the whole tree and accumulates one ObjectInfo per file). This is bounded for
-// the backup/retention use (a handful of snapshots per collection prefix) but a
-// root holding millions of files will materialize them all at once; scope the
-// prefix narrowly for large trees.
+// The walk starts at the deepest directory the prefix fully names (for
+// "acme/col/2024-" that is <root>/acme/col), not at root: retention lists one
+// collection prefix per collection and per run, and an existence probe lists a
+// single key, so walking the whole root would make each backup run cost
+// O(collections × all stored files). The key-prefix filter is still applied to
+// every entry, so the result is identical to a full-root walk.
+//
+// NOTE: like the S3 store, List BUFFERS every matching key in memory (one
+// ObjectInfo per matching file). This is bounded for the backup/retention use
+// (a handful of snapshots per collection prefix) but a prefix spanning millions
+// of files will materialize them all at once; scope the prefix narrowly.
 func (f *FSObjectStore) List(_ context.Context, prefix string) ([]objstore.ObjectInfo, error) {
+	start := f.listStart(prefix)
+	if _, err := os.Stat(start); err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("fsstore: list %q: %w", prefix, err)
+	}
 	var out []objstore.ObjectInfo
-	err := filepath.WalkDir(f.root, func(p string, d fs.DirEntry, err error) error {
+	err := filepath.WalkDir(start, func(p string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return err
 		}
@@ -199,6 +213,28 @@ func (f *FSObjectStore) List(_ context.Context, prefix string) ([]objstore.Objec
 	}
 	sortInfosByKey(out)
 	return out, nil
+}
+
+// listStart returns the directory List should walk for prefix: <root> joined
+// with every COMPLETE "/"-separated segment of prefix (the trailing partial
+// segment, if any, is a name filter, not a directory). A prefix that would
+// escape root (".." segments) falls back to root itself, where the key-prefix
+// filter then matches nothing — never a path outside root.
+func (f *FSObjectStore) listStart(prefix string) string {
+	i := strings.LastIndex(prefix, "/")
+	if i < 0 {
+		return f.root
+	}
+	dir := filepath.Join(f.root, filepath.FromSlash(path.Clean("/"+prefix[:i])))
+	rootAbs, err := filepath.Abs(f.root)
+	if err != nil {
+		return f.root
+	}
+	dirAbs, err := filepath.Abs(dir)
+	if err != nil || (dirAbs != rootAbs && !strings.HasPrefix(dirAbs, rootAbs+string(os.PathSeparator))) {
+		return f.root
+	}
+	return dir
 }
 
 // Delete removes <root>/<key>. Deleting a missing key returns

--- a/backup/fs.go
+++ b/backup/fs.go
@@ -4,6 +4,7 @@ package backup
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"io/fs"
@@ -11,6 +12,7 @@ import (
 	"path"
 	"path/filepath"
 	"strings"
+	"syscall"
 
 	"github.com/rostamlabs/rostam/objstore"
 )
@@ -157,44 +159,72 @@ func (f *FSObjectStore) Get(_ context.Context, key string) (io.ReadCloser, error
 	return file, nil
 }
 
-// List walks the subtree implied by prefix and returns every object whose key
-// begins with prefix (the path relative to root, in forward-slash form), sorted
-// by key. Directories are not reported. A still-empty root, or a prefix whose
-// directory does not exist yet, yields no objects (nil), not an error.
+// List returns every object whose key begins with prefix (the path relative to
+// root, in forward-slash form), sorted by key. Directories are not reported.
 //
 // The walk starts at the deepest directory the prefix fully names (for
-// "acme/col/2024-" that is <root>/acme/col), not at root: retention lists one
+// "acme/col/2024-" that is acme/col), not at root: retention lists one
 // collection prefix per collection and per run, and an existence probe lists a
 // single key, so walking the whole root would make each backup run cost
 // O(collections × all stored files). The key-prefix filter is still applied to
-// every entry, so the result is identical to a full-root walk.
+// every entry, so the result is what a full-root walk filtered by prefix would
+// return.
+//
+// The walk runs inside os.Root, so it cannot leave root through a symlink: the
+// kernel-level check refuses a start path with a symlink in ANY component —
+// even one that stays inside root — rather than resolving it. A full-root walk
+// never descended into a symlink either, so nothing under one was ever
+// listable; the difference is that it stayed silent, whereas List now returns
+// an error. That is deliberate: a tenant directory an operator symlinked onto
+// another disk otherwise surfaces as "no snapshots" from LatestKey/RestoreLatest
+// and as a silent no-op from prune, when the truth is that List cannot see it.
+// path.Clean on the prefix is the only lexical defence and it is not relied on
+// for containment.
+//
+// Error semantics, matching MemStore.List (a pure prefix filter, which cannot
+// fail on the SHAPE of a prefix): a prefix whose directory does not exist yet,
+// or whose directory component names a plain file, or that contains a NUL
+// byte (no key can — keyToPath rejects it) yields no objects (nil), not an
+// error. A missing or unreadable ROOT is an error, as it always was: an
+// unmounted backup volume must not read as "no snapshots".
+//
+// On a case-insensitive filesystem (darwin, Windows) a prefix that differs
+// from the on-disk name only by case walks the directory and yields keys in the
+// prefix's case, where a full-root walk yielded the on-disk case and matched
+// nothing. No caller re-cases a prefix (tenants are validated, collections
+// escaped), so this is documented rather than defended.
 //
 // NOTE: like the S3 store, List BUFFERS every matching key in memory (one
 // ObjectInfo per matching file). This is bounded for the backup/retention use
 // (a handful of snapshots per collection prefix) but a prefix spanning millions
 // of files will materialize them all at once; scope the prefix narrowly.
 func (f *FSObjectStore) List(_ context.Context, prefix string) ([]objstore.ObjectInfo, error) {
-	start := f.listStart(prefix)
-	if _, err := os.Stat(start); err != nil {
-		if os.IsNotExist(err) {
-			return nil, nil
+	if strings.ContainsRune(prefix, '\x00') {
+		return nil, nil
+	}
+	r, err := os.OpenRoot(f.root)
+	if err != nil {
+		return nil, fmt.Errorf("fsstore: list %q: open root: %w", prefix, err)
+	}
+	defer func() { _ = r.Close() }()
+	fsys := r.FS()
+	start := listStart(prefix)
+	if _, err := fs.Stat(fsys, start); err != nil {
+		if errors.Is(err, fs.ErrNotExist) || errors.Is(err, syscall.ENOTDIR) {
+			return nil, nil // no such prefix: nothing to list
 		}
 		return nil, fmt.Errorf("fsstore: list %q: %w", prefix, err)
 	}
 	var out []objstore.ObjectInfo
-	err := filepath.WalkDir(start, func(p string, d fs.DirEntry, err error) error {
+	err = fs.WalkDir(fsys, start, func(p string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return err
 		}
 		if d.IsDir() {
 			return nil
 		}
-		rel, rerr := filepath.Rel(f.root, p)
-		if rerr != nil {
-			return rerr
-		}
-		key := filepath.ToSlash(rel)
-		if !strings.HasPrefix(key, prefix) {
+		// fs.FS paths are already slash-separated and root-relative: p IS the key.
+		if !strings.HasPrefix(p, prefix) {
 			return nil
 		}
 		info, ierr := d.Info()
@@ -202,7 +232,7 @@ func (f *FSObjectStore) List(_ context.Context, prefix string) ([]objstore.Objec
 			return ierr
 		}
 		out = append(out, objstore.ObjectInfo{
-			Key:          key,
+			Key:          p,
 			Size:         info.Size(),
 			LastModified: info.ModTime(),
 		})
@@ -215,26 +245,21 @@ func (f *FSObjectStore) List(_ context.Context, prefix string) ([]objstore.Objec
 	return out, nil
 }
 
-// listStart returns the directory List should walk for prefix: <root> joined
-// with every COMPLETE "/"-separated segment of prefix (the trailing partial
-// segment, if any, is a name filter, not a directory). A prefix that would
-// escape root (".." segments) falls back to root itself, where the key-prefix
-// filter then matches nothing — never a path outside root.
-func (f *FSObjectStore) listStart(prefix string) string {
+// listStart returns the fs.FS path (unrooted, slash-separated, "." for root)
+// List should walk for prefix: every COMPLETE "/"-separated segment of prefix.
+// The trailing partial segment, if any, is a name filter, not a directory.
+// path.Clean resolves "."/".." and a leading "/" lexically; containment itself
+// is enforced by os.Root, not here.
+func listStart(prefix string) string {
 	i := strings.LastIndex(prefix, "/")
 	if i < 0 {
-		return f.root
+		return "."
 	}
-	dir := filepath.Join(f.root, filepath.FromSlash(path.Clean("/"+prefix[:i])))
-	rootAbs, err := filepath.Abs(f.root)
-	if err != nil {
-		return f.root
+	rel := strings.TrimPrefix(path.Clean("/"+prefix[:i]), "/")
+	if rel == "" {
+		return "."
 	}
-	dirAbs, err := filepath.Abs(dir)
-	if err != nil || (dirAbs != rootAbs && !strings.HasPrefix(dirAbs, rootAbs+string(os.PathSeparator))) {
-		return f.root
-	}
-	return dir
+	return rel
 }
 
 // Delete removes <root>/<key>. Deleting a missing key returns

--- a/backup/fs.go
+++ b/backup/fs.go
@@ -170,16 +170,20 @@ func (f *FSObjectStore) Get(_ context.Context, key string) (io.ReadCloser, error
 // every entry, so the result is what a full-root walk filtered by prefix would
 // return.
 //
-// The walk runs inside os.Root, so it cannot leave root through a symlink: the
-// kernel-level check refuses a start path with a symlink in ANY component —
-// even one that stays inside root — rather than resolving it. A full-root walk
-// never descended into a symlink either, so nothing under one was ever
-// listable; the difference is that it stayed silent, whereas List now returns
-// an error. That is deliberate: a tenant directory an operator symlinked onto
-// another disk otherwise surfaces as "no snapshots" from LatestKey/RestoreLatest
-// and as a silent no-op from prune, when the truth is that List cannot see it.
-// path.Clean on the prefix is the only lexical defence and it is not relied on
-// for containment.
+// Symlinks are never followed. A full-root walk never descended into one, so
+// nothing under a symlink was ever listable; a scoped walk must not resolve
+// one on its way to the start directory either, or it would list — and let
+// retention delete — files under keys the full walk never produced. Two layers
+// enforce that. Every component between root and the start directory is
+// Lstat'd and a symlink is an ERROR (where the full walk was silent — that is
+// deliberate: a tenant directory an operator symlinked onto another disk
+// otherwise surfaces as "no snapshots" from LatestKey/RestoreLatest and as a
+// silent no-op from prune, when the truth is that List cannot see it). Behind
+// that, the walk runs inside os.Root, so even a link created between the Lstat
+// and the walk cannot leave root: os.Root refuses absolute and root-escaping
+// link targets outright, and a relative in-root link — which os.Root itself
+// WOULD follow — can at worst alias in-root files. path.Clean on the prefix is
+// the only lexical step and it is not relied on for containment.
 //
 // Error semantics, matching MemStore.List (a pure prefix filter, which cannot
 // fail on the SHAPE of a prefix): a prefix whose directory does not exist yet,
@@ -207,16 +211,15 @@ func (f *FSObjectStore) List(_ context.Context, prefix string) ([]objstore.Objec
 		return nil, fmt.Errorf("fsstore: list %q: open root: %w", prefix, err)
 	}
 	defer func() { _ = r.Close() }()
-	fsys := r.FS()
-	start := listStart(prefix)
-	if _, err := fs.Stat(fsys, start); err != nil {
-		if errors.Is(err, fs.ErrNotExist) || errors.Is(err, syscall.ENOTDIR) {
-			return nil, nil // no such prefix: nothing to list
-		}
+	start, ok, err := listStart(r, prefix)
+	if err != nil {
 		return nil, fmt.Errorf("fsstore: list %q: %w", prefix, err)
 	}
+	if !ok {
+		return nil, nil // no such prefix: nothing to list
+	}
 	var out []objstore.ObjectInfo
-	err = fs.WalkDir(fsys, start, func(p string, d fs.DirEntry, err error) error {
+	err = fs.WalkDir(r.FS(), start, func(p string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return err
 		}
@@ -246,20 +249,48 @@ func (f *FSObjectStore) List(_ context.Context, prefix string) ([]objstore.Objec
 }
 
 // listStart returns the fs.FS path (unrooted, slash-separated, "." for root)
-// List should walk for prefix: every COMPLETE "/"-separated segment of prefix.
-// The trailing partial segment, if any, is a name filter, not a directory.
+// List should walk for prefix: every COMPLETE "/"-separated segment of prefix
+// that exists as a real directory. The trailing partial segment, if any, is a
+// name filter, not a directory. ok=false means the walk would yield nothing
+// (a segment is missing or is a plain file); a symlink segment is an error
+// (see List). Scoping stops at the first segment containing a backslash and
+// walks from its parent instead: on Windows os.Root would treat "\\" as a
+// separator while the key filter treats it as a literal, so a scoped walk
+// there could return keys that do not carry the requested prefix — walking
+// from the parent lets the lexical filter decide, identically everywhere.
 // path.Clean resolves "."/".." and a leading "/" lexically; containment itself
 // is enforced by os.Root, not here.
-func listStart(prefix string) string {
+func listStart(r *os.Root, prefix string) (start string, ok bool, err error) {
+	start = "."
 	i := strings.LastIndex(prefix, "/")
 	if i < 0 {
-		return "."
+		return start, true, nil
 	}
 	rel := strings.TrimPrefix(path.Clean("/"+prefix[:i]), "/")
 	if rel == "" {
-		return "."
+		return start, true, nil
 	}
-	return rel
+	for _, seg := range strings.Split(rel, "/") {
+		if strings.ContainsRune(seg, '\\') {
+			break
+		}
+		next := path.Join(start, seg)
+		info, lerr := r.Lstat(next)
+		if lerr != nil {
+			if errors.Is(lerr, fs.ErrNotExist) || errors.Is(lerr, syscall.ENOTDIR) {
+				return "", false, nil
+			}
+			return "", false, lerr
+		}
+		if info.Mode()&fs.ModeSymlink != 0 {
+			return "", false, fmt.Errorf("%q is a symlink: refusing to list through it", next)
+		}
+		if !info.IsDir() {
+			return "", false, nil // a plain file cannot hold keys beneath it
+		}
+		start = next
+	}
+	return start, true, nil
 }
 
 // Delete removes <root>/<key>. Deleting a missing key returns

--- a/backup/fs.go
+++ b/backup/fs.go
@@ -258,8 +258,12 @@ func (f *FSObjectStore) List(_ context.Context, prefix string) ([]objstore.Objec
 // separator while the key filter treats it as a literal, so a scoped walk
 // there could return keys that do not carry the requested prefix — walking
 // from the parent lets the lexical filter decide, identically everywhere.
-// path.Clean resolves "."/".." and a leading "/" lexically; containment itself
-// is enforced by os.Root, not here.
+// A prefix whose directory part is not already canonical (a leading "/", a
+// "." or ".." segment, a doubled "/") can match no key at all — every key is
+// a clean relative path — so it yields nothing without touching disk, rather
+// than being scoped to the directory its CLEANED form names (which the raw
+// prefix would never match, and which could be a symlink the raw prefix would
+// never have reached). Containment itself is enforced by os.Root, not here.
 func listStart(r *os.Root, prefix string) (start string, ok bool, err error) {
 	start = "."
 	i := strings.LastIndex(prefix, "/")
@@ -267,6 +271,9 @@ func listStart(r *os.Root, prefix string) (start string, ok bool, err error) {
 		return start, true, nil
 	}
 	rel := strings.TrimPrefix(path.Clean("/"+prefix[:i]), "/")
+	if rel != prefix[:i] {
+		return "", false, nil // non-canonical directory part: no key can match
+	}
 	if rel == "" {
 		return start, true, nil
 	}

--- a/backup/fs_test.go
+++ b/backup/fs_test.go
@@ -97,3 +97,78 @@ func listTempFiles(t *testing.T, dir string) []string {
 	}
 	return tmps
 }
+
+// TestFSObjectStoreListPrefixScopedWalk pins that List, which now starts its
+// walk at the directory the prefix implies instead of at root, returns exactly
+// what a full-root walk filtered by key prefix would — including a trailing
+// partial segment ("acme/col/2024-"), a single exact key, a prefix whose
+// directory does not exist (nil, no error), and a ".." prefix (nothing, never
+// a path outside root).
+func TestFSObjectStoreListPrefixScopedWalk(t *testing.T) {
+	ctx := context.Background()
+	root := t.TempDir()
+	fsStore, err := NewFSObjectStore(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	keys := []string{
+		"acme/col/2024-01-01T00:00:00Z.snap",
+		"acme/col/2024-01-01T00:00:00Z.cfg.json",
+		"acme/col/2025-01-01T00:00:00Z.snap",
+		"acme/other/2024-01-01T00:00:00Z.snap",
+		"beta/col/2024-01-01T00:00:00Z.snap",
+		"top.snap",
+	}
+	for _, k := range keys {
+		if err := fsStore.Put(ctx, k, strings.NewReader(k), int64(len(k))); err != nil {
+			t.Fatalf("put %q: %v", k, err)
+		}
+	}
+	// A file outside root that a ".." prefix must never reach.
+	outside := filepath.Join(filepath.Dir(root), "outside.snap")
+	if err := os.WriteFile(outside, []byte("x"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Remove(outside) })
+
+	listKeys := func(prefix string) []string {
+		t.Helper()
+		infos, err := fsStore.List(ctx, prefix)
+		if err != nil {
+			t.Fatalf("list %q: %v", prefix, err)
+		}
+		out := make([]string, 0, len(infos))
+		for _, in := range infos {
+			out = append(out, in.Key)
+		}
+		return out
+	}
+	// Reference: full-root walk filtered by key prefix.
+	fullWalk := func(prefix string) []string {
+		var out []string
+		for _, k := range keys {
+			if strings.HasPrefix(k, prefix) {
+				out = append(out, k)
+			}
+		}
+		sortStrings(out)
+		return out
+	}
+	for _, prefix := range []string{
+		"", "acme/", "acme/col/", "acme/col/2024-", "acme/col/2024-01-01T00:00:00Z.snap",
+		"acme/co", "top", "nope/", "acme/nope/2024-", "../", "../outside",
+	} {
+		got, want := listKeys(prefix), fullWalk(prefix)
+		if strings.Join(got, ",") != strings.Join(want, ",") {
+			t.Errorf("prefix %q: got %v, want %v", prefix, got, want)
+		}
+	}
+}
+
+func sortStrings(s []string) {
+	for i := 1; i < len(s); i++ {
+		for j := i; j > 0 && s[j-1] > s[j]; j-- {
+			s[j-1], s[j] = s[j], s[j-1]
+		}
+	}
+}

--- a/backup/fs_test.go
+++ b/backup/fs_test.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 )
@@ -98,12 +99,13 @@ func listTempFiles(t *testing.T, dir string) []string {
 	return tmps
 }
 
-// TestFSObjectStoreListPrefixScopedWalk pins that List, which now starts its
-// walk at the directory the prefix implies instead of at root, returns exactly
-// what a full-root walk filtered by key prefix would — including a trailing
-// partial segment ("acme/col/2024-"), a single exact key, a prefix whose
-// directory does not exist (nil, no error), and a ".." prefix (nothing, never
-// a path outside root).
+// TestFSObjectStoreListPrefixScopedWalk pins that List, which starts its walk
+// at the directory the prefix implies instead of at root, returns exactly what
+// a full-root walk filtered by key prefix would — including a trailing partial
+// segment ("acme/col/2024-"), a single exact key, a prefix naming a file as a
+// directory, a NUL byte, a ".." prefix, and a prefix whose directory does not
+// exist (nil, no error). Symlinks are the one deliberate difference: a start
+// path through one — escaping root or not — is an error rather than silence.
 func TestFSObjectStoreListPrefixScopedWalk(t *testing.T) {
 	ctx := context.Background()
 	root := t.TempDir()
@@ -156,11 +158,131 @@ func TestFSObjectStoreListPrefixScopedWalk(t *testing.T) {
 	}
 	for _, prefix := range []string{
 		"", "acme/", "acme/col/", "acme/col/2024-", "acme/col/2024-01-01T00:00:00Z.snap",
-		"acme/co", "top", "nope/", "acme/nope/2024-", "../", "../outside",
+		"acme/co", "top", "nope/", "acme/nope/2024-", "../", "../outside", "/acme/col/",
+		"top.snap/", "top.snap/x/y", "acme/col/2024-01-01T00:00:00Z.snap/x/",
+		"a\x00b/", "acme/\x00/",
 	} {
 		got, want := listKeys(prefix), fullWalk(prefix)
 		if strings.Join(got, ",") != strings.Join(want, ",") {
 			t.Errorf("prefix %q: got %v, want %v", prefix, got, want)
+		}
+	}
+}
+
+// TestFSObjectStoreListRefusesSymlinkStart pins the symlink rule: a start path
+// with a symlink in any component is refused by os.Root — whether the link
+// escapes root (the case that let retention delete files outside the backup
+// root) or stays inside it — and List reports that as an error, not as "no
+// snapshots". The link itself is still reported as a plain entry by a walk
+// that merely passes it, exactly as the full-root walk did.
+func TestFSObjectStoreListRefusesSymlinkStart(t *testing.T) {
+	ctx := context.Background()
+	root := t.TempDir()
+	fsStore, err := NewFSObjectStore(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := fsStore.Put(ctx, "acme/col/2024-01-01T00:00:00Z.snap", strings.NewReader("a"), 1); err != nil {
+		t.Fatal(err)
+	}
+	outside := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(outside, "col"), 0o750); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(outside, "col", "escaped.snap"), []byte("x"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(outside, filepath.Join(root, "link")); err != nil {
+		t.Skipf("symlink: %v", err)
+	}
+	if err := os.Symlink(filepath.Join(root, "acme"), filepath.Join(root, "inlink")); err != nil {
+		t.Fatal(err)
+	}
+
+	for _, prefix := range []string{"link/", "link/col/", "inlink/", "inlink/col/"} {
+		infos, err := fsStore.List(ctx, prefix)
+		if err == nil {
+			t.Errorf("list %q through a symlink: want an error, got %d keys", prefix, len(infos))
+		}
+		for _, in := range infos {
+			if strings.HasPrefix(in.Key, "link/") {
+				t.Errorf("list %q escaped root: %q", prefix, in.Key)
+			}
+		}
+	}
+	// Passing the links during a root walk still just reports them as entries.
+	infos, err := fsStore.List(ctx, "")
+	if err != nil {
+		t.Fatalf("root list: %v", err)
+	}
+	var got []string
+	for _, in := range infos {
+		got = append(got, in.Key)
+	}
+	if want := "acme/col/2024-01-01T00:00:00Z.snap,inlink,link"; strings.Join(got, ",") != want {
+		t.Errorf("root list = %v, want %s", got, want)
+	}
+	// The file behind the escaping link was never touched.
+	if _, err := os.Stat(filepath.Join(outside, "col", "escaped.snap")); err != nil {
+		t.Errorf("file outside root disturbed: %v", err)
+	}
+}
+
+// TestFSObjectStoreListIsScoped pins that the walk really starts at the
+// prefix's directory and not at root: an unreadable directory in an UNRELATED
+// subtree fails a root walk (WalkDir reports the ReadDir error) but must not be
+// visited — and so must not fail — by a walk scoped to another prefix. Remove
+// the scoping and this test fails; the equivalence test alone would not.
+func TestFSObjectStoreListIsScoped(t *testing.T) {
+	if runtime.GOOS == "windows" || os.Geteuid() == 0 {
+		t.Skip("needs a directory the process cannot read")
+	}
+	ctx := context.Background()
+	root := t.TempDir()
+	fsStore, err := NewFSObjectStore(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := fsStore.Put(ctx, "acme/col/2024-01-01T00:00:00Z.snap", strings.NewReader("a"), 1); err != nil {
+		t.Fatal(err)
+	}
+	locked := filepath.Join(root, "beta", "locked")
+	if err := os.MkdirAll(locked, 0o750); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chmod(locked, 0); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(locked, 0o750) })
+
+	if _, err := fsStore.List(ctx, ""); err == nil {
+		t.Fatal("root walk must fail on the unreadable directory (fixture check)")
+	}
+	infos, err := fsStore.List(ctx, "acme/col/")
+	if err != nil {
+		t.Fatalf("scoped walk visited an unrelated subtree: %v", err)
+	}
+	if len(infos) != 1 {
+		t.Fatalf("scoped walk = %d keys, want 1", len(infos))
+	}
+}
+
+// TestFSObjectStoreListMissingRootIsError pins that a root that has gone away
+// (an unmounted backup volume) is an error from List — for any prefix — and not
+// an empty result that LatestKey would turn into "no snapshots".
+func TestFSObjectStoreListMissingRootIsError(t *testing.T) {
+	ctx := context.Background()
+	root := filepath.Join(t.TempDir(), "backups")
+	fsStore, err := NewFSObjectStore(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.RemoveAll(root); err != nil {
+		t.Fatal(err)
+	}
+	for _, prefix := range []string{"", "acme/col/"} {
+		if _, err := fsStore.List(ctx, prefix); err == nil {
+			t.Errorf("list %q with a missing root: want an error, got nil", prefix)
 		}
 	}
 }

--- a/backup/fs_test.go
+++ b/backup/fs_test.go
@@ -121,6 +121,13 @@ func TestFSObjectStoreListPrefixScopedWalk(t *testing.T) {
 		"beta/col/2024-01-01T00:00:00Z.snap",
 		"top.snap",
 	}
+	if runtime.GOOS != "windows" {
+		// A literal backslash in a name: scoping must stop before that segment
+		// and let the lexical filter decide, so such keys still list — and a
+		// prefix with a backslash in a complete segment still matches nothing
+		// that a full-root walk would not have matched.
+		keys = append(keys, "bs/x\\y.snap")
+	}
 	for _, k := range keys {
 		if err := fsStore.Put(ctx, k, strings.NewReader(k), int64(len(k))); err != nil {
 			t.Fatalf("put %q: %v", k, err)
@@ -160,7 +167,7 @@ func TestFSObjectStoreListPrefixScopedWalk(t *testing.T) {
 		"", "acme/", "acme/col/", "acme/col/2024-", "acme/col/2024-01-01T00:00:00Z.snap",
 		"acme/co", "top", "nope/", "acme/nope/2024-", "../", "../outside", "/acme/col/",
 		"top.snap/", "top.snap/x/y", "acme/col/2024-01-01T00:00:00Z.snap/x/",
-		"a\x00b/", "acme/\x00/",
+		"a\x00b/", "acme/\x00/", "bs/x\\", "bs\\x/", "bs\\x/y", "acme\\col/",
 	} {
 		got, want := listKeys(prefix), fullWalk(prefix)
 		if strings.Join(got, ",") != strings.Join(want, ",") {
@@ -198,15 +205,24 @@ func TestFSObjectStoreListRefusesSymlinkStart(t *testing.T) {
 	if err := os.Symlink(filepath.Join(root, "acme"), filepath.Join(root, "inlink")); err != nil {
 		t.Fatal(err)
 	}
+	// RELATIVE in-root links are the ones os.Root itself would follow (it only
+	// refuses absolute and root-escaping targets), so they are the real test of
+	// the per-component Lstat: one at the top, one below the tenant directory.
+	if err := os.Symlink("acme", filepath.Join(root, "rel")); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink("col", filepath.Join(root, "acme", "relcol")); err != nil {
+		t.Fatal(err)
+	}
 
-	for _, prefix := range []string{"link/", "link/col/", "inlink/", "inlink/col/"} {
+	for _, prefix := range []string{"link/", "link/col/", "inlink/", "inlink/col/", "rel/", "rel/col/", "acme/relcol/"} {
 		infos, err := fsStore.List(ctx, prefix)
 		if err == nil {
 			t.Errorf("list %q through a symlink: want an error, got %d keys", prefix, len(infos))
 		}
 		for _, in := range infos {
-			if strings.HasPrefix(in.Key, "link/") {
-				t.Errorf("list %q escaped root: %q", prefix, in.Key)
+			if strings.HasPrefix(in.Key, "link/") || strings.HasPrefix(in.Key, "rel/") || strings.HasPrefix(in.Key, "acme/relcol/") {
+				t.Errorf("list %q resolved a symlink: %q", prefix, in.Key)
 			}
 		}
 	}
@@ -219,7 +235,7 @@ func TestFSObjectStoreListRefusesSymlinkStart(t *testing.T) {
 	for _, in := range infos {
 		got = append(got, in.Key)
 	}
-	if want := "acme/col/2024-01-01T00:00:00Z.snap,inlink,link"; strings.Join(got, ",") != want {
+	if want := "acme/col/2024-01-01T00:00:00Z.snap,acme/relcol,inlink,link,rel"; strings.Join(got, ",") != want {
 		t.Errorf("root list = %v, want %s", got, want)
 	}
 	// The file behind the escaping link was never touched.

--- a/backup/fs_test.go
+++ b/backup/fs_test.go
@@ -168,6 +168,7 @@ func TestFSObjectStoreListPrefixScopedWalk(t *testing.T) {
 		"acme/co", "top", "nope/", "acme/nope/2024-", "../", "../outside", "/acme/col/",
 		"top.snap/", "top.snap/x/y", "acme/col/2024-01-01T00:00:00Z.snap/x/",
 		"a\x00b/", "acme/\x00/", "bs/x\\", "bs\\x/", "bs\\x/y", "acme\\col/",
+		"./acme/col/", "acme/./col/", "acme/../acme/col/", "acme//col/", "/",
 	} {
 		got, want := listKeys(prefix), fullWalk(prefix)
 		if strings.Join(got, ",") != strings.Join(want, ",") {
@@ -224,6 +225,14 @@ func TestFSObjectStoreListRefusesSymlinkStart(t *testing.T) {
 			if strings.HasPrefix(in.Key, "link/") || strings.HasPrefix(in.Key, "rel/") || strings.HasPrefix(in.Key, "acme/relcol/") {
 				t.Errorf("list %q resolved a symlink: %q", prefix, in.Key)
 			}
+		}
+	}
+	// A non-canonical prefix that would CLEAN to a path through a link matches no
+	// key (keys are clean), so it must yield nothing — not the link error.
+	for _, prefix := range []string{"../link/col/", "acme/../rel/col/", "/rel/col/", "./acme/relcol/"} {
+		infos, err := fsStore.List(ctx, prefix)
+		if err != nil || len(infos) != 0 {
+			t.Errorf("list %q (non-canonical): got %d keys, err=%v; want none, nil", prefix, len(infos), err)
 		}
 	}
 	// Passing the links during a root walk still just reports them as entries.


### PR DESCRIPTION
**Problem.** `FSObjectStore.List` walked the whole root on every call and filtered afterwards, so its cost was O(all stored files) regardless of prefix. Every caller passes a narrow prefix — `prune` lists one collection prefix per collection and per run, `LatestKey` one collection, and #111's write-once probe a single key — so a backup run on the filesystem backend cost O(collections × all stored files). Surfaced during the #111 review; it is pre-existing `List` behaviour, hence a separate PR.

**Change.** The walk starts at the deepest directory the prefix fully names (`<root>/acme/col` for `acme/col/2024-`); the trailing partial segment remains a name filter. A prefix whose directory does not exist yields `nil`, not an error (same as an empty root today). A prefix that would escape root (`..`) falls back to root, where the key filter matches nothing — the walk never leaves root. The key-prefix filter is still applied to every entry, so results are byte-identical to the full-root walk.

**Test.** `TestFSObjectStoreListPrefixScopedWalk` compares `List` against a full-root walk filtered by prefix across empty, collection, partial-segment, exact-key, missing-directory and `..` prefixes, with a real file planted outside root to prove it is never reached.

No interface or key-layout change; `S3Store.List` already scopes server-side via the `prefix` parameter, `MemStore` is a map scan.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
`FSObjectStore.List` now walks only the subtree its prefix implies instead of the whole root, so filesystem backups no longer cost O(collections × all stored files). The walk runs inside `os.Root`, and results match a full-root prefix-filtered walk except that a prefix path through a symlink returns an error instead of an empty result.

**Behavior**
- The walk starts at the deepest directory the prefix fully names; a trailing partial segment stays a name filter, and a non-canonical prefix (leading `/`, `.` or `..` segment, doubled `/`) matches no key and yields nothing without touching disk.
- Every start-path component is Lstat'd — `os.Root` alone would follow relative in-root symlinks — and scoping stops before a segment containing a backslash, walking from its parent so Windows separator handling stays consistent.
- A missing prefix directory, a prefix naming a plain file, or a NUL byte returns nil; a missing or unreadable root remains an error.
- New tests compare scoped `List` against a full-root filtered walk and pin the symlink, scoping, non-canonical-prefix, and missing-root semantics.

<sup>Written for commit 3982d6ab52a3582dab4c12735a06b5d0691e7e5f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rostamlabs/rostam/pull/125?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved file listing with prefix-scoped traversal for more accurate results.
  * Prevented listings from accessing unrelated directories or escaping the configured root through symlinks.
  * Improved handling of missing directories, invalid prefixes, and file-based paths.
  * Missing storage roots now correctly return an error.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->