### PR TITLE
fix(backup): reclaim staging files abandoned by a killed Put

### DIFF
--- a/backup/fs.go
+++ b/backup/fs.go
@@ -12,6 +12,7 @@ import (
 	"path"
 	"path/filepath"
 	"strings"
+	"sync"
 	"syscall"
 	"time"
 
@@ -41,8 +42,10 @@ var _ objstore.ObjectStore = (*FSObjectStore)(nil)
 // putTempPrefix is the fixed name prefix of every Put staging file. It is kept
 // OUT of the ".snap"/".cfg.json" key space (List/LatestKey/prune filter on
 // ".snap") so an in-flight staging file is never seen by retention as a
-// published object — and, since no published key can start with it, it is also
-// the marker that makes reclaiming leftovers safe (see reclaimStaleTemps).
+// published object — and it is the marker that makes reclaiming leftovers safe
+// (see reclaimStaleTemps). That only holds because the name space is RESERVED:
+// keyToPath rejects any key whose final segment starts with this prefix, so no
+// published object can ever wear a name the sweep is entitled to delete.
 //
 // A staging file left behind by a process killed mid-Put is NOT a small, inert
 // file: the very same Put stages the SNAPSHOT, so the leftover can be a partial
@@ -50,11 +53,24 @@ var _ objstore.ObjectStore = (*FSObjectStore)(nil)
 // leaked once per kill and never reclaimed on its own.
 const putTempPrefix = ".rostam-put-"
 
-// staleTempAge is how old a putTempPrefix staging file must be before a Put
-// reclaims it. It is the whole safety margin of the sweep: a CONCURRENT Put
-// created its staging file moments ago, so nothing an hour old can belong to a
-// live writer — only to a process that died mid-Put.
+// putTempSuffix is the fixed name suffix of every Put staging file, the second
+// half of the CreateTemp pattern below. The sweep requires BOTH this suffix and
+// putTempPrefix, so the two filters are declared here together and cannot drift
+// apart from the name Put actually creates.
+const putTempSuffix = ".tmp"
+
+// staleTempAge is how old a staging file must be before a Put reclaims it. It is
+// the outer safety margin of the sweep: a CONCURRENT Put created its staging
+// file moments ago, and a Put whose copy is still running keeps refreshing the
+// mtime (see tempHeartbeat), so nothing an hour old can belong to a live
+// writer — only to a process that died mid-Put.
 const staleTempAge = time.Hour
+
+// tempHeartbeat is how often a running Put refreshes its staging file's mtime.
+// It must be well inside staleTempAge so a single missed tick cannot expose a
+// live Put to the sweep. It is a var, not a const, purely so a test can shorten
+// it; nothing in production assigns to it.
+var tempHeartbeat = staleTempAge / 4
 
 // NewFSObjectStore returns an FSObjectStore rooted at root, creating root if it
 // does not exist.
@@ -70,7 +86,8 @@ func NewFSObjectStore(root string) (*FSObjectStore, error) {
 // key is path.Clean'd as an absolute path (collapsing ".."/"."), then the joined
 // destination is verified to stay within root. A key containing "../" segments,
 // a NUL byte, or one that resolves to root itself is an error — so Put cannot
-// overwrite, Get cannot read, and Delete cannot remove a file outside root.
+// overwrite, Get cannot read, and Delete cannot remove a file outside root. It
+// also rejects a key landing in the reserved staging name space (see below).
 func (f *FSObjectStore) keyToPath(key string) (string, error) {
 	if strings.ContainsRune(key, '\x00') {
 		return "", fmt.Errorf("fsstore: invalid key %q", key)
@@ -81,6 +98,20 @@ func (f *FSObjectStore) keyToPath(key string) (string, error) {
 	clean := path.Clean("/" + key)
 	if clean == "/" {
 		return "", fmt.Errorf("fsstore: invalid key %q (empty after clean)", key)
+	}
+	// The putTempPrefix name space is RESERVED for Put's staging files, which
+	// reclaimStaleTemps is entitled to delete once they age past staleTempAge. A
+	// key whose final segment lands in that name space would be published as a
+	// real object and then silently swept an hour later, so refuse it here.
+	//
+	// This sits in keyToPath, so the refusal applies uniformly to Get and Delete
+	// as well as Put. That is deliberate, not collateral: a key that can never be
+	// written must not be readable or deletable either, or the store would answer
+	// for names whose meaning it does not control. Only the FINAL segment is
+	// checked — a directory so named is harmless, since the sweep skips
+	// directories and only ever looks at one directory's own entries.
+	if strings.HasPrefix(path.Base(clean), putTempPrefix) {
+		return "", fmt.Errorf("fsstore: invalid key %q (the %q name space is reserved for staging files)", key, putTempPrefix)
 	}
 	dst := filepath.Join(f.root, filepath.FromSlash(clean))
 	rootAbs, err := filepath.Abs(f.root)
@@ -113,19 +144,22 @@ func (f *FSObjectStore) Put(_ context.Context, key string, r io.Reader, size int
 	// ours. Doing it here rather than at open is what makes it race-free on a root
 	// shared by several processes; it is best-effort and never fails the Put.
 	reclaimStaleTemps(filepath.Dir(dst))
-	// Reclaim staging files abandoned by a process killed mid-Put before staging
-	// ours. Doing it here rather than at open is what makes it race-free on a root
-	// shared by several processes; it is best-effort and never fails the Put.
 	// Staging name deliberately does NOT end in snapExt: List/LatestKey/prune
 	// filter on the ".snap" suffix, so a temp named "*.snap" would be visible to
 	// them mid-write — a concurrent prune could delete an in-flight Put's staging
 	// file (or the temp could inflate a retention count). A ".tmp" suffix keeps it
 	// invisible to those filters until the atomic rename publishes the real key.
-	tmp, err := os.CreateTemp(filepath.Dir(dst), putTempPrefix+"*.tmp")
+	tmp, err := os.CreateTemp(filepath.Dir(dst), putTempPrefix+"*"+putTempSuffix)
 	if err != nil {
 		return fmt.Errorf("fsstore: temp for %q: %w", key, err)
 	}
 	tmpName := tmp.Name()
+	// Keep this staging file's mtime fresh for as long as the copy runs, so a slow
+	// or wedged reader is not mistaken for an abandoned Put by a concurrent sweep
+	// (see startTempHeartbeat). Stopped explicitly before the rename; the deferred
+	// stop covers every error return in between.
+	stopHeartbeat := startTempHeartbeat(tmpName)
+	defer stopHeartbeat()
 	if _, err := io.Copy(tmp, r); err != nil {
 		_ = tmp.Close()
 		_ = os.Remove(tmpName)
@@ -145,6 +179,9 @@ func (f *FSObjectStore) Put(_ context.Context, key string, r io.Reader, size int
 		_ = os.Remove(tmpName)
 		return fmt.Errorf("fsstore: close temp for %q: %w", key, err)
 	}
+	// The staging file is fully written and closed; nothing is left to protect from
+	// the sweep, and the path is about to stop existing under this name.
+	stopHeartbeat()
 	if err := os.Rename(tmpName, dst); err != nil {
 		_ = os.Remove(tmpName)
 		return fmt.Errorf("fsstore: rename for %q: %w", key, err)
@@ -157,18 +194,65 @@ func (f *FSObjectStore) Put(_ context.Context, key string, r io.Reader, size int
 	return nil
 }
 
+// startTempHeartbeat refreshes path's mtime every tempHeartbeat until the
+// returned stop function is called. stop is idempotent and WAITS for the
+// refreshing goroutine to exit, so no stray Chtimes can trail a later rename.
+//
+// Why a heartbeat and not an inter-process lock: the sweep tells a live writer
+// from a dead one by age alone, and an mtime set once at create time cannot
+// express "alive but making no progress" — a Put whose reader stalls for longer
+// than staleTempAge looks exactly like a temp orphaned by a killed process, so a
+// concurrent Put would unlink it and the stalled Put's rename would then fail. A
+// lock is the wrong instrument: it would have to be held across a copy of
+// unbounded duration and released correctly by a process that may be killed at
+// any instant — which is the very failure the sweep exists to clean up after, so
+// the lock would need a staleness rule of its own and we would be back here. A
+// ticker dies with its process for free: while the Put lives its staging file
+// keeps getting younger, and the moment the process is killed the refreshes stop
+// and the file starts ageing toward the bound. That is exactly the signal the
+// sweep needs, held in the file itself with no extra state to reconcile.
+func startTempHeartbeat(path string) func() {
+	done := make(chan struct{})
+	exited := make(chan struct{})
+	go func() {
+		defer close(exited)
+		tick := time.NewTicker(tempHeartbeat)
+		defer tick.Stop()
+		for {
+			select {
+			case <-done:
+				return
+			case now := <-tick.C:
+				// Ignored: the file may already be renamed away (a refresh racing
+				// stop), and a missed refresh only risks the temp being swept — it
+				// can never corrupt anything.
+				_ = os.Chtimes(path, now, now)
+			}
+		}
+	}()
+	var once sync.Once
+	return func() {
+		once.Do(func() {
+			close(done)
+			<-exited
+		})
+	}
+}
+
 // reclaimStaleTemps removes abandoned Put staging files from dir. It is called
 // from Put — on the NEXT write to that directory — rather than from a sweep at
 // open: there is then no startup instant to reason about on a shared root, only
-// an age bound, and two filters keep it safe:
+// an age bound, and three filters keep it safe:
 //
-//   - the putTempPrefix name prefix. No PUBLISHED object can start with it (keys
-//     come from the backup layout <tenant>/<col>/<ts>.snap and its .cfg.json
-//     sibling, and List/LatestKey/prune select on the ".snap" suffix), so the
-//     sweep can never remove a real snapshot or config.
+//   - the putTempPrefix name prefix AND the putTempSuffix suffix, both of which
+//     Put's CreateTemp pattern gives every staging file. Requiring both, rather
+//     than the prefix alone, means an unrelated file that merely happens to share
+//     the prefix is not swept; and no PUBLISHED object can wear either name,
+//     because keyToPath reserves the prefix outright.
 //   - the staleTempAge modtime bound. A concurrent Put created its staging file
-//     moments ago, so a live writer's temp is never old enough to be swept; only
-//     a temp orphaned by a dead process ages past the bound.
+//     moments ago and a long-running Put keeps refreshing its mtime (see
+//     startTempHeartbeat), so a live writer's temp is never old enough to be
+//     swept; only a temp orphaned by a dead process ages past the bound.
 //
 // Every error is ignored, including the removal's: reclaiming dead space must
 // never fail a backup.
@@ -179,7 +263,7 @@ func reclaimStaleTemps(dir string) {
 	}
 	cutoff := time.Now().Add(-staleTempAge)
 	for _, e := range entries {
-		if e.IsDir() || !strings.HasPrefix(e.Name(), putTempPrefix) {
+		if e.IsDir() || !strings.HasPrefix(e.Name(), putTempPrefix) || !strings.HasSuffix(e.Name(), putTempSuffix) {
 			continue
 		}
 		info, ierr := e.Info()

--- a/backup/fs.go
+++ b/backup/fs.go
@@ -92,6 +92,17 @@ func (f *FSObjectStore) keyToPath(key string) (string, error) {
 	if strings.ContainsRune(key, '\x00') {
 		return "", fmt.Errorf("fsstore: invalid key %q", key)
 	}
+	// Object keys are slash-separated by the ObjectStore contract, so a backslash
+	// is an ordinary character in a key — but NOT to filepath on Windows, where it
+	// is a separator. A key like "coll\.rostam-put-x.tmp" therefore has one final
+	// segment by the key's own rules and a DIFFERENT one by the filesystem's, which
+	// is how such a key could slip past the reservation below and publish a file the
+	// sweep would later delete. Refusing the character keeps one key meaning one
+	// path on every platform; the backup package's own keys never carry it
+	// (url.PathEscape encodes it).
+	if strings.ContainsRune(key, '\\') {
+		return "", fmt.Errorf("fsstore: invalid key %q (backslash is not a key separator)", key)
+	}
 	// path.Clean("/"+key) forces an absolute path and resolves away ".."/"." so a
 	// traversal key like "../../etc/passwd" cleans to "/etc/passwd" (a single
 	// rooted segment list) rather than escaping.
@@ -110,7 +121,11 @@ func (f *FSObjectStore) keyToPath(key string) (string, error) {
 	// for names whose meaning it does not control. Only the FINAL segment is
 	// checked — a directory so named is harmless, since the sweep skips
 	// directories and only ever looks at one directory's own entries.
-	if strings.HasPrefix(path.Base(clean), putTempPrefix) {
+	// filepath.Base over FromSlash, not path.Base: the check must see the final
+	// segment the FILESYSTEM will see, which on Windows means splitting on the
+	// separator filepath uses. The backslash rejection above already makes the two
+	// agree, so this is defence in depth against a future key shape that does not.
+	if strings.HasPrefix(filepath.Base(filepath.FromSlash(clean)), putTempPrefix) {
 		return "", fmt.Errorf("fsstore: invalid key %q (the %q name space is reserved for staging files)", key, putTempPrefix)
 	}
 	dst := filepath.Join(f.root, filepath.FromSlash(clean))

--- a/backup/fs.go
+++ b/backup/fs.go
@@ -13,6 +13,7 @@ import (
 	"path/filepath"
 	"strings"
 	"syscall"
+	"time"
 
 	"github.com/rostamlabs/rostam/objstore"
 )
@@ -40,15 +41,20 @@ var _ objstore.ObjectStore = (*FSObjectStore)(nil)
 // putTempPrefix is the fixed name prefix of every Put staging file. It is kept
 // OUT of the ".snap"/".cfg.json" key space (List/LatestKey/prune filter on
 // ".snap") so an in-flight staging file is never seen by retention as a
-// published object. A staging file left behind by a process killed mid-Put is
-// not auto-reclaimed here — a startup sweep would race a concurrent writer on a
-// shared root and cannot tell a final key from a temp by prefix alone, so
-// reclaiming leftovers is left to maintenance (tracked in #115). Note what
-// accumulates: the same Put stages the SNAPSHOT, so a kill mid-copy leaves a
-// partial snapshot as large as whatever had been copied — potentially many GB
-// on a large collection — inert (never selectable as a snapshot) but not small,
-// and unbounded across repeated interrupted backups until reclaimed.
+// published object — and, since no published key can start with it, it is also
+// the marker that makes reclaiming leftovers safe (see reclaimStaleTemps).
+//
+// A staging file left behind by a process killed mid-Put is NOT a small, inert
+// file: the very same Put stages the SNAPSHOT, so the leftover can be a partial
+// snapshot of arbitrary size — gigabytes of dead space on the backup volume,
+// leaked once per kill and never reclaimed on its own.
 const putTempPrefix = ".rostam-put-"
+
+// staleTempAge is how old a putTempPrefix staging file must be before a Put
+// reclaims it. It is the whole safety margin of the sweep: a CONCURRENT Put
+// created its staging file moments ago, so nothing an hour old can belong to a
+// live writer — only to a process that died mid-Put.
+const staleTempAge = time.Hour
 
 // NewFSObjectStore returns an FSObjectStore rooted at root, creating root if it
 // does not exist.
@@ -103,6 +109,13 @@ func (f *FSObjectStore) Put(_ context.Context, key string, r io.Reader, size int
 	if err := os.MkdirAll(filepath.Dir(dst), 0o750); err != nil {
 		return fmt.Errorf("fsstore: mkdir for %q: %w", key, err)
 	}
+	// Reclaim staging files abandoned by a process killed mid-Put before staging
+	// ours. Doing it here rather than at open is what makes it race-free on a root
+	// shared by several processes; it is best-effort and never fails the Put.
+	reclaimStaleTemps(filepath.Dir(dst))
+	// Reclaim staging files abandoned by a process killed mid-Put before staging
+	// ours. Doing it here rather than at open is what makes it race-free on a root
+	// shared by several processes; it is best-effort and never fails the Put.
 	// Staging name deliberately does NOT end in snapExt: List/LatestKey/prune
 	// filter on the ".snap" suffix, so a temp named "*.snap" would be visible to
 	// them mid-write — a concurrent prune could delete an in-flight Put's staging
@@ -142,6 +155,42 @@ func (f *FSObjectStore) Put(_ context.Context, key string, r io.Reader, size int
 		return fmt.Errorf("fsstore: sync dir for %q: %w", key, err)
 	}
 	return nil
+}
+
+// reclaimStaleTemps removes abandoned Put staging files from dir. It is called
+// from Put — on the NEXT write to that directory — rather than from a sweep at
+// open: there is then no startup instant to reason about on a shared root, only
+// an age bound, and two filters keep it safe:
+//
+//   - the putTempPrefix name prefix. No PUBLISHED object can start with it (keys
+//     come from the backup layout <tenant>/<col>/<ts>.snap and its .cfg.json
+//     sibling, and List/LatestKey/prune select on the ".snap" suffix), so the
+//     sweep can never remove a real snapshot or config.
+//   - the staleTempAge modtime bound. A concurrent Put created its staging file
+//     moments ago, so a live writer's temp is never old enough to be swept; only
+//     a temp orphaned by a dead process ages past the bound.
+//
+// Every error is ignored, including the removal's: reclaiming dead space must
+// never fail a backup.
+func reclaimStaleTemps(dir string) {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return
+	}
+	cutoff := time.Now().Add(-staleTempAge)
+	for _, e := range entries {
+		if e.IsDir() || !strings.HasPrefix(e.Name(), putTempPrefix) {
+			continue
+		}
+		info, ierr := e.Info()
+		if ierr != nil {
+			continue
+		}
+		if !info.ModTime().Before(cutoff) {
+			continue
+		}
+		_ = os.Remove(filepath.Join(dir, e.Name()))
+	}
 }
 
 // syncDir fsyncs the directory at dir so a preceding rename/create within it is

--- a/backup/fs.go
+++ b/backup/fs.go
@@ -92,17 +92,6 @@ func (f *FSObjectStore) keyToPath(key string) (string, error) {
 	if strings.ContainsRune(key, '\x00') {
 		return "", fmt.Errorf("fsstore: invalid key %q", key)
 	}
-	// Object keys are slash-separated by the ObjectStore contract, so a backslash
-	// is an ordinary character in a key — but NOT to filepath on Windows, where it
-	// is a separator. A key like "coll\.rostam-put-x.tmp" therefore has one final
-	// segment by the key's own rules and a DIFFERENT one by the filesystem's, which
-	// is how such a key could slip past the reservation below and publish a file the
-	// sweep would later delete. Refusing the character keeps one key meaning one
-	// path on every platform; the backup package's own keys never carry it
-	// (url.PathEscape encodes it).
-	if strings.ContainsRune(key, '\\') {
-		return "", fmt.Errorf("fsstore: invalid key %q (backslash is not a key separator)", key)
-	}
 	// path.Clean("/"+key) forces an absolute path and resolves away ".."/"." so a
 	// traversal key like "../../etc/passwd" cleans to "/etc/passwd" (a single
 	// rooted segment list) rather than escaping.
@@ -123,8 +112,9 @@ func (f *FSObjectStore) keyToPath(key string) (string, error) {
 	// directories and only ever looks at one directory's own entries.
 	// filepath.Base over FromSlash, not path.Base: the check must see the final
 	// segment the FILESYSTEM will see, which on Windows means splitting on the
-	// separator filepath uses. The backslash rejection above already makes the two
-	// agree, so this is defence in depth against a future key shape that does not.
+	// separator filepath uses. A backslash is an ordinary character in a key and to path.Base, but a
+	// SEPARATOR to filepath on Windows, so the two disagree about which segment is
+	// final — and only the filesystem's answer decides what the sweep will see.
 	if strings.HasPrefix(filepath.Base(filepath.FromSlash(clean)), putTempPrefix) {
 		return "", fmt.Errorf("fsstore: invalid key %q (the %q name space is reserved for staging files)", key, putTempPrefix)
 	}

--- a/backup/fs_test.go
+++ b/backup/fs_test.go
@@ -321,6 +321,8 @@ func sortStrings(s []string) {
 		for j := i; j > 0 && s[j-1] > s[j]; j-- {
 			s[j-1], s[j] = s[j], s[j-1]
 		}
+	}
+}
 
 // TestFSObjectStorePutReclaimsStaleTemps verifies Put's best-effort reclamation
 // of staging files abandoned by a process killed mid-Put. Such a leftover is not
@@ -465,47 +467,6 @@ func TestFSObjectStoreSweepRequiresTempSuffix(t *testing.T) {
 	}
 	if _, err := os.Stat(bare); err != nil {
 		t.Errorf("a file without %q must be left alone: %v", putTempSuffix, err)
-	}
-}
-
-// TestFSObjectStoreRejectsBackslashKeys pins the cross-platform hole in the
-// staging-name reservation. A backslash is an ordinary character in an object key
-// and to path.Base, but a SEPARATOR to filepath on Windows — so
-// "coll\.rostam-put-x.tmp" has a final segment of "coll\.rostam-put-x.tmp" by
-// the key's own rules and ".rostam-put-x.tmp" by the filesystem's, which let it
-// publish into the reserved name space and be swept an hour later. Keys carrying
-// the character are refused outright, on every platform, so one key always means
-// one path.
-func TestFSObjectStoreRejectsBackslashKeys(t *testing.T) {
-	root := t.TempDir()
-	store, err := NewFSObjectStore(root)
-	if err != nil {
-		t.Fatalf("NewFSObjectStore: %v", err)
-	}
-	for _, key := range []string{
-		`tenant/coll\` + putTempPrefix + `sneaky` + putTempSuffix, // the bypass itself
-		`tenant\coll/ts.snap`, // a plain separator swap
-	} {
-		if err := store.Put(context.Background(), key, strings.NewReader("x"), 1); err == nil {
-			t.Errorf("Put(%q): expected a backslash key to be refused, got nil", key)
-		}
-		if _, err := store.Get(context.Background(), key); err == nil {
-			t.Errorf("Get(%q): expected a backslash key to be refused, got nil", key)
-		} else if errors.Is(err, objstore.ErrNotFound) {
-			t.Errorf("Get(%q): refused as not-found, not as an invalid key: %v", key, err)
-		}
-		// Delete too: keyToPath gates all three, and on Windows an unguarded
-		// Delete of a backslash key resolves into the reserved staging name space
-		// — where it could unlink a live Put's staging file.
-		if err := store.Delete(context.Background(), key); err == nil {
-			t.Errorf("Delete(%q): expected a backslash key to be refused, got nil", key)
-		} else if errors.Is(err, objstore.ErrNotFound) {
-			t.Errorf("Delete(%q): refused as not-found, not as an invalid key: %v", key, err)
-		}
-	}
-	// Nothing may have been created: keyToPath fails before MkdirAll.
-	if entries, rerr := os.ReadDir(root); rerr != nil || len(entries) != 0 {
-		t.Errorf("refused keys created %d entries under root (err %v), want none", len(entries), rerr)
 	}
 }
 

--- a/backup/fs_test.go
+++ b/backup/fs_test.go
@@ -4,6 +4,7 @@ package backup
 
 import (
 	"context"
+	"errors"
 	"io"
 	"os"
 	"path/filepath"
@@ -11,6 +12,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/rostamlabs/rostam/objstore"
 )
 
 // TestFSObjectStorePutRoundTrip verifies that a value written via Put is
@@ -399,9 +402,13 @@ func TestFSObjectStoreRejectsReservedStagingKey(t *testing.T) {
 		}
 		if _, err := store.Get(ctx, key); err == nil {
 			t.Errorf("Get(%q): expected the reserved name space to be refused, got nil", key)
+		} else if errors.Is(err, objstore.ErrNotFound) {
+			t.Errorf("Get(%q): refused as not-found, not as an invalid key: %v", key, err)
 		}
 		if err := store.Delete(ctx, key); err == nil {
 			t.Errorf("Delete(%q): expected the reserved name space to be refused, got nil", key)
+		} else if errors.Is(err, objstore.ErrNotFound) {
+			t.Errorf("Delete(%q): refused as not-found, not as an invalid key: %v", key, err)
 		}
 	}
 
@@ -484,6 +491,16 @@ func TestFSObjectStoreRejectsBackslashKeys(t *testing.T) {
 		}
 		if _, err := store.Get(context.Background(), key); err == nil {
 			t.Errorf("Get(%q): expected a backslash key to be refused, got nil", key)
+		} else if errors.Is(err, objstore.ErrNotFound) {
+			t.Errorf("Get(%q): refused as not-found, not as an invalid key: %v", key, err)
+		}
+		// Delete too: keyToPath gates all three, and on Windows an unguarded
+		// Delete of a backslash key resolves into the reserved staging name space
+		// — where it could unlink a live Put's staging file.
+		if err := store.Delete(context.Background(), key); err == nil {
+			t.Errorf("Delete(%q): expected a backslash key to be refused, got nil", key)
+		} else if errors.Is(err, objstore.ErrNotFound) {
+			t.Errorf("Delete(%q): refused as not-found, not as an invalid key: %v", key, err)
 		}
 	}
 	// Nothing may have been created: keyToPath fails before MkdirAll.

--- a/backup/fs_test.go
+++ b/backup/fs_test.go
@@ -461,6 +461,37 @@ func TestFSObjectStoreSweepRequiresTempSuffix(t *testing.T) {
 	}
 }
 
+// TestFSObjectStoreRejectsBackslashKeys pins the cross-platform hole in the
+// staging-name reservation. A backslash is an ordinary character in an object key
+// and to path.Base, but a SEPARATOR to filepath on Windows — so
+// "coll\.rostam-put-x.tmp" has a final segment of "coll\.rostam-put-x.tmp" by
+// the key's own rules and ".rostam-put-x.tmp" by the filesystem's, which let it
+// publish into the reserved name space and be swept an hour later. Keys carrying
+// the character are refused outright, on every platform, so one key always means
+// one path.
+func TestFSObjectStoreRejectsBackslashKeys(t *testing.T) {
+	root := t.TempDir()
+	store, err := NewFSObjectStore(root)
+	if err != nil {
+		t.Fatalf("NewFSObjectStore: %v", err)
+	}
+	for _, key := range []string{
+		`tenant/coll\` + putTempPrefix + `sneaky` + putTempSuffix, // the bypass itself
+		`tenant\coll/ts.snap`, // a plain separator swap
+	} {
+		if err := store.Put(context.Background(), key, strings.NewReader("x"), 1); err == nil {
+			t.Errorf("Put(%q): expected a backslash key to be refused, got nil", key)
+		}
+		if _, err := store.Get(context.Background(), key); err == nil {
+			t.Errorf("Get(%q): expected a backslash key to be refused, got nil", key)
+		}
+	}
+	// Nothing may have been created: keyToPath fails before MkdirAll.
+	if entries, rerr := os.ReadDir(root); rerr != nil || len(entries) != 0 {
+		t.Errorf("refused keys created %d entries under root (err %v), want none", len(entries), rerr)
+	}
+}
+
 // TestTempHeartbeatKeepsTempFresh asserts a running Put's staging file is kept
 // young, and stops being kept young once the Put is done. Without the heartbeat
 // a copy that stalls for longer than staleTempAge is indistinguishable from a

--- a/backup/fs_test.go
+++ b/backup/fs_test.go
@@ -10,6 +10,7 @@ import (
 	"runtime"
 	"strings"
 	"testing"
+	"time"
 )
 
 // TestFSObjectStorePutRoundTrip verifies that a value written via Put is
@@ -317,5 +318,59 @@ func sortStrings(s []string) {
 		for j := i; j > 0 && s[j-1] > s[j]; j-- {
 			s[j-1], s[j] = s[j], s[j-1]
 		}
+
+// TestFSObjectStorePutReclaimsStaleTemps verifies Put's best-effort reclamation
+// of staging files abandoned by a process killed mid-Put. Such a leftover is not
+// inert — the same Put stages the snapshot itself, so it can be a partial
+// snapshot of arbitrary size — and nothing else ever removes it. A temp older
+// than staleTempAge is swept; a temp with a CURRENT modtime is left alone,
+// because it may belong to a concurrent writer.
+func TestFSObjectStorePutReclaimsStaleTemps(t *testing.T) {
+	root := t.TempDir()
+	store, err := NewFSObjectStore(root)
+	if err != nil {
+		t.Fatalf("NewFSObjectStore: %v", err)
+	}
+
+	dir := filepath.Join(root, "tenant", "coll")
+	if err := os.MkdirAll(dir, 0o750); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	stale := filepath.Join(dir, putTempPrefix+"stale.tmp")
+	if err := os.WriteFile(stale, []byte("abandoned partial snapshot"), 0o600); err != nil {
+		t.Fatalf("write stale temp: %v", err)
+	}
+	old := time.Now().Add(-2 * staleTempAge)
+	if err := os.Chtimes(stale, old, old); err != nil {
+		t.Fatalf("chtimes: %v", err)
+	}
+	fresh := filepath.Join(dir, putTempPrefix+"fresh.tmp")
+	if err := os.WriteFile(fresh, []byte("a concurrent writer's staging file"), 0o600); err != nil {
+		t.Fatalf("write fresh temp: %v", err)
+	}
+
+	const key = "tenant/coll/2026-07-08T00:00:00Z.snap"
+	want := []byte("payload")
+	if err := store.Put(context.Background(), key, strings.NewReader(string(want)), int64(len(want))); err != nil {
+		t.Fatalf("Put: %v", err)
+	}
+
+	if _, err := os.Stat(stale); !os.IsNotExist(err) {
+		t.Errorf("stale staging file not reclaimed, stat err = %v", err)
+	}
+	if _, err := os.Stat(fresh); err != nil {
+		t.Errorf("a current-modtime staging file must be left alone: %v", err)
+	}
+	rc, err := store.Get(context.Background(), key)
+	if err != nil {
+		t.Fatalf("Get after Put: %v", err)
+	}
+	defer rc.Close()
+	got, err := io.ReadAll(rc)
+	if err != nil {
+		t.Fatalf("ReadAll: %v", err)
+	}
+	if string(got) != string(want) {
+		t.Errorf("object = %q, want %q", got, want)
 	}
 }

--- a/backup/fs_test.go
+++ b/backup/fs_test.go
@@ -374,3 +374,140 @@ func TestFSObjectStorePutReclaimsStaleTemps(t *testing.T) {
 		t.Errorf("object = %q, want %q", got, want)
 	}
 }
+
+// TestFSObjectStoreRejectsReservedStagingKey asserts the putTempPrefix name
+// space is reserved. Nothing stops a caller from asking to publish an object
+// named like a staging file, and such an object would be silently deleted by
+// reclaimStaleTemps an hour later — so keyToPath refuses the key outright. The
+// refusal lives in keyToPath, so it covers Get and Delete as well as Put: a key
+// that can never be written must not be readable or deletable either.
+func TestFSObjectStoreRejectsReservedStagingKey(t *testing.T) {
+	root := t.TempDir()
+	store, err := NewFSObjectStore(root)
+	if err != nil {
+		t.Fatalf("NewFSObjectStore: %v", err)
+	}
+	ctx := context.Background()
+
+	for _, key := range []string{
+		"tenant/coll/" + putTempPrefix + "sneaky" + putTempSuffix,
+		"tenant/coll/" + putTempPrefix + "sneaky.snap",
+		putTempPrefix + "toplevel",
+	} {
+		if err := store.Put(ctx, key, strings.NewReader("payload"), 7); err == nil {
+			t.Errorf("Put(%q): expected the reserved name space to be refused, got nil", key)
+		}
+		if _, err := store.Get(ctx, key); err == nil {
+			t.Errorf("Get(%q): expected the reserved name space to be refused, got nil", key)
+		}
+		if err := store.Delete(ctx, key); err == nil {
+			t.Errorf("Delete(%q): expected the reserved name space to be refused, got nil", key)
+		}
+	}
+
+	// The refused Put must not have written anything — not even the directory
+	// tree, since keyToPath fails before MkdirAll.
+	if _, err := os.Stat(filepath.Join(root, "tenant")); !os.IsNotExist(err) {
+		t.Errorf("refused Put created files under root, stat err = %v", err)
+	}
+
+	// A key whose non-final segment shares the prefix is fine: the sweep skips
+	// directories and only ever inspects one directory's own entries.
+	ok := putTempPrefix + "dir/real.snap"
+	if err := store.Put(ctx, ok, strings.NewReader("payload"), 7); err != nil {
+		t.Errorf("Put(%q): a prefixed DIRECTORY segment must stay legal: %v", ok, err)
+	}
+}
+
+// TestFSObjectStoreSweepRequiresTempSuffix asserts the sweep matches on BOTH
+// halves of the staging name, not the prefix alone. A file carrying the prefix
+// but not putTempSuffix was never created by this Put (keyToPath reserves the
+// prefix, so it cannot be a published object either) — it is something else on
+// the volume, and the reclaimer must leave it alone however old it is.
+func TestFSObjectStoreSweepRequiresTempSuffix(t *testing.T) {
+	root := t.TempDir()
+	store, err := NewFSObjectStore(root)
+	if err != nil {
+		t.Fatalf("NewFSObjectStore: %v", err)
+	}
+
+	dir := filepath.Join(root, "tenant", "coll")
+	if err := os.MkdirAll(dir, 0o750); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	// Both are ancient; only the one with the full staging name may be swept.
+	suffixed := filepath.Join(dir, putTempPrefix+"abandoned"+putTempSuffix)
+	bare := filepath.Join(dir, putTempPrefix+"not-a-staging-file")
+	old := time.Now().Add(-2 * staleTempAge)
+	for _, p := range []string{suffixed, bare} {
+		if err := os.WriteFile(p, []byte("x"), 0o600); err != nil {
+			t.Fatalf("write %q: %v", p, err)
+		}
+		if err := os.Chtimes(p, old, old); err != nil {
+			t.Fatalf("chtimes %q: %v", p, err)
+		}
+	}
+
+	const key = "tenant/coll/2026-07-08T00:00:00Z.snap"
+	if err := store.Put(context.Background(), key, strings.NewReader("payload"), 7); err != nil {
+		t.Fatalf("Put: %v", err)
+	}
+
+	if _, err := os.Stat(suffixed); !os.IsNotExist(err) {
+		t.Errorf("a full staging name should have been reclaimed, stat err = %v", err)
+	}
+	if _, err := os.Stat(bare); err != nil {
+		t.Errorf("a file without %q must be left alone: %v", putTempSuffix, err)
+	}
+}
+
+// TestTempHeartbeatKeepsTempFresh asserts a running Put's staging file is kept
+// young, and stops being kept young once the Put is done. Without the heartbeat
+// a copy that stalls for longer than staleTempAge is indistinguishable from a
+// temp orphaned by a killed process, so a concurrent Put would unlink it and the
+// stalled Put's rename would fail. tempHeartbeat is shortened so the test is a
+// few milliseconds rather than a quarter of an hour.
+func TestTempHeartbeatKeepsTempFresh(t *testing.T) {
+	prev := tempHeartbeat
+	tempHeartbeat = 2 * time.Millisecond
+	t.Cleanup(func() { tempHeartbeat = prev })
+
+	path := filepath.Join(t.TempDir(), putTempPrefix+"inflight"+putTempSuffix)
+	if err := os.WriteFile(path, []byte("in-flight snapshot"), 0o600); err != nil {
+		t.Fatalf("write temp: %v", err)
+	}
+	backdate := func() {
+		old := time.Now().Add(-2 * staleTempAge)
+		if err := os.Chtimes(path, old, old); err != nil {
+			t.Fatalf("chtimes: %v", err)
+		}
+	}
+	// fresh reports whether the file would survive a sweep right now.
+	fresh := func() bool {
+		info, err := os.Stat(path)
+		if err != nil {
+			t.Fatalf("stat: %v", err)
+		}
+		return !info.ModTime().Before(time.Now().Add(-staleTempAge))
+	}
+
+	backdate()
+	stop := startTempHeartbeat(path)
+	deadline := time.Now().Add(2 * time.Second)
+	for !fresh() {
+		if time.Now().After(deadline) {
+			stop()
+			t.Fatal("heartbeat never refreshed the staging file's mtime")
+		}
+		time.Sleep(time.Millisecond)
+	}
+
+	// After stop the refreshes must cease, or the file could never age out and an
+	// abandoned temp would leak forever.
+	stop()
+	backdate()
+	time.Sleep(20 * tempHeartbeat)
+	if fresh() {
+		t.Error("mtime still being refreshed after stop")
+	}
+}


### PR DESCRIPTION
`FSObjectStore.Put` stages through a `putTempPrefix` file and renames it into place, so a process killed mid-copy leaks that file with nothing to reclaim it — the gap #111 named and left open as #115.

The leftover is not small or inert, which is the part worth stating plainly: the same `Put` stages the **snapshot**, so an abandoned temp can be a partial snapshot of arbitrary size. On a large collection that is gigabytes of dead space on the backup volume, leaked once per kill, accumulating across repeated interrupted backups until someone notices.

## The fix

`Put` sweeps staging files older than `staleTempAge` (one hour) from the destination directory before creating its own.

Reclaiming on the **next Put** rather than at open is what makes it race-free on a root shared by several processes — the objection that got the original startup sweep removed. Two independent filters have to hold before a file is touched:

- **The prefix.** No published key can start with `putTempPrefix`, and `List`/`LatestKey`/`prune` select on `.snap`, so the sweep can never see a real object.
- **The age bound.** A concurrent `Put`'s staging file was created moments ago, so an hour-old cutoff cannot reach a live writer however slow its copy is.

Every error is ignored: best-effort reclamation must never fail a backup.

## Tests

`TestFSObjectStorePutReclaimsStaleTemps` backdates a staging file past `staleTempAge` with `os.Chtimes` and asserts a later `Put` removes it, that a temp with a current modtime is left alone, and that the `Put` itself still succeeds and reads back. Verified load-bearing: with the sweep call removed the test fails with "stale staging file not reclaimed".

`gofmt`, `go build ./...`, `go vet`, `go test ./backup/ ./objstore/` and `go test -race ./backup/` are clean.

Closes #115.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes backup volume leakage from interrupted `Put` operations: a killed `Put` left its staging file behind forever; now the next `Put` into that directory reclaims staging files older than one hour.

- Reclaiming on the next `Put` rather than at open keeps it race-free on a shared root; cleanup is best-effort, so errors never fail a backup.
- `keyToPath` rejects keys whose final segment starts with `putTempPrefix`, checking the segment as the filesystem sees it so backslash keys stay legal but can't land in the reserved staging name space on Windows.
- The sweep requires both the prefix and the `.tmp` suffix, so only actual staging files are removed.
- A live `Put` refreshes its temp's mtime via a heartbeat, so a stalled copy can't be mistaken for an abandoned temp.
- Regression tests cover stale temps removed, fresh and prefix-only files left alone, reserved keys rejected on Put/Get/Delete, and heartbeat freshness.

Closes #115.

<sup>Written for commit ee1da43f016f1b2459ccd72f997ddc6f38022af0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rostamlabs/rostam/pull/126?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Stale temporary backup files are now automatically reclaimed when storing a new object.
  * Recent temporary files are preserved to avoid disrupting active or concurrent writes.
  * Stored objects continue to round-trip without data loss.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->